### PR TITLE
Fix a batch of LTR bugs: token-creation triggers, legendary cast restriction, Denethor scope, Ring-bearer block, dies-trigger stack text

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatMath.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatMath.kt
@@ -77,6 +77,18 @@ object CombatMath {
         // We return true here — menace is handled at the assignment level
         // since a single canBeBlockedBy check can't express "needs 2 blockers"
 
+        // Ring-bearer evasion (CR 701.54c): a Ring-bearer can't be blocked by creatures with power
+        // greater than the Ring-bearer's power, while still controlled by its designator. Driven by
+        // RingBearerComponent rather than a card static, so it's invisible to the static-ability
+        // checks below — mirror the engine's RingBearerCantBeBlockedByGreaterPowerRule here.
+        val ringBearer = state.getEntity(attacker)
+            ?.get<com.wingedsheep.engine.state.components.identity.RingBearerComponent>()
+        if (ringBearer != null && projected.getController(attacker) == ringBearer.ownerId) {
+            val bearerPower = projected.getPower(attacker) ?: 0
+            val blockerPower = projected.getPower(blocker) ?: 0
+            if (blockerPower > bearerPower) return false
+        }
+
         // Landwalk checks (approximate — check if opponent controls matching land)
         val attackerController = projected.getController(attacker)
         val blockerController = projected.getController(blocker)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatAdvisorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatAdvisorTest.kt
@@ -2309,6 +2309,71 @@ class CombatAdvisorTest : FunSpec({
         // Must attack — free damage with no risk
         result.attackers shouldContainKey attacker
     }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // Ring-bearer evasion (CR 701.54c): a Ring-bearer can't be blocked by a
+    // creature with greater power. This is driven by RingBearerComponent, not a
+    // card static, so the AI's block-legality model must account for it — else it
+    // proposes an illegal block that the engine rejects (regression: the AI then
+    // looped forever re-declaring the same illegal block).
+    // ═════════════════════════════════════════════════════════════════════
+
+    test("does not assign a greater-power blocker to a Ring-bearer attacker") {
+        val (driver, registry, advisor) = setup(emptyList())
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(p1, "Grizzly Bears") // 2/2 Ring-bearer
+        driver.removeSummoningSickness(attacker)
+        driver.addComponent(attacker, com.wingedsheep.engine.state.components.identity.RingBearerComponent(p1))
+
+        val bigBlocker = driver.putCreatureOnBattlefield(p2, "Hill Giant") // 3/3, power 3 > 2
+        driver.removeSummoningSickness(bigBlocker)
+
+        // Face lethal so the AI is strongly motivated to (chump-)block — proving the
+        // restriction holds even when blocking is desirable.
+        driver.replaceState(driver.state.withLifeTotal(p2, 2))
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submit(DeclareAttackers(p1, mapOf(attacker to p2)))
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // The block-legality model reflects the Ring-bearer restriction.
+        CombatMath.canBeBlockedBy(
+            driver.state, driver.state.projectedState, attacker, bigBlocker, registry
+        ) shouldBe false
+
+        // ...so the advisor never proposes the illegal block.
+        val result = advisor.chooseBlockers(
+            driver.state, buildBlockAction(p2, listOf(bigBlocker)), p2
+        ) as DeclareBlockers
+        result.blockers.shouldNotContainKey(bigBlocker)
+    }
+
+    test("allows an equal-or-lesser-power blocker to block a Ring-bearer attacker") {
+        val (driver, registry, _) = setup(emptyList())
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(p1, "Grizzly Bears") // 2/2 Ring-bearer
+        driver.removeSummoningSickness(attacker)
+        driver.addComponent(attacker, com.wingedsheep.engine.state.components.identity.RingBearerComponent(p1))
+
+        val smallBlocker = driver.putCreatureOnBattlefield(p2, "Eager Cadet") // 1/1, power 1 <= 2
+        driver.removeSummoningSickness(smallBlocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submit(DeclareAttackers(p1, mapOf(attacker to p2)))
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        CombatMath.canBeBlockedBy(
+            driver.state, driver.state.projectedState, attacker, smallBlocker, registry
+        ) shouldBe true
+    }
 })
 
 /**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -30,7 +30,10 @@ section; do not let SDK additions land without a corresponding doc update.
   Phyrexian (`{W/P}` — colour or 2 life), and monocolored hybrid / "twobrid" (`{2/B}` — two
   generic **or** one mana of the colour; mana value counts the generic side per CR 202.3f).
   Gurmag Nightwatch's `{2/B}{2/G}{2/U}` is the canonical twobrid example.
-- `typeLine: String` — full type line including supertypes and subtypes.
+- `typeLine: String` — full type line including supertypes and subtypes. A `Legendary Instant` /
+  `Legendary Sorcery` automatically gets the CR 205.4e casting restriction (can be cast only while
+  its controller controls a legendary creature or legendary planeswalker) — the engine enforces this
+  from the type line in both legal-action enumeration and the cast handler; no per-card opt-in needed.
 - `oracleText: String` — rules text; auto-generated from abilities if omitted.
 - `power: Int?`, `toughness: Int?` — base P/T for creatures.
 - `dynamicPower`, `dynamicToughness` — characteristic-defining P/T (e.g. `*/*` Tarmogoyf).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1189,6 +1189,16 @@ for any other (filter, binding, to/excludeTo) combination.
   any-controller deaths); `excludeTo = GRAVEYARD` gives "leaves without dying"
   (Three Tree Scribe shape); leaving both null gives "leaves to any zone."
 
+**Token creation**
+
+- `EventPattern.TokenCreationEvent(controller = ControllerFilter.You, tokenFilter? = null)` — used as
+  a trigger, "Whenever you create a token" (Mirkwood Bats). **Per-token**: fires once for *each* token
+  created, so an effect that creates three tokens at once fires it three times. Matched against each
+  token-creation `ZoneChangeEvent` (`fromZone == null`); a token that's a copy of a permanent spell
+  enters from the stack and is **not** "created" (CR 608.3f / 111.13), so it doesn't fire this. The
+  same `EventPattern` also serves as a replacement-effect filter (token doublers); the two uses don't
+  conflict.
+
 ### Combat
 
 Named sugar for the common cases; reach for `attacks(...)` / `blocks(...)` /

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -958,28 +958,60 @@ class GamePlayHandler(
                     broadcastStateUpdate(gameSession, result.events)
                 }
                 is GameSession.ActionResult.Failure -> {
-                    logger.warn("AI action failed: {} — falling back to PassPriority", result.reason)
-                    // Action failed (e.g., can't afford, invalid target) — pass priority
-                    // so the game doesn't get stuck
-                    val passResult = gameSession.executeAction(aiPlayerId, com.wingedsheep.engine.core.PassPriority(aiPlayerId))
-                    when (passResult) {
-                        is GameSession.ActionResult.Success -> {
-                            broadcastStateUpdate(gameSession, passResult.events)
-                            if (gameSession.isGameOver()) handleGameOver(gameSession, events = passResult.events)
+                    // The chosen action was rejected (e.g. an illegal block the AI's combat model
+                    // didn't foresee, like Ring-bearer "can't be blocked by greater power"). Try a
+                    // sequence of step-appropriate, always-legal fallbacks so the game can't get
+                    // stuck. During DECLARE_BLOCKERS/DECLARE_ATTACKERS, PassPriority is itself
+                    // illegal ("you must declare blockers before passing priority"), so a do-nothing
+                    // declaration must come first — otherwise the AI re-receives the same state and
+                    // loops forever.
+                    logger.warn("AI action failed: {} — trying safe fallbacks", result.reason)
+                    var recovered = false
+                    for (fallback in safeFallbackActions(gameSession, aiPlayerId)) {
+                        when (val fb = gameSession.executeAction(aiPlayerId, fallback)) {
+                            is GameSession.ActionResult.Success -> {
+                                broadcastStateUpdate(gameSession, fb.events)
+                                if (gameSession.isGameOver()) handleGameOver(gameSession, events = fb.events)
+                                recovered = true
+                            }
+                            is GameSession.ActionResult.PausedForDecision -> {
+                                broadcastStateUpdate(gameSession, fb.events)
+                                recovered = true
+                            }
+                            is GameSession.ActionResult.Failure -> {
+                                logger.warn("AI fallback {} also failed: {}", fallback::class.simpleName, fb.reason)
+                            }
                         }
-                        is GameSession.ActionResult.PausedForDecision -> {
-                            broadcastStateUpdate(gameSession, passResult.events)
-                        }
-                        is GameSession.ActionResult.Failure -> {
-                            logger.warn("AI fallback PassPriority also failed: {}", passResult.reason)
-                            // Last resort: broadcast current state so AI gets another chance
-                            broadcastStateUpdate(gameSession, emptyList())
-                        }
+                        if (recovered) break
+                    }
+                    if (!recovered) {
+                        // Last resort: broadcast current state so the AI gets another chance.
+                        broadcastStateUpdate(gameSession, emptyList())
                     }
                 }
             }
         } catch (e: Exception) {
             logger.error("Error handling AI action", e)
+        }
+    }
+
+    /**
+     * Step-appropriate, always-legal recovery actions to try (in order) when an AI's chosen action
+     * is rejected. During the declare steps a "do nothing" declaration (no blockers / no attackers)
+     * is always legal and advances combat; `PassPriority` is NOT legal there, so it can only be the
+     * last resort. Outside combat declaration, passing priority is the safe no-op.
+     */
+    private fun safeFallbackActions(
+        gameSession: GameSession,
+        aiPlayerId: EntityId
+    ): List<com.wingedsheep.engine.core.GameAction> {
+        val pass = com.wingedsheep.engine.core.PassPriority(aiPlayerId)
+        return when (gameSession.getStateForTesting()?.step) {
+            com.wingedsheep.sdk.core.Step.DECLARE_BLOCKERS ->
+                listOf(com.wingedsheep.engine.core.DeclareBlockers(aiPlayerId, emptyMap()), pass)
+            com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS ->
+                listOf(com.wingedsheep.engine.core.DeclareAttackers(aiPlayerId, emptyMap()), pass)
+            else -> listOf(pass)
         }
     }
 

--- a/manual-scenarios/cards/g/goblin-fireleaper.json
+++ b/manual-scenarios/cards/g/goblin-fireleaper.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Lightning Bolt"],
+    "battlefield": [
+      {"name": "Goblin Fireleaper"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Snarling Warg"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Snarling Warg"},
+      {"name": "Easterling Vanguard"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Easterling Vanguard"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/cards/i/isildurs-fateful-strike.json
+++ b/manual-scenarios/cards/i/isildurs-fateful-strike.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Denethor, Ruling Steward", "Isildur's Fateful Strike"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Isildur's Fateful Strike"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Snarling Warg", "Easterling Vanguard", "Goblin Fireleaper", "Mountain", "Mountain", "Mountain"],
+    "battlefield": [
+      {"name": "Snarling Warg"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Easterling Vanguard"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/cards/m/mirkwood-bats.json
+++ b/manual-scenarios/cards/m/mirkwood-bats.json
@@ -1,0 +1,38 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mirkwood Bats"},
+      {"name": "Horn of Gondor"},
+      {"name": "Denethor, Ruling Steward"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Goblin Fireleaper", "Snarling Warg"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Easterling Vanguard"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Easterling Vanguard"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/cards/s/shire-shirriff.json
+++ b/manual-scenarios/cards/s/shire-shirriff.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Horn of Gondor", "Shire Shirriff"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Shire Shirriff", "Snarling Warg"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Easterling Vanguard"},
+      {"name": "Snarling Warg"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Easterling Vanguard"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArtifactMutation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArtifactMutation.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.sdk.scripting.values.EntityReference
  *
  * The token count reads the destroyed artifact's mana value via [DynamicAmount.EntityProperty];
  * mana value is a card characteristic that survives the move to the graveyard, so the count
- * resolves correctly after [Effects.Destroy] (CR 608.2g — last-known information). Mirrors
+ * resolves correctly after [Effects.Destroy] (CR 608.2h — last-known information). Mirrors
  * [AuraMutation]. If the artifact is an illegal target on resolution the whole spell is countered
  * by the rules and no Saprolings are created.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AuraMutation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AuraMutation.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.sdk.scripting.values.EntityReference
  *
  * The token count reads the destroyed enchantment's mana value via
  * [DynamicAmount.EntityProperty]; mana value is a card characteristic that survives the move to
- * the graveyard, so the count resolves correctly after [Effects.Destroy] (CR 608.2g — last-known
+ * the graveyard, so the count resolves correctly after [Effects.Destroy] (CR 608.2h — last-known
  * information). If the enchantment is an illegal target on resolution the whole spell is countered
  * by the rules and no Saprolings are created.
  */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DenethorRulingSteward.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DenethorRulingSteward.kt
@@ -31,7 +31,9 @@ val DenethorRulingSteward = card("Denethor, Ruling Steward") {
 
     triggeredAbility {
         trigger = Triggers.YourEndStep
-        triggerCondition = Conditions.CreatureDiedThisTurn
+        // "if a creature died under your control this turn" — scoped to Denethor's controller,
+        // not any player (CreatureDiedThisTurn would wrongly fire on an opponent's creature dying).
+        triggerCondition = Conditions.ControlledCreatureDiedThisTurn
         effect = Effects.CreateToken(
             power = 1,
             toughness = 1,

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -2151,7 +2151,7 @@
                     ],
                     "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6181330-7521-4ec6-be6c-b35487c2d2d4.jpg?1699974464"
                 },
-                "triggerCondition": "CreatureDiedThisTurn"
+                "triggerCondition": "ControlledCreatureDiedThisTurn"
             }
         ],
         "activatedAbilities": [

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -61,7 +61,7 @@ data class TriggeredAbilityContinuation(
     val lastKnownPower: Int? = null,
     val lastKnownToughness: Int? = null,
     val triggerModesChosenCount: Int? = null,
-    /** Power of the aura/equipment's attached creature, captured at trigger time (CR 608.2g LKI). */
+    /** Power of the aura/equipment's attached creature, captured at trigger time (CR 608.2h LKI). */
     val enchantedCreatureLastKnownPower: Int? = null,
     /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -64,7 +64,7 @@ data class TriggerContext(
     val modesChosenCount: Int? = null,
     /**
      * Power of the creature the trigger's source (an Aura/Equipment) was attached to, captured
-     * when the trigger fired. Carried as last-known information (CR 608.2g) so that an
+     * when the trigger fired. Carried as last-known information (CR 608.2h) so that an
      * "enchanted creature deals damage equal to its power" ability still uses the right power
      * if the creature — and the aura — leave before the ability resolves. Null for non-attached
      * sources. Populated by [TriggerDetector], not [fromEvent] (which has no game state).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -980,7 +980,7 @@ class TriggerDetector(
                         // read "enchanted/equipped creature ... its power" (e.g. Pain for All). The
                         // creature — and the aura — may leave before the ability resolves (removed in
                         // response to the aura's ETB trigger), in which case the resolver falls back to
-                        // this last-known value (CR 608.2g).
+                        // this last-known value (CR 608.2h).
                         val enchantedPower = state.getEntity(entityId)
                             ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
                             ?.targetId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -157,6 +157,10 @@ class TriggerIndex(
 
             return when (trigger) {
                 is SdkGameEvent.ZoneChangeEvent -> listOf(TriggerCategory.ZONE_CHANGE)
+                // "Whenever you create a token" matches token-creation ZoneChangeEvents (fromZone ==
+                // null), so it indexes under the same category as those events (TriggerMatcher.
+                // matchesTokenCreationTrigger does the create-specific filtering).
+                is SdkGameEvent.TokenCreationEvent -> listOf(TriggerCategory.ZONE_CHANGE)
                 is SdkGameEvent.DrawEvent -> listOf(TriggerCategory.DRAW)
                 is SdkGameEvent.NthCardDrawnEvent -> listOf(TriggerCategory.DRAW)
                 is SdkGameEvent.CardRevealedFromDrawEvent -> listOf(TriggerCategory.CARD_REVEALED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.engine.core.UntappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
@@ -41,6 +42,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.events.ControllerFilter
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.events.DamageType
@@ -353,7 +355,9 @@ class TriggerMatcher(
             // Replacement-effect-only events never match as triggers
             is EventPattern.DamageEvent -> false
             is EventPattern.CounterPlacementEvent -> false
-            is EventPattern.TokenCreationEvent -> false
+            // "Whenever you create a token" (Mirkwood Bats) — fires per token created (CR's
+            // singular templating), matched against each token-creation ZoneChangeEvent.
+            is EventPattern.TokenCreationEvent -> matchesTokenCreationTrigger(trigger, event, controllerId, state)
             is EventPattern.LifeLossEvent -> {
                 event is LifeChangedEvent &&
                     event.reason != com.wingedsheep.engine.core.LifeChangeReason.LIFE_GAIN &&
@@ -440,6 +444,45 @@ class TriggerMatcher(
         return event.cardIds.count { cardId ->
             predicateEvaluator.matches(state, projected, cardId, filter, predicateContext)
         }
+    }
+
+    /**
+     * "Whenever you create a token" (Mirkwood Bats). A token is *created* when it enters the
+     * battlefield from nowhere — its [ZoneChangeEvent] has `fromZone == null`. A token that's a
+     * copy of a permanent spell enters from [Zone.STACK] instead and is explicitly **not** created
+     * (CR 608.3f / 111.13), so the `fromZone == null` gate excludes it. One event is emitted per
+     * token, so this fires once per token created (the singular "a token" templating), e.g. each
+     * Soldier from Horn of Gondor's `{3},{T}` drains separately.
+     */
+    private fun matchesTokenCreationTrigger(
+        trigger: EventPattern.TokenCreationEvent,
+        event: EngineGameEvent,
+        controllerId: EntityId,
+        state: GameState
+    ): Boolean {
+        if (event !is ZoneChangeEvent) return false
+        if (event.fromZone != null || event.toZone != Zone.BATTLEFIELD) return false
+        val entity = state.getEntity(event.entityId) ?: return false
+        if (!entity.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()) return false
+
+        // Controller of the freshly-created token (owner == controller at creation; prefer projected).
+        val tokenController = state.projectedState.getController(event.entityId) ?: event.ownerId
+        val controllerMatches = when (trigger.controller) {
+            is ControllerFilter.You -> tokenController == controllerId
+            is ControllerFilter.Opponent -> tokenController != controllerId
+            is ControllerFilter.Any -> true
+        }
+        if (!controllerMatches) return false
+
+        val filter = trigger.tokenFilter
+        if (filter != null && !predicateEvaluator.matches(
+                state, state.projectedState, event.entityId, filter,
+                PredicateContext(controllerId = controllerId)
+            )
+        ) {
+            return false
+        }
+        return true
     }
 
     fun matchesZoneChangeTrigger(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -209,7 +209,7 @@ class DynamicAmountEvaluator(
                 // has detached: the enchanted creature (and the aura) can leave the battlefield
                 // before the ability resolves — e.g. removed in response to the aura's ETB
                 // trigger — and "deals damage equal to its power" must use the power as it last
-                // existed on the battlefield (CR 608.2g). Captured at trigger time.
+                // existed on the battlefield (CR 608.2h). Captured at trigger time.
                 if (amount.entity is EntityReference.EnchantedCreature &&
                     amount.numericProperty is EntityNumericProperty.Power &&
                     (entityId == null || entityId !in state.getBattlefield())

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -133,7 +133,7 @@ data class EffectContext(
     /**
      * Power of the creature an Aura/Equipment was attached to, captured when its triggered
      * ability fired. Read by [EntityReference.EnchantedCreature] power reads as last-known
-     * information (CR 608.2g) when the attached creature — and the aura — have left the
+     * information (CR 608.2h) when the attached creature — and the aura — have left the
      * battlefield before the ability resolves (e.g. the creature is removed in response to
      * the aura's enters-the-battlefield trigger). Null for non-attached sources.
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -85,6 +85,8 @@ class EffectAndTriggerContinuationResumer(
                 triggerTotalCounterCount = continuation.triggerTotalCounterCount,
                 triggerLastKnownCounters = continuation.triggerLastKnownCounters,
                 triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+                lastKnownPower = continuation.lastKnownPower,
+                lastKnownToughness = continuation.lastKnownToughness,
                 triggerScryCount = continuation.triggerScryCount,
                 triggerExcessDamageAmount = continuation.triggerExcessDamageAmount
             )
@@ -127,6 +129,8 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+            lastKnownPower = continuation.lastKnownPower,
+            lastKnownToughness = continuation.lastKnownToughness,
             triggerModesChosenCount = continuation.triggerModesChosenCount,
             enchantedCreatureLastKnownPower = continuation.enchantedCreatureLastKnownPower,
             triggerScryCount = continuation.triggerScryCount,
@@ -244,6 +248,8 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+            lastKnownPower = continuation.lastKnownPower,
+            lastKnownToughness = continuation.lastKnownToughness,
             damageDistribution = response.distribution
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -12,6 +13,7 @@ import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.targets.TargetPlayer
 import com.wingedsheep.sdk.scripting.targets.TargetOpponent
@@ -139,6 +141,8 @@ class ReflexiveTriggerEffectExecutor(
      *
      * Walks the action effect tree looking for gating sub-effects:
      *  - [SelectTargetEffect] with no legal targets → infeasible
+     *  - [SacrificeEffect] with fewer controlled matches than its count → infeasible
+     *    (e.g. Shire Shirriff's "you may sacrifice a token" when you control no token)
      *  - [ChooseActionEffect] with no feasible choice → infeasible
      *  - [CompositeEffect] → feasible iff every step is feasible (top-level sequencing)
      *  - any other effect → assumed feasible (don't gate on shapes we don't recognize)
@@ -154,6 +158,14 @@ class ReflexiveTriggerEffectExecutor(
             controllerId = context.controllerId,
             sourceId = context.sourceId
         ).isNotEmpty()
+        is SacrificeEffect -> {
+            // You can only sacrifice permanents you control that match the filter (mirrors
+            // SacrificeExecutor.findValidPermanents). Fewer than `count` → can't pay → infeasible.
+            val excludeId = if (action.excludeSource) context.sourceId else null
+            BattlefieldFilterUtils.findMatchingOnBattlefield(
+                state, action.filter.youControl(), context, excludeSelfId = excludeId
+            ).size >= action.count
+        }
         is ChooseActionEffect -> action.choices.any { choice ->
             checkFeasibility(state, context.controllerId, choice.feasibilityCheck)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -101,13 +101,14 @@ class EnumerationContext(
     }
 
     /**
-     * Whether this player can't cast the specific card [cardId] right now — the blanket lock OR a
-     * per-spell static restriction (Mana Maze's color sharing, a filtered [PlayersCantCastSpells]).
-     * Every cast-enumeration site that has a candidate card in hand consults this, so filtered
-     * prohibitions are honoured across every casting zone.
+     * Whether this player can't cast the specific card [cardId] right now — the blanket lock, the
+     * CR 205.4e legendary-instant/sorcery restriction, OR a per-spell static restriction (Mana
+     * Maze's color sharing, a filtered [PlayersCantCastSpells]). Every cast-enumeration site that
+     * has a candidate card consults this, so the prohibitions are honoured across every casting zone.
      */
     fun cantCastSpell(cardId: EntityId): Boolean =
         cantCastSpells ||
+            castPermissionUtils.lacksLegendaryControlForLegendarySpell(state, playerId, cardId) ||
             (perSpellCastRestrictionPresent &&
                 castPermissionUtils.spellSpecificallyRestricted(state, playerId, cardId))
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -195,7 +195,42 @@ class CastPermissionUtils(
         if (blockedByPlayersCantCastSpells(state, playerId, spellCardId)) {
             return "An effect prevents you from casting that spell right now"
         }
+        if (lacksLegendaryControlForLegendarySpell(state, playerId, spellCardId)) {
+            return "You can cast a legendary instant or sorcery only if you control a legendary creature or planeswalker"
+        }
         return null
+    }
+
+    /**
+     * CR 205.4e: an instant or sorcery spell with the "legendary" supertype can be cast only if its
+     * controller controls a legendary creature or a legendary planeswalker. Returns true when
+     * [spellCardId] is such a spell and [playerId] controls neither — i.e. the cast must be blocked.
+     *
+     * Cheap in the common case: the supertype/card-type gate short-circuits before the battlefield
+     * scan, so only a legendary instant/sorcery ever pays for [controlsLegendaryCreatureOrPlaneswalker].
+     * The spell's type line is read from base state (it's being cast from a non-battlefield zone).
+     */
+    fun lacksLegendaryControlForLegendarySpell(
+        state: GameState,
+        playerId: EntityId,
+        spellCardId: EntityId
+    ): Boolean {
+        val typeLine = state.getEntity(spellCardId)?.get<CardComponent>()?.typeLine ?: return false
+        if (!typeLine.isLegendary) return false
+        if (!typeLine.isInstant && !typeLine.isSorcery) return false
+        return !controlsLegendaryCreatureOrPlaneswalker(state, playerId)
+    }
+
+    /**
+     * Whether [playerId] controls at least one legendary creature or legendary planeswalker, read
+     * from projected state (CR 205.4e). Type, supertype, and control can all be altered by
+     * continuous effects, so this must go through the projection rather than base components.
+     */
+    fun controlsLegendaryCreatureOrPlaneswalker(state: GameState, playerId: EntityId): Boolean {
+        val projected = state.projectedState
+        return projected.getBattlefieldControlledBy(playerId).any { id ->
+            projected.isLegendary(id) && (projected.isCreature(id) || projected.isPlaneswalker(id))
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -107,7 +107,7 @@ data class TriggeredAbilityOnStackComponent(
     /** Number of mode picks recorded by the spell-cast that fired this trigger (Riku of Many Paths). */
     val triggerModesChosenCount: Int? = null,
     /** Power of the aura/equipment's attached creature, captured at trigger time; LKI for
-     *  "enchanted creature ... its power" reads when the creature has left (CR 608.2g). */
+     *  "enchanted creature ... its power" reads when the creature has left (CR 608.2h). */
     val enchantedCreatureLastKnownPower: Int? = null,
     /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DenethorRulingStewardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DenethorRulingStewardTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Denethor, Ruling Steward — "At the beginning of your end step, if a creature died under your
+ * control this turn, create a 1/1 white Human Soldier creature token."
+ *
+ * Regression: Denethor used `Conditions.CreatureDiedThisTurn` (any player's creature) instead of
+ * `Conditions.ControlledCreatureDiedThisTurn`, so the intervening-if fired even when only an
+ * opponent's creature died — ignoring the "under your control" clause. The death tracker
+ * (`CreaturesDiedThisTurnComponent`) is per-player, credited to the dying creature's controller, so
+ * scoping the condition to Denethor's controller is the fix.
+ */
+class DenethorRulingStewardTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+    }
+
+    fun GameTestDriver.soldierTokenCount(playerId: com.wingedsheep.sdk.model.EntityId): Int =
+        getCreatures(playerId).count {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Human Soldier Token"
+        }
+
+    test("creates a Soldier token when a creature died under YOUR control this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.putPermanentOnBattlefield(you, "Denethor, Ruling Steward")
+        // A creature died under your control this turn (engine-maintained per-player tracker).
+        d.addComponent(you, CreaturesDiedThisTurnComponent(1))
+
+        d.passPriorityUntil(Step.END)
+        while (d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.soldierTokenCount(you) shouldBe 1
+    }
+
+    test("does NOT create a token when only an OPPONENT's creature died this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.putPermanentOnBattlefield(you, "Denethor, Ruling Steward")
+        // The death happened under the opponent's control — not yours.
+        d.addComponent(opponent, CreaturesDiedThisTurnComponent(1))
+
+        d.passPriorityUntil(Step.END)
+        while (d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.soldierTokenCount(you) shouldBe 0
+    }
+
+    test("does NOT create a token when no creature died this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.putPermanentOnBattlefield(you, "Denethor, Ruling Steward")
+
+        d.passPriorityUntil(Step.END)
+        while (d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.soldierTokenCount(you) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiesTriggerSourcePowerStackTextTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiesTriggerSourcePowerStackTextTest.kt
@@ -25,8 +25,9 @@ import io.kotest.matchers.string.shouldNotContain
  *
  * Root cause: when a *targeted* triggered ability's continuation was resumed into its on-stack
  * component ([com.wingedsheep.engine.handlers.continuations.EffectAndTriggerContinuationResumer]),
- * the captured `lastKnownPower`/`lastKnownToughness` (CR 603.10 / 608.2g — the dead source's
- * power "as it last existed on the battlefield") were dropped. With no LKI on the component:
+ * the captured `lastKnownPower`/`lastKnownToughness` (CR 608.2h / 113.7a — an effect that needs
+ * info from a source no longer in its zone uses the source's last known information; 603.10 makes
+ * the dies trigger itself look back in time) were dropped. With no LKI on the component:
  *  - execution (source-id = the dead card) still fell back to the card's *printed* base power, so
  *    an un-pumped creature dealt the right number by luck — but a buffed creature would deal its
  *    base power, ignoring counters/pumps;

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiesTriggerSourcePowerStackTextTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiesTriggerSourcePowerStackTextTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * Regression for the Goblin Fireleaper bug: a dies trigger that "deals damage equal to its power"
+ * ([DynamicAmounts.sourcePower]) rendered "Deal 0 damage to target" on the stack, even though the
+ * resolved damage was right.
+ *
+ * Root cause: when a *targeted* triggered ability's continuation was resumed into its on-stack
+ * component ([com.wingedsheep.engine.handlers.continuations.EffectAndTriggerContinuationResumer]),
+ * the captured `lastKnownPower`/`lastKnownToughness` (CR 603.10 / 608.2g — the dead source's
+ * power "as it last existed on the battlefield") were dropped. With no LKI on the component:
+ *  - execution (source-id = the dead card) still fell back to the card's *printed* base power, so
+ *    an un-pumped creature dealt the right number by luck — but a buffed creature would deal its
+ *    base power, ignoring counters/pumps;
+ *  - the client stack text (source-id = the ability's own stack entity, which has no card stats)
+ *    fell all the way through to 0.
+ *
+ * A +1/+1 counter makes last-known power (4) differ from printed power (3), so both the dealt
+ * damage and the rendered text must reflect 4.
+ */
+class DiesTriggerSourcePowerStackTextTest : FunSpec({
+
+    val Fireleaper = card("LKI Fireleaper") {
+        manaCost = "{0}"; typeLine = "Creature — Goblin"; power = 3; toughness = 3
+        triggeredAbility {
+            trigger = Triggers.Dies
+            val tgt = target("any target", Targets.Any)
+            effect = Effects.DealDamage(DynamicAmounts.sourcePower(), tgt)
+        }
+    }
+
+    val Bolt = card("LKI Lethal Bolt") {
+        manaCost = "{0}"; typeLine = "Sorcery"; oracleText = "Deal 9 damage to target creature."
+        spell {
+            val c = target("target creature", Targets.Creature)
+            effect = Effects.DealDamage(9, c)
+        }
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(Fireleaper, Bolt))
+    }
+
+    test("dies trigger 'deals damage equal to its power' shows the real power on the stack, not 0") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val fireleaper = d.putCreatureOnBattlefield(active, "LKI Fireleaper")
+        // +1/+1 counter: last-known power becomes 4, distinct from the printed 3.
+        d.addComponent(
+            fireleaper,
+            CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1))
+        )
+
+        // Kill it with a sorcery; its dies trigger then asks for a target.
+        val bolt = d.putCardInHand(active, "LKI Lethal Bolt")
+        d.castSpell(active, bolt, listOf(fireleaper))
+        d.bothPass() // resolve the bolt -> Fireleaper dies -> dies trigger pauses for a target
+
+        (fireleaper !in d.state.getBattlefield()) shouldBe true
+
+        // Aim the dies trigger at the opponent player so the resolved amount is observable as life loss.
+        val oppLifeBefore = d.getLifeTotal(opp)
+        d.submitTargetSelection(active, listOf(opp))
+
+        // The triggered ability is now on the stack — render it and assert the resolved power.
+        val stackId = d.state.stack.first()
+        val view = ClientStateTransformer(cardRegistry = d.cardRegistry)
+            .transform(d.state, viewingPlayerId = active)
+        val stackCard = view.cards[stackId]
+        stackCard.shouldNotBeNull()
+        stackCard.oracleText shouldContain "4"
+        stackCard.oracleText shouldNotContain "0 damage"
+
+        // And the resolved damage matches the rendered amount.
+        d.bothPass()
+        d.getLifeTotal(opp) shouldBe oppLifeBefore - 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegendaryInstantSorceryCastRestrictionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegendaryInstantSorceryCastRestrictionTest.kt
@@ -1,0 +1,187 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * CR 205.4e — "Any instant or sorcery spell with the supertype 'legendary' is subject to a casting
+ * restriction. A player can't cast a legendary instant or sorcery spell unless that player controls
+ * a legendary creature or a legendary planeswalker."
+ *
+ * The restriction is intrinsic to the card's type line (not a per-card opt-in), so it's enforced in
+ * the engine's two cast chokepoints: legal-action enumeration ([com.wingedsheep.engine.legalactions
+ * .EnumerationContext.cantCastSpell]) and the authoritative [com.wingedsheep.engine.handlers.actions
+ * .spell.CastSpellHandler] (via `reasonCannotCast`). Both are asserted below.
+ */
+class LegendaryInstantSorceryCastRestrictionTest : ScenarioTestBase() {
+
+    init {
+        // Argument-free spells so the restriction is tested in isolation (no target/mana noise).
+        val legendaryInstant = card("Test Legendary Instant") {
+            manaCost = "{0}"; typeLine = "Legendary Instant"
+            spell { effect = Effects.DrawCards(1) }
+        }
+        val legendarySorcery = card("Test Legendary Sorcery") {
+            manaCost = "{0}"; typeLine = "Legendary Sorcery"
+            spell { effect = Effects.DrawCards(1) }
+        }
+        val plainInstant = card("Test Plain Instant") {
+            manaCost = "{0}"; typeLine = "Instant"
+            spell { effect = Effects.DrawCards(1) }
+        }
+        val legendaryCreature = card("Test Legend Bear") {
+            manaCost = "{0}"; typeLine = "Legendary Creature — Bear"; power = 2; toughness = 2
+        }
+        val plainCreature = card("Test Plain Bear") {
+            manaCost = "{0}"; typeLine = "Creature — Bear"; power = 2; toughness = 2
+        }
+        val legendaryArtifact = card("Test Legend Relic") {
+            manaCost = "{0}"; typeLine = "Legendary Artifact"
+        }
+        val legendaryPlaneswalker = card("Test Legend Walker") {
+            manaCost = "{0}"; typeLine = "Legendary Planeswalker — Tester"; startingLoyalty = 3
+        }
+        cardRegistry.register(
+            listOf(
+                legendaryInstant, legendarySorcery, plainInstant,
+                legendaryCreature, plainCreature, legendaryArtifact, legendaryPlaneswalker
+            )
+        )
+
+        val RESTRICTION_MSG = "legendary creature or planeswalker"
+
+        fun TestGame.castOfferedFor(spellName: String): Boolean =
+            getLegalActions(1).any { info ->
+                val a = info.action
+                a is CastSpell && state.getEntity(a.cardId)?.get<CardComponent>()?.name == spellName
+            }
+
+        test("legendary instant is NOT castable with no legendary permanents (enumeration + handler)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeFalse()
+
+            val result = game.castSpell(1, "Test Legendary Instant")
+            result.isSuccess.shouldBeFalse()
+            result.error!! shouldContain RESTRICTION_MSG
+        }
+
+        test("legendary instant IS castable while controlling a legendary creature") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardOnBattlefield(1, "Test Legend Bear")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeTrue()
+            game.castSpell(1, "Test Legendary Instant").isSuccess.shouldBeTrue()
+        }
+
+        test("legendary instant IS castable while controlling a legendary planeswalker") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardOnBattlefield(1, "Test Legend Walker")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeTrue()
+            game.castSpell(1, "Test Legendary Instant").isSuccess.shouldBeTrue()
+        }
+
+        test("a NON-legendary creature does not satisfy the restriction") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardOnBattlefield(1, "Test Plain Bear")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeFalse()
+            game.castSpell(1, "Test Legendary Instant").error!! shouldContain RESTRICTION_MSG
+        }
+
+        test("a legendary NON-creature/non-planeswalker (artifact) does not satisfy the restriction") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardOnBattlefield(1, "Test Legend Relic")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeFalse()
+            game.castSpell(1, "Test Legendary Instant").error!! shouldContain RESTRICTION_MSG
+        }
+
+        test("the restriction applies to legendary SORCERIES too") {
+            val without = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Sorcery")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+            without.castOfferedFor("Test Legendary Sorcery").shouldBeFalse()
+            without.castSpell(1, "Test Legendary Sorcery").error!! shouldContain RESTRICTION_MSG
+
+            val with = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Sorcery")
+                .withCardOnBattlefield(1, "Test Legend Bear")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+            with.castOfferedFor("Test Legendary Sorcery").shouldBeTrue()
+            with.castSpell(1, "Test Legendary Sorcery").isSuccess.shouldBeTrue()
+        }
+
+        test("a NON-legendary instant is unaffected (castable with no legendary permanents)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Plain Instant")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Plain Instant").shouldBeTrue()
+            game.castSpell(1, "Test Plain Instant").isSuccess.shouldBeTrue()
+        }
+
+        test("only the OPPONENT's legendary creature does not let you cast (control matters)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Legendary Instant")
+                .withCardOnBattlefield(2, "Test Legend Bear")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Test Legendary Instant").shouldBeFalse()
+            game.castSpell(1, "Test Legendary Instant").error!! shouldContain RESTRICTION_MSG
+        }
+
+        test("the real Isildur's Fateful Strike is blocked without a legendary permanent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Isildur's Fateful Strike")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withCardOnBattlefield(2, "Test Plain Bear")
+                .withCardInLibrary(1, "Test Plain Bear")
+                .build()
+
+            game.castOfferedFor("Isildur's Fateful Strike").shouldBeFalse()
+
+            val bearId = game.findPermanent("Test Plain Bear")!!
+            val result = game.castSpell(1, "Isildur's Fateful Strike", bearId)
+            result.isSuccess.shouldBeFalse()
+            result.error!! shouldContain RESTRICTION_MSG
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirkwoodBatsTokenCreationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirkwoodBatsTokenCreationTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mirkwood Bats — "Flying. Whenever you create or sacrifice a token, each opponent loses 1 life."
+ *
+ * Regression: the token-creation half never fired. `EventPattern.TokenCreationEvent` was treated as
+ * a replacement-effect-only pattern (`matchesTrigger` returned false) and was never indexed as a
+ * trigger, so creating a token under your control drained no life — e.g. Horn of Gondor's Soldier.
+ *
+ * The fix matches the trigger against each token-creation `ZoneChangeEvent` (`fromZone == null`),
+ * one per token, so the ability fires once per token created (singular "a token" templating).
+ */
+class MirkwoodBatsTokenCreationTest : ScenarioTestBase() {
+
+    init {
+        val makeOneToken = card("Make One Token") {
+            manaCost = "{0}"; typeLine = "Sorcery"
+            spell {
+                effect = Effects.CreateToken(
+                    power = 1, toughness = 1, creatureTypes = setOf("Spirit"), count = 1
+                )
+            }
+        }
+        val makeThreeTokens = card("Make Three Tokens") {
+            manaCost = "{0}"; typeLine = "Sorcery"
+            spell {
+                effect = Effects.CreateToken(
+                    power = 1, toughness = 1, creatureTypes = setOf("Spirit"), count = 3
+                )
+            }
+        }
+        cardRegistry.register(listOf(makeOneToken, makeThreeTokens))
+
+        test("creating one token under your control drains each opponent 1 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mirkwood Bats")
+                .withCardInHand(1, "Make One Token")
+                .withCardInLibrary(1, "Make One Token")
+                .build()
+
+            game.castSpell(1, "Make One Token").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Spirit Token").size shouldBe 1
+            game.getLifeTotal(2) shouldBe 19
+            game.getLifeTotal(1) shouldBe 20
+        }
+
+        test("creating three tokens at once drains 3 (fires once per token)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mirkwood Bats")
+                .withCardInHand(1, "Make Three Tokens")
+                .withCardInLibrary(1, "Make One Token")
+                .build()
+
+            game.castSpell(1, "Make Three Tokens").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Spirit Token").size shouldBe 3
+            game.getLifeTotal(2) shouldBe 17
+        }
+
+        test("a token created by an OPPONENT does not trigger your Mirkwood Bats") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mirkwood Bats")
+                .withCardInHand(2, "Make One Token")
+                .withCardInLibrary(2, "Make One Token")
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .build()
+
+            game.castSpell(2, "Make One Token").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Spirit Token").size shouldBe 1
+            // "you create" is the Bats' controller (player 1); player 2's token doesn't trigger it,
+            // so no one loses life.
+            game.getLifeTotal(1) shouldBe 20
+            game.getLifeTotal(2) shouldBe 20
+        }
+
+        test("no Mirkwood Bats: creating a token drains nothing") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Make One Token")
+                .withCardInLibrary(1, "Make One Token")
+                .build()
+
+            game.castSpell(1, "Make One Token").error shouldBe null
+            game.resolveStack()
+
+            game.getLifeTotal(2) shouldBe 20
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShireShirriffTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShireShirriffTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Shire Shirriff — "When this creature enters, you may sacrifice a token. When you do, exile
+ * target creature an opponent controls until this creature leaves the battlefield."
+ *
+ * Regression: the optional reflexive trigger ("you may [action]. When you do, [reflexive]") gated
+ * the may-decision on [ReflexiveTriggerEffectExecutor.isActionFeasible], which only understood a
+ * few action shapes and fell through to "feasible" for a [SacrificeEffect]. So with no token to
+ * sacrifice the player was still asked, and answering yes performed an empty sacrifice yet still
+ * fired the exile payoff. The fix teaches isActionFeasible that a sacrifice needs enough controlled
+ * matching permanents.
+ */
+class ShireShirriffTest : ScenarioTestBase() {
+
+    init {
+        test("no token to sacrifice: the may-decision is skipped and nothing is exiled") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Shire Shirriff")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(2, "Easterling Vanguard")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Mountain")
+                .build()
+
+            game.castSpell(1, "Shire Shirriff").error shouldBe null
+            game.resolveStack()
+
+            // Alice controls no token, so the sacrifice is infeasible — no prompt is presented...
+            game.state.pendingDecision shouldBe null
+            // ...and the opponent's creature is NOT exiled.
+            game.isOnBattlefield("Easterling Vanguard") shouldBe true
+            game.isOnBattlefield("Shire Shirriff") shouldBe true
+        }
+
+        test("with a token: sacrificing it exiles the opponent's creature") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Shire Shirriff")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Food", isToken = true)
+                .withCardOnBattlefield(2, "Easterling Vanguard")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Mountain")
+                .build()
+
+            game.castSpell(1, "Shire Shirriff").error shouldBe null
+            game.resolveStack()
+
+            // The sacrifice IS feasible now, so we're asked.
+            game.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            game.answerYesNo(true)
+
+            // Sacrificing the token fires the reflexive exile, which targets the opponent's creature.
+            val vanguard = game.findPermanent("Easterling Vanguard")
+            vanguard.shouldNotBeNull()
+            game.selectTargets(listOf(vanguard))
+            game.resolveStack()
+
+            game.isOnBattlefield("Easterling Vanguard") shouldBe false  // exiled
+            game.isOnBattlefield("Food") shouldBe false                 // sacrificed
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Six LTR bug fixes plus a CR-citation cleanup. Each reuses existing SDK
primitives — no new effect/trigger/condition types.

- **Mirkwood Bats** — "whenever you create a token" never fired:
  `TokenCreationEvent` was replacement-only, now matched as a trigger against
  each token-creation `ZoneChangeEvent` (fires once per token).
- **Legendary instant/sorcery cast restriction (CR 205.4e)** — enforced at
  both cast chokepoints (legal-action enumeration + cast handler), read from
  the type line with no per-card opt-in.
- **Denethor, Ruling Steward** — end-step trigger now requires a death *under
  your control* (`ControlledCreatureDiedThisTurn`), not any player's.
- **Ring-bearer evasion** — the AI proposed an illegal "blocked by greater
  power" block and looped forever; the block-legality model now accounts for
  `RingBearerComponent`, plus a step-appropriate safe-fallback chain.
- **Shire Shirriff** — optional "you may sacrifice a token" no longer prompts
  (or fires its payoff) when you control no token.
- **Goblin Fireleaper** — dies trigger "deals damage equal to its power"
  rendered 0 on the stack; last-known P/T is now propagated into all on-stack
  component constructions (CR 608.2h).
- **CR cleanup** — corrected last-known-info citations 608.2g → 608.2h across
  9 comment sites.

## Tests

New scenario tests per fix (rules-engine + AI); docs updated. All green.