### PR TITLE
Deckbuilder: completion mode + selectable Auto-build alternatives

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/assist/DeckBuildAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/assist/DeckBuildAdvisor.kt
@@ -41,12 +41,28 @@ data class DeckBuildRequest(
     val setCodes: List<String> = emptyList(),
 )
 
+/**
+ * The result of a deckbuild: one or more candidate decks the player can choose between. Engines that
+ * only produce a single deck (the heuristic, a completion) return a one-element [builds] list;
+ * engines that explore several archetypes (Draftsim's "Auto-build") return the best few so the
+ * client can show them side by side. [builds] is ordered best-first and never empty on success.
+ */
 data class DeckBuildResult(
     val advisorId: String,
+    /** Candidate decks, ordered best-first. Empty only when the pool yields nothing to build. */
+    val builds: List<DeckBuildOption>,
+    /** Index into [builds] of the deck to apply by default (the recommended one). */
+    val recommended: Int = 0,
+)
+
+/** One candidate deck within a [DeckBuildResult]. */
+data class DeckBuildOption(
     /** Full decklist (spells + lands, including basics) as name → count. */
     val deckList: Map<String, Int>,
     /** Intrinsic quality estimate (sum of card ratings), or null if the engine doesn't score. */
     val score: Double? = null,
     /** Detected/targeted archetype label, if the engine identifies one. */
     val archetype: String? = null,
+    /** The deck's build colors (WUBRG single-letter codes), for the picker's color pips. */
+    val colors: List<String> = emptyList(),
 )

--- a/ai/src/main/kotlin/com/wingedsheep/ai/assist/DraftsimDeckBuildAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/assist/DraftsimDeckBuildAdvisor.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.ai.assist
 
+import com.wingedsheep.ai.draftsim.DraftsimBuild
 import com.wingedsheep.ai.draftsim.DraftsimData
 import com.wingedsheep.ai.draftsim.DraftsimDeckBuilder
 import com.wingedsheep.ai.draftsim.DraftsimPoolCard
@@ -11,37 +12,47 @@ import com.wingedsheep.ai.draftsim.toScorerCard
  * 23-nonland + 17-land deck.
  *
  * When [DeckBuildRequest.locked] is empty this is a **full rebuild from the pool** (the "Auto-build"
- * button) — it ranks archetypes and returns the best fresh 40-card limited build. When locked is
- * non-empty (the "Complete Deck" button) it switches the builder to completion mode: the locked
- * cards are forced into the build, protected from removal/swap, and the rest is filled around them in
- * the locked cards' colors. (Draftsim still fixes its own 23/17 land split, so [DeckBuildRequest.targetSize]
- * is not honored.) Basics are reported by name so the client splits them out like any other result.
+ * button) — it ranks archetypes and returns the best few fresh 40-card limited builds (top 3) so the
+ * client can offer them as alternatives. When locked is non-empty (the "Complete Deck" button) it
+ * switches the builder to completion mode: the locked cards are forced into the build, protected from
+ * removal/swap, and the rest is filled around them in the locked cards' colors — a single completed
+ * deck. (Draftsim still fixes its own 23/17 land split, so [DeckBuildRequest.targetSize] is not
+ * honored.) Basics are reported by name so the client splits them out like any other result.
  */
 object DraftsimDeckBuildAdvisor : DeckBuildAdvisor {
     override val id = "draftsim"
     override val displayName = "Draftsim"
+
+    /** How many alternative builds to surface from a fresh Auto-build (completion always yields one). */
+    private const val MAX_OPTIONS = 3
 
     private val COLOR_TO_BASIC = mapOf("W" to "Plains", "U" to "Island", "B" to "Swamp", "R" to "Mountain", "G" to "Forest")
 
     override fun buildDeck(request: DeckBuildRequest): DeckBuildResult {
         val builder = DraftsimDeckBuilder(DraftsimData.tablesFor(request.setCodes))
         val pool = request.pool.mapIndexed { i, def -> DraftsimPoolCard(def.toScorerCard(), "pool-$i") }
-
-        val builds = builder.buildDecks(pool, mode = "sealed", forced = lockedInstanceIds(pool, request.locked))
-        val best = builds.firstOrNull()
-            ?: return DeckBuildResult(advisorId = id, deckList = emptyMap(), score = null)
-
         val byId = pool.associateBy { it.instanceId }
+
+        // buildDecks returns the candidates best-first (completion mode: exactly one); take the top few.
+        val builds = builder.buildDecks(pool, mode = "sealed", forced = lockedInstanceIds(pool, request.locked))
+            .take(MAX_OPTIONS)
+        if (builds.isEmpty()) return DeckBuildResult(advisorId = id, builds = emptyList())
+
+        return DeckBuildResult(advisorId = id, builds = builds.map { toOption(it, byId) }, recommended = 0)
+    }
+
+    /** Materialize one [DraftsimBuild]'s pool instances + basics into a name → count [DeckBuildOption]. */
+    private fun toOption(build: DraftsimBuild, byId: Map<String, DraftsimPoolCard>): DeckBuildOption {
         val deckList = LinkedHashMap<String, Int>()
-        for (instanceId in best.deckInstanceIds) {
+        for (instanceId in build.deckInstanceIds) {
             val name = byId[instanceId]?.card?.name ?: continue
             deckList[name] = (deckList[name] ?: 0) + 1
         }
-        for ((color, count) in best.basicsNeeded) {
+        for ((color, count) in build.basicsNeeded) {
             val name = COLOR_TO_BASIC[color] ?: continue
             if (count > 0) deckList[name] = (deckList[name] ?: 0) + count
         }
-        return DeckBuildResult(advisorId = id, deckList = deckList, score = best.score, archetype = best.name)
+        return DeckBuildOption(deckList = deckList, score = build.score, archetype = build.name, colors = build.colors)
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/assist/DraftsimDeckBuildAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/assist/DraftsimDeckBuildAdvisor.kt
@@ -10,10 +10,12 @@ import com.wingedsheep.ai.draftsim.toScorerCard
  * archetypes (`kf`), greedily builds + refines each (`vX`/`ek`), and returns the highest-scoring
  * 23-nonland + 17-land deck.
  *
- * Unlike the heuristic engine this is a **full rebuild from the pool** — it does not honor
- * [DeckBuildRequest.locked] or [DeckBuildRequest.targetSize] (the bundle's Auto-Build always
- * replaces the deck with a fresh 40-card limited build). Basics are reported by name so the client
- * splits them out like any other deckbuild result.
+ * When [DeckBuildRequest.locked] is empty this is a **full rebuild from the pool** (the "Auto-build"
+ * button) — it ranks archetypes and returns the best fresh 40-card limited build. When locked is
+ * non-empty (the "Complete Deck" button) it switches the builder to completion mode: the locked
+ * cards are forced into the build, protected from removal/swap, and the rest is filled around them in
+ * the locked cards' colors. (Draftsim still fixes its own 23/17 land split, so [DeckBuildRequest.targetSize]
+ * is not honored.) Basics are reported by name so the client splits them out like any other result.
  */
 object DraftsimDeckBuildAdvisor : DeckBuildAdvisor {
     override val id = "draftsim"
@@ -25,7 +27,7 @@ object DraftsimDeckBuildAdvisor : DeckBuildAdvisor {
         val builder = DraftsimDeckBuilder(DraftsimData.tablesFor(request.setCodes))
         val pool = request.pool.mapIndexed { i, def -> DraftsimPoolCard(def.toScorerCard(), "pool-$i") }
 
-        val builds = builder.buildDecks(pool, mode = "sealed")
+        val builds = builder.buildDecks(pool, mode = "sealed", forced = lockedInstanceIds(pool, request.locked))
         val best = builds.firstOrNull()
             ?: return DeckBuildResult(advisorId = id, deckList = emptyMap(), score = null)
 
@@ -40,5 +42,24 @@ object DraftsimDeckBuildAdvisor : DeckBuildAdvisor {
             if (count > 0) deckList[name] = (deckList[name] ?: 0) + count
         }
         return DeckBuildResult(advisorId = id, deckList = deckList, score = best.score, archetype = best.name)
+    }
+
+    /**
+     * Map the in-progress deck ([DeckBuildRequest.locked], name → count) to concrete nonland pool
+     * instances to force into the build. Lands are left out — basics aren't in the pool and the
+     * manabase is rebuilt around the kept spells. Empty locked → empty set → a fresh build.
+     */
+    private fun lockedInstanceIds(pool: List<DraftsimPoolCard>, locked: Map<String, Int>): Set<String> {
+        val remaining = locked.filterValues { it > 0 }.toMutableMap()
+        if (remaining.isEmpty()) return emptySet()
+        val forced = HashSet<String>()
+        for (pc in pool) {
+            if (pc.card.typeLine.contains("Land", ignoreCase = true)) continue
+            val want = remaining[pc.card.name] ?: continue
+            if (want <= 0) continue
+            forced += pc.instanceId
+            remaining[pc.card.name] = want - 1
+        }
+        return forced
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/assist/HeuristicDeckBuildAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/assist/HeuristicDeckBuildAdvisor.kt
@@ -31,6 +31,7 @@ object HeuristicDeckBuildAdvisor : DeckBuildAdvisor {
             if (def == null || def.typeLine.isLand) 0.0 else LimitedCardRater.rate(def) * count
         }
 
-        return DeckBuildResult(advisorId = id, deckList = deckList, score = score)
+        // The heuristic explores no archetype alternatives, so it returns a single candidate build.
+        return DeckBuildResult(advisorId = id, builds = listOf(DeckBuildOption(deckList = deckList, score = score)))
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
@@ -66,8 +66,16 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
     // dW — orchestrator (the entry point)
     // =========================================================================
 
-    /** `dW(pool, mode)` → builds best-first. `mode` ∈ "draft" (top 2) / "sealed" (top 3 + good stuff). */
-    fun buildDecks(pool: List<DraftsimPoolCard>, mode: String): List<DraftsimBuild> {
+    /**
+     * `dW(pool, mode)` → builds best-first. `mode` ∈ "draft" (top 2) / "sealed" (top 3 + good stuff).
+     *
+     * When [forced] is non-empty the builder switches to **completion mode** (the deckbuild
+     * "Complete Deck" button): every forced pool instance is kept and protected from removal/swap,
+     * the build colors are taken from those locked cards, and the rest is filled with the normal
+     * greedy + refine machinery so the completed deck is scored and mana-based identically.
+     */
+    fun buildDecks(pool: List<DraftsimPoolCard>, mode: String, forced: Set<String> = emptySet()): List<DraftsimBuild> {
+        if (forced.isNotEmpty()) return listOf(completeBuild(pool, forced))
         val nonlandCards = pool.filter { !ops.isLand(it.card) }.map { it.card }
         val archColors = scorer.archColorMap(nonlandCards)
         val ranked = deckScorer.rankArchetypes(pool.map { it.card }, archColors)
@@ -77,6 +85,42 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
             .toMutableList()
         if (mode == "sealed") goodStuffBuild(pool)?.let { builds += refine(it, pool) }
         return builds.sortedByDescending { it.score }
+    }
+
+    // =========================================================================
+    // Completion mode — keep the player's locked cards, fill the rest
+    // =========================================================================
+
+    /** Build a single deck that keeps every [forced] pool instance, in the locked cards' colors. */
+    private fun completeBuild(pool: List<DraftsimPoolCard>, forced: Set<String>): DraftsimBuild {
+        val forcedNonland = pool.filter { it.instanceId in forced && !ops.isLand(it.card) }.map { it.card }
+        val colors = completionColors(forcedNonland, pool)
+        return refine(greedyBuild(pool, "Completion", colors, forced), pool, forced = forced)
+    }
+
+    /**
+     * The ≤2 build colors for a completion: the heaviest colors by mana-pip weight among the locked
+     * cards, topped up from the pool's overall pip weight when the locked cards don't pin two colors.
+     */
+    private fun completionColors(forcedNonland: List<ScorerCard>, pool: List<DraftsimPoolCard>): List<String> {
+        fun weigh(cards: List<ScorerCard>): Map<String, Double> {
+            val pips = HashMap<String, Double>()
+            for (card in cards) {
+                val counts = DraftsimMana.pipCounts(card.manaCost)
+                if (counts.isEmpty()) ops.colorsOf(card).forEach { pips[it] = (pips[it] ?: 0.0) + 1.0 }
+                else counts.forEach { (c, v) -> pips[c] = (pips[c] ?: 0.0) + v }
+            }
+            return pips
+        }
+        val ordered = weigh(forcedNonland).entries.sortedByDescending { it.value }.map { it.key }.toMutableList()
+        if (ordered.size < 2) {
+            val poolWeights = weigh(pool.filter { !ops.isLand(it.card) }.map { it.card })
+            for (color in poolWeights.entries.sortedByDescending { it.value }.map { it.key }) {
+                if (ordered.size >= 2) break
+                if (color !in ordered) ordered += color
+            }
+        }
+        return ordered.take(2)
     }
 
     // =========================================================================
@@ -95,6 +139,11 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
         val copies = HashMap<String, Int>()
         val buckets = HashMap<Int, Int>()
         var creatures = 0
+        /** Locked (completion) picks — kept unconditionally and never removed/swapped. */
+        val forced = HashSet<String>()
+
+        /** Force-include a locked card, bypassing the copy/bucket caps and marking it protected. */
+        fun seed(item: Scored) { add(item); forced += item.pc.instanceId }
 
         fun canAdd(item: Scored): Boolean {
             val card = item.pc.card
@@ -120,7 +169,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
     }
 
     private fun greedyBuild(
-        pool: List<DraftsimPoolCard>, archName: String, archColors: List<String>,
+        pool: List<DraftsimPoolCard>, archName: String, archColors: List<String>, forced: Set<String> = emptySet(),
     ): DraftsimBuild {
         val nonlandPC = pool.filter { !ops.isLand(it.card) }
         val poolLands = pool.filter { ops.isLand(it.card) && !ops.isBasic(it.card) }
@@ -135,6 +184,9 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
         val otherCards = scored.filter { !isRemoval(it.pc.card) && castable(it.pc.card, archColors) }
 
         val st = BuildState()
+
+        // Completion: seed the locked cards first so the phases fill around them (and never drop them).
+        if (forced.isNotEmpty()) for (item in scored) if (item.pc.instanceId in forced) st.seed(item)
 
         // Phase 1 — removal first (cap 6).
         var removalTaken = 0
@@ -193,7 +245,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
             ops.isCreature(it.pc.card) && it.pc.instanceId !in st.chosen &&
                 (st.copies[it.pc.card.name] ?: 0) < copyCap(it.pc.card)
         }
-        val victims = st.deck.filter { !ops.isCreature(it.pc.card) && !isRemoval(it.pc.card) }.sortedBy { it.total }
+        val victims = st.deck.filter { !ops.isCreature(it.pc.card) && !isRemoval(it.pc.card) && it.pc.instanceId !in st.forced }.sortedBy { it.total }
         val k = minOf(CREATURE_FLOOR - st.creatures, victims.size, candidates.size)
         for (x in 0 until k) { st.remove(victims[x]); st.add(candidates[x]) }
     }
@@ -219,7 +271,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
             val k = ops.colorsOf(item.pc.card).first { it !in d }
             if (splashColor != null && k != splashColor) continue
             if (st.deck.size < DECK_NONLAND) { st.add(item); splashColor = k } else {
-                val weakest = st.deck.filter { !isRemoval(it.pc.card) }.minByOrNull { it.total } ?: break
+                val weakest = st.deck.filter { !isRemoval(it.pc.card) && it.pc.instanceId !in st.forced }.minByOrNull { it.total } ?: break
                 if (item.rawRating > weakest.rawRating) { st.remove(weakest); st.add(item); splashColor = k } else break
             }
         }
@@ -322,7 +374,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
     // ek — post-build refinement (hill climbing)
     // =========================================================================
 
-    private fun refine(build: DraftsimBuild, pool: List<DraftsimPoolCard>, iterations: Int = 3): DraftsimBuild {
+    private fun refine(build: DraftsimBuild, pool: List<DraftsimPoolCard>, iterations: Int = 3, forced: Set<String> = emptySet()): DraftsimBuild {
         val chosen = build.deckInstanceIds.toHashSet()
         val deckNonland = pool.filter { it.instanceId in chosen && !ops.isLand(it.card) }.toMutableList()
         var best = deckScorer.scoreNonlandSet(deckNonland.map { it.card })
@@ -333,7 +385,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
                     (ops.colorsOf(it.card).isEmpty() || DraftsimMana.fitsColors(it.card.manaCost, build.colors))
             }
             if (candidates.isEmpty()) return@repeat
-            val worstFirst = deckNonland.sortedBy { ops.ratingOrDefault(it.card) }
+            val worstFirst = deckNonland.filter { it.instanceId !in forced }.sortedBy { ops.ratingOrDefault(it.card) }
             val bestFirst = candidates.sortedByDescending { ops.ratingOrDefault(it.card) }
             var improved = false
             outer@ for (out in worstFirst) {

--- a/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
@@ -99,19 +99,22 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
     }
 
     /**
-     * The build colors for a completion: **every** color the locked cards need, heaviest-first by
-     * mana-pip weight, so [buildManabase] fixes all of them and no locked card is left uncastable
-     * (locking a three-color pile yields a three-color manabase). When the locked cards don't pin two
-     * colors (mono-color or colorless picks) it's topped up from the pool's overall pip weight so the
-     * fill still has a real two-color base to build around.
+     * The build colors for a completion: **every** color the locked cards strictly require, heaviest-
+     * first by colored-pip weight, so [buildManabase] fixes all of them and no locked card is left
+     * uncastable (locking a three-color pile yields a three-color manabase). When the locked cards
+     * don't pin two colors (mono-color or colorless picks) it's topped up from the pool's overall pip
+     * weight so the fill still has a real two-color base to build around.
+     *
+     * Only **plain** colored pips select colors. Hybrid / Phyrexian pips are flexible — payable from
+     * another color or generic mana — so they must not pull their color into the manabase, which would
+     * add basics the deck can't use (e.g. a `{2/B}` card in a GU deck must not summon Swamps).
      */
     private fun completionColors(forcedNonland: List<ScorerCard>, pool: List<DraftsimPoolCard>): List<String> {
         fun weigh(cards: List<ScorerCard>): Map<String, Double> {
             val pips = HashMap<String, Double>()
             for (card in cards) {
-                val counts = DraftsimMana.pipCounts(card.manaCost)
-                if (counts.isEmpty()) ops.colorsOf(card).forEach { pips[it] = (pips[it] ?: 0.0) + 1.0 }
-                else counts.forEach { (c, v) -> pips[c] = (pips[c] ?: 0.0) + v }
+                DraftsimMana.castRequirement(card.manaCost).plainPips
+                    .forEach { (c, v) -> pips[c] = (pips[c] ?: 0.0) + v }
             }
             return pips
         }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilder.kt
@@ -99,8 +99,11 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
     }
 
     /**
-     * The ≤2 build colors for a completion: the heaviest colors by mana-pip weight among the locked
-     * cards, topped up from the pool's overall pip weight when the locked cards don't pin two colors.
+     * The build colors for a completion: **every** color the locked cards need, heaviest-first by
+     * mana-pip weight, so [buildManabase] fixes all of them and no locked card is left uncastable
+     * (locking a three-color pile yields a three-color manabase). When the locked cards don't pin two
+     * colors (mono-color or colorless picks) it's topped up from the pool's overall pip weight so the
+     * fill still has a real two-color base to build around.
      */
     private fun completionColors(forcedNonland: List<ScorerCard>, pool: List<DraftsimPoolCard>): List<String> {
         fun weigh(cards: List<ScorerCard>): Map<String, Double> {
@@ -120,7 +123,7 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
                 if (color !in ordered) ordered += color
             }
         }
-        return ordered.take(2)
+        return ordered
     }
 
     // =========================================================================
@@ -188,10 +191,12 @@ class DraftsimDeckBuilder(private val tables: DraftsimSetTables) {
         // Completion: seed the locked cards first so the phases fill around them (and never drop them).
         if (forced.isNotEmpty()) for (item in scored) if (item.pc.instanceId in forced) st.seed(item)
 
-        // Phase 1 — removal first (cap 6).
-        var removalTaken = 0
+        // Phase 1 — removal first (cap 6). Seeded (locked) removal is already in the deck: skip it so
+        // it isn't double-added, but count it against the cap so completion doesn't over-stack removal.
+        var removalTaken = st.deck.count { isRemoval(it.pc.card) }
         for (item in removalCards) {
-            if (removalTaken >= 6) break
+            if (removalTaken >= 6 || st.deck.size >= DECK_NONLAND) break
+            if (item.pc.instanceId in st.chosen) continue
             if (st.canAdd(item)) { st.add(item); removalTaken++ }
         }
         // Phase 2 — interleave removal vs. best other until 9 removal or 23 cards.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/assist/AiAssistAdvisorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/assist/AiAssistAdvisorTest.kt
@@ -145,8 +145,9 @@ class AiAssistAdvisorTest : FunSpec({
         )
 
         result.advisorId shouldBe "heuristic"
-        result.deckList.values.sum() shouldBe 40
-        (result.score ?: 0.0) shouldBeGreaterThan 0.0
+        val build = result.builds.single()
+        build.deckList.values.sum() shouldBe 40
+        (build.score ?: 0.0) shouldBeGreaterThan 0.0
     }
 
     test("completion mode keeps locked cards and fills to the target size") {
@@ -157,9 +158,10 @@ class AiAssistAdvisorTest : FunSpec({
         )
 
         // Every locked card is preserved at (at least) its locked count.
-        result.deckList["Green 1"]!! shouldBeGreaterThan 2
-        result.deckList["Green 2"]!! shouldBeGreaterThan 1
-        result.deckList.values.sum() shouldBe 40
+        val deckList = result.builds.single().deckList
+        deckList["Green 1"]!! shouldBeGreaterThan 2
+        deckList["Green 2"]!! shouldBeGreaterThan 1
+        deckList.values.sum() shouldBe 40
     }
 
     test("completion respects pool copy limits — never exceeds available copies") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/assist/DraftsimAdvisorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/assist/DraftsimAdvisorTest.kt
@@ -62,10 +62,16 @@ class DraftsimAdvisorTest : FunSpec({
         )
 
         result.advisorId shouldBe "draftsim"
-        result.deckList.values.sum() shouldBeGreaterThan 30
+        // A fresh Auto-build surfaces several alternative decks (up to 3), ordered best-first.
+        (result.builds.size in 2..3) shouldBe true
+        result.recommended shouldBe 0
+        result.builds.zipWithNext().all { (a, b) -> (a.score ?: 0.0) >= (b.score ?: 0.0) } shouldBe true
+        val best = result.builds.first()
+        best.deckList.values.sum() shouldBeGreaterThan 30
         // A real archetype/colour label is attached.
-        (result.archetype != null) shouldBe true
-        (result.score != null) shouldBe true
+        (best.archetype != null) shouldBe true
+        (best.score != null) shouldBe true
+        best.colors.isNotEmpty() shouldBe true
     }
 
     test("deckbuild advisor completes a partial deck without dropping the locked cards") {
@@ -78,9 +84,11 @@ class DraftsimAdvisorTest : FunSpec({
         )
 
         result.advisorId shouldBe "draftsim"
+        // Completion mode yields exactly one deck (no archetype alternatives to choose from).
+        val build = result.builds.single()
         for ((name, count) in locked) {
-            (result.deckList[name] ?: 0) shouldBe count
+            (build.deckList[name] ?: 0) shouldBe count
         }
-        result.deckList.values.sum() shouldBeGreaterThan 30
+        build.deckList.values.sum() shouldBeGreaterThan 30
     }
 })

--- a/ai/src/test/kotlin/com/wingedsheep/ai/assist/DraftsimAdvisorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/assist/DraftsimAdvisorTest.kt
@@ -67,4 +67,20 @@ class DraftsimAdvisorTest : FunSpec({
         (result.archetype != null) shouldBe true
         (result.score != null) shouldBe true
     }
+
+    test("deckbuild advisor completes a partial deck without dropping the locked cards") {
+        val pool = ltr.cards.filter { it.metadata.let { m -> m.rarity != null } && !it.typeLine.isBasicLand }
+        // Lock a handful of real nonland spells from the pool; "Complete Deck" must keep every one.
+        val locked = pool.filterNot { it.typeLine.isLand }.take(6).associate { it.name to 1 }
+
+        val result = DraftsimDeckBuildAdvisor.buildDeck(
+            DeckBuildRequest(pool = pool, locked = locked, targetSize = 40, setCodes = listOf("LTR")),
+        )
+
+        result.advisorId shouldBe "draftsim"
+        for ((name, count) in locked) {
+            (result.deckList[name] ?: 0) shouldBe count
+        }
+        result.deckList.values.sum() shouldBeGreaterThan 30
+    }
 })

--- a/ai/src/test/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilderTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilderTest.kt
@@ -108,6 +108,30 @@ class DraftsimDeckBuilderTest : FunSpec({
         listOf("Zap1", "Zap2", "Zap3").forEach { name -> nonland.count { it.name == name } shouldBe 1 }
     }
 
+    test("completion does not add off-color basics for a flexible hybrid card") {
+        val ratings = HashMap<String, Double>()
+        val cards = mutableListOf<DraftsimPoolCard>()
+        var n = 0
+        fun add(card: ScorerCard, rating: Double) {
+            ratings[DraftsimData.nameKey(card.name)] = rating
+            cards += DraftsimPoolCard(card, "id-${n++}")
+        }
+        // A pure GU pool — plus a {2/B} monocolor-hybrid card that is castable with generic mana
+        // (no black ever needed). Locking it must NOT pull black into the build / manabase.
+        for (i in 1..14) add(BCard("GreenCreature$i", "{1}{G}", "Creature — Beast", listOf("G")), 2.6)
+        for (i in 1..14) add(BCard("BlueCreature$i", "{1}{U}", "Creature — Wizard", listOf("U")), 2.6)
+        add(BCard("Flexible", "{2/B}", "Creature — Horror", listOf("B")), 3.0)
+        val tables = DraftsimSetTables(ratings, emptySet(), emptyMap())
+        val builder = DraftsimDeckBuilder(tables)
+
+        val forced = cards.filter { it.card.name in setOf("GreenCreature1", "BlueCreature1", "Flexible") }
+            .map { it.instanceId }.toSet()
+        val build = builder.buildDecks(cards, mode = "sealed", forced = forced).single()
+
+        build.colors.toSet() shouldBe setOf("G", "U")
+        (build.basicsNeeded["B"] ?: 0) shouldBe 0
+    }
+
     test("completion fixes mana for every locked color, even a third") {
         val ratings = HashMap<String, Double>()
         val cards = mutableListOf<DraftsimPoolCard>()

--- a/ai/src/test/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilderTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/draftsim/DraftsimDeckBuilderTest.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.ai.draftsim
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 
@@ -87,5 +89,47 @@ class DraftsimDeckBuilderTest : FunSpec({
         val chosenNames = best.deckInstanceIds.mapNotNull { byId[it]?.card?.name }
         // An RG build should not be reaching for {2}{U} filler.
         chosenNames.count { it.startsWith("BlueFiller") } shouldBe 0
+    }
+
+    test("completion keeping locked removal still builds a full 23/17 deck (no double-add)") {
+        val (pool, tables) = buildPool()
+        val byId = pool.associateBy { it.instanceId }
+        val builder = DraftsimDeckBuilder(tables)
+
+        // Lock three removal spells — these are seeded before the removal phase, which must not re-add them.
+        val forced = pool.filter { it.card.name in setOf("Zap1", "Zap2", "Zap3") }.map { it.instanceId }.toSet()
+        val build = builder.buildDecks(pool, mode = "sealed", forced = forced).single()
+
+        val nonland = build.deckInstanceIds.mapNotNull { byId[it]?.card }
+            .filter { !it.typeLine.lowercase().contains("land") }
+        nonland.size shouldBe 23
+        (build.deckInstanceIds.size + build.basicsNeeded.values.sum()) shouldBe 40
+        // Every locked removal spell is present exactly once.
+        listOf("Zap1", "Zap2", "Zap3").forEach { name -> nonland.count { it.name == name } shouldBe 1 }
+    }
+
+    test("completion fixes mana for every locked color, even a third") {
+        val ratings = HashMap<String, Double>()
+        val cards = mutableListOf<DraftsimPoolCard>()
+        var n = 0
+        fun add(card: ScorerCard, rating: Double) {
+            ratings[DraftsimData.nameKey(card.name)] = rating
+            cards += DraftsimPoolCard(card, "id-${n++}")
+        }
+        // A WU-heavy pool with a small black slice to lock as the off-axis third color.
+        for (i in 1..14) add(BCard("WhiteCreature$i", "{1}{W}", "Creature — Soldier", listOf("W")), 2.6)
+        for (i in 1..14) add(BCard("BlueCreature$i", "{1}{U}", "Creature — Wizard", listOf("U")), 2.6)
+        for (i in 1..3) add(BCard("BlackBomb$i", "{1}{B}", "Creature — Demon", listOf("B")), 3.5)
+        val tables = DraftsimSetTables(ratings, emptySet(), emptyMap())
+        val builder = DraftsimDeckBuilder(tables)
+
+        // Lock one card of each colour, including the third (black).
+        val forced = cards.filter { it.card.name in setOf("WhiteCreature1", "BlueCreature1", "BlackBomb1") }
+            .map { it.instanceId }.toSet()
+        val build = builder.buildDecks(cards, mode = "sealed", forced = forced).single()
+
+        // All three locked colours are build colours and the manabase carries basics for each.
+        build.colors shouldContainAll listOf("W", "U", "B")
+        listOf("W", "U", "B").forEach { c -> (build.basicsNeeded[c] ?: 0) shouldBeGreaterThan 0 }
     }
 })

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/AiAssistControllerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/AiAssistControllerTest.kt
@@ -93,7 +93,7 @@ class AiAssistControllerTest : FunSpec({
         advice.scores.size shouldBeGreaterThan 0
 
         val deck = controller.autoBuild(AiAssistController.AutoBuildBody(lobbyId = null, pool = pack))
-        deck.deckList.values.sum() shouldBeGreaterThan 0
+        deck.builds.first().deckList.values.sum() shouldBeGreaterThan 0
     }
 
     test("an unknown lobbyId is treated as practice (allowed), not rejected") {
@@ -136,7 +136,7 @@ class AiAssistControllerTest : FunSpec({
         // never crashing on the empty input.
         val basics = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
         val deck = controller.autoBuild(AiAssistController.AutoBuildBody(pool = emptyList()))
-        deck.deckList.keys.all { it in basics } shouldBe true
+        deck.builds.first().deckList.keys.all { it in basics } shouldBe true
     }
 
     test("advisor catalog lists the heuristic engines for the dropdowns") {

--- a/web-client/src/api/aiAssist.ts
+++ b/web-client/src/api/aiAssist.ts
@@ -27,11 +27,21 @@ export interface DraftPickAdvice {
   readonly recommended: readonly string[]
 }
 
-export interface DeckBuildResult {
-  readonly advisorId: string
+/** One candidate deck within a {@link DeckBuildResult}. */
+export interface DeckBuildOption {
   readonly deckList: Readonly<Record<string, number>>
   readonly score: number | null
   readonly archetype: string | null
+  /** Build colors as WUBRG single-letter codes (for color pips); empty if the engine doesn't report them. */
+  readonly colors: readonly string[]
+}
+
+export interface DeckBuildResult {
+  readonly advisorId: string
+  /** Candidate decks, ordered best-first. A single-deck engine returns one entry. */
+  readonly builds: readonly DeckBuildOption[]
+  /** Index into `builds` of the deck to apply by default. */
+  readonly recommended: number
 }
 
 // The engine list is fixed for the server's lifetime, but both the draft and deckbuild controls

--- a/web-client/src/components/sealed/DeckBuilderOverlay.tsx
+++ b/web-client/src/components/sealed/DeckBuilderOverlay.tsx
@@ -10,6 +10,7 @@ import { useDfcHoverFlip } from '../ui/useDfcHoverFlip'
 import { SetSynergiesButton, type Archetype } from '../draft/SetSynergiesOverlay'
 import { DeckbuilderChatPanel } from './DeckbuilderChatPanel'
 import { fetchAdvisors, type AdvisorInfo } from '@/api/aiAssist'
+import type { AutoBuildResult } from '@/store/slices/types'
 import {
   detectProducedColors,
   suggestBasicLands,
@@ -1399,6 +1400,7 @@ function AutoBuildControl({
   responsive: ReturnType<typeof useResponsive>
 }) {
   const autoBuildDeck = useGameStore((s) => s.autoBuildDeck)
+  const applyAutoBuildOption = useGameStore((s) => s.applyAutoBuildOption)
   const aiAssistBusy = useGameStore((s) => s.aiAssistBusy)
   const aiAssistError = useGameStore((s) => s.aiAssistError)
   const autoBuildResult = useGameStore((s) => s.autoBuildResult)
@@ -1511,29 +1513,73 @@ function AutoBuildControl({
           Hide scores
         </button>
       )}
-      {!aiAssistBusy && autoBuildResult && autoBuildResult.score != null && (
-        <span
-          title="Score of the most recent Auto-build"
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-            padding: '4px 10px',
-            fontSize: 13,
-            fontWeight: 600,
-            color: '#e8d9ff',
-            backgroundColor: 'rgba(126, 87, 194, 0.25)',
-            border: '1px solid #7e57c2',
-            borderRadius: 6,
-          }}
-        >
-          {`Deck score: ${formatBuildScore(autoBuildResult.advisorId, autoBuildResult.score)}`}
-          {autoBuildResult.archetype && (
-            <span style={{ color: '#b9a6e0', fontWeight: 500 }}>· {autoBuildResult.archetype}</span>
-          )}
-        </span>
+      {!aiAssistBusy && autoBuildResult && (
+        <BuildOptionPicker result={autoBuildResult} onPick={applyAutoBuildOption} />
       )}
       {aiAssistError && <span style={{ color: '#ff6b6b', fontSize: 12 }}>{aiAssistError}</span>}
+    </div>
+  )
+}
+
+/**
+ * The Auto-build outcome: the candidate decks as selectable chips. The recommended deck is applied
+ * immediately (highlighted here); clicking another chip swaps the deck to that candidate. With a
+ * single candidate (heuristic / completion) it renders one non-interactive score badge.
+ */
+function BuildOptionPicker({
+  result,
+  onPick,
+}: {
+  result: AutoBuildResult
+  onPick: (index: number) => void
+}) {
+  const multiple = result.options.length > 1
+  return (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      {multiple && <span style={{ color: '#b9a6e0', fontSize: 12, fontWeight: 600 }}>Builds:</span>}
+      {result.options.map((option, i) => {
+        const isApplied = i === result.appliedIndex
+        const scoreText = option.score != null ? formatBuildScore(result.advisorId, option.score) : null
+        return (
+          <button
+            key={i}
+            onClick={() => onPick(i)}
+            disabled={!multiple}
+            title={
+              multiple
+                ? isApplied
+                  ? 'This build is applied to your deck'
+                  : 'Switch your deck to this build'
+                : 'Score of the most recent Auto-build'
+            }
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '4px 10px',
+              fontSize: 13,
+              fontWeight: 600,
+              color: isApplied ? '#e8d9ff' : '#b9a6e0',
+              backgroundColor: isApplied ? 'rgba(126, 87, 194, 0.35)' : 'rgba(126, 87, 194, 0.12)',
+              border: `1px solid ${isApplied ? '#9b7fd4' : 'rgba(126, 87, 194, 0.5)'}`,
+              borderRadius: 6,
+              cursor: multiple ? 'pointer' : 'default',
+            }}
+          >
+            {option.colors.length > 0 && (
+              <span style={{ display: 'inline-flex', gap: 2 }}>
+                {option.colors.map((c) => (
+                  <ManaSymbol key={c} symbol={c} size={14} />
+                ))}
+              </span>
+            )}
+            {option.archetype && <span>{option.archetype}</span>}
+            {scoreText && (
+              <span style={{ color: isApplied ? '#fff' : '#cdbbef', fontWeight: 700 }}>{scoreText}</span>
+            )}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/web-client/src/store/slices/draftSlice.ts
+++ b/web-client/src/store/slices/draftSlice.ts
@@ -1,7 +1,7 @@
 /**
  * Draft slice - handles sealed deck building and drafting logic.
  */
-import type { SliceCreator, DeckBuildingState, PickScore, AutoBuildSummary } from './types'
+import type { SliceCreator, DeckBuildingState, PickScore, AutoBuildResult } from './types'
 import {
   createCreateSealedGameMessage,
   createJoinSealedGameMessage,
@@ -21,6 +21,27 @@ import { getWebSocket, saveDeckState } from './shared'
 
 export type { PickScore }
 
+/**
+ * Split a built decklist (name → count, spells + basics mixed) into the flat non-land card list and
+ * basic-land counts that {@link DraftSliceActions.setDeck} expects. `basicNames` are the pool's basic
+ * land names; everything else is treated as a deck card with one entry per copy.
+ */
+function splitDeckList(
+  deckList: Readonly<Record<string, number>>,
+  basicNames: ReadonlySet<string>,
+): { deck: string[]; landCounts: Record<string, number> } {
+  const deck: string[] = []
+  const landCounts: Record<string, number> = {}
+  for (const [name, count] of Object.entries(deckList)) {
+    if (basicNames.has(name)) {
+      landCounts[name] = count
+    } else {
+      for (let i = 0; i < count; i++) deck.push(name)
+    }
+  }
+  return { deck, landCounts }
+}
+
 export interface DraftSliceState {
   deckBuildingState: DeckBuildingState | null
   /**
@@ -34,8 +55,8 @@ export interface DraftSliceState {
   aiAssistBusy: boolean
   /** Last AI-assist error message (e.g. assistance disabled), or null. */
   aiAssistError: string | null
-  /** Score/archetype from the most recent Auto-build, or null until one runs. */
-  autoBuildResult: AutoBuildSummary | null
+  /** Candidate decks + applied index from the most recent Auto-build, or null until one runs. */
+  autoBuildResult: AutoBuildResult | null
   /** Engine the player selected in the draft "Suggest Pick" dropdown; persists across edits. */
   draftAdvisorId: string | null
   /** Engine the player selected in the deckbuild "Auto-build" dropdown; persists across edits. */
@@ -70,6 +91,8 @@ export interface DraftSliceActions {
   clearPickSuggestion: () => void
   /** Build (empty deck) or complete (partial deck) the deck from the pool with the chosen engine. */
   autoBuildDeck: (advisorId?: string) => Promise<void>
+  /** Switch the deck to a different Auto-build candidate (by index into `autoBuildResult.options`). */
+  applyAutoBuildOption: (index: number) => void
   /** Remember the selected draft "Suggest Pick" engine. */
   setDraftAdvisorId: (advisorId: string | null) => void
   /** Remember the selected deckbuild "Auto-build" engine. */
@@ -395,25 +418,27 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set, get) => ({
         setCodes: lobbyState?.settings.setCodes ?? [],
       })
 
-      // Split the built decklist into non-land cards (deck) and basic-land counts (landCounts),
-      // then apply via setDeck (which re-caps to pool availability and the 4-of rule).
-      const basicNames = new Set(deckBuildingState.basicLands.map((c) => c.name))
-      const newDeck: string[] = []
-      const newLandCounts: Record<string, number> = {}
-      for (const [name, count] of Object.entries(result.deckList)) {
-        if (basicNames.has(name)) {
-          newLandCounts[name] = count
-        } else {
-          for (let i = 0; i < count; i++) newDeck.push(name)
-        }
+      if (result.builds.length === 0) {
+        set({ aiAssistBusy: false, aiAssistError: 'Auto-build produced no deck', autoBuildResult: null })
+        return
       }
-      get().setDeck(newDeck, newLandCounts)
+
+      // Apply the recommended build immediately; keep every candidate so the player can switch.
+      const applied = Math.min(Math.max(result.recommended, 0), result.builds.length - 1)
+      const basicNames = new Set(deckBuildingState.basicLands.map((c) => c.name))
+      const { deck, landCounts } = splitDeckList(result.builds[applied]!.deckList, basicNames)
+      get().setDeck(deck, landCounts)
       set({
         aiAssistBusy: false,
         autoBuildResult: {
           advisorId: result.advisorId,
-          score: result.score,
-          archetype: result.archetype,
+          options: result.builds.map((b) => ({
+            score: b.score,
+            archetype: b.archetype,
+            colors: b.colors,
+            deckList: b.deckList,
+          })),
+          appliedIndex: applied,
         },
       })
     } catch (e) {
@@ -423,6 +448,18 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set, get) => ({
         autoBuildResult: null,
       })
     }
+  },
+
+  applyAutoBuildOption: (index) => {
+    const { deckBuildingState, autoBuildResult } = get()
+    if (!deckBuildingState || !autoBuildResult) return
+    const option = autoBuildResult.options[index]
+    if (!option || index === autoBuildResult.appliedIndex) return
+
+    const basicNames = new Set(deckBuildingState.basicLands.map((c) => c.name))
+    const { deck, landCounts } = splitDeckList(option.deckList, basicNames)
+    get().setDeck(deck, landCounts)
+    set({ autoBuildResult: { ...autoBuildResult, appliedIndex: index } })
   },
 
   setDraftAdvisorId: (advisorId) => set({ draftAdvisorId: advisorId }),

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -409,14 +409,26 @@ export interface PickScore {
   readonly reason: string
 }
 
-/** Summary of the most recent Auto-build, surfaced in the deck builder. */
-export interface AutoBuildSummary {
-  /** Engine that produced the build (e.g. "draftsim", "heuristic"). */
-  readonly advisorId: string
+/** One candidate deck from an Auto-build, shown as a choice in the deck builder. */
+export interface AutoBuildOption {
   /** Deck score (Draftsim: 0–10; heuristic: sum of card ratings), or null if unscored. */
   readonly score: number | null
   /** Targeted archetype / colour label, if the engine identifies one. */
   readonly archetype: string | null
+  /** Build colors as WUBRG single-letter codes, for the option's color pips. */
+  readonly colors: readonly string[]
+  /** Full decklist (spells + basics) for this option, re-applied when the player switches to it. */
+  readonly deckList: Readonly<Record<string, number>>
+}
+
+/** The most recent Auto-build: its candidate decks plus which one is currently applied. */
+export interface AutoBuildResult {
+  /** Engine that produced the builds (e.g. "draftsim", "heuristic"). */
+  readonly advisorId: string
+  /** Candidate decks, ordered best-first. */
+  readonly options: readonly AutoBuildOption[]
+  /** Index of the option currently applied to the deck. */
+  readonly appliedIndex: number
 }
 
 export interface DeckBuildingState {
@@ -845,8 +857,8 @@ export type GameStore = {
   recommendedPick: readonly string[]
   aiAssistBusy: boolean
   aiAssistError: string | null
-  /** Score/archetype from the most recent Auto-build, or null. */
-  autoBuildResult: AutoBuildSummary | null
+  /** Candidate decks + applied index from the most recent Auto-build, or null. */
+  autoBuildResult: AutoBuildResult | null
   /** Selected engine for the draft / deckbuild dropdowns; persists across edits and remounts. */
   draftAdvisorId: string | null
   deckbuildAdvisorId: string | null
@@ -859,6 +871,8 @@ export type GameStore = {
   suggestPick: (advisorId?: string) => Promise<void>
   clearPickSuggestion: () => void
   autoBuildDeck: (advisorId?: string) => Promise<void>
+  /** Switch the deck to a different Auto-build candidate (by index into `autoBuildResult.options`). */
+  applyAutoBuildOption: (index: number) => void
 
   // Pipeline slice
   pipelineState: ActionPipelineState | null


### PR DESCRIPTION
Two deckbuild improvements for sealed, plus correctness fixes.

Completion mode ("Complete Deck")
- Locked cards are forced into the build, protected from removal/swap,
  and the rest is filled around them with the normal greedy + refine
  machinery so the result is scored and mana-based identically.
- The manabase fixes every color the locked cards need (a three-color
  lock yields a three-color base); no locked card is left uncastable.

Alternative builds (Auto-build)
- DeckBuildResult now returns a best-first list of candidate decks plus
  a recommended index. The heuristic/completion engines return one; a
  fresh Auto-build surfaces the top ~3 archetypes side by side.
- Client shows them as selectable chips (color pips + archetype + score);
  the recommended deck is applied immediately, clicking another swaps in
  that candidate with no extra server round-trip.

Fixes
- Completion no longer double-adds locked removal spells (was under-
  building to a sub-40 deck); the removal phase skips seeded cards and
  caps deck size at 23 nonland.

Tests
- Builder tests for locked-removal completion (23/17, no dup) and
  three-color manabase fixing; advisor + controller tests updated for
  the new result shape. :ai and :game-server suites green; web client
  typechecks.
  
  
<img width="533" height="36" alt="image" src="https://github.com/user-attachments/assets/dcaa5336-15e5-493e-aab6-66ec5225e46b" />
