### PR TITLE
Add TMT basic lands so the deckbuilder can add lands

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
@@ -23,6 +23,10 @@ object TeenageMutantNinjaTurtlesSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TeenageMutantNinjaTurtlesBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TeenageMutantNinjaTurtlesBasicLands.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** One BEMOCS art variant (TMT 191-195) per basic-land type — the deckbuilder offers one entry per name. */
+
+val TmtPlains = basicLand("Plains") {
+    collectorNumber = "191"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b405611-27d4-435a-8e8e-6d528626fd27.jpg?1771343562"
+}
+
+val TmtIsland = basicLand("Island") {
+    collectorNumber = "192"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be2319a6-d089-4d13-8a7b-3552e654cdc5.jpg?1771343569"
+}
+
+val TmtSwamp = basicLand("Swamp") {
+    collectorNumber = "193"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41c7688d-8155-45fd-83ba-ff9be4d414a3.jpg?1771343575"
+}
+
+val TmtMountain = basicLand("Mountain") {
+    collectorNumber = "194"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/6243f79f-b0e3-4fba-b899-7535e1a277e2.jpg?1771343582"
+}
+
+val TmtForest = basicLand("Forest") {
+    collectorNumber = "195"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/6194850b-d70a-4f3e-be3e-bfb23ce1170b.jpg?1771343588"
+}


### PR DESCRIPTION
Teenage Mutant Ninja Turtles defined no basic lands, so it fell back to the MtgSet default of emptyList(). The draft/sealed land pool is sourced from the set (GameBeansConfig: basicLands = (basicLandsFallback ?: this).basicLands), so a land-less set offered no basics to add in the deckbuilder.

Add one canonical basicLand() per type using TMT's booster art (cards 191-195, BEMOCS) and the basicLands discovery override (mirrors the BLB pattern). One variant per type is deterministic: the catalog surfaces a single entry per basic name, so a single variant avoids nondeterministic art selection across printings.