### PR TITLE
Fill AI targets for activated abilities, not just spells

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -182,8 +182,17 @@ class Strategist(
         playerId: EntityId
     ): com.wingedsheep.engine.core.GameAction {
         if (!action.requiresTargets) return action.action
-        val castSpell = action.action as? CastSpell ?: return action.action
-        if (castSpell.targets.isNotEmpty()) return action.action
+        // Only CastSpell and ActivateAbility carry a `targets` list the AI fills in. A targeted
+        // activated ability (e.g. "{4}{R}, Sacrifice: deal 3 damage to target") that isn't handled
+        // here is submitted with no target, rejected by the engine ("requires a target"), and the
+        // AI re-picks it forever — an infinite loop.
+        val baseAction = action.action
+        val existingTargets = when (baseAction) {
+            is CastSpell -> baseAction.targets
+            is ActivateAbility -> baseAction.targets
+            else -> return action.action
+        }
+        if (existingTargets.isNotEmpty()) return action.action
 
         val projected = state.projectedState
 
@@ -243,7 +252,11 @@ class Strategist(
             }
         }
 
-        return castSpell.copy(targets = chosenTargets)
+        return when (baseAction) {
+            is CastSpell -> baseAction.copy(targets = chosenTargets)
+            is ActivateAbility -> baseAction.copy(targets = chosenTargets)
+            else -> action.action
+        }
     }
 
     /**

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
@@ -5,11 +5,18 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.MtgSetCatalog
 import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -400,5 +407,57 @@ class AIPlayerTest : FunSpec({
         val autoPayable = mayPayDecision.copy(id = "d3", autoPaySuggestion = listOf(treasureId))
         val autoPayResponse = responder.respond(state, autoPayable, playerId) as ManaSourcesSelectedResponse
         autoPayResponse.autoPay shouldBe true
+    }
+
+    // Regression: a targeted *activated* ability (e.g. "{T}: deal 2 damage to target creature")
+    // must come back from the AI with its target filled. Previously the strategist only filled
+    // targets for CastSpell, so a chosen ActivateAbility was submitted with no target, rejected by
+    // the engine ("requires a target"), and re-picked forever — an infinite loop.
+    test("AI fills the target for a targeted activated ability instead of looping") {
+        val pinger = card("Test Pinger") {
+            manaCost = "{2}"
+            typeLine = "Creature — Wizard"
+            power = 1
+            toughness = 1
+            activatedAbility {
+                cost = Costs.Tap
+                val t = target("target creature", Targets.Creature)
+                effect = Effects.DealDamage(2, t)
+            }
+        }
+        val bear = card("Test Bear") {
+            manaCost = "{1}{G}"
+            typeLine = "Creature — Bear"
+            power = 2
+            toughness = 2
+        }
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(pinger, bear))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val aiId = driver.activePlayer!!
+        val opp = driver.getOpponent(aiId)
+
+        val myPinger = driver.putCreatureOnBattlefield(aiId, "Test Pinger")
+        driver.removeSummoningSickness(myPinger)
+        driver.putCreatureOnBattlefield(opp, "Test Bear")
+        driver.passPriorityUntil(Phase.PRECOMBAT_MAIN)
+
+        val ai = AIPlayer.create(driver.cardRegistry, aiId)
+        val simulator = GameSimulator(driver.cardRegistry)
+        val legalActions = simulator.getLegalActions(driver.state, aiId)
+        val activate = legalActions.find { it.actionType == "ActivateAbility" && it.requiresTargets }
+        activate.shouldNotBeNull()
+        val pass = legalActions.find { it.actionType == "PassPriority" }
+        pass.shouldNotBeNull()
+
+        // Killing the opponent's 2/2 for a single tap clearly beats passing, so the AI picks the
+        // ability — and with the fix it carries a valid creature target.
+        val chosen = ai.chooseFrom(driver.state, listOf(activate, pass)).action
+        (chosen is ActivateAbility).shouldBeTrue()
+        (chosen as ActivateAbility).targets.shouldNotBeEmpty()
+
+        // The decisive anti-loop guarantee: the AI's chosen action is actually legal.
+        driver.submit(chosen).isSuccess shouldBe true
     }
 })


### PR DESCRIPTION
Strategist.resolveTargetsForSimulation only handled CastSpell, so a chosen targeted ActivateAbility (e.g. "{4}{R}, Sacrifice: deal 3 damage to target") was returned with no target, rejected by the engine ("requires a target"), and re-picked every time the AI regained priority — an infinite loop. Generalize the target-fill to both CastSpell and ActivateAbility. This also makes evaluate1Ply score such abilities on their real effect instead of as a no-op.

Adds an AIPlayerTest regression covering a pinger that must enter combat with a filled target and submit a legal action.

```
2026-06-11T09:04:00.778+02:00 DEBUG 25527 --- [argentum-game-server] [atcher-worker-2] c.w.g.repository.RedisGameRepository     : Persisted game session 8b5b3668-dc41-4b72-b5f2-72a3ed8e01fe to Redis
2026-06-11T09:04:01.290+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.ai.engine.EngineAiPlayerController   : Engine AI chose: ActivateAbility
2026-06-11T09:04:01.290+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.ai.AiWebSocketSession     : AI chose response: Action(ActivateAbility)
2026-06-11T09:04:01.290+02:00  WARN 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.handler.GamePlayHandler   : AI action failed: This ability requires a target — trying safe fallbacks
2026-06-11T09:04:01.295+02:00 DEBUG 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.priority.AutoPassManager  : STOP: Opponent's spell/ability on stack
2026-06-11T09:04:01.296+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.handler.GamePlayHandler   : AI combat state: step=DECLARE_ATTACKERS, priorityPlayer=ai-fe74a34b, aiPlayer=ai-fe74a34b, legalActions=[PassPriority(Pass priority), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {G}), ActivateAbility({T}: Add {U}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({4}{R}, Sacrifice this permanent: Deal 3 damage to target)]
2026-06-11T09:04:01.305+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-1] c.w.gameserver.ai.AiWebSocketSession     : AI received StateUpdate: phase=COMBAT, step=DECLARE_ATTACKERS, priority=AI, legalActions=18, pendingDecision=null
2026-06-11T09:04:01.305+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-1] c.w.gameserver.ai.AiWebSocketSession     : AI has 18 legal actions: PassPriority(Pass priority), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {G}), ActivateAbility({T}: Add {U}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({4}{R}, Sacrifice this permanent: Deal 3 damage to target)
2026-06-11T09:04:01.309+02:00 DEBUG 25527 --- [argentum-game-server] [atcher-worker-2] c.w.g.repository.RedisGameRepository     : Persisted game session 8b5b3668-dc41-4b72-b5f2-72a3ed8e01fe to Redis
2026-06-11T09:04:01.832+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.ai.engine.EngineAiPlayerController   : Engine AI chose: ActivateAbility
2026-06-11T09:04:01.832+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.ai.AiWebSocketSession     : AI chose response: Action(ActivateAbility)
2026-06-11T09:04:01.833+02:00  WARN 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.handler.GamePlayHandler   : AI action failed: This ability requires a target — trying safe fallbacks
2026-06-11T09:04:01.839+02:00 DEBUG 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.priority.AutoPassManager  : STOP: Opponent's spell/ability on stack
2026-06-11T09:04:01.842+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-2] c.w.gameserver.handler.GamePlayHandler   : AI combat state: step=DECLARE_ATTACKERS, priorityPlayer=ai-fe74a34b, aiPlayer=ai-fe74a34b, legalActions=[PassPriority(Pass priority), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {G}), ActivateAbility({T}: Add {U}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({4}{R}, Sacrifice this permanent: Deal 3 damage to target)]
2026-06-11T09:04:01.855+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-1] c.w.gameserver.ai.AiWebSocketSession     : AI received StateUpdate: phase=COMBAT, step=DECLARE_ATTACKERS, priority=AI, legalActions=18, pendingDecision=null
2026-06-11T09:04:01.855+02:00  INFO 25527 --- [argentum-game-server] [atcher-worker-1] c.w.gameserver.ai.AiWebSocketSession     : AI has 18 legal actions: PassPriority(Pass priority), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({T}: Add {G}), ActivateAbility({T}: Add {U}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {R}), ActivateAbility({T}: Add {W}), ActivateAbility({T}: Add {B}), ActivateAbility({4}{R}, Sacrifice this permanent: Deal 3 damage to target)
2026-06-11T09:04:01.872+02:00 DEBUG 25527 --- [argentum-game-server] [atcher-worker-2] c.w.g.repository.RedisGameRepository     : Persisted game session 8b5b3668-dc41-4b72-b5f2-72a3ed8e01fe to Redis
```