### PR TITLE
Add Serendib Djinn (ARN) + fix forced-sacrifice prompt

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 63 / 78
+**Implemented:** 64 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -33,7 +33,7 @@
 - [x] Island Fish Jasconius
 - [x] Merchant Ship
 - [x] Old Man of the Sea
-- [ ] Serendib Djinn
+- [x] Serendib Djinn
 - [x] Serendib Efreet
 - [x] Sindbad
 - [x] Unstable Mutation

--- a/manual-scenarios/cards/s/serendib-djinn-upkeep-sacrifice.json
+++ b/manual-scenarios/cards/s/serendib-djinn-upkeep-sacrifice.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Serendib Djinn", "summoningSickness": false},
+      {"name": "Island"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "BEGINNING",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/SerendibDjinn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/SerendibDjinn.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Serendib Djinn
+ * {2}{U}{U}
+ * Creature — Djinn
+ * 5/6
+ * Flying
+ * At the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way,
+ * this creature deals 3 damage to you.
+ * When you control no lands, sacrifice this creature.
+ *
+ * Composition (no new engine features needed):
+ *  - Upkeep trigger fires `Effects.Sacrifice(Land, target = Controller)` so you choose which
+ *    land to sacrifice during resolution (CR ruling: the land is chosen on resolution). The
+ *    sacrificed permanent's snapshot flows into `EffectContext.sacrificedPermanents`.
+ *  - The self-damage rider is a `ConditionalEffect` gated on `SacrificedHadSubtype("Island")`,
+ *    reading that snapshot — same pattern as Rise of the Witch-king's "if you sacrificed a
+ *    creature this way" rider. `damageSource = Self` so the 3 damage comes from this creature.
+ *  - "When you control no lands, sacrifice this creature" is a `stateTriggeredAbility`
+ *    (CR 603.8 state trigger), mirroring Dandân's "when you control no Islands" sacrifice.
+ */
+val SerendibDjinn = card("Serendib Djinn") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn"
+    power = 5
+    toughness = 6
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way, " +
+        "this creature deals 3 damage to you.\n" +
+        "When you control no lands, sacrifice this creature."
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Land,
+            count = 1,
+            target = EffectTarget.Controller
+        ).then(
+            ConditionalEffect(
+                condition = Conditions.SacrificedHadSubtype("Island"),
+                effect = Effects.DealDamage(
+                    3,
+                    EffectTarget.Controller,
+                    damageSource = EffectTarget.Self
+                )
+            )
+        )
+        description = "At the beginning of your upkeep, sacrifice a land. " +
+            "If you sacrifice an Island this way, this creature deals 3 damage to you."
+    }
+
+    stateTriggeredAbility {
+        condition = Conditions.YouControl(GameObjectFilter.Land, negate = true)
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+        description = "When you control no lands, sacrifice this creature"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Anson Maddocks"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg?1562895874"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -2785,6 +2785,89 @@
     ]
 }
 
+// Serendib Djinn
+{
+    "name": "Serendib Djinn",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Djinn",
+    "oracleText": "Flying\nAt the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way, this creature deals 3 damage to you.\nWhen you control no lands, sacrifice this creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForceSacrifice",
+                            "filter": "land",
+                            "target": "Controller"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SacrificedPermanentHadSubtype",
+                                    "subtype": "Island"
+                                }
+                            },
+                            "then": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": "Controller",
+                                "damageSource": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way, this creature deals 3 damage to you."
+            }
+        ],
+        "stateTriggeredAbilities": [
+            {
+                "id": "ability_2",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land",
+                    "negate": true
+                },
+                "effect": {
+                    "type": "SacrificeTarget",
+                    "target": "Self"
+                },
+                "descriptionOverride": "When you control no lands, sacrifice this creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "RARE",
+        "artist": "Anson Maddocks",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg?1562895874"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Serendib Efreet
 {
     "name": "Serendib Efreet",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ForceSacrificeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ForceSacrificeExecutor.kt
@@ -123,9 +123,18 @@ class ForceSacrificeExecutor(
         count: Int,
         priorEvents: List<GameEvent>
     ): EffectResult {
+        // Describe the actual filter ("a land", "a creature", "an artifact"...) rather than
+        // hardcoding "creature" — Serendib Djinn / Goblin Firebug sacrifice lands, edicts
+        // sacrifice creatures, etc.
+        val noun = filter.description
         val prompt = buildString {
             append("Choose ")
-            if (minSelections == 1) append("a creature") else append("$minSelections creatures")
+            if (minSelections == 1) {
+                append(if (noun.firstOrNull()?.lowercaseChar() in setOf('a', 'e', 'i', 'o', 'u')) "an " else "a ")
+                append(noun)
+            } else {
+                append("$minSelections ${noun}s")
+            }
             append(" to sacrifice")
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerendibDjinnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerendibDjinnScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Serendib Djinn (ARN #19).
+ *
+ * "{2}{U}{U} Creature — Djinn 5/6. Flying.
+ *  At the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way,
+ *  this creature deals 3 damage to you.
+ *  When you control no lands, sacrifice this creature."
+ *
+ * Pins the composition over existing primitives (no new engine features):
+ *  - The upkeep trigger sacrifices a land you choose (`Effects.Sacrifice(Land, Controller)`),
+ *    and a `ConditionalEffect` gated on `SacrificedHadSubtype("Island")` reads the sacrificed
+ *    permanent's snapshot to deal 3 damage to you only when the sacrificed land was an Island.
+ *  - The "control no lands" clause is a state-triggered ability (CR 603.8) that sacrifices the
+ *    Djinn, mirroring Dandân.
+ */
+class SerendibDjinnScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Serendib Djinn upkeep land sacrifice") {
+
+            test("sacrificing an Island deals 3 damage to you") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Serendib Djinn", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Library fuel so neither player decks during the step advances.
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                // Advance to player 1's upkeep so the "your upkeep" trigger fires.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // Two lands, sacrifice one — choose the Island.
+                val island = game.findPermanent("Island")!!
+                game.selectCards(listOf(island))
+                game.resolveStack()
+
+                withClue("Island should be in the graveyard") {
+                    game.isInGraveyard(1, "Island") shouldBe true
+                }
+                withClue("Sacrificing an Island deals 3 damage: 20 - 3 = 17") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+                withClue("Mountain remains, so the Djinn is not state-sacrificed") {
+                    game.isOnBattlefield("Serendib Djinn") shouldBe true
+                }
+            }
+
+            test("sacrificing a non-Island land deals no damage") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Serendib Djinn", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // Choose the Mountain — not an Island, so no self-damage.
+                val mountain = game.findPermanent("Mountain")!!
+                game.selectCards(listOf(mountain))
+                game.resolveStack()
+
+                withClue("Mountain should be in the graveyard") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                }
+                withClue("Sacrificing a non-Island land deals no damage") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+
+        context("Serendib Djinn state-triggered sacrifice") {
+
+            test("is sacrificed when its controller controls no lands") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Serendib Djinn", summoningSickness = false)
+                    // No lands controlled — the state trigger should fire.
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("With no lands, the state-triggered ability sacrifices the Djinn") {
+                    game.isOnBattlefield("Serendib Djinn") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerendibDjinnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerendibDjinnScenarioTest.kt
@@ -45,6 +45,10 @@ class SerendibDjinnScenarioTest : ScenarioTestBase() {
                 game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
                 game.resolveStack()
 
+                withClue("Sacrifice prompt should name the actual filter (land), not 'creature'") {
+                    game.getPendingDecision()?.prompt shouldBe "Choose a land to sacrifice"
+                }
+
                 // Two lands, sacrifice one — choose the Island.
                 val island = game.findPermanent("Island")!!
                 game.selectCards(listOf(island))


### PR DESCRIPTION
## Add Serendib Djinn to Arabian Nights

{2}{U}{U} 5/6 Flying Djinn (ARN #19). Composes existing primitives — no new engine features:

- **Flying** — `keywords(Keyword.FLYING)`.
- **"At the beginning of your upkeep, sacrifice a land. If you sacrifice an Island this way, this creature deals 3 damage to you."** — `Effects.Sacrifice(Land, Controller)` (you
choose the land at resolution) `.then(ConditionalEffect(SacrificedHadSubtype("Island"), DealDamage(3, Controller, source = Self)))`. The sacrifice executor snapshots the
sacrificed permanent so the rider can read its type — same pattern as Rise of the Witch-king.
- **"When you control no lands, sacrifice this creature."** — `stateTriggeredAbility` gated on `YouControl(Land, negate = true)`, mirroring Dandân.

Scenario test covers the Island-damage branch, the non-Island branch, and the no-lands state trigger. Adds a manual DevScenario for the card. Canonical placement verified in ARN
(earliest printing).

## Fix ForceSacrificeExecutor prompt to name the actual filter

Separate commit. The forced-sacrifice decision prompt hardcoded "Choose a creature to sacrifice" regardless of the filter, so land-sacrifice cards (Serendib Djinn, Goblin
Firebug) and artifact edicts showed the wrong noun. Now derived from `filter.description` with the right a/an article and plural ("Choose a land to sacrifice", "Choose an
artifact to sacrifice") — creature edicts read unchanged. The multi-player edict re-prompt routes back through `processPlayers`, so this one method covers every path. Regression
assertion added to the scenario test; Diabolic Edict tests still green.