### PR TITLE
Close the fail-open defaults (sdk-analysis §1.3)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -678,9 +678,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     success → `then`, failure → `otherwise`. This is "[action]. If you do, [then]" (a declined or
     no-op action runs `otherwise`, not `then`), distinct from `MayDecide` (gates on the yes/no) and
     `MayPay` (gates on paying a cost). `successCriterion` defaults to `SuccessCriterion.Auto`, which
-    infers success from the action's terminal zone-move (a pipeline `MoveCollection`, or a single
-    `MoveToZone` of the source itself) growing its destination zone; non-zone-move actions fall
-    through to fail-open. The executor pre-pushes a `GatedActionContinuation` so a paused action
+    infers success from the action's terminal zone-move (a pipeline `MoveCollection` to a zone, or a
+    single `MoveToZone` of the source itself) growing its destination zone. **Auto is only legal on
+    shapes it can infer** (`SuccessCriterion.Auto.canInfer`): card-load validation (`CardValidator`,
+    enforced corpus-wide by `SuccessCriterionValidationTest`) rejects an Auto criterion on any other
+    action — non-zone-move actions (deal damage, gain life, …) must state `SuccessCriterion.Always`
+    or `CollectionNonEmpty(name, min)` explicitly instead of silently inheriting a fail-open
+    "it happened". The executor pre-pushes a `GatedActionContinuation` so a paused action
     auto-resumes and evaluates after its own continuations drain. Replaces `IfYouDoEffect` (see
     "Sequencing & conditional" below).
   - `Gate.MayPayX` — **not a yes/no, a number chooser.** "You may pay {X}. If you do, [then]." The
@@ -748,9 +752,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   preserved for existing cards; it now **lowers to `GatedEffect(Gate.DoAction(action,
   successCriterion), then = ifYouDo, otherwise = ifYouDont)`** (compiled form is `Gated`, not a
   distinct `IfYouDo` type or executor). `successCriterion` defaults to `SuccessCriterion.Auto` (infer
-  from the action's terminal zone-move); use `SuccessCriterion.Always` / `CollectionNonEmpty(name, min)`
-  when that inference is wrong. Wrap with `MayEffect` for the optional "You may [action]. If you do,
-  [effect]" shape.
+  from the action's terminal zone-move); an action shape Auto *can't* infer from is a card-load
+  validation error — state `SuccessCriterion.Always` / `CollectionNonEmpty(name, min)` explicitly
+  there (and use them whenever the inference is wrong). Wrap with `MayEffect` for the optional
+  "You may [action]. If you do, [effect]" shape.
 - `ReflexiveTriggerEffect(action, reflexive, optional)` — same shape but the reflexive effect goes on the stack.
 
 ### Modal & choice
@@ -1007,6 +1012,16 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.targetPlayerControls(target)` — controlled by a referenced player. Resolves `EffectTarget`
   bindings/context targets, plus `EffectTarget.ControllerOfTriggeringEntity` (controller of the
   entity that fired the trigger — e.g. Tectonic Instability "tap all lands its controller controls").
+- `.ownedByYou()` / `.ownedByOpponent()` — owner predicates (for graveyard/exile cards without a
+  controller, and "you own" battlefield wordings).
+- `.withControllerPredicate(p)` — set any `ControllerPredicate` directly; the entry point for the
+  **composed** predicates `ControllerPredicate.And(list)` / `Or(list)` / `Not(p)`, which express
+  heterogeneous controller/owner relationships in one filter — e.g. "creatures you own but don't
+  control" = `withControllerPredicate(And(listOf(OwnedByYou, Not(ControlledByYou))))`. Every engine
+  evaluation site (live projection, zone-change last-known-controller, grant fast paths) shares the
+  combinator recursion via the `evaluateWith` fold next to `ControllerPredicate`. Note that
+  `GameObjectFilter.and` **rejects** two sides carrying *different* controller predicates (it used
+  to silently keep only one) — state the intent with a composed predicate instead.
 - `.withSubtype(s)` / `.withKeyword(k)` — type/ability predicate.
 - `.ofColor(c)` / `.ofColors(set)` — color predicate.
 - `.withColor(c)` / `.withAnyColor(c…)` / `.notColor(c)` — fixed-color predicates (`CardPredicate.HasColor`/`NotColor`).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1789,6 +1789,11 @@ object Effects {
      * "[action]. If you do, [ifYouDo]" — gates [ifYouDo] on whether [action] actually
      * accomplished its work, not on a yes/no decision. Wrap with `MayEffect` for the
      * common "You may [action]. If you do, [effect]" pattern.
+     *
+     * The default [SuccessCriterion.Auto] is only legal on action shapes it can infer
+     * success from (a terminal zone move) — card-load validation rejects it elsewhere;
+     * pass [SuccessCriterion.Always] / [SuccessCriterion.CollectionNonEmpty] explicitly
+     * for actions whose outcome isn't a zone-size delta.
      */
     fun IfYouDo(
         action: Effect,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -307,13 +307,54 @@ sealed interface SuccessCriterion {
      * for a terminal zone move — either a pipeline [MoveCollectionEffect] or a
      * single-target `MoveToZoneEffect` whose target is the source itself; if found, the
      * destination zone is snapshot pre-execution and counted as "succeeded" iff it grew
-     * by at least one entry. Actions whose outcome isn't a zone-size delta (deal damage,
-     * gain/lose life, …) fall through to [Always] (fail-open), which is the correct
-     * default for them. Use an explicit criterion when that inference is wrong.
+     * by at least one entry.
+     *
+     * Auto is only legal on actions whose shape it can actually infer ([canInfer]) —
+     * card-load validation ([com.wingedsheep.sdk.serialization.CardValidator]) rejects
+     * everything else. An action whose outcome isn't a zone-size delta (deal damage,
+     * gain/lose life, …) must state its criterion explicitly ([Always] when performing
+     * the action can't fail, [CollectionNonEmpty] to gate on a pipeline result) instead
+     * of silently inheriting a fail-open "it happened".
      */
     @SerialName("SuccessCriterion.Auto")
     @Serializable
-    data object Auto : SuccessCriterion
+    data object Auto : SuccessCriterion {
+
+        /**
+         * Whether [Auto] can infer "did it happen" for [action]. This is the single
+         * source of truth for the shape probe — the engine's gated-action executor
+         * snapshots exactly the shapes accepted here, and card-load validation rejects
+         * an [Auto] criterion on any action this returns false for.
+         */
+        fun canInfer(action: Effect): Boolean {
+            terminalCollectionMove(action)?.let { return it.destination is CardDestination.ToZone }
+            terminalSingleMove(action)?.let { return it.target is EffectTarget.Self }
+            return false
+        }
+
+        /**
+         * The last [MoveCollectionEffect] in execution order, or null when the shape
+         * isn't recognized. Checked before [terminalSingleMove] so a pipeline ending in
+         * a collection move keeps its semantics.
+         */
+        fun terminalCollectionMove(action: Effect): MoveCollectionEffect? = when (action) {
+            is MoveCollectionEffect -> action
+            is CompositeEffect -> action.effects.asReversed().firstNotNullOfOrNull { terminalCollectionMove(it) }
+            else -> null
+        }
+
+        /**
+         * The last single-target [MoveToZoneEffect] in execution order, or null when the
+         * shape isn't recognized. Only a [EffectTarget.Self] target is inferable — other
+         * targets can't be resolved to a destination zone owner without full target
+         * resolution.
+         */
+        fun terminalSingleMove(action: Effect): MoveToZoneEffect? = when (action) {
+            is MoveToZoneEffect -> action
+            is CompositeEffect -> action.effects.asReversed().firstNotNullOfOrNull { terminalSingleMove(it) }
+            else -> null
+        }
+    }
 
     /**
      * Action succeeded iff `pipeline.storedCollections[name].size >= min` after the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -592,16 +592,51 @@ data class GameObjectFilter(
     /** Must be owned by an opponent (for cards in graveyards/exile that don't have controllers) */
     fun ownedByOpponent() = copy(controllerPredicate = ControllerPredicate.OwnedByOpponent)
 
+    /**
+     * Must match [predicate] on the controller/owner axis. The entry point for *composed*
+     * predicates ([ControllerPredicate.And] / [ControllerPredicate.Or] / [ControllerPredicate.Not])
+     * — e.g. "permanents you own but don't control":
+     * `withControllerPredicate(ControllerPredicate.And(listOf(OwnedByYou, ControlledByOpponent)))`.
+     * For the plain single predicates, prefer the named builders ([youControl],
+     * [opponentControls], [ownedByYou], …).
+     */
+    fun withControllerPredicate(predicate: ControllerPredicate) = copy(controllerPredicate = predicate)
+
     // =============================================================================
     // Composition
     // =============================================================================
 
-    /** Combine with another filter using AND logic */
-    infix fun and(other: GameObjectFilter) = copy(
-        cardPredicates = cardPredicates + other.cardPredicates,
-        statePredicates = statePredicates + other.statePredicates,
-        controllerPredicate = other.controllerPredicate ?: controllerPredicate
-    )
+    /**
+     * Combine with another filter using AND logic.
+     *
+     * Both sides may carry the *same* controller predicate (or only one side any), but two
+     * *different* controller predicates are rejected: silently keeping one of them was the
+     * old fail-open behavior, and there is no single right merge (AND-ing `youControl` with
+     * `opponentControls` is unsatisfiable, while "owned by you AND controlled by an
+     * opponent" is a real MTG concept). State the intent explicitly with a composed
+     * [ControllerPredicate.And] via [withControllerPredicate] instead.
+     */
+    infix fun and(other: GameObjectFilter): GameObjectFilter {
+        require(
+            controllerPredicate == null ||
+                other.controllerPredicate == null ||
+                controllerPredicate == other.controllerPredicate
+        ) {
+            "Cannot AND two filters with different controller predicates " +
+                "('${controllerPredicate?.description}' vs '${other.controllerPredicate?.description}'). " +
+                "Compose them explicitly with withControllerPredicate(ControllerPredicate.And(...))."
+        }
+        require(other.anyOf.isEmpty()) {
+            "Cannot AND a filter whose right-hand side carries an anyOf union " +
+                "('${other.description}') — the union branches would be silently dropped. " +
+                "Restructure so the union is the left-hand side, or distribute the AND over the branches."
+        }
+        return copy(
+            cardPredicates = cardPredicates + other.cardPredicates,
+            statePredicates = statePredicates + other.statePredicates,
+            controllerPredicate = controllerPredicate ?: other.controllerPredicate
+        )
+    }
 
     /**
      * Combine with another filter using OR logic.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
@@ -95,4 +95,46 @@ sealed interface ControllerPredicate {
     data object OwnedByOpponent : ControllerPredicate {
         override val description: String = "an opponent owns"
     }
+
+    // =============================================================================
+    // Composite / Logical Combinators
+    // =============================================================================
+    // Mirror StatePredicate's And/Or/Not. These let one filter express heterogeneous
+    // controller/owner relationships ("you own but don't control", "you or the targeted
+    // player controls") without falling back to the recursive anyOf union.
+
+    @SerialName("ControllerAnd")
+    @Serializable
+    data class And(val predicates: List<ControllerPredicate>) : ControllerPredicate {
+        override val description: String = predicates.joinToString(" and ") { it.description }
+    }
+
+    @SerialName("ControllerOr")
+    @Serializable
+    data class Or(val predicates: List<ControllerPredicate>) : ControllerPredicate {
+        override val description: String = predicates.joinToString(" or ") { it.description }
+    }
+
+    @SerialName("ControllerNot")
+    @Serializable
+    data class Not(val predicate: ControllerPredicate) : ControllerPredicate {
+        override val description: String = "not ${predicate.description}"
+    }
+}
+
+/**
+ * Structural fold for evaluating a [ControllerPredicate] tree against site-specific leaf
+ * semantics. The combinators ([ControllerPredicate.And] / [ControllerPredicate.Or] /
+ * [ControllerPredicate.Not]) recurse here; every leaf predicate is delegated to [leaf].
+ *
+ * The engine evaluates controller predicates in several contexts with different controller
+ * notions (live projected state, zone-change last-known-controller snapshots, grant-provider
+ * fast paths). Each site supplies only its own leaf semantics and shares the combinator
+ * logic through this fold, so a composed predicate behaves consistently everywhere.
+ */
+fun ControllerPredicate.evaluateWith(leaf: (ControllerPredicate) -> Boolean): Boolean = when (this) {
+    is ControllerPredicate.And -> predicates.all { it.evaluateWith(leaf) }
+    is ControllerPredicate.Or -> predicates.any { it.evaluateWith(leaf) }
+    is ControllerPredicate.Not -> !predicate.evaluateWith(leaf)
+    else -> leaf(this)
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -39,7 +39,13 @@ import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
 import com.wingedsheep.sdk.scripting.effects.TurnFaceDownEffect
 import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Post-deserialization validation for CardDefinition objects.
@@ -49,6 +55,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * - Target index out of bounds
  * - Aura/Equipment consistency
  * - Orphaned targets
+ * - SuccessCriterion.Auto on action shapes it can't infer
  */
 object CardValidator {
 
@@ -60,8 +67,58 @@ object CardValidator {
         validateAuraConsistency(card, errors)
         validateEquipmentConsistency(card, errors)
         validatePlaneswalkerLoyalty(card, errors)
+        validateSuccessCriteria(card, errors)
 
         return errors
+    }
+
+    /**
+     * Every `Gate.DoAction` whose criterion is [SuccessCriterion.Auto] must wrap an action
+     * shape Auto can actually infer ([SuccessCriterion.Auto.canInfer]). Unknown shapes used
+     * to fall through to "it happened" (fail-open); now they are a card-load error asking
+     * for an explicit criterion.
+     *
+     * The card is scanned via its serialized JSON tree rather than a hand-maintained
+     * effect-container walk, so `DoAction` gates are found wherever they sit — spell
+     * effects, triggered/activated abilities, modes, faces, granted abilities — including
+     * containers added after this validator was written.
+     */
+    private fun validateSuccessCriteria(card: CardDefinition, errors: MutableList<CardValidationError>) {
+        val tree = CardSerialization.json.encodeToJsonElement(CardDefinition.serializer(), card)
+        forEachJsonObject(tree) { obj ->
+            if (obj["type"]?.jsonPrimitive?.contentOrNull != "Gate.DoAction") return@forEachJsonObject
+            // encodeDefaults=false: an absent successCriterion field IS the Auto default.
+            val criterion = obj["successCriterion"]
+            val isAuto = criterion == null ||
+                (criterion as? JsonObject)?.get("type")?.jsonPrimitive?.contentOrNull == "SuccessCriterion.Auto"
+            if (!isAuto) return@forEachJsonObject
+
+            val actionJson = obj["action"] ?: return@forEachJsonObject
+            val action = CardSerialization.json.decodeFromJsonElement(Effect.serializer(), actionJson)
+            if (!SuccessCriterion.Auto.canInfer(action)) {
+                errors.add(
+                    CardValidationError.UninferableSuccessCriterion(
+                        cardName = card.name,
+                        message = "'${card.name}' has an \"if you do\" gate (Gate.DoAction) whose action " +
+                            "('${action.description}') has no shape SuccessCriterion.Auto can infer success from " +
+                            "(terminal collection move to a zone, or a single move of Self). " +
+                            "Specify an explicit criterion (SuccessCriterion.Always / CollectionNonEmpty)."
+                    )
+                )
+            }
+        }
+    }
+
+    /** Depth-first visit of every [JsonObject] in [element], including nested arrays. */
+    private fun forEachJsonObject(element: JsonElement, visit: (JsonObject) -> Unit) {
+        when (element) {
+            is JsonObject -> {
+                visit(element)
+                element.values.forEach { forEachJsonObject(it, visit) }
+            }
+            is JsonArray -> element.forEach { forEachJsonObject(it, visit) }
+            else -> {}
+        }
     }
 
     private fun validateCreatureStats(card: CardDefinition, errors: MutableList<CardValidationError>) {
@@ -277,6 +334,11 @@ sealed interface CardValidationError {
     ) : CardValidationError
 
     data class MissingPlaneswalkerLoyalty(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    data class UninferableSuccessCriterion(
         override val cardName: String,
         override val message: String
     ) : CardValidationError

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/GameObjectFilterCompositionTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/GameObjectFilterCompositionTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
+import com.wingedsheep.sdk.serialization.CardSerialization
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Pins the fail-open closures on [GameObjectFilter.and] and the [ControllerPredicate]
+ * combinators (sdk-analysis §1.3): AND-ing two filters used to silently discard the left
+ * controller predicate on conflict; heterogeneous controller relationships now compose
+ * explicitly via [ControllerPredicate.And]/[ControllerPredicate.Or]/[ControllerPredicate.Not].
+ */
+class GameObjectFilterCompositionTest : DescribeSpec({
+
+    describe("GameObjectFilter.and controller predicates") {
+
+        it("keeps the predicate when only one side has one") {
+            (GameObjectFilter.Creature.youControl() and GameObjectFilter.Artifact)
+                .controllerPredicate shouldBe ControllerPredicate.ControlledByYou
+            (GameObjectFilter.Creature and GameObjectFilter.Artifact.youControl())
+                .controllerPredicate shouldBe ControllerPredicate.ControlledByYou
+        }
+
+        it("keeps a predicate both sides share") {
+            (GameObjectFilter.Creature.youControl() and GameObjectFilter.Artifact.youControl())
+                .controllerPredicate shouldBe ControllerPredicate.ControlledByYou
+        }
+
+        it("rejects two different controller predicates instead of silently discarding one") {
+            val exception = shouldThrow<IllegalArgumentException> {
+                GameObjectFilter.Creature.youControl() and GameObjectFilter.Artifact.opponentControls()
+            }
+            exception.message shouldContain "withControllerPredicate"
+        }
+
+        it("rejects a right-hand side whose anyOf union would be silently dropped") {
+            val union = GameObjectFilter.Artifact or GameObjectFilter.Creature.tapped()
+            shouldThrow<IllegalArgumentException> {
+                GameObjectFilter.Creature and union
+            }
+        }
+    }
+
+    describe("ControllerPredicate combinators") {
+
+        // Leaf semantics for the fold: "owned by you" is true, everything else false.
+        val leaf: (ControllerPredicate) -> Boolean = { it == ControllerPredicate.OwnedByYou }
+
+        it("And requires every branch") {
+            ControllerPredicate.And(
+                listOf(ControllerPredicate.OwnedByYou, ControllerPredicate.ControlledByOpponent)
+            ).evaluateWith(leaf) shouldBe false
+            ControllerPredicate.And(
+                listOf(ControllerPredicate.OwnedByYou, ControllerPredicate.OwnedByYou)
+            ).evaluateWith(leaf) shouldBe true
+        }
+
+        it("Or requires any branch") {
+            ControllerPredicate.Or(
+                listOf(ControllerPredicate.ControlledByOpponent, ControllerPredicate.OwnedByYou)
+            ).evaluateWith(leaf) shouldBe true
+            ControllerPredicate.Or(
+                listOf(ControllerPredicate.ControlledByOpponent, ControllerPredicate.ControlledByYou)
+            ).evaluateWith(leaf) shouldBe false
+        }
+
+        it("Not inverts, including when nested") {
+            ControllerPredicate.Not(ControllerPredicate.OwnedByYou).evaluateWith(leaf) shouldBe false
+            ControllerPredicate.Not(
+                ControllerPredicate.And(
+                    listOf(ControllerPredicate.OwnedByYou, ControllerPredicate.ControlledByYou)
+                )
+            ).evaluateWith(leaf) shouldBe true
+        }
+
+        it("survives a JSON round-trip inside a filter") {
+            val filter = GameObjectFilter.Permanent.withControllerPredicate(
+                ControllerPredicate.And(
+                    listOf(
+                        ControllerPredicate.OwnedByYou,
+                        ControllerPredicate.Not(ControllerPredicate.ControlledByYou),
+                    )
+                )
+            )
+            val json = CardSerialization.json.encodeToString(GameObjectFilter.serializer(), filter)
+            val decoded = CardSerialization.json.decodeFromString(GameObjectFilter.serializer(), json)
+            decoded shouldBe filter
+        }
+
+        it("describes composed predicates readably") {
+            ControllerPredicate.And(
+                listOf(
+                    ControllerPredicate.OwnedByYou,
+                    ControllerPredicate.Not(ControllerPredicate.ControlledByYou),
+                )
+            ).description shouldBe "you own and not you control"
+        }
+    }
+})

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardValidatorTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardValidatorTest.kt
@@ -11,15 +11,19 @@ import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.scripting.targets.AnyTarget
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -338,6 +342,105 @@ class CardValidatorTest : DescribeSpec({
             val errors = CardValidator.validate(card)
             errors shouldHaveSize 1
             errors[0].shouldBeInstanceOf<CardValidationError.InvalidTargetIndex>().index shouldBe 9
+        }
+    }
+
+    describe("UninferableSuccessCriterion") {
+
+        it("flags a Gate.DoAction whose Auto criterion can't infer from the action shape") {
+            val card = CardDefinition(
+                name = "Punisher",
+                manaCost = ManaCost.parse("{R}"),
+                typeLine = TypeLine.instant(),
+                script = CardScript(
+                    spellEffect = IfYouDoEffect(
+                        // Deal-damage has no zone-move shape — Auto used to fail open here.
+                        action = DealDamageEffect(DynamicAmount.Fixed(2), EffectTarget.Controller),
+                        ifYouDo = DrawCardsEffect(1),
+                    ),
+                ),
+            )
+            val errors = CardValidator.validate(card)
+            errors shouldHaveSize 1
+            errors[0].shouldBeInstanceOf<CardValidationError.UninferableSuccessCriterion>()
+                .message shouldContain "explicit criterion"
+        }
+
+        it("finds the gate in nested containers (mode inside a triggered ability)") {
+            val card = CardDefinition(
+                name = "Nested Punisher",
+                manaCost = ManaCost.parse("{1}{R}"),
+                typeLine = TypeLine.creature(setOf(Subtype("Goblin"))),
+                creatureStats = CreatureStats(1, 1),
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility.create(
+                            trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
+                            effect = ModalEffect.chooseOne(
+                                Mode.noTarget(
+                                    IfYouDoEffect(
+                                        action = DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                                        ifYouDo = DrawCardsEffect(1),
+                                    )
+                                ),
+                                Mode.noTarget(DrawCardsEffect(1)),
+                            ),
+                        )
+                    ),
+                ),
+            )
+            val errors = CardValidator.validate(card)
+            errors shouldHaveSize 1
+            errors[0].shouldBeInstanceOf<CardValidationError.UninferableSuccessCriterion>()
+        }
+
+        it("accepts Auto on a terminal collection move to a zone") {
+            val card = CardDefinition(
+                name = "Discard Payoff",
+                manaCost = ManaCost.parse("{B}"),
+                typeLine = TypeLine.instant(),
+                script = CardScript(
+                    spellEffect = IfYouDoEffect(
+                        action = MoveCollectionEffect(
+                            from = "discarded",
+                            destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                        ),
+                        ifYouDo = DrawCardsEffect(1),
+                    ),
+                ),
+            )
+            CardValidator.validate(card).shouldBeEmpty()
+        }
+
+        it("accepts Auto on a terminal single move of Self") {
+            val card = CardDefinition(
+                name = "Self Exiler",
+                manaCost = ManaCost.parse("{U}"),
+                typeLine = TypeLine.instant(),
+                script = CardScript(
+                    spellEffect = IfYouDoEffect(
+                        action = MoveToZoneEffect(EffectTarget.Self, Zone.EXILE),
+                        ifYouDo = DrawCardsEffect(1),
+                    ),
+                ),
+            )
+            CardValidator.validate(card).shouldBeEmpty()
+        }
+
+        it("accepts an uninferable action shape when the criterion is explicit") {
+            val card = CardDefinition(
+                name = "Explicit Punisher",
+                manaCost = ManaCost.parse("{R}"),
+                typeLine = TypeLine.instant(),
+                script = CardScript(
+                    spellEffect = IfYouDoEffect(
+                        action = DealDamageEffect(DynamicAmount.Fixed(2), EffectTarget.Controller),
+                        ifYouDo = DrawCardsEffect(1),
+                        successCriterion = SuccessCriterion.Always,
+                    ),
+                ),
+            )
+            CardValidator.validate(card).shouldBeEmpty()
         }
     }
 

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/SuccessCriterionValidationTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/SuccessCriterionValidationTest.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets
+
+import com.wingedsheep.sdk.serialization.CardValidationError
+import com.wingedsheep.sdk.serialization.CardValidator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Corpus-wide gate for the [CardValidationError.UninferableSuccessCriterion] check
+ * (sdk-analysis §1.3 "close the fail-open defaults"): every `Gate.DoAction` whose
+ * criterion is `SuccessCriterion.Auto` must wrap an action shape Auto can infer
+ * success from. Unrecognized shapes used to silently count as "it happened" —
+ * now the card must state an explicit criterion (`Always` / `CollectionNonEmpty`),
+ * and this test is what makes that a build-time failure for the whole corpus.
+ */
+class SuccessCriterionValidationTest : FunSpec({
+
+    test("no registered card relies on SuccessCriterion.Auto's former fail-open default") {
+        val errors = MtgSetCatalog.all.flatMap { set ->
+            set.cards.flatMap { card ->
+                CardValidator.validate(card)
+                    .filterIsInstance<CardValidationError.UninferableSuccessCriterion>()
+                    .map { "[${set.code}] ${it.message}" }
+            }
+        }
+        errors.shouldBeEmpty()
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.scripting.effects.WardCost
 import com.wingedsheep.sdk.scripting.effects.WardCounterEffect
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 
 /**
  * Resolves triggered abilities for entities by checking the AbilityRegistry,
@@ -150,12 +151,13 @@ class TriggerAbilityResolver(
                 if (!matchesAll) continue
 
                 // Check controller predicate relative to the source permanent's controller
-                val controllerMatch = when (filter.controllerPredicate) {
-                    is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
-                    is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
-                    null -> true
-                    else -> true
-                }
+                val controllerMatch = filter.controllerPredicate?.evaluateWith { leaf ->
+                    when (leaf) {
+                        is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
+                        is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
+                        else -> true
+                    }
+                } ?: true
                 if (controllerMatch) {
                     result.add(ability.ability)
                 }
@@ -274,12 +276,13 @@ class TriggerAbilityResolver(
                 if (!matchesAll) continue
 
                 // Check controller predicate relative to the source permanent's controller
-                val controllerMatch = when (filter.controllerPredicate) {
-                    is ControllerPredicate.ControlledByYou -> targetControllerId == entry.sourceControllerId
-                    is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != entry.sourceControllerId
-                    null -> true
-                    else -> true
-                }
+                val controllerMatch = filter.controllerPredicate?.evaluateWith { leaf ->
+                    when (leaf) {
+                        is ControllerPredicate.ControlledByYou -> targetControllerId == entry.sourceControllerId
+                        is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != entry.sourceControllerId
+                        else -> true
+                    }
+                } ?: true
                 if (controllerMatch) add(entry.grant.ability)
             }
         }
@@ -409,12 +412,13 @@ class TriggerAbilityResolver(
                 if (!matchesState) continue
 
                 // Check controller predicate
-                val controllerMatch = when (filter.controllerPredicate) {
-                    is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
-                    is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
-                    null -> true
-                    else -> true
-                }
+                val controllerMatch = filter.controllerPredicate?.evaluateWith { leaf ->
+                    when (leaf) {
+                        is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
+                        is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
+                        else -> true
+                    }
+                } ?: true
                 if (!controllerMatch) continue
 
                 // Check excludeSelf

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -50,6 +50,8 @@ import com.wingedsheep.sdk.scripting.events.RecipientFilter
 import com.wingedsheep.sdk.scripting.events.AttackPredicate
 import com.wingedsheep.sdk.scripting.events.SourceFilter
 import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
@@ -667,23 +669,18 @@ class TriggerMatcher(
             // YOUR graveyard from the battlefield" cares about ownership, since a permanent
             // always goes to its owner's graveyard regardless of who last controlled it
             // (CR 400.3, e.g. Soulcatchers' Aerie).
-            if (trigger.filter.controllerPredicate != null) {
+            trigger.filter.controllerPredicate?.let { pred ->
                 val effectiveController = event.lastKnownController ?: event.ownerId
-                when (trigger.filter.controllerPredicate) {
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByYou -> {
-                        if (effectiveController != controllerId) return false
+                val controllerMatches = pred.evaluateWith { leaf ->
+                    when (leaf) {
+                        is ControllerPredicate.ControlledByYou -> effectiveController == controllerId
+                        is ControllerPredicate.ControlledByOpponent -> effectiveController != controllerId
+                        is ControllerPredicate.OwnedByYou -> event.ownerId == controllerId
+                        is ControllerPredicate.OwnedByOpponent -> event.ownerId != controllerId
+                        else -> true
                     }
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByOpponent -> {
-                        if (effectiveController == controllerId) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.OwnedByYou -> {
-                        if (event.ownerId != controllerId) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.OwnedByOpponent -> {
-                        if (event.ownerId == controllerId) return false
-                    }
-                    else -> {}
                 }
+                if (!controllerMatches) return false
             }
         }
 
@@ -950,19 +947,18 @@ class TriggerMatcher(
             // Check controller predicate. Spells on the stack aren't in projected state
             // (only battlefield permanents are), so fall back to the spell's own controller
             // component for spell-target events (Surrak, Elusive Hunter).
-            if (trigger.targetFilter.controllerPredicate != null) {
+            trigger.targetFilter.controllerPredicate?.let { pred ->
                 val targetController = projected.getController(event.targetEntityId)
                     ?: targetContainer.get<SpellOnStackComponent>()?.casterId
                     ?: return false
-                when (trigger.targetFilter.controllerPredicate) {
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByYou -> {
-                        if (targetController != controllerId) return false
+                val controllerMatches = pred.evaluateWith { leaf ->
+                    when (leaf) {
+                        is ControllerPredicate.ControlledByYou -> targetController == controllerId
+                        is ControllerPredicate.ControlledByOpponent -> targetController != controllerId
+                        else -> true
                     }
-                    is com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByOpponent -> {
-                        if (targetController == controllerId) return false
-                    }
-                    else -> {}
                 }
+                if (!controllerMatches) return false
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -541,6 +541,14 @@ class PredicateEvaluator {
         // These predicates are used for cards in graveyards/exile which don't have ControllerComponent —
         // so handle them before the controller lookup below.
         return when (predicate) {
+            is ControllerPredicate.And -> predicate.predicates.all {
+                matchesControllerPredicate(state, projected, entityId, it, context)
+            }
+            is ControllerPredicate.Or -> predicate.predicates.any {
+                matchesControllerPredicate(state, projected, entityId, it, context)
+            }
+            is ControllerPredicate.Not ->
+                !matchesControllerPredicate(state, projected, entityId, predicate.predicate, context)
             ControllerPredicate.OwnedByYou -> {
                 val card = container.get<CardComponent>()
                 card?.ownerId == context.controllerId
@@ -576,7 +584,8 @@ class PredicateEvaluator {
                         referenced?.let { controllerId == it } ?: false
                     }
                     // Already handled above
-                    ControllerPredicate.OwnedByYou, ControllerPredicate.OwnedByOpponent -> true
+                    ControllerPredicate.OwnedByYou, ControllerPredicate.OwnedByOpponent,
+                    is ControllerPredicate.And, is ControllerPredicate.Or, is ControllerPredicate.Not -> true
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -58,6 +58,7 @@ import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 
 /**
  * Result of a zone change redirect check.
@@ -527,23 +528,25 @@ object ZoneMovementUtils {
 
         // Check controller/owner predicate
         val controllerPredicate = filter.controllerPredicate ?: return true
-        return when (controllerPredicate) {
-            ControllerPredicate.OwnedByOpponent -> {
-                val ownerId = cardComponent.ownerId
-                ownerId != null && ownerId != sourceControllerId
+        return controllerPredicate.evaluateWith { leaf ->
+            when (leaf) {
+                ControllerPredicate.OwnedByOpponent -> {
+                    val ownerId = cardComponent.ownerId
+                    ownerId != null && ownerId != sourceControllerId
+                }
+                ControllerPredicate.OwnedByYou -> {
+                    cardComponent.ownerId == sourceControllerId
+                }
+                ControllerPredicate.ControlledByYou -> {
+                    val controllerId = container.get<ControllerComponent>()?.playerId
+                    controllerId == sourceControllerId
+                }
+                ControllerPredicate.ControlledByOpponent -> {
+                    val controllerId = container.get<ControllerComponent>()?.playerId
+                    controllerId != null && controllerId != sourceControllerId
+                }
+                else -> true
             }
-            ControllerPredicate.OwnedByYou -> {
-                cardComponent.ownerId == sourceControllerId
-            }
-            ControllerPredicate.ControlledByYou -> {
-                val controllerId = container.get<ControllerComponent>()?.playerId
-                controllerId == sourceControllerId
-            }
-            ControllerPredicate.ControlledByOpponent -> {
-                val controllerId = container.get<ControllerComponent>()?.playerId
-                controllerId != null && controllerId != sourceControllerId
-            }
-            else -> true
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -410,18 +410,17 @@ class GatedEffectExecutor(
     /**
      * Capture the data the [SuccessCriterion] needs to evaluate the post-action delta.
      *
-     * For [SuccessCriterion.Auto], the probe recognizes two zone-move shapes and records the
-     * destination zone's pre-execution size:
+     * For [SuccessCriterion.Auto], the shape probe is [SuccessCriterion.Auto.canInfer]'s
+     * walkers — the SDK owns them so card-load validation and this snapshot recognize
+     * exactly the same shapes — and the destination zone's pre-execution size is recorded:
      * - a terminal pipeline [MoveCollectionEffect] (multi-object moves), and
      * - a terminal single-target [MoveToZoneEffect] whose target is [EffectTarget.Self]
      *   (e.g. "exile this card from your graveyard. If you do, …" — Council's Deliberation).
      *
      * The collection move is checked first so a pipeline that ends in one keeps its existing
-     * semantics. Single-target moves with a non-Self target aren't resolvable here without full
-     * target resolution, so they (and genuinely non-move actions such as deal-damage / gain-life)
-     * yield an empty snapshot and fall through to the criterion's intrinsic evaluation — for
-     * [SuccessCriterion.Auto] that means [evaluateAuto]'s fail-open default, which is correct for
-     * actions whose "did it happen" isn't a zone delta.
+     * semantics. Shapes the probe rejects are a card-load validation error, so an empty
+     * snapshot here only happens for runtime-unresolvable pieces (a destination player that
+     * doesn't resolve), where [evaluateAuto] treats the action as performed.
      */
     private fun captureSnapshot(
         state: GameState,
@@ -431,16 +430,16 @@ class GatedEffectExecutor(
     ): GatedActionSnapshot {
         if (criterion !is SuccessCriterion.Auto) return GatedActionSnapshot()
 
-        findTerminalMove(action)?.let { move ->
+        SuccessCriterion.Auto.terminalCollectionMove(action)?.let { move ->
             val destination = move.destination as? CardDestination.ToZone ?: return GatedActionSnapshot()
             val ownerId = resolvePlayer(destination.player, context) ?: return GatedActionSnapshot()
             return zoneSnapshot(state, ownerId, destination.zone)
         }
 
-        findTerminalSingleMove(action)?.let { move ->
+        SuccessCriterion.Auto.terminalSingleMove(action)?.let { move ->
             // Only the Self target resolves to a concrete moved entity here; the destination
             // zone is owned by that entity's owner (e.g. self-exile from a graveyard lands in
-            // that card's owner's exile). Other targets fall through to fail-open as before.
+            // that card's owner's exile).
             if (move.target !is EffectTarget.Self) return GatedActionSnapshot()
             val movedId = context.sourceId ?: return GatedActionSnapshot()
             val ownerId = state.getEntity(movedId)?.get<OwnerComponent>()?.playerId ?: return GatedActionSnapshot()
@@ -456,26 +455,6 @@ class GatedEffectExecutor(
             destinationZoneType = zone,
             destinationZonePreSize = state.zones[ZoneKey(ownerId, zone)]?.size ?: 0
         )
-
-    /**
-     * Walk the effect tree for the last [MoveCollectionEffect] in execution order.
-     * Returns null for shapes the auto-probe doesn't recognize.
-     */
-    private fun findTerminalMove(effect: Effect): MoveCollectionEffect? = when (effect) {
-        is MoveCollectionEffect -> effect
-        is CompositeEffect -> effect.effects.asReversed().firstNotNullOfOrNull { findTerminalMove(it) }
-        else -> null
-    }
-
-    /**
-     * Walk the effect tree for the last single-target [MoveToZoneEffect] in execution order.
-     * Returns null for shapes the auto-probe doesn't recognize.
-     */
-    private fun findTerminalSingleMove(effect: Effect): MoveToZoneEffect? = when (effect) {
-        is MoveToZoneEffect -> effect
-        is CompositeEffect -> effect.effects.asReversed().firstNotNullOfOrNull { findTerminalSingleMove(it) }
-        else -> null
-    }
 
     private fun resolvePlayer(player: Player, context: EffectContext): EntityId? = when (player) {
         is Player.You -> context.controllerId
@@ -531,11 +510,10 @@ class GatedEffectExecutor(
             val owner = snapshot.destinationZoneOwner
             val zone = snapshot.destinationZoneType
             if (owner == null || zone == null) {
-                // No zone-move probe was capturable. This is reached only for non-zone-move actions
-                // (deal damage, gain/lose life, draw, …) whose "did it happen" isn't a zone-size
-                // delta — for those, treating the action as performed (fail open) is the correct
-                // default. Zone-move shapes (collection moves and self-target single moves) are
-                // probed in captureSnapshot and never land here.
+                // No zone-move probe was capturable. Card-load validation rejects Auto on action
+                // shapes the probe doesn't recognize, so this is reached only when a recognized
+                // shape couldn't be resolved at runtime (destination player didn't resolve, source
+                // already gone) — treat the action as performed rather than failing mid-resolution.
                 return true
             }
             val postSize = state.zones[ZoneKey(owner, zone)]?.size ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 
 /**
@@ -272,14 +273,17 @@ internal class AffectsFilterResolver {
             val projected = projectedValues[entityId]
 
             // Check controller predicate
-            if (baseFilter.controllerPredicate != null) {
+            baseFilter.controllerPredicate?.let { pred ->
                 val entityController = projectedController(state, entityId, projectedValues)
-                when (baseFilter.controllerPredicate) {
-                    ControllerPredicate.ControlledByYou -> if (entityController != controller) return@filter false
-                    ControllerPredicate.ControlledByOpponent -> if (entityController == controller) return@filter false
-                    ControllerPredicate.ControlledByAny -> { /* matches all */ }
-                    else -> { /* other predicates not applicable in static ability context */ }
+                val controllerMatches = pred.evaluateWith { leaf ->
+                    when (leaf) {
+                        ControllerPredicate.ControlledByYou -> entityController == controller
+                        ControllerPredicate.ControlledByOpponent -> entityController != controller
+                        ControllerPredicate.ControlledByAny -> true
+                        else -> true // other predicates not applicable in static ability context
+                    }
                 }
+                if (!controllerMatches) return@filter false
             }
 
             // Check card predicates using projected values when available

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -904,12 +904,16 @@ class StaticAbilityHandler(
             return AffectsFilter.WithSubtype(subtypePredicate.subtype.value)
         }
 
-        // Handle controller-only filters (no subtype or other complex predicates)
+        // Handle controller-only filters (no subtype or other complex predicates).
+        // Only predicates this fast path understands map to the simple filters; anything
+        // else (composed And/Or/Not, referenced-player, …) must keep full predicate
+        // evaluation via Generic rather than silently widening to AllCreatures.
         if (subtypePredicate == null && !hasAnyOfSubtypes && baseFilter.statePredicates.isEmpty()) {
             return when (controllerPredicate) {
                 ControllerPredicate.ControlledByYou -> AffectsFilter.AllCreaturesYouControl
                 ControllerPredicate.ControlledByOpponent -> AffectsFilter.AllCreaturesOpponentsControl
-                else -> AffectsFilter.AllCreatures
+                null, ControllerPredicate.ControlledByAny -> AffectsFilter.AllCreatures
+                else -> AffectsFilter.Generic(filter)
             }
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ControllerPredicateCombinatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ControllerPredicateCombinatorScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the [ControllerPredicate] combinators (sdk-analysis §1.3):
+ * `And` / `Or` / `Not` must evaluate through [com.wingedsheep.engine.handlers.PredicateEvaluator]
+ * against the *projected* controller, not the base [ControllerComponent].
+ *
+ * The setup steals a creature with Threaten (a `Duration.EndOfTurn` control-changing floating
+ * effect — visible only via state projection; the base ControllerComponent still names the
+ * owner). A combinator that read base state instead of projection would misclassify the stolen
+ * creature in both tests.
+ */
+class ControllerPredicateCombinatorScenarioTest : ScenarioTestBase() {
+
+    // "Destroy all creatures an opponent owns that you control." — And over an owner
+    // leaf and a controller leaf, the heterogeneous shape that used to need anyOf.
+    private val repossessionAudit = card("Repossession Audit") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "Destroy all creatures an opponent owns that you control."
+        spell {
+            effect = Effects.DestroyAll(
+                GameObjectFilter.Creature.withControllerPredicate(
+                    ControllerPredicate.And(
+                        listOf(
+                            ControllerPredicate.OwnedByOpponent,
+                            ControllerPredicate.ControlledByYou,
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    // "Destroy all creatures you don't control." — Not over a controller leaf.
+    private val purgeOfTheUnruled = card("Purge of the Unruled") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "Destroy all creatures you don't control."
+        spell {
+            effect = Effects.DestroyAll(
+                GameObjectFilter.Creature.withControllerPredicate(
+                    ControllerPredicate.Not(ControllerPredicate.ControlledByYou)
+                )
+            )
+        }
+    }
+
+    init {
+        cardRegistry.register(repossessionAudit)
+        cardRegistry.register(purgeOfTheUnruled)
+
+        test("And(OwnedByOpponent, ControlledByYou) destroys only the stolen creature") {
+            val game = scenario()
+                .withPlayers("Thief", "Victim")
+                .withCardOnBattlefield(1, "Glory Seeker")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardInHand(1, "Threaten")
+                .withCardInHand(1, "Repossession Audit")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bearsId = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Threaten", bearsId)
+            game.resolveStack()
+
+            // Stolen: base controller component still says player 2; projection says player 1.
+            game.state.projectedState.getController(bearsId) shouldBe game.player1Id
+
+            game.castSpell(1, "Repossession Audit")
+            game.resolveStack()
+
+            // Only the stolen bears match (owned by an opponent AND controlled by you).
+            game.findPermanent("Grizzly Bears").shouldBeNull()
+            game.findPermanent("Glory Seeker").shouldNotBeNull()   // owned by you
+            game.findPermanent("Hill Giant").shouldNotBeNull()     // not controlled by you
+            game.state.getGraveyard(game.player2Id).size shouldBe 1
+        }
+
+        test("Not(ControlledByYou) spares a creature you only control via projection") {
+            val game = scenario()
+                .withPlayers("Thief", "Victim")
+                .withCardOnBattlefield(1, "Glory Seeker")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardInHand(1, "Threaten")
+                .withCardInHand(1, "Purge of the Unruled")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bearsId = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Threaten", bearsId)
+            game.resolveStack()
+
+            game.castSpell(1, "Purge of the Unruled")
+            game.resolveStack()
+
+            // The stolen bears are controlled by you (projection) — spared. A base-state
+            // read would have destroyed them alongside the Hill Giant.
+            game.findPermanent("Grizzly Bears").shouldNotBeNull()
+            game.findPermanent("Glory Seeker").shouldNotBeNull()
+            game.findPermanent("Hill Giant").shouldBeNull()
+        }
+    }
+}


### PR DESCRIPTION
Implements [§1.3 of the revised SDK plan](../blob/main/backlog/sdk-analysis-2026-06-revised.md) — three small fail-open paths become explicit failures or composable semantics.

## 1. `GameObjectFilter.and` no longer silently discards predicates

AND-ing two filters used to keep only the right side's controller predicate on conflict (`ObjectFilter.kt`), and silently dropped a right-hand `anyOf` union. Both are now `require` failures at filter construction time — since filters are built when card definitions load, the corpus-wide tests surface any violation at build time. The error message points at the explicit alternative (`withControllerPredicate(ControllerPredicate.And(...))`).

## 2. `ControllerPredicate` combinators (`And` / `Or` / `Not`)

Mirrors `StatePredicate`'s existing combinators (`ControllerAnd`/`ControllerOr`/`ControllerNot` serial names). Heterogeneous controller/owner filters — "creatures you own but don't control" — now compose in one predicate instead of needing the `anyOf` escape hatch.

Evaluator support is a shared structural fold, `ControllerPredicate.evaluateWith(leaf)`, next to the predicate type: each engine site keeps only its own leaf semantics (live projected controller, zone-change last-known-controller, grant-provider fast paths) and shares the combinator recursion. Wired through:

- `PredicateEvaluator.matchesControllerPredicate` (explicit recursion, exhaustive `when` kept)
- `TriggerMatcher` (zone-change LKI + targeted-trigger sites)
- `TriggerAbilityResolver` (three grant-resolution sites)
- `ZoneMovementUtils`, `AffectsFilterResolver`
- `StaticAbilityHandler`: the controller fast path now maps unknown predicates to `AffectsFilter.Generic` (full evaluation) instead of silently widening them to `AllCreatures` — the same fail-open class, closed in passing

DSL entry point: `GameObjectFilter.withControllerPredicate(p)`.

## 3. `SuccessCriterion.Auto` rejects shapes it can't infer, at card load

`Gate.DoAction` with the default `Auto` criterion used to score *any* unrecognized action shape as "it happened" (fail open). Now:

- The shape probe is the SDK's single source of truth: `SuccessCriterion.Auto.canInfer` + the terminal-move walkers, which `GatedEffectExecutor` delegates to — the validator and the runtime snapshot recognize exactly the same shapes.
- `CardValidator` walks the card's **serialized JSON tree** to find every `Gate.DoAction` (spell effects, triggered/activated abilities, modes, faces, granted abilities — stale-proof against new effect containers) and errors with "specify an explicit criterion" when `Auto` can't infer.
- `SuccessCriterionValidationTest` (mtg-sets) enforces this corpus-wide at build time. The current corpus is already clean — every existing `IfYouDo` either has an inferable terminal zone move or an explicit criterion, so no card migrations were needed.
- Runtime keeps a graceful fallback only for the genuinely runtime-unresolvable residue (e.g. a destination player that doesn't resolve), which validation can't see statically.

## Tests

- `GameObjectFilterCompositionTest` (mtg-sdk): `and` conflict/anyOf rejection, combinator fold semantics, JSON round-trip, descriptions.
- `CardValidatorTest` additions: uninferable `Auto` flagged (incl. nested inside a mode inside a triggered ability), inferable shapes and explicit criteria accepted.
- `ControllerPredicateCombinatorScenarioTest` (rules-engine): steals a creature with Threaten (control change visible only via projection) and proves `And(OwnedByOpponent, ControlledByYou)` and `Not(ControlledByYou)` evaluate against the *projected* controller — a base-state read fails both tests.
- `SuccessCriterionValidationTest` (mtg-sets): the corpus-wide gate.

Full suite green: 4,218 tests across mtg-sdk / mtg-sets / rules-engine / game-server / mtgish-tooling, 0 failures. Card snapshot goldens unchanged (no serialized forms changed). No mtgish bridge/emitter updates needed: nothing was renamed, and the emitter never renders composed controller predicates.

Docs: `card-sdk-language-reference.md` updated (chained-predicates section + both `SuccessCriterion.Auto` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)