### PR TITLE
De-risk new-set registration (sdk-analysis §5.1)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -34,6 +34,17 @@ class GameBeansConfig(
         // cards from all sets, even those gated out of sealed/draft via game.sets.disabled-by-default.
         // Booster/sealed/draft generation still respects the active-set filter via boosterGenerator.
         for (set in MtgSetCatalog.all) {
+            // A set that contributes nothing has almost always shipped hollow because its
+            // CARDS_PACKAGE constant has a typo — discovery scans the wrong package and silently
+            // returns empty. Turn that worst-case silent failure into a named, immediate error.
+            // (All-reprint sets like Eighth Edition legitimately have no own `cards`, so reprints
+            // and basic lands count too.)
+            check(
+                set.cards.isNotEmpty() || set.printings.isNotEmpty() || set.basicLands.isNotEmpty(),
+            ) {
+                "Set ${set.code} (${set.displayName}) loaded no cards, printings, or basic lands — " +
+                    "typo in its CARDS_PACKAGE?"
+            }
             register(set.cards.stamp(set).withLegalities())
             register(set.basicLands.withLegalities())
             set.basicLandsFallback?.let { register(it.basicLands.withLegalities()) }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -1,256 +1,34 @@
 package com.wingedsheep.mtg.sets
 
-import com.wingedsheep.mtg.sets.definitions.akh.AmonkhetSet
-import com.wingedsheep.mtg.sets.definitions.ala.ShardsOfAlaraSet
-import com.wingedsheep.mtg.sets.definitions.arn.ArabianNightsSet
-import com.wingedsheep.mtg.sets.definitions.avr.AvacynRestoredSet
-import com.wingedsheep.mtg.sets.definitions.bfz.BattleForZendikarSet
-import com.wingedsheep.mtg.sets.definitions.big.TheBigScoreSet
-import com.wingedsheep.mtg.sets.definitions.blb.BloomburrowSet
-import com.wingedsheep.mtg.sets.definitions.blc.BloomburrowCommanderSet
-import com.wingedsheep.mtg.sets.definitions.bro.BrothersWarSet
-import com.wingedsheep.mtg.sets.definitions.c15.Commander2015Set
-import com.wingedsheep.mtg.sets.definitions.c17.Commander2017Set
-import com.wingedsheep.mtg.sets.definitions.`8ed`.EighthEditionSet
-import com.wingedsheep.mtg.sets.definitions.apc.ApocalypseSet
-import com.wingedsheep.mtg.sets.definitions.atq.AntiquitiesSet
-import com.wingedsheep.mtg.sets.definitions.mmq.MercadianMasquesSet
-import com.wingedsheep.mtg.sets.definitions.nem.NemesisSet
-import com.wingedsheep.mtg.sets.definitions.pcy.ProphecySet
-import com.wingedsheep.mtg.sets.definitions.pls.PlaneshiftSet
-import com.wingedsheep.mtg.sets.definitions.ptk.PortalThreeKingdomsSet
-import com.wingedsheep.mtg.sets.definitions.s99.Starter1999Set
-import com.wingedsheep.mtg.sets.definitions.sth.StrongholdSet
-import com.wingedsheep.mtg.sets.definitions.tor.TormentSet
-import com.wingedsheep.mtg.sets.definitions.uds.UrzasDestinySet
-import com.wingedsheep.mtg.sets.definitions.ulg.UrzasLegacySet
-import com.wingedsheep.mtg.sets.definitions.cmd.Commander2011Set
-import com.wingedsheep.mtg.sets.definitions.cmr.CommanderLegendsSet
-import com.wingedsheep.mtg.sets.definitions.`5dn`.FifthDawnSet
-import com.wingedsheep.mtg.sets.definitions.aer.AetherRevoltSet
-import com.wingedsheep.mtg.sets.definitions.c14.Commander2014Set
-import com.wingedsheep.mtg.sets.definitions.chk.ChampionsOfKamigawaSet
-import com.wingedsheep.mtg.sets.definitions.csp.ColdsnapSet
-import com.wingedsheep.mtg.sets.definitions.dis.DissensionSet
-import com.wingedsheep.mtg.sets.definitions.emn.EldritchMoonSet
-import com.wingedsheep.mtg.sets.definitions.gtc.GatecrashSet
-import com.wingedsheep.mtg.sets.definitions.isd.InnistradSet
-import com.wingedsheep.mtg.sets.definitions.jou.JourneyIntoNyxSet
-import com.wingedsheep.mtg.sets.definitions.kld.KaladeshSet
-import com.wingedsheep.mtg.sets.definitions.m11.Magic2011Set
-import com.wingedsheep.mtg.sets.definitions.m13.Magic2013Set
-import com.wingedsheep.mtg.sets.definitions.m15.Magic2015Set
-import com.wingedsheep.mtg.sets.definitions.m19.CoreSet2019Set
-import com.wingedsheep.mtg.sets.definitions.m20.CoreSet2020Set
-import com.wingedsheep.mtg.sets.definitions.ogw.OathOfTheGatewatchSet
-import com.wingedsheep.mtg.sets.definitions.ori.MagicOriginsSet
-import com.wingedsheep.mtg.sets.definitions.pc2.Planechase2012Set
-import com.wingedsheep.mtg.sets.definitions.plc.PlanarChaosSet
-import com.wingedsheep.mtg.sets.definitions.rtr.ReturnToRavnicaSet
-import com.wingedsheep.mtg.sets.definitions.shm.ShadowmoorSet
-import com.wingedsheep.mtg.sets.definitions.ths.TherosSet
-import com.wingedsheep.mtg.sets.definitions.zen.ZendikarSet
-import com.wingedsheep.mtg.sets.definitions.con.ConfluxSet
-import com.wingedsheep.mtg.sets.definitions.dft.AetherdriftSet
-import com.wingedsheep.mtg.sets.definitions.dtk.DragonsOfTarkirSet
-import com.wingedsheep.mtg.sets.definitions.dom.DominariaSet
-import com.wingedsheep.mtg.sets.definitions.dmu.DominariaUnitedSet
-import com.wingedsheep.mtg.sets.definitions.dsk.DuskmournSet
-import com.wingedsheep.mtg.sets.definitions.gpt.GuildpactSet
-import com.wingedsheep.mtg.sets.definitions.m10.Magic2010Set
-import com.wingedsheep.mtg.sets.definitions.m12.Magic2012Set
-import com.wingedsheep.mtg.sets.definitions.m14.Magic2014Set
-import com.wingedsheep.mtg.sets.definitions.m21.CoreSet2021Set
-import com.wingedsheep.mtg.sets.definitions.ody.OdysseySet
-import com.wingedsheep.mtg.sets.definitions.tsp.TimeSpiralSet
-import com.wingedsheep.mtg.sets.definitions.eoe.EdgeOfEternitiesSet
-import com.wingedsheep.mtg.sets.definitions.exo.ExodusSet
-import com.wingedsheep.mtg.sets.definitions.fdn.FoundationsSet
-import com.wingedsheep.mtg.sets.definitions.frf.FateReforgedSet
-import com.wingedsheep.mtg.sets.definitions.fin.FinalFantasySet
-import com.wingedsheep.mtg.sets.definitions.inr.InnistradRemasteredSet
-import com.wingedsheep.mtg.sets.definitions.inv.InvasionSet
-import com.wingedsheep.mtg.sets.definitions.jud.JudgmentSet
-import com.wingedsheep.mtg.sets.definitions.mid.InnistradMidnightHuntSet
-import com.wingedsheep.mtg.sets.definitions.vow.InnistradCrimsonVowSet
-import com.wingedsheep.mtg.sets.definitions.khm.KaldheimSet
-import com.wingedsheep.mtg.sets.definitions.ktk.KhansOfTarkirSet
-import com.wingedsheep.mtg.sets.definitions.lea.AlphaSet
-import com.wingedsheep.mtg.sets.definitions.leg.LegendsSet
-import com.wingedsheep.mtg.sets.definitions.lgn.LegionsSet
-import com.wingedsheep.mtg.sets.definitions.lrw.LorwynSet
-import com.wingedsheep.mtg.sets.definitions.ecl.LorwynEclipsedSet
-import com.wingedsheep.mtg.sets.definitions.lci.LostCavernsOfIxalanSet
-import com.wingedsheep.mtg.sets.definitions.ltr.LordOfTheRingsSet
-import com.wingedsheep.mtg.sets.definitions.mbs.MirrodinBesiegedSet
-import com.wingedsheep.mtg.sets.definitions.mir.MirageSet
-import com.wingedsheep.mtg.sets.definitions.mrd.MirrodinSet
-import com.wingedsheep.mtg.sets.definitions.mkm.MurdersAtKarlovManorSet
-import com.wingedsheep.mtg.sets.definitions.mom.MarchOfTheMachineSet
-import com.wingedsheep.mtg.sets.definitions.ncc.NewCapennaCommanderSet
-import com.wingedsheep.mtg.sets.definitions.one.PhyrexiaAllWillBeOneSet
-import com.wingedsheep.mtg.sets.definitions.ons.OnslaughtSet
-import com.wingedsheep.mtg.sets.definitions.p02.PortalSecondAgeSet
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
-import com.wingedsheep.mtg.sets.definitions.pz2.TreasureChestSet
-import com.wingedsheep.mtg.sets.definitions.rix.RivalsOfIxalanSet
-import com.wingedsheep.mtg.sets.definitions.rav.RavnicaCityOfGuildsSet
-import com.wingedsheep.mtg.sets.definitions.rna.RavnicaAllegianceSet
-import com.wingedsheep.mtg.sets.definitions.xln.IxalanSet
-import com.wingedsheep.mtg.sets.definitions.roe.RiseOfTheEldraziSet
-import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
-import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
-import com.wingedsheep.mtg.sets.definitions.stx.StrixhavenSchoolOfMagesSet
-import com.wingedsheep.mtg.sets.definitions.sos.SecretsOfStrixhavenSet
-import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
-import com.wingedsheep.mtg.sets.definitions.usg.UrzasSagaSet
-import com.wingedsheep.mtg.sets.definitions.vis.VisionsSet
-import com.wingedsheep.mtg.sets.definitions.wth.WeatherlightSet
-import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
-import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
-import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
-import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
-import com.wingedsheep.mtg.sets.definitions.tmt.TeenageMutantNinjaTurtlesSet
-import com.wingedsheep.mtg.sets.definitions.war.WarOfTheSparkSet
-import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
-import com.wingedsheep.mtg.sets.definitions.wwk.WorldwakeSet
-import com.wingedsheep.mtg.sets.definitions.drk.TheDarkSet
-import com.wingedsheep.mtg.sets.definitions.hml.HomelandsSet
-import com.wingedsheep.mtg.sets.definitions.all.AlliancesSet
-import com.wingedsheep.mtg.sets.definitions.ice.IceAgeSet
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.MtgSet
 
 /**
  * Single source of truth for all known MTG sets.
  *
- * Adding a new set: implement [MtgSet] and append the object to [all].
- * The game-server, gym, and tests discover sets through this catalog —
- * no other registration is required.
+ * The catalog is auto-discovered: every [MtgSet] `object` declared anywhere under
+ * [DEFINITIONS_PACKAGE] is found on the classpath via [CardDiscovery.findSets]. Adding a new set
+ * is therefore just implementing [MtgSet] in its `definitions/<set>/` package — no import block to
+ * extend and no list to append to (the two places that used to be easy to forget). Sets are
+ * ordered chronologically by [MtgSet.releaseDate] (sets without a date sort last), then by [code]
+ * for a stable, deterministic order regardless of classpath scan order.
+ *
+ * The game-server, gym, and tests discover sets through this catalog — no other registration
+ * is required.
  */
 object MtgSetCatalog {
 
-    val all: List<MtgSet> = listOf(
-        AlphaSet,
-        EighthEditionSet,
-        AntiquitiesSet,
-        StrongholdSet,
-        UrzasLegacySet,
-        UrzasDestinySet,
-        MercadianMasquesSet,
-        NemesisSet,
-        ProphecySet,
-        PlaneshiftSet,
-        ApocalypseSet,
-        TormentSet,
-        PortalThreeKingdomsSet,
-        Starter1999Set,
-        ArabianNightsSet,
-        LegendsSet,
-        TheDarkSet,
-        IceAgeSet,
-        HomelandsSet,
-        AlliancesSet,
-        PortalSet,
-        PortalSecondAgeSet,
-        MirageSet,
-        VisionsSet,
-        WeatherlightSet,
-        TempestSet,
-        ExodusSet,
-        UrzasSagaSet,
-        InvasionSet,
-        LorwynSet,
-        KaldheimSet,
-        OnslaughtSet,
-        ScourgeSet,
-        LegionsSet,
-        KhansOfTarkirSet,
-        FateReforgedSet,
-        DragonsOfTarkirSet,
-        MirrodinSet,
-        MirrodinBesiegedSet,
-        RiseOfTheEldraziSet,
-        AvacynRestoredSet,
-        DominariaSet,
-        DominariaUnitedSet,
-        PhyrexiaAllWillBeOneSet,
-        BrothersWarSet,
-        Commander2011Set,
-        CommanderLegendsSet,
-        FifthDawnSet,
-        AetherRevoltSet,
-        Commander2014Set,
-        ChampionsOfKamigawaSet,
-        ColdsnapSet,
-        DissensionSet,
-        EldritchMoonSet,
-        GatecrashSet,
-        InnistradSet,
-        JourneyIntoNyxSet,
-        KaladeshSet,
-        Magic2011Set,
-        Magic2013Set,
-        Magic2015Set,
-        CoreSet2019Set,
-        CoreSet2020Set,
-        OathOfTheGatewatchSet,
-        MagicOriginsSet,
-        Planechase2012Set,
-        PlanarChaosSet,
-        ReturnToRavnicaSet,
-        ShadowmoorSet,
-        TherosSet,
-        ZendikarSet,
-        Commander2015Set,
-        TreasureChestSet,
-        Commander2017Set,
-        InnistradRemasteredSet,
-        InnistradMidnightHuntSet,
-        InnistradCrimsonVowSet,
-        MarchOfTheMachineSet,
-        NewCapennaCommanderSet,
-        MurdersAtKarlovManorSet,
-        WildsOfEldrainSet,
-        IxalanSet,
-        RivalsOfIxalanSet,
-        LostCavernsOfIxalanSet,
-        BloomburrowSet,
-        BloomburrowCommanderSet,
-        FoundationsSet,
-        FinalFantasySet,
-        DuskmournSet,
-        AetherdriftSet,
-        EdgeOfEternitiesSet,
-        LorwynEclipsedSet,
-        OutlawsOfThunderJunctionSet,
-        TheBigScoreSet,
-        SpiderManSet,
-        TarkirDragonstormSet,
-        AvatarTheLastAirbenderSet,
-        TeenageMutantNinjaTurtlesSet,
-        WarOfTheSparkSet,
-        RavnicaCityOfGuildsSet,
-        RavnicaAllegianceSet,
-        OdysseySet,
-        JudgmentSet,
-        GuildpactSet,
-        TimeSpiralSet,
-        ConfluxSet,
-        ShardsOfAlaraSet,
-        Magic2010Set,
-        Magic2012Set,
-        Magic2014Set,
-        CoreSet2021Set,
-        BattleForZendikarSet,
-        AmonkhetSet,
-        ShadowsOverInnistradSet,
-        WorldwakeSet,
-        LordOfTheRingsSet,
-        StrixhavenSchoolOfMagesSet,
-        SecretsOfStrixhavenSet,
-    )
+    private const val DEFINITIONS_PACKAGE = "com.wingedsheep.mtg.sets.definitions"
 
-    private val byCode: Map<String, MtgSet> = all.associateBy { it.code }
+    /** Sorts after any real ISO `YYYY-MM-DD` release date, so undated sets land at the end. */
+    private const val UNKNOWN_DATE_SENTINEL = "9999-99-99"
+
+    val all: List<MtgSet> by lazy {
+        CardDiscovery.findSets(DEFINITIONS_PACKAGE)
+            .sortedWith(compareBy({ it.releaseDate ?: UNKNOWN_DATE_SENTINEL }, { it.code }))
+    }
+
+    private val byCode: Map<String, MtgSet> by lazy { all.associateBy { it.code } }
 
     fun byCode(code: String): MtgSet? = byCode[code]
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/5dn/FifthDawnSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/5dn/FifthDawnSet.kt
@@ -28,7 +28,7 @@ object FifthDawnSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/EighthEditionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/EighthEditionSet.kt
@@ -28,7 +28,7 @@ object EighthEditionSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/AetherRevoltSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/AetherRevoltSet.kt
@@ -28,7 +28,7 @@ object AetherRevoltSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/AlliancesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/AlliancesSet.kt
@@ -27,7 +27,7 @@ object AlliancesSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/BloomburrowSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/BloomburrowSet.kt
@@ -28,7 +28,7 @@ object BloomburrowSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/BloomburrowCommanderSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/BloomburrowCommanderSet.kt
@@ -26,7 +26,7 @@ object BloomburrowCommanderSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/Commander2014Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/Commander2014Set.kt
@@ -27,7 +27,7 @@ object Commander2014Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/ChampionsOfKamigawaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/ChampionsOfKamigawaSet.kt
@@ -28,7 +28,7 @@ object ChampionsOfKamigawaSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/CommanderLegendsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/CommanderLegendsSet.kt
@@ -32,7 +32,7 @@ object CommanderLegendsSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/ColdsnapSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/ColdsnapSet.kt
@@ -28,7 +28,7 @@ object ColdsnapSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dis/DissensionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dis/DissensionSet.kt
@@ -28,7 +28,7 @@ object DissensionSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/DominariaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/DominariaSet.kt
@@ -32,7 +32,7 @@ object DominariaSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/TheDarkSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/TheDarkSet.kt
@@ -26,7 +26,7 @@ object TheDarkSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/LorwynEclipsedSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/LorwynEclipsedSet.kt
@@ -31,7 +31,7 @@ object LorwynEclipsedSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/EldritchMoonSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/EldritchMoonSet.kt
@@ -28,7 +28,7 @@ object EldritchMoonSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/EdgeOfEternitiesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/EdgeOfEternitiesSet.kt
@@ -24,7 +24,7 @@ object EdgeOfEternitiesSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/GatecrashSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/GatecrashSet.kt
@@ -28,7 +28,7 @@ object GatecrashSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hml/HomelandsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hml/HomelandsSet.kt
@@ -26,7 +26,7 @@ object HomelandsSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/IceAgeSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/IceAgeSet.kt
@@ -27,7 +27,7 @@ object IceAgeSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/InvasionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/InvasionSet.kt
@@ -27,7 +27,7 @@ object InvasionSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/InnistradSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/InnistradSet.kt
@@ -28,7 +28,7 @@ object InnistradSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/JourneyIntoNyxSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/JourneyIntoNyxSet.kt
@@ -28,7 +28,7 @@ object JourneyIntoNyxSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/KaladeshSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/KaladeshSet.kt
@@ -28,7 +28,7 @@ object KaladeshSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/KhansOfTarkirSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/KhansOfTarkirSet.kt
@@ -27,7 +27,7 @@ object KhansOfTarkirSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/LegendsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/LegendsSet.kt
@@ -27,7 +27,7 @@ object LegendsSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/Magic2011Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/Magic2011Set.kt
@@ -27,7 +27,7 @@ object Magic2011Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/Magic2013Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/Magic2013Set.kt
@@ -27,7 +27,7 @@ object Magic2013Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/Magic2015Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/Magic2015Set.kt
@@ -27,7 +27,7 @@ object Magic2015Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/CoreSet2019Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/CoreSet2019Set.kt
@@ -27,7 +27,7 @@ object CoreSet2019Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/CoreSet2020Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/CoreSet2020Set.kt
@@ -27,7 +27,7 @@ object CoreSet2020Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/OathOfTheGatewatchSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/OathOfTheGatewatchSet.kt
@@ -28,7 +28,7 @@ object OathOfTheGatewatchSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/OnslaughtSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/OnslaughtSet.kt
@@ -27,7 +27,7 @@ object OnslaughtSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ons.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/MagicOriginsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/MagicOriginsSet.kt
@@ -27,7 +27,7 @@ object MagicOriginsSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/PortalSecondAgeSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/PortalSecondAgeSet.kt
@@ -27,7 +27,7 @@ object PortalSecondAgeSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/Planechase2012Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/Planechase2012Set.kt
@@ -27,7 +27,7 @@ object Planechase2012Set : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/plc/PlanarChaosSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/plc/PlanarChaosSet.kt
@@ -28,7 +28,7 @@ object PlanarChaosSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/PortalSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/PortalSet.kt
@@ -27,7 +27,7 @@ object PortalSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/RavnicaCityOfGuildsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/RavnicaCityOfGuildsSet.kt
@@ -24,7 +24,7 @@ object RavnicaCityOfGuildsSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/ReturnToRavnicaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/ReturnToRavnicaSet.kt
@@ -28,7 +28,7 @@ object ReturnToRavnicaSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/ShadowmoorSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/ShadowmoorSet.kt
@@ -28,7 +28,7 @@ object ShadowmoorSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
@@ -23,7 +23,7 @@ object TarkirDragonstormSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/TherosSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/TherosSet.kt
@@ -28,7 +28,7 @@ object TherosSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
@@ -24,7 +24,7 @@ object TeenageMutantNinjaTurtlesSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/ZendikarSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/ZendikarSet.kt
@@ -28,7 +28,7 @@ object ZendikarSet : MtgSet {
     }
 
     override val basicLands: List<CardDefinition> by lazy {
-        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/discovery/CardDiscovery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/discovery/CardDiscovery.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.discovery
 
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
 import io.github.classgraph.ClassGraph
 import java.lang.reflect.Modifier
@@ -27,10 +28,16 @@ import java.util.concurrent.ConcurrentHashMap
  * `val FooBasicLands = listOf(...)` are skipped automatically because their field type
  * is `List<CardDefinition>`, not `CardDefinition`.
  *
- * `setCode` is **not** stamped here. Today, `cards` are stamped centrally at registry-load
- * time (`GameBeansConfig.stamp(...)`), and `basicLands` are stamped by each set via
- * `.copy(setCode = code)`. Discovery preserves both behaviors — call sites stamp as they
- * do today. Printings already carry their own `setCode` so no stamping is needed.
+ * `cards` are stamped with their `setCode` centrally at registry-load time
+ * (`GameBeansConfig.stamp(...)`), so [findIn] returns them unstamped. `basicLands`, on the
+ * other hand, are consumed directly off `MtgSet.basicLands` by the booster/sealed/random-deck
+ * paths (which never go through the card registry and key land identifiers on `setCode`), so
+ * they must carry their `setCode` at the source: use the [findBasicLandsIn] overload that takes
+ * a `setCode` to stamp them in one place instead of each set repeating `.copy(setCode = code)`.
+ * Printings already carry their own `setCode` so no stamping is needed.
+ *
+ * [findSets] discovers the set objects themselves the same way, so `MtgSetCatalog` no longer has
+ * to hand-maintain an import block plus a parallel list — both of which were easy to forget.
  */
 object CardDiscovery {
 
@@ -48,8 +55,41 @@ object CardDiscovery {
     fun findBasicLandsIn(packageName: String): List<CardDefinition> =
         cache.getOrPut(packageName) { scan(packageName) }.basicLands
 
+    /**
+     * Like [findBasicLandsIn], but stamps each variant with [setCode]. This is the single place
+     * basic lands get their set identity — sets call this instead of repeating
+     * `.copy(setCode = code)`, so the stamp can't drift between sets and consumers that read
+     * `MtgSet.basicLands` directly (booster/sealed/random-deck) always see a set-stamped land.
+     */
+    fun findBasicLandsIn(packageName: String, setCode: String): List<CardDefinition> =
+        findBasicLandsIn(packageName).map { it.copy(setCode = setCode) }
+
     fun findPrintingsIn(packageName: String): List<Printing> =
         cache.getOrPut(packageName) { scan(packageName) }.printings
+
+    /**
+     * Auto-discovers every [MtgSet] implementation under [packageName] (recursively), so the
+     * set catalog is a view over the classpath instead of a hand-maintained import block + list.
+     *
+     * Every set is declared as a Kotlin `object`, which compiles to a class carrying a public
+     * static `INSTANCE` field — that's the singleton we read. Non-object implementations (none
+     * today) are skipped: they have no `INSTANCE`, and a set with no stable singleton has no
+     * place in the catalog. Ordering is non-deterministic here; callers sort.
+     */
+    fun findSets(packageName: String): List<MtgSet> =
+        ClassGraph()
+            .acceptPackages(packageName)
+            .enableClassInfo()
+            .scan()
+            .use { scanResult ->
+                scanResult.getClassesImplementing(MtgSet::class.java.name)
+                    .filter { !it.isInterface && !it.isAbstract }
+                    .mapNotNull { classInfo ->
+                        val cls = runCatching { classInfo.loadClass() }.getOrNull()
+                            ?: return@mapNotNull null
+                        runCatching { cls.getField("INSTANCE").get(null) as? MtgSet }.getOrNull()
+                    }
+            }
 
     private fun scan(packageName: String): ScannedPackage {
         val cards = mutableListOf<CardDefinition>()

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalogTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalogTest.kt
@@ -1,16 +1,24 @@
 package com.wingedsheep.mtg.sets
 
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlin.io.path.name
 import kotlin.io.path.readText
 
 class MtgSetCatalogTest : FunSpec({
 
-    test("every <Name>Set.kt under definitions is registered in MtgSetCatalog.all") {
+    // Guards auto-discovery: every `*Set.kt` on disk must surface in MtgSetCatalog.all (built by
+    // CardDiscovery.findSets). A set declared as something other than an `object`, or otherwise
+    // missed by the classpath scan, would silently vanish from the catalog — this catches it.
+    test("every <Name>Set.kt under definitions is discovered into MtgSetCatalog.all") {
         val definitionsDir = Paths.get(
             "src/main/kotlin/com/wingedsheep/mtg/sets/definitions"
         ).toAbsolutePath()
@@ -37,5 +45,35 @@ class MtgSetCatalogTest : FunSpec({
             .filterValues { it.size > 1 }
             .keys
         duplicates.shouldBeEmpty()
+    }
+
+    // The same hollow-set failure GameBeansConfig guards at server boot, caught here in CI: a set
+    // that contributes no cards, printings, or basic lands has almost always typo'd its
+    // CARDS_PACKAGE. (All-reprint sets like Eighth Edition have no own cards but do carry printings.)
+    test("no registered set is hollow") {
+        assertSoftly {
+            for (set in MtgSetCatalog.all) {
+                withClue("${set.code} (${set.displayName})") {
+                    val hasContent = set.cards.isNotEmpty() ||
+                        set.printings.isNotEmpty() ||
+                        set.basicLands.isNotEmpty()
+                    hasContent shouldBe true
+                }
+            }
+        }
+    }
+
+    test("release dates, when present, are parseable ISO YYYY-MM-DD") {
+        assertSoftly {
+            for (set in MtgSetCatalog.all) {
+                val date = set.releaseDate ?: continue
+                withClue("${set.code} releaseDate=$date") {
+                    val parsed = runCatching {
+                        LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE)
+                    }.isSuccess
+                    parsed shouldBe true
+                }
+            }
+        }
     }
 })


### PR DESCRIPTION
Implements **§5.1 De-risk new-set registration** from `backlog/sdk-analysis-2026-06-revised.md` — three silent failure modes in set registration, three fixes.

## 1. Auto-discover sets the way cards are discovered
`CardDiscovery.findSets(pkg)` scans the classpath for `MtgSet` implementations via ClassGraph (every set is a Kotlin `object`, so it reads the synthetic `INSTANCE` field — no kotlin-reflect dependency). `MtgSetCatalog.all` becomes a `by lazy` view over it, sorted deterministically by `(releaseDate, code)` so classpath scan order doesn't leak through.

This deletes the hand-maintained **118-line import block + parallel `listOf(...)`** — the two places you had to remember to touch when adding a set, and which silently shipped a set "missing" if you forgot.

## 2. Zero content = hard error
The registry-load loop in `GameBeansConfig.cardRegistry()` now `check()`s that each set contributes **cards, printings, or basic lands**. A typo in a set's `CARDS_PACKAGE` makes discovery scan the wrong package and return empty — previously the set just shipped hollow. Now it's a named, immediate error. (All-reprint sets like Eighth Edition legitimately have no own `cards`, so printings/basics count.)

`MtgSetCatalogTest` gains the same hollow-set guard (so it fails in CI, not just at server boot), plus assertions that release dates parse as ISO `YYYY-MM-DD`. The existing "every `*Set.kt` is registered" test now meaningfully guards that auto-discovery is complete.

## 3. Stamp basic-land `setCode` in one place
The 44 copies of `findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }` collapse to a single `CardDiscovery.findBasicLandsIn(pkg, setCode)` overload.

**Note on placement:** the analysis suggested stamping basics in the registry-load pass alongside cards. I kept the stamp at the *source* instead, because the booster/sealed/random-deck paths read `MtgSet.basicLands` **directly** (not through the card registry), and `BoosterGenerator.distributeBasicLandVariants` keys land identifiers on `setCode` (`"Plains#${setCode}-$cn"`). Moving the stamp to the registry-only pass would have left those consumers with `setCode = null` and degraded cross-set basic-land disambiguation. Centralizing into one discovery helper achieves the stated goal (delete the per-set boilerplate, one stamp point) while preserving behavior for every consumer.

## Verification
- `:mtg-sets:test` (full suite) green — including `CardDefinitionSnapshotTest` (basics produce byte-identical stamped output → no snapshot churn) and `CardDiscoveryEquivalenceTest`.
- New/updated `MtgSetCatalogTest`: discovery completeness, unique codes, no hollow set, parseable dates — all pass.
- Compiles clean across all `MtgSetCatalog` consumers: `game-server`, `gym-server`, `mtgish-tooling`, `rules-engine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)