### PR TITLE
Add LTR basic lands + golden Ring-bearer icon

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/LordOfTheRingsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/LordOfTheRingsSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.ltr
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -22,12 +21,15 @@ object LordOfTheRingsSet : MtgSet {
     override val code = "LTR"
     override val displayName = "The Lord of the Rings: Tales of Middle-earth"
     override val releaseDate = "2023-06-23"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
     override val sealedSupported = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ltr.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LordOfTheRingsBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LordOfTheRingsBasicLands.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * The Lord of the Rings: Tales of Middle-earth Basic Lands
+ *
+ * The main set numbers 262-281 carry two art treatments of each basic land type:
+ * cards 262-271 are the regular booster basics (2 art variants per type) and
+ * cards 272-281 are the full-art "Middle-earth map" basics by Deven Rue (2 per type).
+ */
+
+// =============================================================================
+// Plains (Cards 262-263, 272-273)
+// =============================================================================
+
+val LordOfTheRingsPlains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Tomáš Honz"
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg?1686970429"
+}
+
+val LordOfTheRingsPlains263 = basicLand("Plains") {
+    collectorNumber = "263"
+    artist = "Constantin Marin"
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5bb495cc-9908-455e-bec9-3993d595f4f9.jpg?1686970443"
+}
+
+val LordOfTheRingsPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4ff9fbf5-de6f-4ef9-a6ab-56da4b341b77.jpg?1686970554"
+}
+
+val LordOfTheRingsPlains273 = basicLand("Plains") {
+    collectorNumber = "273"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/8538a97f-302d-468a-8a6c-50c800d614e5.jpg?1686970566"
+}
+
+// =============================================================================
+// Island (Cards 264-265, 274-275)
+// =============================================================================
+
+val LordOfTheRingsIsland264 = basicLand("Island") {
+    collectorNumber = "264"
+    artist = "Tomáš Honz"
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg?1686970455"
+}
+
+val LordOfTheRingsIsland265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Constantin Marin"
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/671516eb-b088-4a15-aec9-1781ca016e11.jpg?1686970468"
+}
+
+val LordOfTheRingsIsland274 = basicLand("Island") {
+    collectorNumber = "274"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eba0c7c5-ed63-41a5-93e1-a979a6f983b9.jpg?1686970579"
+}
+
+val LordOfTheRingsIsland275 = basicLand("Island") {
+    collectorNumber = "275"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8fee8302-39ca-43c3-b139-62e591559306.jpg?1686970591"
+}
+
+// =============================================================================
+// Swamp (Cards 266-267, 276-277)
+// =============================================================================
+
+val LordOfTheRingsSwamp266 = basicLand("Swamp") {
+    collectorNumber = "266"
+    artist = "Shahab Alizadeh"
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg?1686970481"
+}
+
+val LordOfTheRingsSwamp267 = basicLand("Swamp") {
+    collectorNumber = "267"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d86cd8fb-4ba7-4311-b0f3-b06fa112eda5.jpg?1686970493"
+}
+
+val LordOfTheRingsSwamp276 = basicLand("Swamp") {
+    collectorNumber = "276"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b5f68bc-1842-4efd-b85a-d897cfd63bde.jpg?1686970604"
+}
+
+val LordOfTheRingsSwamp277 = basicLand("Swamp") {
+    collectorNumber = "277"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d412d727-4fe8-4c21-a2cb-609395935dd8.jpg?1686970616"
+}
+
+// =============================================================================
+// Mountain (Cards 268-269, 278-279)
+// =============================================================================
+
+val LordOfTheRingsMountain268 = basicLand("Mountain") {
+    collectorNumber = "268"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg?1686970505"
+}
+
+val LordOfTheRingsMountain269 = basicLand("Mountain") {
+    collectorNumber = "269"
+    artist = "Marco Gorlei"
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adf13285-d127-4534-9f49-aa86914da175.jpg?1686970519"
+}
+
+val LordOfTheRingsMountain278 = basicLand("Mountain") {
+    collectorNumber = "278"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b1902b98-7579-4b7a-8cb8-9bd0e0da5f67.jpg?1686970629"
+}
+
+val LordOfTheRingsMountain279 = basicLand("Mountain") {
+    collectorNumber = "279"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/af1b83d9-078b-44dc-a118-4659201f4854.jpg?1686970641"
+}
+
+// =============================================================================
+// Forest (Cards 270-271, 280-281)
+// =============================================================================
+
+val LordOfTheRingsForest270 = basicLand("Forest") {
+    collectorNumber = "270"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg?1686970531"
+}
+
+val LordOfTheRingsForest271 = basicLand("Forest") {
+    collectorNumber = "271"
+    artist = "Tomáš Honz"
+    imageUri = "https://cards.scryfall.io/normal/front/0/7/07264de1-4322-4adb-8f08-c0aa236747c7.jpg?1686970543"
+}
+
+val LordOfTheRingsForest280 = basicLand("Forest") {
+    collectorNumber = "280"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2f5b488e-d725-4ef7-90f4-71091325c0b6.jpg?1686970652"
+}
+
+val LordOfTheRingsForest281 = basicLand("Forest") {
+    collectorNumber = "281"
+    artist = "Deven Rue"
+    imageUri = "https://cards.scryfall.io/normal/front/3/e/3efeaa30-9db9-4e68-a658-9064d6e67516.jpg?1686970665"
+}
+
+/**
+ * All Lord of the Rings basic land variants.
+ */
+val LordOfTheRingsBasicLands = listOf(
+    LordOfTheRingsPlains262, LordOfTheRingsPlains263, LordOfTheRingsPlains272, LordOfTheRingsPlains273,
+    LordOfTheRingsIsland264, LordOfTheRingsIsland265, LordOfTheRingsIsland274, LordOfTheRingsIsland275,
+    LordOfTheRingsSwamp266, LordOfTheRingsSwamp267, LordOfTheRingsSwamp276, LordOfTheRingsSwamp277,
+    LordOfTheRingsMountain268, LordOfTheRingsMountain269, LordOfTheRingsMountain278, LordOfTheRingsMountain279,
+    LordOfTheRingsForest270, LordOfTheRingsForest271, LordOfTheRingsForest280, LordOfTheRingsForest281,
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -190,6 +190,14 @@ data class ClientCard(
      */
     val isCommander: Boolean = false,
 
+    /**
+     * True iff this permanent carries `RingBearerComponent` — i.e. it is its controller's
+     * Ring-bearer (CR 701.54). Battlefield only; the designation is stripped on a real control
+     * change so a token/stolen permanent never falsely shows it. Lets the UI render a prominent
+     * golden Ring icon on the bearer.
+     */
+    val isRingBearer: Boolean = false,
+
     /** Zone this card is currently in */
     val zone: ZoneKey?,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -871,6 +871,12 @@ class ClientStateTransformer(
         // (CR 903.10a) so this is naturally false on token clones.
         val isCommander = container.has<com.wingedsheep.engine.state.components.identity.CommanderComponent>()
 
+        // Ring-bearer flag — surfaced so the UI can render a prominent golden Ring icon on the
+        // creature a player designated as their Ring-bearer (CR 701.54). The designation is stripped
+        // on a real control change (see RingBearerComponent), so the presence of the component is
+        // enough — a stolen permanent or token copy never falsely carries it.
+        val isRingBearer = container.has<com.wingedsheep.engine.state.components.identity.RingBearerComponent>()
+
         // Get targets for spells/abilities on stack (for targeting arrows)
         val targetsComponent = container.get<TargetsComponent>()
         val targets = targetsComponent?.targets?.mapNotNull { chosenTarget ->
@@ -1059,6 +1065,7 @@ class ClientStateTransformer(
             ownerId = ownerId,
             isToken = isToken,
             isCommander = isCommander,
+            isRingBearer = isRingBearer,
             zone = zoneKey,
             attachedTo = attachedTo,
             attachments = attachments,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.state.components.identity.RingBearerComponent
 import com.wingedsheep.engine.state.components.player.TheRingComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Effects
@@ -100,6 +101,22 @@ class TheRingScenarioTest : FunSpec({
         driver.state.getEntity(active)?.get<TheRingComponent>()?.temptCount shouldBe 1
         driver.state.getEntity(bear)?.get<RingBearerComponent>()?.ownerId shouldBe active
         projector.project(driver.state).isLegendary(bear) shouldBe true
+    }
+
+    test("the Ring-bearer is surfaced to the client as isRingBearer; a non-bearer is not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(active, "Ring Bear")
+        val ogre = driver.putCreatureOnBattlefield(active, "Big Ogre")
+        driver.tempt(active, bear)
+
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = active)
+        view.cards[bear]?.isRingBearer shouldBe true
+        view.cards[ogre]?.isRingBearer shouldBe false
     }
 
     test("CR 701.54a: another player gaining control ends the Ring-bearer designation permanently") {

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1264,6 +1264,51 @@ function GameCardImpl({
         </div>
       )}
 
+      {/* Ring-bearer badge (CR 701.54) — a prominent golden Ring marker pinned to the top-left of
+          the creature a player designated as their Ring-bearer. Gold fill + glow makes the bearer
+          unmistakable at a glance across the battlefield. mana-font 1.18.0 ships the
+          `ms-ability-ring-bearer` CSS class but its woff lacks the glyph (renders as tofu), so we
+          draw the One Ring inline as a golden band instead. */}
+      {battlefield && !faceDown && card.isRingBearer && (() => {
+        const badge = responsive.badges.ptFontSize * 1.7
+        const ring = responsive.badges.ptFontSize * 1.15
+        return (
+          <div
+            aria-label="Ring-bearer"
+            title="Ring-bearer"
+            style={{
+              position: 'absolute',
+              top: 3,
+              left: 3,
+              width: badge,
+              height: badge,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: '50%',
+              background: 'radial-gradient(circle at 35% 30%, #3a2c00 0%, #1a1206 80%)',
+              border: '1px solid rgba(212, 175, 55, 0.85)',
+              boxShadow: '0 0 6px 1px rgba(212, 175, 55, 0.65), inset 0 1px 1px rgba(0, 0, 0, 0.5)',
+              zIndex: 7,
+              pointerEvents: 'none',
+            }}
+          >
+            {/* The One Ring — a gold band drawn as a vertical ellipse so it reads as a ring. */}
+            <svg
+              width={ring}
+              height={ring}
+              viewBox="0 0 24 24"
+              fill="none"
+              style={{ filter: 'drop-shadow(0 0 1.5px rgba(212, 175, 55, 0.9))' }}
+              aria-hidden
+            >
+              <ellipse cx="12" cy="12" rx="6" ry="8.5" stroke="#f2d472" strokeWidth="2.6" />
+              <ellipse cx="12" cy="12" rx="6" ry="8.5" stroke="#9c7b1e" strokeWidth="0.8" />
+            </svg>
+          </div>
+        )
+      })()}
+
       {/* P/T overlay for creatures on battlefield (server sends 2/2 for face-down creatures) */}
       {battlefield && card.power !== null && card.toughness !== null && (
         <div style={{

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -180,6 +180,13 @@ export interface ClientCard {
    */
   readonly isCommander?: boolean
 
+  /**
+   * True when this permanent is its controller's Ring-bearer (CR 701.54). Battlefield only — the
+   * designation is stripped on a real control change, so a stolen permanent / token copy never
+   * carries it. Drives the prominent golden Ring badge on the card.
+   */
+  readonly isRingBearer?: boolean
+
   /** Zone this card is currently in */
   readonly zone: ZoneId | null
 


### PR DESCRIPTION
## Summary

Two changes for **The Lord of the Rings: Tales of Middle-earth** (LTR):

### 1. LTR basic lands
LTR was borrowing Portal's basic lands via `basicLandsFallback = PortalSet`. This gives the set its own basics: the 20 main-set basic lands —
- **262–271**: regular basics (2 art variants per type)
- **272–281**: full-art "Middle-earth map" basics by Deven Rue (2 per type)

discovered via `CardDiscovery.findBasicLandsIn` like every other set. The Portal fallback is dropped so the deckbuilder, booster generator, and printing registry surface LTR's own art (`GameBeansConfig` uses `(basicLandsFallback ?: this).basicLands`).

### 2. Prominent golden Ring-bearer icon
The Ring-bearer designation (CR 701.54) was only shown as a player-level "The Ring" emblem badge with the bearer's name in text. Now the bearer itself is marked:
- New `ClientCard.isRingBearer` flag, set from `RingBearerComponent` in `ClientStateTransformer` (mirrors the existing `isCommander` crown pattern). The designation is stripped on a real control change, so a stolen permanent / token copy never falsely shows it.
- A prominent **golden Ring badge** pinned to the top-left of the bearer on the battlefield.

> Note: `mana-font` 1.18.0 defines the `ms-ability-ring-bearer` CSS class but its woff **lacks the actual glyph** (it renders as a tofu box — verified in the running app). So the badge draws the One Ring as an inline golden SVG band instead, following the project's existing "font lacks the glyph → local fallback" pattern.

## Testing
- `mtg-sets`: `CardDiscoveryEquivalenceTest` (manual ↔ discovered basics agree), `CardDefinitionSnapshotTest` — pass.
- `rules-engine`: extended `TheRingScenarioTest` with a case asserting the transformed client view sets `isRingBearer = true` on the bearer and `false` on a non-bearer — pass.
- `web-client`: `npm run typecheck` clean.
- Manually verified in the running app: cast a tempt spell, designated a Ring-bearer, and confirmed the golden ring badge renders on the bearer (no tofu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)