### PR TITLE
Unify cost vocabulary under CostAtom (§3.2: PayCost + AdditionalCost)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -145,6 +145,18 @@ excluded.
 
 ## 3. Costs (`Costs.*`)
 
+> **One cost vocabulary (`CostAtom`).** The payable things shared across cost *contexts* — mana, life,
+> sacrifice, discard, exile-from-zone, tap, return-to-hand, reveal — are defined **once** in the
+> `CostAtom` sealed hierarchy (`scripting/costs/CostAtom.kt`). The context wrappers carry them: a
+> `PayCost.Atom(atom)` and an `AdditionalCost.Atom(atom)` each hold one `CostAtom`, leaving only their
+> genuinely context-specific members on the wrapper (`PayCost.OwnManaCost` / `PayCost.Choice`;
+> `AdditionalCost`'s Behold / Blight / Forage / ChooseEntity / per-target life / variable exile). The
+> `Costs.*` facades below are unchanged — they construct the right `…Atom(CostAtom.X(…))` for you, so
+> card authoring is identical. A *new* payable thing is one `CostAtom` variant + one engine payment
+> branch, available in every context. (`AbilityCost` — the activated-ability cost hierarchy — is the
+> next wrapper slated to fold onto `CostAtom`; until then its `Costs.*` top-level members are still its
+> own subtypes.)
+
 - `Costs.Free` — costs nothing (`{0}`).
 - `Costs.Tap` — `{T}`; tap this permanent.
 - `Costs.Untap` — `{Q}`; untap this permanent.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.*
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.SourceCastForImpending
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
@@ -1179,7 +1180,7 @@ class CardBuilder(private val name: String) {
         val finalKeywordAbilities = buildList {
             addAll(keywordAbilityList)
             when {
-                morph != null -> add(KeywordAbility.Morph(PayCost.Mana(ManaCost.parse(morph!!)), morphFaceUpEffect))
+                morph != null -> add(KeywordAbility.Morph(PayCost.Atom(CostAtom.Mana(ManaCost.parse(morph!!))), morphFaceUpEffect))
                 morphCost != null -> add(KeywordAbility.Morph(morphCost!!, morphFaceUpEffect))
             }
             if (warp != null) add(KeywordAbility.Warp(ManaCost.parse(warp!!)))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.CostZone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 
 /**
@@ -313,14 +314,14 @@ object Costs {
 
         /** Sacrifice [count] permanents matching [filter] (Natural Order). */
         fun SacrificePermanent(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): AdditionalCost =
-            AdditionalCost.SacrificePermanent(filter, count)
+            AdditionalCost.Atom(CostAtom.Sacrifice(filter, count))
 
         /** Discard [count] cards matching [filter] (Force of Will). */
         fun DiscardCards(count: Int = 1, filter: GameObjectFilter = GameObjectFilter.Any): AdditionalCost =
-            AdditionalCost.DiscardCards(count, filter)
+            AdditionalCost.Atom(CostAtom.Discard(count, filter))
 
         /** Pay [amount] life. */
-        fun PayLife(amount: Int): AdditionalCost = AdditionalCost.PayLife(amount)
+        fun PayLife(amount: Int): AdditionalCost = AdditionalCost.Atom(CostAtom.PayLife(amount))
 
         /** Pay [amountPerTarget] life for each target chosen by this spell (Phyrexian Purge). */
         fun PayLifePerTarget(amountPerTarget: Int): AdditionalCost =
@@ -331,7 +332,7 @@ object Costs {
             count: Int = 1,
             filter: GameObjectFilter = GameObjectFilter.Any,
             fromZone: CostZone = CostZone.GRAVEYARD
-        ): AdditionalCost = AdditionalCost.ExileCards(count, filter, fromZone)
+        ): AdditionalCost = AdditionalCost.Atom(CostAtom.ExileFrom(fromZone.toZone(), filter, count))
 
         /** Exile a variable number (at least [minCount]) of cards matching [filter] from [fromZone] (Chill Haunting). */
         fun ExileVariableCards(
@@ -390,7 +391,7 @@ object Costs {
 
         /** Tap [count] untapped permanents matching [filter] you control. */
         fun TapPermanents(count: Int = 1, filter: GameObjectFilter = GameObjectFilter.Creature): AdditionalCost =
-            AdditionalCost.TapPermanents(count, filter)
+            AdditionalCost.Atom(CostAtom.TapPermanents(count, filter))
 
         /** Choose one entity across [zoneFilters] without moving it, recording it under [storeAs] (Close Encounter). */
         fun ChooseEntity(
@@ -412,10 +413,10 @@ object Costs {
     object pay {
 
         /** Pay a mana cost. */
-        fun Mana(cost: ManaCost): PayCost = PayCost.Mana(cost)
+        fun Mana(cost: ManaCost): PayCost = PayCost.Atom(CostAtom.Mana(cost))
 
         /** Pay a mana cost parsed from a string (e.g. "{2}{U}"). */
-        fun Mana(cost: String): PayCost = PayCost.Mana(ManaCost.parse(cost))
+        fun Mana(cost: String): PayCost = PayCost.Atom(CostAtom.Mana(ManaCost.parse(cost)))
 
         /** Pay the source permanent's own mana cost (Essence Leak). */
         val OwnManaCost: PayCost = PayCost.OwnManaCost
@@ -425,35 +426,35 @@ object Costs {
             filter: GameObjectFilter = GameObjectFilter.Any,
             count: Int = 1,
             random: Boolean = false
-        ): PayCost = PayCost.Discard(filter, count, random)
+        ): PayCost = PayCost.Atom(CostAtom.Discard(count, filter, random))
 
         /** Sacrifice [count] permanents matching [filter]. */
         fun Sacrifice(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
-            PayCost.Sacrifice(filter, count)
+            PayCost.Atom(CostAtom.Sacrifice(filter, count))
 
         /** Pay [amount] life. */
-        fun PayLife(amount: Int): PayCost = PayCost.PayLife(amount)
+        fun PayLife(amount: Int): PayCost = PayCost.Atom(CostAtom.PayLife(amount))
 
         /** Exile [count] cards matching [filter] from [zone]. */
         fun Exile(
             filter: GameObjectFilter = GameObjectFilter.Any,
             zone: Zone = Zone.HAND,
             count: Int = 1
-        ): PayCost = PayCost.Exile(filter, zone, count)
+        ): PayCost = PayCost.Atom(CostAtom.ExileFrom(zone, filter, count))
 
         /** Reveal [count] cards matching [filter] from hand. */
         fun RevealCard(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
-            PayCost.RevealCard(filter, count)
+            PayCost.Atom(CostAtom.RevealFromHand(filter, count))
 
         /** Choose one of [options] to pay. */
         fun Choice(options: List<PayCost>): PayCost = PayCost.Choice(options)
 
         /** Return [count] permanents matching [filter] you control to their owner's hand. */
         fun ReturnToHand(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
-            PayCost.ReturnToHand(filter, count)
+            PayCost.Atom(CostAtom.ReturnToHand(filter, count))
 
         /** Tap [count] untapped permanents matching [filter] you control. */
         fun Tap(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
-            PayCost.Tap(filter, count)
+            PayCost.Atom(CostAtom.TapPermanents(count, filter))
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2704,8 +2704,10 @@ object Effects {
         target = target,
         targetFilter = targetFilter,
         copyRecipient = com.wingedsheep.sdk.scripting.effects.CopyRecipient.TARGET_CONTROLLER,
-        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Sacrifice(
-            filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Land
+        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Atom(
+            com.wingedsheep.sdk.scripting.costs.CostAtom.Sacrifice(
+                filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Land
+            )
         ),
         copyTargetRequirement = com.wingedsheep.sdk.scripting.targets.TargetObject(filter = targetFilter),
         spellName = spellName
@@ -2723,7 +2725,9 @@ object Effects {
         action = DealDamage(amount, target),
         target = target,
         copyRecipient = com.wingedsheep.sdk.scripting.effects.CopyRecipient.AFFECTED_PLAYER,
-        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Discard(),
+        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Atom(
+            com.wingedsheep.sdk.scripting.costs.CostAtom.Discard()
+        ),
         copyTargetRequirement = com.wingedsheep.sdk.scripting.targets.AnyTarget(),
         spellName = spellName
     )
@@ -2757,8 +2761,10 @@ object Effects {
         target = target,
         targetFilter = targetFilter,
         copyRecipient = com.wingedsheep.sdk.scripting.effects.CopyRecipient.TARGET_CONTROLLER,
-        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Sacrifice(
-            filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Land
+        copyCost = com.wingedsheep.sdk.scripting.costs.PayCost.Atom(
+            com.wingedsheep.sdk.scripting.costs.CostAtom.Sacrifice(
+                filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Land
+            )
         ),
         copyTargetRequirement = com.wingedsheep.sdk.scripting.targets.TargetObject(filter = targetFilter),
         spellName = spellName

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -1,7 +1,8 @@
 package com.wingedsheep.sdk.scripting
 
-import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import kotlinx.serialization.SerialName
@@ -15,6 +16,12 @@ import kotlinx.serialization.Serializable
  * - Pay life (Phyrexian mana)
  *
  * Additional costs are declared in the CardScript and validated/paid during casting.
+ *
+ * The payable things shared with the other cost contexts (sacrifice, discard, pay life, exile from a
+ * zone, tap permanents) live in the [CostAtom] vocabulary and are carried here by [Atom]. The remaining
+ * subtypes are genuinely casting-context-specific: alternative "X or pay mana" shapes (Blight/Behold),
+ * pipeline-storage flow (Behold/ExileFromStorage/Composite), per-target life, variable exile, and the
+ * cross-zone [ChooseEntity] pick.
  */
 @Serializable
 sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
@@ -34,75 +41,20 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
-     * Sacrifice a permanent matching the given filter.
-     * Example: "Sacrifice a green creature" for Natural Order
-     *
-     * @property filter Which permanents can be sacrificed
-     * @property count Number of permanents to sacrifice
+     * A single shared payable thing — see [CostAtom]. Covers the additional costs that mean the same
+     * here as in any other context: sacrifice a permanent (Natural Order), discard cards (Force of
+     * Will), pay life (Phyrexian mana), exile cards from a zone, tap permanents. Additional-cost text
+     * leads a clause, so the description is the atom's phrase with its first letter capitalized.
      */
-    @SerialName("SacrificePermanent")
+    @SerialName("AdditionalAtom")
     @Serializable
-    data class SacrificePermanent(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val count: Int = 1
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Sacrifice ")
-            if (count == 1) {
-                append("a ")
-            } else {
-                append("$count ")
-            }
-            append(filter.description)
-            if (count != 1) append("s")
-        }
+    data class Atom(val atom: CostAtom) : AdditionalCost {
+        override val description: String get() = atom.description.replaceFirstChar { it.uppercase() }
 
         override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
+            val newAtom = atom.applyTextReplacement(replacer)
+            return if (newAtom !== atom) copy(atom = newAtom) else this
         }
-    }
-
-    /**
-     * Discard cards from hand.
-     * Example: "Discard a card" or "Discard 2 cards"
-     *
-     * @property count Number of cards to discard
-     * @property filter Which cards can be discarded
-     */
-    @SerialName("DiscardCards")
-    @Serializable
-    data class DiscardCards(
-        val count: Int = 1,
-        val filter: GameObjectFilter = GameObjectFilter.Any
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Discard ")
-            if (count == 1) {
-                append("a ")
-            } else {
-                append("$count ")
-            }
-            append(filter.description)
-            if (count != 1) append("s")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Pay life as an additional cost.
-     * Example: "Pay 1 life" for Phyrexian mana
-     */
-    @SerialName("PayLife")
-    @Serializable
-    data class PayLife(
-        val amount: Int
-    ) : AdditionalCost {
-        override val description: String = "Pay $amount life"
     }
 
     /**
@@ -120,39 +72,6 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
         val amountPerTarget: Int
     ) : AdditionalCost {
         override val description: String = "This spell costs $amountPerTarget life more to cast for each target"
-    }
-
-    /**
-     * Exile cards from a zone (usually graveyard or hand).
-     * Example: "Exile a creature card from your graveyard"
-     *
-     * @property count Number of cards to exile
-     * @property filter Which cards can be exiled
-     * @property fromZone Zone to exile from
-     */
-    @SerialName("ExileCards")
-    @Serializable
-    data class ExileCards(
-        val count: Int = 1,
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val fromZone: CostZone = CostZone.GRAVEYARD
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Exile ")
-            if (count == 1) {
-                append("a ")
-            } else {
-                append("$count ")
-            }
-            append(filter.description)
-            if (count != 1) append("s")
-            append(" from your ${fromZone.description}")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
     }
 
     /**
@@ -183,13 +102,6 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
         }
     }
 
-    /**
-     * Tap permanents you control.
-     * Example: "Tap an untapped creature you control"
-     *
-     * @property count Number of permanents to tap
-     * @property filter Which permanents can be tapped
-     */
     /**
      * Sacrifice any number of permanents matching the given filter as an additional cost.
      * Each sacrifice reduces the spell's generic mana cost by [costReductionPerCreature].
@@ -222,17 +134,6 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
-     * Blight N or pay additional mana: the caster must either put N -1/-1 counters on a creature
-     * they control, or pay extra mana on top of the spell's base mana cost.
-     * Used by Lorwyn Eclipsed cards (e.g., Wild Unraveling).
-     *
-     * The enumerator produces two legal actions: one for the blight path (base cost + creature selection)
-     * and one for the pay path (base cost + [alternativeManaCost]).
-     *
-     * @property blightAmount Number of -1/-1 counters to place
-     * @property alternativeManaCost Extra mana to pay instead of blighting (e.g., "{1}")
-     */
-    /**
      * Blight X (variable): the caster declares X at cast time, puts X -1/-1
      * counters on a creature they control, and X is exposed to the spell's
      * effects via `DynamicAmount.CastChoice(ChoiceSlot.BLIGHT_AMOUNT)`.
@@ -253,6 +154,17 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
             "blight X. X can't be greater than the greatest toughness among creatures you control"
     }
 
+    /**
+     * Blight N or pay additional mana: the caster must either put N -1/-1 counters on a creature
+     * they control, or pay extra mana on top of the spell's base mana cost.
+     * Used by Lorwyn Eclipsed cards (e.g., Wild Unraveling).
+     *
+     * The enumerator produces two legal actions: one for the blight path (base cost + creature selection)
+     * and one for the pay path (base cost + [alternativeManaCost]).
+     *
+     * @property blightAmount Number of -1/-1 counters to place
+     * @property alternativeManaCost Extra mana to pay instead of blighting (e.g., "{1}")
+     */
     @SerialName("BlightOrPay")
     @Serializable
     data class BlightOrPay(
@@ -401,30 +313,6 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
             "Remove $totalCount counters from among creatures you control"
     }
 
-    @SerialName("TapPermanents")
-    @Serializable
-    data class TapPermanents(
-        val count: Int = 1,
-        val filter: GameObjectFilter = GameObjectFilter.Creature
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Tap ")
-            if (count == 1) {
-                append("an untapped ")
-            } else {
-                append("$count untapped ")
-            }
-            append(filter.description)
-            if (count != 1) append("s")
-            append(" you control")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
     /**
      * Choose one entity from any of the zones declared in [zoneFilters], applying
      * the matching filter for that zone, without moving it. The chosen entity ID
@@ -460,8 +348,8 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     @SerialName("ChooseEntity")
     @Serializable
     data class ChooseEntity(
-        val zoneFilters: Map<com.wingedsheep.sdk.core.Zone, GameObjectFilter> =
-            mapOf(com.wingedsheep.sdk.core.Zone.BATTLEFIELD to GameObjectFilter.Any),
+        val zoneFilters: Map<Zone, GameObjectFilter> =
+            mapOf(Zone.BATTLEFIELD to GameObjectFilter.Any),
         val storeAs: String = "chosen",
         val captureSnapshot: Boolean = false,
         /**
@@ -503,7 +391,15 @@ enum class CostZone(val description: String) {
     HAND("hand"),
     GRAVEYARD("graveyard"),
     LIBRARY("library"),
-    BATTLEFIELD("battlefield")
+    BATTLEFIELD("battlefield");
+
+    /** The engine [Zone] this cost-zone maps to. */
+    fun toZone(): Zone = when (this) {
+        HAND -> Zone.HAND
+        GRAVEYARD -> Zone.GRAVEYARD
+        LIBRARY -> Zone.LIBRARY
+        BATTLEFIELD -> Zone.BATTLEFIELD
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.WardCost
 import kotlinx.serialization.SerialName
@@ -331,7 +332,7 @@ sealed interface KeywordAbility {
         val faceUpEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null
     ) : KeywordAbility {
         /** Convenience constructor for mana-based morph costs. */
-        constructor(cost: ManaCost) : this(PayCost.Mana(cost))
+        constructor(cost: ManaCost) : this(PayCost.Atom(CostAtom.Mana(cost)))
 
         override val description: String = "Morph ${morphCost.description}"
     }
@@ -660,7 +661,7 @@ sealed interface KeywordAbility {
         /**
          * Create Morph with life payment cost.
          */
-        fun morphPayLife(amount: Int): KeywordAbility = Morph(PayCost.PayLife(amount))
+        fun morphPayLife(amount: Int): KeywordAbility = Morph(PayCost.Atom(CostAtom.PayLife(amount)))
 
         /**
          * Create Flashback with mana cost from string.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -1,0 +1,207 @@
+package com.wingedsheep.sdk.scripting.costs
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.text.TextReplaceable
+import com.wingedsheep.sdk.scripting.text.TextReplacer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One shared vocabulary of *atomic* payable things — the things you can be asked to pay
+ * regardless of which cost *context* asks for them.
+ *
+ * MTG has three parallel cost contexts: an activated-ability cost ([com.wingedsheep.sdk.scripting.AbilityCost]),
+ * an additional cost paid while casting a spell ([com.wingedsheep.sdk.scripting.AdditionalCost]), and a
+ * "payable cost" used by morph / "unless you …" / player-choice mechanics
+ * ([PayCost]). Before [CostAtom] existed, each context redefined the *same* payable things — "sacrifice
+ * a creature", "discard a card", "pay N life", "exile from a zone", … — so a new payable thing had to be
+ * implemented once per context and could land in one but not the others. This is the **§3.2 "one cost
+ * language"** vocabulary: each payable concept is declared *once*, here, and each context carries it via
+ * its own `Atom` wrapper.
+ *
+ * **What lives here:** payable things whose meaning is identical across contexts — the *what* is paid,
+ * not the *when* or *why*. Counts are plain [Int]s because every current shared cost has a fixed count;
+ * genuinely *variable* costs (exile X cards, pay X life, blight X) and context-specific oddities (Forage,
+ * Behold, Echo timing, kicker linkage) are deliberately **not** atoms — they stay as subtypes on the
+ * wrapper that owns their context-specific behavior.
+ *
+ * Each atom's [description] is a canonical, lower-case-leading phrase ("sacrifice a Goblin"); the wrapper
+ * adapts casing for its context (mid-sentence "unless you sacrifice a Goblin" vs. leading "Sacrifice a
+ * Goblin").
+ */
+@Serializable
+sealed interface CostAtom : TextReplaceable<CostAtom> {
+    /** Canonical, lower-case-leading human phrase for this atom (e.g. "sacrifice a Goblin"). */
+    val description: String
+
+    /**
+     * Number of distinct entities the payer must select for this atom, or 0 for atoms that take no
+     * selection (mana, life, random discard). Used by every context to drive selection prompts and
+     * affordability checks against the same number.
+     */
+    val selectionCount: Int
+        get() = 0
+
+    /** Pay a mana cost. */
+    @SerialName("AtomMana")
+    @Serializable
+    data class Mana(val cost: ManaCost) : CostAtom {
+        override val description: String get() = cost.toString()
+    }
+
+    /** Pay [amount] life (CR 119.4 — payable only while life total ≥ amount). */
+    @SerialName("AtomPayLife")
+    @Serializable
+    data class PayLife(val amount: Int) : CostAtom {
+        override val description: String get() = "pay $amount life"
+    }
+
+    /** Sacrifice [count] permanents matching [filter]. */
+    @SerialName("AtomSacrifice")
+    @Serializable
+    data class Sacrifice(
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1
+    ) : CostAtom {
+        override val selectionCount: Int get() = count
+        override val description: String get() = "sacrifice ${quantify(count, filter.description)}"
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
+     * Discard [count] cards matching [filter].
+     *
+     * @property random when true the discard is at random (no player selection — e.g. Pillaging Horde).
+     */
+    @SerialName("AtomDiscard")
+    @Serializable
+    data class Discard(
+        val count: Int = 1,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val random: Boolean = false
+    ) : CostAtom {
+        // A random discard is paid without the player choosing which cards, so it takes no selection.
+        override val selectionCount: Int get() = if (random) 0 else count
+        override val description: String get() = buildString {
+            append("discard ")
+            append(quantify(count, filter.description))
+            if (random) append(" at random")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /** Exile [count] cards matching [filter] from [zone]. */
+    @SerialName("AtomExileFrom")
+    @Serializable
+    data class ExileFrom(
+        val zone: Zone,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1
+    ) : CostAtom {
+        override val selectionCount: Int get() = count
+        override val description: String get() =
+            "exile ${quantify(count, filter.description)} from your ${zone.name.lowercase()}"
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /** Tap [count] untapped permanents matching [filter] you control. */
+    @SerialName("AtomTapPermanents")
+    @Serializable
+    data class TapPermanents(
+        val count: Int = 1,
+        val filter: GameObjectFilter = GameObjectFilter.Any
+    ) : CostAtom {
+        override val selectionCount: Int get() = count
+        override val description: String get() = buildString {
+            append("tap ")
+            if (count == 1) append("an untapped ${filter.description}")
+            else append("$count untapped ${filter.description}s")
+            append(" you control")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /** Return [count] permanents matching [filter] you control to their owner's hand. */
+    @SerialName("AtomReturnToHand")
+    @Serializable
+    data class ReturnToHand(
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1
+    ) : CostAtom {
+        override val selectionCount: Int get() = count
+        override val description: String get() = buildString {
+            append("return ")
+            append(quantify(count, filter.description))
+            append(" you control to its owner's hand")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /** Reveal [count] cards matching [filter] from your hand (the cards stay in hand). */
+    @SerialName("AtomRevealFromHand")
+    @Serializable
+    data class RevealFromHand(
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1
+    ) : CostAtom {
+        override val selectionCount: Int get() = count
+        override val description: String get() = buildString {
+            append("reveal ")
+            append(quantify(count, filter.description))
+            append(" in your hand")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+}
+
+/**
+ * "a Goblin" / "three Goblins" — the article-or-count phrase shared by the selection atoms. Small
+ * counts are spelled out (oracle convention); the article respects a vowel-leading filter description.
+ */
+private fun quantify(count: Int, filterDescription: String): String =
+    if (count == 1) {
+        val article = if (filterDescription.firstOrNull()?.lowercaseChar() in listOf('a', 'e', 'i', 'o', 'u')) "an" else "a"
+        "$article $filterDescription"
+    } else {
+        "${numberToWord(count)} ${filterDescription}s"
+    }
+
+private fun numberToWord(n: Int): String = when (n) {
+    1 -> "one"
+    2 -> "two"
+    3 -> "three"
+    4 -> "four"
+    5 -> "five"
+    6 -> "six"
+    7 -> "seven"
+    8 -> "eight"
+    9 -> "nine"
+    10 -> "ten"
+    else -> n.toString()
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/PayCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/PayCost.kt
@@ -1,8 +1,5 @@
 package com.wingedsheep.sdk.scripting.costs
 
-import com.wingedsheep.sdk.core.ManaCost
-import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import kotlinx.serialization.SerialName
@@ -13,21 +10,31 @@ import kotlinx.serialization.Serializable
  * - Morph face-up costs (e.g., "Morph {2}{U}" or "Morph—Pay 5 life")
  * - "Unless" mechanics via PayOrSufferEffect (e.g., "unless you sacrifice a creature")
  * - Any future mechanic that requires a payable cost
+ *
+ * Most payable things — mana, life, sacrifice, discard, exile, tap, return, reveal — are shared with the
+ * other cost contexts and live in the [CostAtom] vocabulary; [Atom] carries one of them. The two members
+ * left on this wrapper are the ones genuinely specific to *this* context: [OwnManaCost] (resolved against
+ * the source permanent's own printed cost at payment time) and [Choice] (a player picks one of several
+ * payable costs to satisfy).
  */
 @Serializable
 sealed interface PayCost : TextReplaceable<PayCost> {
     val description: String
 
     /**
-     * Pay a mana cost.
-     * "Pay {2}{U}" or "Morph {3}{G}{G}"
-     *
-     * @property cost The mana cost to pay
+     * A single shared payable thing — see [CostAtom]. The common case: "Morph {2}{U}", "unless you
+     * sacrifice a creature", "unless you pay 3 life", etc. PayCost is used mid-sentence, so the
+     * description is taken verbatim from the atom (lower-case-leading).
      */
-    @SerialName("PayMana")
+    @SerialName("PayAtom")
     @Serializable
-    data class Mana(val cost: ManaCost) : PayCost {
-        override val description: String = cost.toString()
+    data class Atom(val atom: CostAtom) : PayCost {
+        override val description: String get() = atom.description
+
+        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
+            val newAtom = atom.applyTextReplacement(replacer)
+            return if (newAtom !== atom) copy(atom = newAtom) else this
+        }
     }
 
     /**
@@ -36,172 +43,13 @@ sealed interface PayCost : TextReplaceable<PayCost> {
      * Resolved at payment time by reading the source permanent's `CardComponent.manaCost`,
      * so it works for granted abilities like Essence Leak ("...sacrifice this permanent
      * unless you pay its mana cost"), where the affected permanent — not a fixed cost — owns
-     * the mana cost. The engine converts this into a concrete [Mana] cost against that
+     * the mana cost. The engine converts this into a concrete [CostAtom.Mana] cost against that
      * permanent before prompting.
      */
     @SerialName("OwnManaCost")
     @Serializable
     data object OwnManaCost : PayCost {
         override val description: String = "its mana cost"
-    }
-
-    /**
-     * Discard one or more cards matching a filter.
-     * "...unless you discard a land card"
-     *
-     * @property filter Which cards can be discarded
-     * @property count How many cards must be discarded (default 1)
-     * @property random If true, the discard is random (e.g., Pillaging Horde)
-     */
-    @SerialName("Discard")
-    @Serializable
-    data class Discard(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val count: Int = 1,
-        val random: Boolean = false
-    ) : PayCost {
-        override val description: String = buildString {
-            append("discard ")
-            if (count == 1) {
-                append("a ${filter.description}")
-            } else {
-                append("$count ${filter.description}s")
-            }
-            if (random) append(" at random")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Sacrifice one or more permanents matching a filter to avoid the consequence.
-     * "...unless you sacrifice three Forests"
-     *
-     * @property filter Which permanents can be sacrificed
-     * @property count How many permanents must be sacrificed (default 1)
-     */
-    @SerialName("Sacrifice")
-    @Serializable
-    data class Sacrifice(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val count: Int = 1
-    ) : PayCost {
-        override val description: String = buildString {
-            append("sacrifice ")
-            val filterDesc = filter.description
-            if (count == 1) {
-                append(if (filterDesc.first().lowercaseChar() in "aeiou") "an" else "a")
-                append(" $filterDesc")
-            } else {
-                append(numberToWord(count))
-                append(" ${filterDesc}s")
-            }
-        }
-
-        private fun numberToWord(n: Int): String = when (n) {
-            1 -> "one"
-            2 -> "two"
-            3 -> "three"
-            4 -> "four"
-            5 -> "five"
-            else -> n.toString()
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Pay life to avoid the consequence.
-     * "...unless you pay 3 life"
-     *
-     * @property amount How much life to pay
-     */
-    @SerialName("PayLife")
-    @Serializable
-    data class PayLife(
-        val amount: Int
-    ) : PayCost {
-        override val description: String = "pay $amount life"
-    }
-
-    /**
-     * Exile one or more cards matching a filter from a specific zone.
-     * "...unless you exile a blue card from your hand"
-     * "Morph—Exile two cards from your graveyard."
-     *
-     * @property filter Which cards can be exiled
-     * @property zone The zone to exile from (HAND, GRAVEYARD, etc.)
-     * @property count How many cards must be exiled (default 1)
-     */
-    @SerialName("ExileFromZone")
-    @Serializable
-    data class Exile(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val zone: Zone = Zone.HAND,
-        val count: Int = 1
-    ) : PayCost {
-        override val description: String = buildString {
-            append("exile ")
-            val filterDesc = filter.description
-            if (count == 1) {
-                append(if (filterDesc.first().lowercaseChar() in "aeiou") "an" else "a")
-                append(" $filterDesc")
-            } else {
-                append("$count ${filterDesc}s")
-            }
-            append(" from your ${zone.name.lowercase()}")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Return one or more permanents you control matching a filter to their owner's hand.
-     * "Morph—Return a Bird you control to its owner's hand."
-     *
-     * @property filter Which permanents can be returned
-     * @property count How many permanents must be returned (default 1)
-     */
-    /**
-     * Reveal a card from hand matching a filter.
-     * "Morph—Reveal a white card in your hand."
-     *
-     * The card stays in hand; it is merely shown publicly.
-     *
-     * @property filter Which cards can be revealed
-     * @property count How many cards must be revealed (default 1)
-     */
-    @SerialName("RevealCard")
-    @Serializable
-    data class RevealCard(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val count: Int = 1
-    ) : PayCost {
-        override val description: String = buildString {
-            append("Reveal ")
-            val filterDesc = filter.description
-            if (count == 1) {
-                append(if (filterDesc.first().lowercaseChar() in "aeiou") "an" else "a")
-                append(" $filterDesc")
-            } else {
-                append("$count ${filterDesc}s")
-            }
-            append(" in your hand")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
     }
 
     /**
@@ -217,71 +65,10 @@ sealed interface PayCost : TextReplaceable<PayCost> {
     data class Choice(
         val options: List<PayCost>
     ) : PayCost {
-        override val description: String = options.joinToString(" or ") { it.description }
+        override val description: String get() = options.joinToString(" or ") { it.description }
         override fun applyTextReplacement(replacer: TextReplacer): PayCost {
             val newOptions = options.map { it.applyTextReplacement(replacer) }
             return if (newOptions.zip(options).any { (a, b) -> a !== b }) copy(options = newOptions) else this
-        }
-    }
-
-    @SerialName("ReturnToHand")
-    @Serializable
-    data class ReturnToHand(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val count: Int = 1
-    ) : PayCost {
-        override val description: String = buildString {
-            append("Return ")
-            val filterDesc = filter.description
-            if (count == 1) {
-                append(if (filterDesc.first().lowercaseChar() in "aeiou") "an" else "a")
-                append(" $filterDesc")
-            } else {
-                append("$count ${filterDesc}s")
-            }
-            append(" you control to its owner's hand")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Tap one or more untapped permanents you control to avoid the consequence.
-     * "...unless you tap an untapped permanent you control"
-     *
-     * The executor restricts candidates to permanents the paying player controls that
-     * are untapped, and excludes the source itself. Tapping the selected permanent(s)
-     * emits a `TappedEvent` for each one, so "becomes tapped" triggers fire normally.
-     *
-     * Used by Command Bridge.
-     *
-     * @property filter Additional filter on the permanents that can be tapped
-     *                  (`Any` by default — any of your untapped permanents qualify).
-     * @property count How many untapped permanents must be tapped (default 1).
-     */
-    @SerialName("Tap")
-    @Serializable
-    data class Tap(
-        val filter: GameObjectFilter = GameObjectFilter.Companion.Any,
-        val count: Int = 1
-    ) : PayCost {
-        override val description: String = buildString {
-            append("tap ")
-            val filterDesc = filter.description
-            if (count == 1) {
-                // The article always precedes "untapped", so it is always "an".
-                append("an untapped $filterDesc you control")
-            } else {
-                append("$count untapped ${filterDesc}s you control")
-            }
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): PayCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
         }
     }
 }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * §3.2 "one cost language": [CostAtom] is the single shared vocabulary of payable things, carried by
+ * every cost *context* ([PayCost.Atom], [AdditionalCost.Atom], and — once migrated — `AbilityCost`).
+ *
+ * This is the SDK-side coverage net (the PR #606 pattern applied to the cost vocabulary): every
+ * concrete [CostAtom] subtype must have a representative below that round-trips through the
+ * polymorphic serializer inside both wrappers. The `sealedSubclasses` completeness assertion fails the
+ * moment a new atom is added without a representative — forcing a conscious decision (and a reminder to
+ * add the matching engine payment branch; the engine `when (atom)` blocks are exhaustive, so a missing
+ * branch is already a compile error).
+ */
+class CostAtomSerializationTest : FunSpec({
+
+    val json = CardSerialization.json
+
+    // One representative instance per concrete CostAtom subtype.
+    val representatives: List<CostAtom> = listOf(
+        CostAtom.Mana(ManaCost.parse("{2}{U}")),
+        CostAtom.PayLife(3),
+        CostAtom.Sacrifice(GameObjectFilter.Creature, count = 2),
+        CostAtom.Discard(count = 1, filter = GameObjectFilter.Any, random = true),
+        CostAtom.ExileFrom(Zone.GRAVEYARD, GameObjectFilter.Creature, count = 3),
+        CostAtom.TapPermanents(count = 1, filter = GameObjectFilter.Creature),
+        CostAtom.ReturnToHand(GameObjectFilter.Any, count = 1),
+        CostAtom.RevealFromHand(GameObjectFilter.Any, count = 1),
+    )
+
+    test("every concrete CostAtom subtype has a representative in this test") {
+        val expected = CostAtom::class.sealedSubclasses
+            .map { it.simpleName }
+            .toSet()
+        val covered = representatives.map { it::class.simpleName }.toSet()
+        covered shouldBe expected
+    }
+
+    test("each CostAtom round-trips through the polymorphic serializer") {
+        for (atom in representatives) {
+            val restored = json.decodeFromString(CostAtom.serializer(), json.encodeToString(CostAtom.serializer(), atom))
+            restored shouldBe atom
+        }
+    }
+
+    test("each CostAtom round-trips inside a PayCost.Atom wrapper") {
+        for (atom in representatives) {
+            val cost: PayCost = PayCost.Atom(atom)
+            val restored = json.decodeFromString(PayCost.serializer(), json.encodeToString(PayCost.serializer(), cost))
+            restored shouldBe cost
+        }
+    }
+
+    test("each CostAtom round-trips inside an AdditionalCost.Atom wrapper") {
+        for (atom in representatives) {
+            val cost: AdditionalCost = AdditionalCost.Atom(atom)
+            val restored = json.decodeFromString(AdditionalCost.serializer(), json.encodeToString(AdditionalCost.serializer(), cost))
+            restored shouldBe cost
+        }
+    }
+
+    test("selectionCount is the per-atom selection size and 0 for non-selection atoms") {
+        CostAtom.Mana(ManaCost.parse("{1}")).selectionCount shouldBe 0
+        CostAtom.PayLife(3).selectionCount shouldBe 0
+        CostAtom.Discard(count = 2, random = true).selectionCount shouldBe 0  // random discard takes no selection
+        CostAtom.Discard(count = 2, random = false).selectionCount shouldBe 2
+        CostAtom.Sacrifice(count = 2).selectionCount shouldBe 2
+        CostAtom.ExileFrom(Zone.GRAVEYARD, count = 3).selectionCount shouldBe 3
+        CostAtom.TapPermanents(count = 1).selectionCount shouldBe 1
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -1235,8 +1235,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{2}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "suffer": {
                         "type": "DealDamage",
@@ -1699,8 +1702,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{B}{B}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{B}{B}"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -2206,8 +2212,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -2324,8 +2333,11 @@
                     "effect": {
                         "type": "PayOrSuffer",
                         "cost": {
-                            "type": "PayMana",
-                            "cost": "{1}"
+                            "type": "PayAtom",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "suffer": {
                             "type": "LoseLife",

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -623,8 +623,11 @@
                         {
                             "type": "PayOrSuffer",
                             "cost": {
-                                "type": "Discard",
-                                "filter": "nonland"
+                                "type": "PayAtom",
+                                "atom": {
+                                    "type": "AtomDiscard",
+                                    "filter": "nonland"
+                                }
                             },
                             "suffer": {
                                 "type": "Composite",
@@ -15927,7 +15930,10 @@
             "countsAsModalSpell": false
         },
         "additionalCosts": [
-            "DiscardCards"
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
         ]
     },
     "metadata": {
@@ -18364,10 +18370,16 @@
                         "type": "Choice",
                         "options": [
                             {
-                                "type": "Sacrifice",
-                                "filter": "nonland"
+                                "type": "PayAtom",
+                                "atom": {
+                                    "type": "AtomSacrifice",
+                                    "filter": "nonland"
+                                }
                             },
-                            "Discard"
+                            {
+                                "type": "PayAtom",
+                                "atom": "AtomDiscard"
+                            }
                         ]
                     },
                     "suffer": {
@@ -19551,7 +19563,10 @@
                         {
                             "type": "GrantPlayWithAdditionalCost",
                             "from": "nonland",
-                            "additionalCost": "DiscardCards"
+                            "additionalCost": {
+                                "type": "AdditionalAtom",
+                                "atom": "AtomDiscard"
+                            }
                         }
                     ]
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -673,7 +673,10 @@
             ]
         },
         "additionalCosts": [
-            "DiscardCards"
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
         ]
     },
     "metadata": {

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -4802,26 +4802,29 @@
         {
             "type": "Kicker",
             "additionalCost": {
-                "type": "SacrificePermanent",
-                "filter": {
-                    "cardPredicates": [
-                        {
-                            "type": "Or",
-                            "predicates": [
-                                "IsArtifact",
-                                {
-                                    "type": "And",
-                                    "predicates": [
-                                        "IsCreature",
-                                        {
-                                            "type": "HasSubtype",
-                                            "subtype": "Goblin"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsArtifact",
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Goblin"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         }
@@ -9601,8 +9604,11 @@
                             "effect": {
                                 "type": "PayOrSuffer",
                                 "cost": {
-                                    "type": "Sacrifice",
-                                    "filter": "creature"
+                                    "type": "PayAtom",
+                                    "atom": {
+                                        "type": "AtomSacrifice",
+                                        "filter": "creature"
+                                    }
                                 },
                                 "suffer": {
                                     "type": "DealDamage",
@@ -13920,23 +13926,26 @@
                         {
                             "type": "PayOrSuffer",
                             "cost": {
-                                "type": "ExileFromZone",
-                                "filter": {
-                                    "cardPredicates": [
-                                        {
-                                            "type": "Or",
-                                            "predicates": [
-                                                "IsArtifact",
-                                                "IsLegendary",
-                                                {
-                                                    "type": "HasSubtype",
-                                                    "subtype": "Saga"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "zone": "Graveyard"
+                                "type": "PayAtom",
+                                "atom": {
+                                    "type": "AtomExileFrom",
+                                    "zone": "Graveyard",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            {
+                                                "type": "Or",
+                                                "predicates": [
+                                                    "IsArtifact",
+                                                    "IsLegendary",
+                                                    {
+                                                        "type": "HasSubtype",
+                                                        "subtype": "Saga"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
                             },
                             "suffer": {
                                 "type": "Composite",
@@ -14187,8 +14196,11 @@
         {
             "type": "Kicker",
             "additionalCost": {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         }
     ],
@@ -15128,8 +15140,11 @@
             "manaCost": "{3}{U}",
             "additionalCosts": [
                 {
-                    "type": "TapPermanents",
-                    "filter": "artifact"
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "artifact"
+                    }
                 }
             ]
         }

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -15,8 +15,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}"
+                }
             },
             "faceUpEffect": {
                 "type": "AddCounters",

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -3887,8 +3887,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{2}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "suffer": {
                         "type": "Composite",

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -2270,7 +2270,10 @@
                 },
                 "effect": {
                     "type": "PayOrSuffer",
-                    "cost": "Tap",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": "AtomTapPermanents"
+                    },
                     "suffer": "SacrificeSelf"
                 },
                 "descriptionOverride": "When this land enters, sacrifice it unless you tap an untapped permanent you control."
@@ -4329,8 +4332,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "artifact|creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|creature"
+                }
             }
         ]
     },
@@ -13206,8 +13212,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "artifact|creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|creature"
+                }
             }
         ]
     },
@@ -18166,8 +18175,11 @@
             "type": "Warp",
             "cost": "{B}",
             "additionalCost": {
-                "type": "PayLife",
-                "amount": 2
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomPayLife",
+                    "amount": 2
+                }
             },
             "fromGraveyard": true
         }

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -185,8 +185,11 @@
                             "then": {
                                 "type": "AnyPlayerMayPay",
                                 "cost": {
-                                    "type": "PayLife",
-                                    "amount": 5
+                                    "type": "PayAtom",
+                                    "atom": {
+                                        "type": "AtomPayLife",
+                                        "amount": 5
+                                    }
                                 },
                                 "consequenceIfNonePaid": {
                                     "type": "MoveCollection",
@@ -16738,8 +16741,11 @@
                     "effect": {
                         "type": "PayOrSuffer",
                         "cost": {
-                            "type": "PayLife",
-                            "amount": 1
+                            "type": "PayAtom",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "suffer": {
                             "type": "SacrificeTarget",

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -15,8 +15,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{B}{G}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{B}{G}{U}"
+                }
             }
         }
     ],
@@ -454,8 +457,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{W}{B}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{W}{B}{G}"
+                }
             }
         }
     ],
@@ -599,8 +605,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}"
+                }
             }
         }
     ],
@@ -1020,8 +1029,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}{R}"
+                }
             }
         }
     ],
@@ -2170,8 +2182,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{R}"
+                }
             }
         }
     ],
@@ -3239,8 +3254,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "RevealCard",
-                "filter": "blue"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomRevealFromHand",
+                    "filter": "blue"
+                }
             }
         }
     ],
@@ -3505,8 +3523,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}{R}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}{R}{W}"
+                }
             }
         }
     ],
@@ -4251,8 +4272,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{U}"
+                }
             }
         }
     ],
@@ -4340,8 +4364,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{B}"
+                }
             }
         }
     ],
@@ -4799,8 +4826,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G}{G}"
+                }
             },
             "faceUpEffect": {
                 "type": "AddCounters",
@@ -4894,8 +4924,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "RevealCard",
-                "filter": "red"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomRevealFromHand",
+                    "filter": "red"
+                }
             }
         }
     ],
@@ -5042,8 +5075,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}{U}"
+                }
             }
         }
     ],
@@ -5219,8 +5255,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{R}"
+                }
             }
         }
     ],
@@ -6173,8 +6212,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{U}{U}"
+                }
             }
         }
     ],
@@ -6320,8 +6362,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{G}"
+                }
             }
         }
     ],
@@ -6365,8 +6410,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{B}"
+                }
             }
         }
     ],
@@ -7236,8 +7284,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{W}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{W}{W}"
+                }
             }
         }
     ],
@@ -7528,8 +7579,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -7631,8 +7685,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -7816,8 +7873,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -8196,8 +8256,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}"
+                }
             }
         }
     ],
@@ -8240,8 +8303,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{R}{W}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{R}{W}{B}"
+                }
             }
         }
     ],
@@ -8650,8 +8716,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}"
+                }
             }
         }
     ],
@@ -9177,8 +9246,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "RevealCard",
-                "filter": "black"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomRevealFromHand",
+                    "filter": "black"
+                }
             }
         }
     ],
@@ -9287,8 +9359,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{W}"
+                }
             }
         }
     ],
@@ -9320,8 +9395,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}"
+                }
             }
         }
     ],
@@ -9354,8 +9432,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{G}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G}{U}"
+                }
             }
         }
     ],
@@ -10455,8 +10536,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{B}"
+                }
             }
         }
     ],
@@ -10832,8 +10916,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{G}{U}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{G}{U}{R}"
+                }
             }
         }
     ],
@@ -12026,8 +12113,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "RevealCard",
-                "filter": "green"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomRevealFromHand",
+                    "filter": "green"
+                }
             }
         }
     ],
@@ -12264,8 +12354,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{U}{U}"
+                }
             }
         }
     ],
@@ -12494,7 +12587,10 @@
             }
         },
         "additionalCosts": [
-            "DiscardCards"
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
         ]
     },
     "metadata": {
@@ -13123,8 +13219,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{W}"
+                }
             }
         }
     ],
@@ -13273,8 +13372,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "RevealCard",
-                "filter": "white"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomRevealFromHand",
+                    "filter": "white"
+                }
             }
         }
     ],
@@ -13810,8 +13912,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}"
+                }
             }
         }
     ],
@@ -13908,8 +14013,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}"
+                }
             }
         }
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -23,7 +23,10 @@
                     ],
                     "description": "Discard a card — destroy target creature or planeswalker",
                     "additionalCosts": [
-                        "DiscardCards"
+                        {
+                            "type": "AdditionalAtom",
+                            "atom": "AtomDiscard"
+                        }
                     ]
                 },
                 {
@@ -42,8 +45,11 @@
                     "description": "Pay 3 life — destroy target creature or planeswalker",
                     "additionalCosts": [
                         {
-                            "type": "PayLife",
-                            "amount": 3
+                            "type": "AdditionalAtom",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 3
+                            }
                         }
                     ]
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -90,8 +90,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}"
+                }
             }
         }
     ],
@@ -255,8 +258,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{X}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{X}{B}{B}"
+                }
             }
         }
     ],
@@ -485,8 +491,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{6}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{6}{R}"
+                }
             }
         }
     ],
@@ -543,8 +552,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{G}"
+                }
             }
         }
     ],
@@ -923,8 +935,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{U}"
+                }
             }
         }
     ],
@@ -1519,8 +1534,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}"
+                }
             }
         }
     ],
@@ -1571,8 +1589,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
             }
         }
     ],
@@ -1780,8 +1801,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}{W}"
+                }
             }
         }
     ],
@@ -1916,8 +1940,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}{U}"
+                }
             }
         }
     ],
@@ -2224,8 +2251,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -3777,8 +3807,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{6}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{6}{R}{R}"
+                }
             }
         }
     ],
@@ -3865,8 +3898,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}"
+                }
             }
         }
     ],
@@ -4081,8 +4117,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{7}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{7}{G}{G}"
+                }
             }
         }
     ],
@@ -4098,8 +4137,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{G}{G}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{G}{G}"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -4263,8 +4305,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
             }
         }
     ],
@@ -4438,8 +4483,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -4540,8 +4588,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}"
+                }
             }
         }
     ],
@@ -4724,8 +4775,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}"
+                }
             }
         }
     ],
@@ -4868,8 +4922,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{G}"
+                }
             }
         }
     ],
@@ -5152,8 +5209,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G}"
+                }
             }
         }
     ],
@@ -5398,8 +5458,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}{R}"
+                }
             }
         }
     ],
@@ -5555,8 +5618,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}"
+                }
             }
         }
     ],
@@ -5649,8 +5715,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}{B}"
+                }
             }
         }
     ],
@@ -5933,8 +6002,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{R}"
+                }
             }
         }
     ],
@@ -6104,8 +6176,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}"
+                }
             }
         }
     ],
@@ -6634,8 +6709,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}"
+                }
             }
         }
     ],
@@ -6711,8 +6789,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{R}{R}"
+                }
             }
         }
     ],
@@ -6868,8 +6949,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}{U}"
+                }
             }
         }
     ],
@@ -6922,8 +7006,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -7012,8 +7099,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{X}{X}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{X}{X}{R}"
+                }
             }
         }
     ],
@@ -7150,8 +7240,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{U}"
+                }
             }
         }
     ],
@@ -7301,8 +7394,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}"
+                }
             }
         }
     ],
@@ -7400,8 +7496,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{W}"
+                }
             }
         }
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -6670,8 +6670,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "artifact|creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|creature"
+                }
             }
         ]
     },
@@ -7138,8 +7141,11 @@
                     "description": "Sacrifice a creature — destroy target creature",
                     "additionalCosts": [
                         {
-                            "type": "SacrificePermanent",
-                            "filter": "creature"
+                            "type": "AdditionalAtom",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -9051,8 +9057,11 @@
                     "effect": {
                         "type": "PayOrSuffer",
                         "cost": {
-                            "type": "PayLife",
-                            "amount": 2
+                            "type": "PayAtom",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         },
                         "suffer": {
                             "type": "MoveToZone",
@@ -9227,8 +9236,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -10203,7 +10215,10 @@
             ]
         },
         "additionalCosts": [
-            "DiscardCards"
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
         ]
     },
     "metadata": {

--- a/mtg-sets/src/test/resources/snapshots/cards/MIR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MIR.json
@@ -3378,8 +3378,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "creature"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "creature"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -4554,8 +4557,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{U}{U}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{U}{U}"
+                        }
                     },
                     "suffer": "PhaseOut"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOM.json
@@ -82,8 +82,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2710,8 +2710,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "artifact"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact"
+                }
             }
         ]
     },
@@ -3929,8 +3932,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "artifact"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -472,8 +472,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -776,8 +779,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -1415,8 +1421,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{R}{R}"
+                }
             }
         }
     ],
@@ -1529,8 +1538,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{G}"
+                }
             }
         }
     ],
@@ -1690,8 +1702,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{R}{R}"
+                }
             }
         }
     ],
@@ -1876,8 +1891,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{B}"
+                }
             }
         }
     ],
@@ -1997,8 +2015,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{G}"
+                }
             }
         }
     ],
@@ -2150,8 +2171,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}{B}"
+                }
             }
         }
     ],
@@ -2562,7 +2586,10 @@
                 "name": "target"
             },
             "copyRecipient": "AFFECTED_PLAYER",
-            "copyCost": "Discard",
+            "copyCost": {
+                "type": "PayAtom",
+                "atom": "AtomDiscard"
+            },
             "copyTargetRequirement": "AnyTarget",
             "spellName": "Chain of Plasma"
         },
@@ -2610,8 +2637,11 @@
             },
             "copyRecipient": "TARGET_CONTROLLER",
             "copyCost": {
-                "type": "Sacrifice",
-                "filter": "land"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "land"
+                }
             },
             "copyTargetRequirement": {
                 "type": "TargetObject",
@@ -2747,8 +2777,11 @@
             },
             "copyRecipient": "TARGET_CONTROLLER",
             "copyCost": {
-                "type": "Sacrifice",
-                "filter": "land"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "land"
+                }
             },
             "copyTargetRequirement": {
                 "type": "TargetObject",
@@ -2793,8 +2826,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}"
+                }
             }
         }
     ],
@@ -3592,8 +3628,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{W}"
+                }
             }
         }
     ],
@@ -3787,8 +3826,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "land"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land"
+                        }
                     },
                     "suffer": {
                         "type": "GiveControlToTargetPlayer",
@@ -3982,8 +4024,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}"
+                }
             }
         }
     ],
@@ -4039,8 +4084,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{W}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{W}{W}"
+                }
             }
         }
     ],
@@ -4103,8 +4151,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
             }
         }
     ],
@@ -4601,8 +4652,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -4964,8 +5018,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{R}"
+                }
             }
         }
     ],
@@ -5038,8 +5095,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}{B}"
+                }
             }
         }
     ],
@@ -5588,8 +5648,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -5884,8 +5947,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{W}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{W}{W}"
+                }
             }
         }
     ],
@@ -6036,8 +6102,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{B}"
+                }
             }
         }
     ],
@@ -6511,8 +6580,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}"
+                }
             }
         }
     ],
@@ -7404,8 +7476,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{R}"
+                }
             }
         }
     ],
@@ -7671,8 +7746,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
             }
         }
     ],
@@ -7823,8 +7901,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{B}{B}"
+                }
             }
         }
     ],
@@ -8186,8 +8267,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{B}"
+                }
             }
         }
     ],
@@ -8369,8 +8453,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{B}"
+                }
             }
         }
     ],
@@ -8489,8 +8576,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}{G}"
+                }
             }
         }
     ],
@@ -8888,8 +8978,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{W}"
+                }
             }
         }
     ],
@@ -9294,8 +9387,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{6}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{6}{G}{G}"
+                }
             }
         }
     ],
@@ -10045,8 +10141,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{U}{U}"
+                }
             }
         }
     ],
@@ -10355,8 +10454,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -11306,9 +11408,12 @@
                 "effect": {
                     "type": "AnyPlayerMayPay",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "creature",
-                        "count": 2
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "creature",
+                            "count": 2
+                        }
                     },
                     "consequence": "SacrificeSelf"
                 }
@@ -11384,8 +11489,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{U}"
+                }
             }
         }
     ],
@@ -11785,8 +11893,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}"
+                }
             }
         }
     ],
@@ -11883,8 +11994,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}{U}"
+                }
             }
         }
     ],
@@ -12872,8 +12986,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}{G}"
+                }
             }
         }
     ],
@@ -13302,8 +13419,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{B}{B}"
+                }
             }
         }
     ],
@@ -13467,8 +13587,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{R}"
+                }
             }
         }
     ],
@@ -13642,8 +13765,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{R}"
+                }
             }
         }
     ],
@@ -13888,8 +14014,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{R}{R}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}{R}"
+                }
             }
         }
     ],
@@ -13952,8 +14081,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{G}{G}"
+                }
             }
         }
     ],
@@ -14202,8 +14334,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{B}"
+                }
             }
         }
     ],
@@ -14283,8 +14418,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}"
+                }
             }
         }
     ],
@@ -15388,8 +15526,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{B}{B}"
+                }
             }
         }
     ],
@@ -15553,8 +15694,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{6}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{6}{G}"
+                }
             }
         }
     ],
@@ -15681,8 +15825,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}"
+                }
             }
         }
     ],
@@ -16175,8 +16322,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G}{G}"
+                }
             }
         }
     ],
@@ -16456,8 +16606,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -16936,8 +17089,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}"
+                }
             }
         }
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/PLS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PLS.json
@@ -314,8 +314,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -374,8 +377,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -1925,8 +1925,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -3013,8 +3016,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Discard",
-                        "filter": "creature"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomDiscard",
+                            "filter": "creature"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -3825,8 +3831,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Discard",
-                        "random": true
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomDiscard",
+                            "random": true
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -3865,8 +3874,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "land Forest"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land Forest"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -3905,9 +3917,12 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "land Forest",
-                        "count": 3
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land Forest",
+                            "count": 3
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -5108,8 +5123,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Sacrifice",
-                        "filter": "land Island"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land Island"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -5149,8 +5167,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "Discard",
-                        "filter": "land"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomDiscard",
+                            "filter": "land"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1318,8 +1318,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -507,8 +507,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{W}"
+                }
             }
         }
     ],
@@ -2760,8 +2763,11 @@
                 "effect": {
                     "type": "PayOrSuffer",
                     "cost": {
-                        "type": "PayMana",
-                        "cost": "{R}{R}{R}{R}"
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{R}{R}{R}{R}"
+                        }
                     },
                     "suffer": "SacrificeSelf"
                 }
@@ -3721,8 +3727,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W}"
+                }
             }
         }
     ],
@@ -4136,8 +4145,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{3}{W}{W}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{W}{W}"
+                }
             }
         }
     ],
@@ -4802,8 +4814,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}{U}"
+                }
             }
         }
     ],
@@ -5366,8 +5381,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{0}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{0}"
+                }
             }
         }
     ],
@@ -5407,8 +5425,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "Discard",
-                "filter": "Zombie"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomDiscard",
+                    "filter": "Zombie"
+                }
             }
         }
     ],
@@ -5520,8 +5541,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "ReturnToHand",
-                "filter": "creature Bird"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomReturnToHand",
+                    "filter": "creature Bird"
+                }
             }
         }
     ],
@@ -5550,8 +5574,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{U}{U}"
+                }
             }
         }
     ],
@@ -5738,8 +5765,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{1}{U}{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}{U}"
+                }
             }
         }
     ],
@@ -5873,8 +5903,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{5}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}{G}"
+                }
             }
         }
     ],
@@ -6014,8 +6047,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{U}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}"
+                }
             }
         }
     ],
@@ -6201,9 +6237,12 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "Sacrifice",
-                "filter": "land Mountain",
-                "count": 2
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "land Mountain",
+                    "count": 2
+                }
             }
         }
     ],
@@ -6254,8 +6293,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -6383,8 +6425,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{B}{B}{B}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{B}{B}{B}"
+                }
             }
         }
     ],
@@ -6862,8 +6907,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{4}{G}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}{G}{G}"
+                }
             }
         }
     ],
@@ -7590,8 +7638,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayMana",
-                "cost": "{2}{G}{G}"
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{G}{G}"
+                }
             }
         }
     ],
@@ -7739,8 +7790,11 @@
         {
             "type": "Morph",
             "morphCost": {
-                "type": "PayLife",
-                "amount": 5
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomPayLife",
+                    "amount": 5
+                }
             }
         }
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -4721,8 +4721,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },
@@ -19383,8 +19386,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1076,8 +1076,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "land"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "land"
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5378,8 +5378,11 @@
         {
             "type": "Kicker",
             "additionalCost": {
-                "type": "SacrificePermanent",
-                "filter": "artifact|creature"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|creature"
+                }
             }
         }
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -210,8 +210,11 @@
         },
         "additionalCosts": [
             {
-                "type": "SacrificePermanent",
-                "filter": "creature green"
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature green"
+                }
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  * [onDeclined]. Either way it then calls `checkForMore`, so a caller-pushed frame beneath this one
  * resumes for non-effect follow-ups.
  *
- * [PayCost.OwnManaCost] is resolved to a concrete [PayCost.Mana] (against the source's printed cost)
+ * [PayCost.OwnManaCost] is resolved to a concrete [PayCost.Atom] (CostAtom.Mana) (against the source's printed cost)
  * before the frame is created, so it never appears here. A [PayCost.Choice] is stored already reduced
  * to the *affordable* options, so the chosen option index maps positionally onto [PayCost.Choice.options]
  * and an index past the end means "decline".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -28,6 +28,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 
 /**
@@ -733,33 +734,31 @@ class CostHandler(
         controllerId: EntityId
     ): Boolean {
         return when (cost) {
-            is AdditionalCost.SacrificePermanent -> {
-                findMatchingPermanentsUnified(state, controllerId, cost.filter).size >= cost.count
-            }
-            is AdditionalCost.DiscardCards -> {
-                val handZone = ZoneKey(controllerId, Zone.HAND)
-                findMatchingCardsUnified(state, state.getZone(handZone), cost.filter, controllerId).size >= cost.count
-            }
-            is AdditionalCost.PayLife -> {
-                val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
-                // CR 119.4 — a player may pay life only if their life total is >= the payment.
-                life >= cost.amount
+            is AdditionalCost.Atom -> when (val atom = cost.atom) {
+                is CostAtom.Sacrifice ->
+                    findMatchingPermanentsUnified(state, controllerId, atom.filter).size >= atom.count
+                is CostAtom.Discard ->
+                    findMatchingCardsUnified(state, state.getZone(ZoneKey(controllerId, Zone.HAND)), atom.filter, controllerId).size >= atom.count
+                is CostAtom.PayLife -> {
+                    val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
+                    // CR 119.4 — a player may pay life only if their life total is >= the payment.
+                    life >= atom.amount
+                }
+                is CostAtom.ExileFrom ->
+                    findMatchingCardsUnified(state, state.getZone(ZoneKey(controllerId, atom.zone)), atom.filter, controllerId).size >= atom.count
+                is CostAtom.TapPermanents ->
+                    findUntappedMatchingPermanentsUnified(state, controllerId, atom.filter).size >= atom.count
+                // Mana / return-to-hand / reveal are not produced as spell additional costs today.
+                is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand -> false
             }
             is AdditionalCost.PayLifePerTarget -> {
                 // Always payable: choosing zero targets pays zero life. Per-target life
                 // is validated against the chosen target count at CastSpellHandler time.
                 true
             }
-            is AdditionalCost.ExileCards -> {
-                val zone = ZoneKey(controllerId, cost.fromZone.toZone())
-                findMatchingCardsUnified(state, state.getZone(zone), cost.filter, controllerId).size >= cost.count
-            }
             is AdditionalCost.ExileVariableCards -> {
                 val zone = ZoneKey(controllerId, cost.fromZone.toZone())
                 findMatchingCardsUnified(state, state.getZone(zone), cost.filter, controllerId).size >= cost.minCount
-            }
-            is AdditionalCost.TapPermanents -> {
-                findUntappedMatchingPermanentsUnified(state, controllerId, cost.filter).size >= cost.count
             }
             is AdditionalCost.SacrificeCreaturesForCostReduction -> {
                 // Always payable - sacrificing 0 creatures is valid

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -29,6 +29,7 @@ import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -83,12 +84,14 @@ class TurnFaceUpHandler(
         // Validate cost payment based on morph cost type.
         // Apply morph cost increases from permanents like Exiled Doomsayer.
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(state)
-        when (val morphCost = morphData.morphCost) {
-            is PayCost.Mana -> {
+        val morphCost = morphData.morphCost
+        val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
+        when {
+            manaMorph != null -> {
                 // Mana morph payment stays in this handler: it carries the rich up-front UX
                 // (explicit mana-source selection, X, auto-tap preview) that the shared
                 // CostPaymentService's yes/no mana path deliberately doesn't model.
-                val manaCost = costCalculator.increaseGenericCost(morphCost.cost, morphCostIncrease)
+                val manaCost = costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
                 val xValue = action.xValue ?: 0
                 when (action.paymentStrategy) {
                     is PaymentStrategy.AutoPay -> {
@@ -164,9 +167,11 @@ class TurnFaceUpHandler(
         // Pay the morph cost (including any morph cost increases)
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(currentState)
         val xValue = action.xValue ?: 0
-        when (val morphCost = morphData.morphCost) {
-            is PayCost.Mana -> {
-                val manaCost = costCalculator.increaseGenericCost(morphCost.cost, morphCostIncrease)
+        val morphCost = morphData.morphCost
+        val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
+        when {
+            manaMorph != null -> {
+                val manaCost = costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
                 when (action.paymentStrategy) {
                     is PaymentStrategy.FromPool -> {
                         val poolComponent = currentState.getEntity(action.playerId)?.get<ManaPoolComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -67,6 +67,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.CastRestriction
 import com.wingedsheep.sdk.scripting.EventPattern as SdkGameEvent
@@ -944,31 +945,110 @@ class CastSpellHandler(
         }
         for (additionalCost in flattenedCosts) {
             when (additionalCost) {
-                is AdditionalCost.SacrificePermanent -> {
-                    val sacrificed = action.additionalCostPayment?.sacrificedPermanents ?: emptyList()
-                    val filterDesc = additionalCost.filter.description
-                    if (sacrificed.size < additionalCost.count) {
-                        return "You must sacrifice ${additionalCost.count} $filterDesc to cast this spell"
+                is AdditionalCost.Atom -> when (val atom = additionalCost.atom) {
+                    is CostAtom.Sacrifice -> {
+                        val sacrificed = action.additionalCostPayment?.sacrificedPermanents ?: emptyList()
+                        val filterDesc = atom.filter.description
+                        if (sacrificed.size < atom.count) {
+                            return "You must sacrifice ${atom.count} $filterDesc to cast this spell"
+                        }
+                        for (permId in sacrificed) {
+                            val permContainer = state.getEntity(permId)
+                                ?: return "Sacrificed permanent not found: $permId"
+                            val permCard = permContainer.get<CardComponent>()
+                                ?: return "Sacrificed entity is not a card: $permId"
+                            val permController = projected.getController(permId)
+                            if (permController != action.playerId) {
+                                return "You can only sacrifice permanents you control"
+                            }
+                            if (permId !in state.getBattlefield()) {
+                                return "Sacrificed permanent is not on the battlefield: $permId"
+                            }
+                            // Use unified filter with projected state
+                            val context = PredicateContext(controllerId = action.playerId)
+                            val matches = predicateEvaluator.matches(state, projected, permId, atom.filter, context)
+                            if (!matches) {
+                                return "${permCard.name} doesn't match the required filter: $filterDesc"
+                            }
+                        }
                     }
-                    for (permId in sacrificed) {
-                        val permContainer = state.getEntity(permId)
-                            ?: return "Sacrificed permanent not found: $permId"
-                        val permCard = permContainer.get<CardComponent>()
-                            ?: return "Sacrificed entity is not a card: $permId"
-                        val permController = projected.getController(permId)
-                        if (permController != action.playerId) {
-                            return "You can only sacrifice permanents you control"
+                    is CostAtom.ExileFrom -> {
+                        val exiled = action.additionalCostPayment?.exiledCards ?: emptyList()
+                        val zoneDesc = atom.zone.name.lowercase()
+                        if (exiled.size < atom.count) {
+                            return "You must exile ${atom.count} ${atom.filter.description}(s) from your $zoneDesc"
                         }
-                        if (permId !in state.getBattlefield()) {
-                            return "Sacrificed permanent is not on the battlefield: $permId"
-                        }
-                        // Use unified filter with projected state
+                        val zoneCards = state.getZone(ZoneKey(action.playerId, atom.zone))
                         val context = PredicateContext(controllerId = action.playerId)
-                        val matches = predicateEvaluator.matches(state, projected, permId, additionalCost.filter, context)
-                        if (!matches) {
-                            return "${permCard.name} doesn't match the required filter: $filterDesc"
+                        for (cardId in exiled) {
+                            if (cardId !in zoneCards) {
+                                return "Card to exile is not in your $zoneDesc"
+                            }
+                            if (!predicateEvaluator.matches(state, projected, cardId, atom.filter, context)) {
+                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
+                                return "$cardName doesn't match the required filter: ${atom.filter.description}"
+                            }
                         }
                     }
+                    is CostAtom.Discard -> {
+                        val discarded = action.additionalCostPayment?.discardedCards ?: emptyList()
+                        if (discarded.size < atom.count) {
+                            return "You must discard ${atom.count} card(s) to cast this spell"
+                        }
+                        val handCards = state.getZone(ZoneKey(action.playerId, Zone.HAND))
+                        val context = PredicateContext(controllerId = action.playerId)
+                        for (cardId in discarded) {
+                            if (cardId !in handCards) {
+                                return "Card to discard is not in your hand"
+                            }
+                            if (cardId == action.cardId) {
+                                return "Cannot discard the spell being cast"
+                            }
+                            if (atom.filter != com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
+                                if (!predicateEvaluator.matches(state, state.projectedState, cardId, atom.filter, context)) {
+                                    val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
+                                    return "$cardName doesn't match the required filter: ${atom.filter.description}"
+                                }
+                            }
+                        }
+                    }
+                    is CostAtom.TapPermanents -> {
+                        val tapped = action.additionalCostPayment?.tappedPermanents ?: emptyList()
+                        if (tapped.size < atom.count) {
+                            return "You must tap ${atom.count} ${atom.filter.description}(s) to cast this spell"
+                        }
+                        val context = PredicateContext(controllerId = action.playerId)
+                        for (permId in tapped) {
+                            val permContainer = state.getEntity(permId)
+                                ?: return "Tapped permanent not found: $permId"
+                            val permCard = permContainer.get<CardComponent>()
+                                ?: return "Tapped entity is not a card: $permId"
+                            val permController = projected.getController(permId)
+                            if (permController != action.playerId) {
+                                return "You can only tap permanents you control"
+                            }
+                            if (permContainer.has<TappedComponent>()) {
+                                return "${permCard.name} is already tapped"
+                            }
+                            if (permId !in state.getBattlefield()) {
+                                return "Tapped permanent is not on the battlefield: $permId"
+                            }
+                            val matches = predicateEvaluator.matches(state, projected, permId, atom.filter, context)
+                            if (!matches) {
+                                return "${permCard.name} doesn't match the required filter: ${atom.filter.description}"
+                            }
+                        }
+                    }
+                    is CostAtom.PayLife -> {
+                        val currentLife = state.getEntity(action.playerId)
+                            ?.get<LifeTotalComponent>()?.life ?: 0
+                        // CR 119.4 — you can't pay life unless you have at least that much
+                        if (currentLife < atom.amount) {
+                            return "Not enough life to pay ${atom.amount} life"
+                        }
+                    }
+                    // Mana / return / reveal are not produced as spell additional costs today.
+                    is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand -> {}
                 }
                 is AdditionalCost.ExileVariableCards -> {
                     val exiled = action.additionalCostPayment?.exiledCards ?: emptyList()
@@ -991,80 +1071,6 @@ class CastSpellHandler(
                         if (!predicateEvaluator.matches(state, projected, cardId, additionalCost.filter, context)) {
                             val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
                             return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                        }
-                    }
-                }
-                is AdditionalCost.ExileCards -> {
-                    val exiled = action.additionalCostPayment?.exiledCards ?: emptyList()
-                    if (exiled.size < additionalCost.count) {
-                        return "You must exile ${additionalCost.count} ${additionalCost.filter.description}(s) from your ${additionalCost.fromZone.description}"
-                    }
-                    val zone = when (additionalCost.fromZone) {
-                        com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD -> Zone.GRAVEYARD
-                        com.wingedsheep.sdk.scripting.CostZone.HAND -> Zone.HAND
-                        com.wingedsheep.sdk.scripting.CostZone.LIBRARY -> Zone.LIBRARY
-                        com.wingedsheep.sdk.scripting.CostZone.BATTLEFIELD -> Zone.BATTLEFIELD
-                    }
-                    val zoneKey = ZoneKey(action.playerId, zone)
-                    val zoneCards = state.getZone(zoneKey)
-                    val context = PredicateContext(controllerId = action.playerId)
-                    for (cardId in exiled) {
-                        if (cardId !in zoneCards) {
-                            return "Card to exile is not in your ${additionalCost.fromZone.description}"
-                        }
-                        if (!predicateEvaluator.matches(state, projected, cardId, additionalCost.filter, context)) {
-                            val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                            return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                        }
-                    }
-                }
-                is AdditionalCost.DiscardCards -> {
-                    val discarded = action.additionalCostPayment?.discardedCards ?: emptyList()
-                    if (discarded.size < additionalCost.count) {
-                        return "You must discard ${additionalCost.count} card(s) to cast this spell"
-                    }
-                    val handZone = ZoneKey(action.playerId, Zone.HAND)
-                    val handCards = state.getZone(handZone)
-                    val context = PredicateContext(controllerId = action.playerId)
-                    for (cardId in discarded) {
-                        if (cardId !in handCards) {
-                            return "Card to discard is not in your hand"
-                        }
-                        if (cardId == action.cardId) {
-                            return "Cannot discard the spell being cast"
-                        }
-                        if (additionalCost.filter != com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
-                            if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
-                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                                return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                            }
-                        }
-                    }
-                }
-                is AdditionalCost.TapPermanents -> {
-                    val tapped = action.additionalCostPayment?.tappedPermanents ?: emptyList()
-                    if (tapped.size < additionalCost.count) {
-                        return "You must tap ${additionalCost.count} ${additionalCost.filter.description}(s) to cast this spell"
-                    }
-                    val context = PredicateContext(controllerId = action.playerId)
-                    for (permId in tapped) {
-                        val permContainer = state.getEntity(permId)
-                            ?: return "Tapped permanent not found: $permId"
-                        val permCard = permContainer.get<CardComponent>()
-                            ?: return "Tapped entity is not a card: $permId"
-                        val permController = projected.getController(permId)
-                        if (permController != action.playerId) {
-                            return "You can only tap permanents you control"
-                        }
-                        if (permContainer.has<TappedComponent>()) {
-                            return "${permCard.name} is already tapped"
-                        }
-                        if (permId !in state.getBattlefield()) {
-                            return "Tapped permanent is not on the battlefield: $permId"
-                        }
-                        val matches = predicateEvaluator.matches(state, projected, permId, additionalCost.filter, context)
-                        if (!matches) {
-                            return "${permCard.name} doesn't match the required filter: ${additionalCost.filter.description}"
                         }
                     }
                 }
@@ -1264,14 +1270,6 @@ class CastSpellHandler(
                         if (actual < demandedCount) {
                             return "Creature does not have $demandedCount $counterType counters to remove"
                         }
-                    }
-                }
-                is AdditionalCost.PayLife -> {
-                    val currentLife = state.getEntity(action.playerId)
-                        ?.get<LifeTotalComponent>()?.life ?: 0
-                    // CR 119.4 — you can't pay life unless you have at least that much
-                    if (currentLife < additionalCost.amount) {
-                        return "Not enough life to pay ${additionalCost.amount} life"
                     }
                 }
                 is AdditionalCost.PayLifePerTarget -> {
@@ -1556,9 +1554,10 @@ class CastSpellHandler(
         // payment is applied regardless of whether the client included an
         // AdditionalCostPayment object.
         for (additionalCost in flattenedAllCosts) {
-            val lifeToPay = when (additionalCost) {
-                is AdditionalCost.PayLife -> additionalCost.amount
-                is AdditionalCost.PayLifePerTarget -> additionalCost.amountPerTarget * action.targets.size
+            val atom = (additionalCost as? AdditionalCost.Atom)?.atom
+            val lifeToPay = when {
+                atom is CostAtom.PayLife -> atom.amount
+                additionalCost is AdditionalCost.PayLifePerTarget -> additionalCost.amountPerTarget * action.targets.size
                 else -> continue
             }
             if (lifeToPay == 0) continue
@@ -1574,68 +1573,98 @@ class CastSpellHandler(
         if (flattenedAllCosts.isNotEmpty() && action.additionalCostPayment != null) {
             for (additionalCost in flattenedAllCosts) {
                 when (additionalCost) {
-                    is AdditionalCost.SacrificePermanent -> {
-                        // Snapshot projected subtypes and P/T before zone change
-                        // (Rule 112.7a / 608.2h — "as it last existed on the battlefield")
-                        val projectedBeforeSacrifice = currentState.projectedState
-                        sacrificedSnapshots.addAll(
-                            capturePermanentSnapshots(action.additionalCostPayment.sacrificedPermanents, projectedBeforeSacrifice)
-                        )
-                        for (permId in action.additionalCostPayment.sacrificedPermanents) {
-                            val permContainer = currentState.getEntity(permId) ?: continue
-                            val permCard = permContainer.get<CardComponent>() ?: continue
-                            val controllerId = permContainer.get<ControllerComponent>()?.playerId ?: action.playerId
-                            val ownerId = permCard.ownerId ?: action.playerId
-                            val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
-                            val graveyardZone = ZoneKey(ownerId, Zone.GRAVEYARD)
+                    is AdditionalCost.Atom -> when (val atom = additionalCost.atom) {
+                        is CostAtom.Sacrifice -> {
+                            // Snapshot projected subtypes and P/T before zone change
+                            // (Rule 112.7a / 608.2h — "as it last existed on the battlefield")
+                            val projectedBeforeSacrifice = currentState.projectedState
+                            sacrificedSnapshots.addAll(
+                                capturePermanentSnapshots(action.additionalCostPayment.sacrificedPermanents, projectedBeforeSacrifice)
+                            )
+                            for (permId in action.additionalCostPayment.sacrificedPermanents) {
+                                val permContainer = currentState.getEntity(permId) ?: continue
+                                val permCard = permContainer.get<CardComponent>() ?: continue
+                                val controllerId = permContainer.get<ControllerComponent>()?.playerId ?: action.playerId
+                                val ownerId = permCard.ownerId ?: action.playerId
+                                val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
+                                val graveyardZone = ZoneKey(ownerId, Zone.GRAVEYARD)
 
-                            currentState = currentState.removeFromZone(battlefieldZone, permId)
-                            currentState = currentState.addToZone(graveyardZone, permId)
+                                currentState = currentState.removeFromZone(battlefieldZone, permId)
+                                currentState = currentState.addToZone(graveyardZone, permId)
 
-                            events.add(PermanentsSacrificedEvent(action.playerId, listOf(permId), listOf(permCard.name)))
-                            events.add(ZoneChangeEvent(
-                                entityId = permId,
-                                entityName = permCard.name,
-                                fromZone = Zone.BATTLEFIELD,
-                                toZone = Zone.GRAVEYARD,
-                                ownerId = ownerId
-                            ))
+                                events.add(PermanentsSacrificedEvent(action.playerId, listOf(permId), listOf(permCard.name)))
+                                events.add(ZoneChangeEvent(
+                                    entityId = permId,
+                                    entityName = permCard.name,
+                                    fromZone = Zone.BATTLEFIELD,
+                                    toZone = Zone.GRAVEYARD,
+                                    ownerId = ownerId
+                                ))
+                            }
                         }
-                    }
-                    is AdditionalCost.DiscardCards -> {
-                        val discardedCards = action.additionalCostPayment.discardedCards
-                        for (cardId in discardedCards) {
-                            val cardContainer = currentState.getEntity(cardId) ?: continue
-                            val card = cardContainer.get<CardComponent>() ?: continue
-                            val handZone = ZoneKey(action.playerId, Zone.HAND)
-                            val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
+                        is CostAtom.Discard -> {
+                            val discardedCards = action.additionalCostPayment.discardedCards
+                            for (cardId in discardedCards) {
+                                val cardContainer = currentState.getEntity(cardId) ?: continue
+                                val card = cardContainer.get<CardComponent>() ?: continue
+                                val handZone = ZoneKey(action.playerId, Zone.HAND)
+                                val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
 
-                            currentState = currentState.removeFromZone(handZone, cardId)
-                            currentState = currentState.addToZone(graveyardZone, cardId)
+                                currentState = currentState.removeFromZone(handZone, cardId)
+                                currentState = currentState.addToZone(graveyardZone, cardId)
 
-                            events.add(ZoneChangeEvent(
-                                entityId = cardId,
-                                entityName = card.name,
-                                fromZone = Zone.HAND,
-                                toZone = Zone.GRAVEYARD,
-                                ownerId = action.playerId
-                            ))
+                                events.add(ZoneChangeEvent(
+                                    entityId = cardId,
+                                    entityName = card.name,
+                                    fromZone = Zone.HAND,
+                                    toZone = Zone.GRAVEYARD,
+                                    ownerId = action.playerId
+                                ))
+                            }
+                            val discardNames = discardedCards.map { currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
+                            events.add(CardsDiscardedEvent(action.playerId, discardedCards, discardNames))
                         }
-                        val discardNames = discardedCards.map { currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
-                        events.add(CardsDiscardedEvent(action.playerId, discardedCards, discardNames))
+                        is CostAtom.ExileFrom -> {
+                            val exiledCards = action.additionalCostPayment.exiledCards
+                            for (cardId in exiledCards) {
+                                val cardContainer = currentState.getEntity(cardId) ?: continue
+                                val card = cardContainer.get<CardComponent>() ?: continue
+                                val sourceZone = ZoneKey(action.playerId, atom.zone)
+                                val exileZone = ZoneKey(action.playerId, Zone.EXILE)
+
+                                currentState = currentState.removeFromZone(sourceZone, cardId)
+                                currentState = currentState.addToZone(exileZone, cardId)
+
+                                events.add(ZoneChangeEvent(
+                                    entityId = cardId,
+                                    entityName = card.name,
+                                    fromZone = atom.zone,
+                                    toZone = Zone.EXILE,
+                                    ownerId = action.playerId
+                                ))
+                            }
+                            exiledCardCount = exiledCards.size
+                        }
+                        is CostAtom.TapPermanents -> {
+                            // Tap permanents as additional cost (e.g., Zahid's tap an artifact)
+                            val tappedPerms = action.additionalCostPayment.tappedPermanents
+                            for (permId in tappedPerms) {
+                                val permContainer = currentState.getEntity(permId) ?: continue
+                                if (!permContainer.has<TappedComponent>()) {
+                                    currentState = currentState.updateEntity(permId) { c ->
+                                        c.with(TappedComponent)
+                                    }
+                                    val permCard = permContainer.get<CardComponent>()
+                                    events.add(TappedEvent(permId, permCard?.name ?: "Permanent"))
+                                }
+                            }
+                        }
+                        // PayLife is auto-paid in the loop above; mana / return / reveal aren't spell additional costs.
+                        is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand -> {}
                     }
-                    is AdditionalCost.ExileVariableCards, is AdditionalCost.ExileCards -> {
+                    is AdditionalCost.ExileVariableCards -> {
                         val exiledCards = action.additionalCostPayment.exiledCards
-                        val fromZone = when (additionalCost) {
-                            is AdditionalCost.ExileVariableCards -> additionalCost.fromZone
-                            is AdditionalCost.ExileCards -> additionalCost.fromZone
-                        }
-                        val zone = when (fromZone) {
-                            com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD -> Zone.GRAVEYARD
-                            com.wingedsheep.sdk.scripting.CostZone.HAND -> Zone.HAND
-                            com.wingedsheep.sdk.scripting.CostZone.LIBRARY -> Zone.LIBRARY
-                            com.wingedsheep.sdk.scripting.CostZone.BATTLEFIELD -> Zone.BATTLEFIELD
-                        }
+                        val zone = additionalCost.fromZone.toZone()
                         for (cardId in exiledCards) {
                             val cardContainer = currentState.getEntity(cardId) ?: continue
                             val card = cardContainer.get<CardComponent>() ?: continue
@@ -1654,20 +1683,6 @@ class CastSpellHandler(
                             ))
                         }
                         exiledCardCount = exiledCards.size
-                    }
-                    is AdditionalCost.TapPermanents -> {
-                        // Tap permanents as additional cost (e.g., Zahid's tap an artifact)
-                        val tappedPerms = action.additionalCostPayment.tappedPermanents
-                        for (permId in tappedPerms) {
-                            val permContainer = currentState.getEntity(permId) ?: continue
-                            if (!permContainer.has<TappedComponent>()) {
-                                currentState = currentState.updateEntity(permId) { c ->
-                                    c.with(TappedComponent)
-                                }
-                                val permCard = permContainer.get<CardComponent>()
-                                events.add(TappedEvent(permId, permCard?.name ?: "Permanent"))
-                            }
-                        }
                     }
                     is AdditionalCost.SacrificeCreaturesForCostReduction -> {
                         // Process sacrifices for cost reduction (e.g., Torgaar)
@@ -1869,9 +1884,6 @@ class CastSpellHandler(
                                 entityName = entityName
                             ))
                         }
-                    }
-                    is AdditionalCost.PayLife -> {
-                        // Handled in the auto-pay pre-pass above (PayLife requires no player choice).
                     }
                     is AdditionalCost.PayLifePerTarget -> {
                         // Handled in the auto-pay pre-pass above (life total scales with target count).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.*
 import com.wingedsheep.sdk.scripting.targets.AnyTarget
@@ -68,13 +69,13 @@ class ChainSpellContinuationResumer(
         }
 
         // Present cost payment based on PayCost type
-        return when (copyCost) {
-            is PayCost.Sacrifice -> {
-                val candidates = ChainCopyExecutor.findMatchingPermanents(state, controllerId, copyCost.filter)
-                if (candidates.size < copyCost.count) {
+        return when (val atom = (copyCost as? PayCost.Atom)?.atom) {
+            is CostAtom.Sacrifice -> {
+                val candidates = ChainCopyExecutor.findMatchingPermanents(state, controllerId, atom.filter)
+                if (candidates.size < atom.count) {
                     return checkForMore(state, emptyList())
                 }
-                if (candidates.size == copyCost.count) {
+                if (candidates.size == atom.count) {
                     // Auto-pay when exactly enough resources
                     return payCostAndPresentTargets(
                         state, controllerId, copyCost, candidates,
@@ -83,14 +84,14 @@ class ChainSpellContinuationResumer(
                 }
                 presentCostSelection(
                     state, controllerId, effect, continuation.sourceId, candidates,
-                    "Choose a ${copyCost.filter.description} to sacrifice for the copy of ${effect.spellName}",
+                    "Choose a ${atom.filter.description} to sacrifice for the copy of ${effect.spellName}",
                     useTargetingUI = true
                 )
             }
-            is PayCost.Discard -> {
+            is CostAtom.Discard -> {
                 val handZone = ZoneKey(controllerId, Zone.HAND)
                 val hand = state.getZone(handZone)
-                if (hand.size < copyCost.count) {
+                if (hand.size < atom.count) {
                     return checkForMore(state, emptyList())
                 }
                 presentCostSelection(
@@ -419,8 +420,8 @@ class ChainSpellContinuationResumer(
         var newState = state
         val events = mutableListOf<GameEvent>()
 
-        when (cost) {
-            is PayCost.Sacrifice -> {
+        when ((cost as? PayCost.Atom)?.atom) {
+            is CostAtom.Sacrifice -> {
                 for (cardId in selectedCards) {
                     val container = newState.getEntity(cardId) ?: continue
                     val cardComponent = container.get<CardComponent>() ?: continue
@@ -444,7 +445,7 @@ class ChainSpellContinuationResumer(
                     ))
                 }
             }
-            is PayCost.Discard -> {
+            is CostAtom.Discard -> {
                 val handZone = ZoneKey(controllerId, Zone.HAND)
                 val graveyardZone = ZoneKey(controllerId, Zone.GRAVEYARD)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.mechanics.cost.CostPaymentContext
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.mechanics.cost.PaymentResult
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.Effect
 
@@ -43,19 +44,21 @@ class CostPaymentContinuationResumer(
         checkForMore: CheckForMore
     ): ExecutionResult = when (val cost = continuation.cost) {
         is PayCost.Choice -> resumeChoice(state, continuation, cost, response, checkForMore)
-        // Yes/no costs: mana, life, and random discard.
-        is PayCost.Mana, is PayCost.PayLife ->
-            resumeYesNo(state, continuation, cost, response, checkForMore)
-        is PayCost.Discard ->
-            if (cost.random) resumeYesNo(state, continuation, cost, response, checkForMore)
-            else resumeSelection(state, continuation, cost, response, checkForMore)
-        // Selection costs.
-        is PayCost.Exile, is PayCost.RevealCard, is PayCost.Sacrifice,
-        is PayCost.ReturnToHand, is PayCost.Tap ->
-            resumeSelection(state, continuation, cost, response, checkForMore)
         // Resolved away before the frame is built; should never reach the resumer.
         is PayCost.OwnManaCost ->
             ExecutionResult.error(state, "OwnManaCost should have been resolved before payment")
+        is PayCost.Atom -> when (val atom = cost.atom) {
+            // Yes/no costs: mana, life, and random discard.
+            is CostAtom.Mana, is CostAtom.PayLife ->
+                resumeYesNo(state, continuation, cost, response, checkForMore)
+            is CostAtom.Discard ->
+                if (atom.random) resumeYesNo(state, continuation, cost, response, checkForMore)
+                else resumeSelection(state, continuation, cost, response, checkForMore)
+            // Selection costs.
+            is CostAtom.ExileFrom, is CostAtom.RevealFromHand, is CostAtom.Sacrifice,
+            is CostAtom.ReturnToHand, is CostAtom.TapPermanents ->
+                resumeSelection(state, continuation, cost, response, checkForMore)
+        }
     }
 
     private fun resumeYesNo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
 
@@ -598,8 +599,8 @@ class SacrificeAndPayContinuationResumer(
     ): ExecutionResult {
         val playerId = continuation.currentPlayerId
 
-        when (continuation.cost) {
-            is PayCost.Sacrifice -> {
+        when ((continuation.cost as? PayCost.Atom)?.atom) {
+            is CostAtom.Sacrifice -> {
                 if (response !is CardsSelectedResponse) {
                     return ExecutionResult.error(state, "Expected card selection response for any player may pay")
                 }
@@ -619,7 +620,7 @@ class SacrificeAndPayContinuationResumer(
                 return runAnyPlayerMayPayConsequence(newState, continuation, continuation.consequence, events, checkForMore)
             }
 
-            is PayCost.PayLife -> {
+            is CostAtom.PayLife -> {
                 if (response !is YesNoResponse) {
                     return ExecutionResult.error(state, "Expected yes/no response for any player may pay life")
                 }
@@ -694,15 +695,15 @@ class SacrificeAndPayContinuationResumer(
 
         for ((index, nextPlayerId) in continuation.remainingPlayers.withIndex()) {
             val remainingAfter = continuation.remainingPlayers.drop(index + 1)
-            when (cost) {
-                is PayCost.Sacrifice -> {
+            when (val atom = (cost as? PayCost.Atom)?.atom) {
+                is CostAtom.Sacrifice -> {
                     val battlefield = state.getZone(ZoneKey(nextPlayerId, Zone.BATTLEFIELD))
                     val context = PredicateContext(controllerId = nextPlayerId)
                     val validPermanents = battlefield.filter { permanentId ->
-                        predicateEvaluator.matches(state, projected, permanentId, cost.filter, context)
+                        predicateEvaluator.matches(state, projected, permanentId, atom.filter, context)
                     }
-                    if (validPermanents.size >= cost.count) {
-                        val prompt = "You may sacrifice ${cost.count} ${cost.filter.description}s to cause ${continuation.sourceName} to be sacrificed, or skip"
+                    if (validPermanents.size >= atom.count) {
+                        val prompt = "You may sacrifice ${atom.count} ${atom.filter.description}s to cause ${continuation.sourceName} to be sacrificed, or skip"
                         val decisionResult = decisionHandler.createCardSelectionDecision(
                             state = state,
                             playerId = nextPlayerId,
@@ -711,7 +712,7 @@ class SacrificeAndPayContinuationResumer(
                             prompt = prompt,
                             options = validPermanents,
                             minSelections = 0,
-                            maxSelections = cost.count,
+                            maxSelections = atom.count,
                             ordered = false,
                             phase = DecisionPhase.RESOLUTION,
                             useTargetingUI = true
@@ -730,12 +731,12 @@ class SacrificeAndPayContinuationResumer(
                     }
                 }
 
-                is PayCost.PayLife -> {
+                is CostAtom.PayLife -> {
                     val life = state.getEntity(nextPlayerId)
                         ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
-                    if (life >= cost.amount) {
+                    if (life >= atom.amount) {
                         val decisionId = java.util.UUID.randomUUID().toString()
-                        val prompt = "Pay ${cost.amount} life to prevent ${continuation.sourceName}'s effect?"
+                        val prompt = "Pay ${atom.amount} life to prevent ${continuation.sourceName}'s effect?"
                         val decision = YesNoDecision(
                             id = decisionId,
                             playerId = nextPlayerId,
@@ -745,7 +746,7 @@ class SacrificeAndPayContinuationResumer(
                                 sourceName = continuation.sourceName,
                                 phase = DecisionPhase.RESOLUTION
                             ),
-                            yesText = "Pay ${cost.amount} life",
+                            yesText = "Pay ${atom.amount} life",
                             noText = "Don't pay"
                         )
                         val newContinuation = continuation.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/chain/ChainCopyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/chain/ChainCopyExecutor.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.ChainCopyEffect
 import com.wingedsheep.sdk.scripting.effects.CopyRecipient
@@ -194,14 +195,14 @@ class ChainCopyExecutor(
          */
         fun canPayCopyCost(state: GameState, playerId: EntityId, cost: PayCost?): Boolean {
             if (cost == null) return true
-            return when (cost) {
-                is PayCost.Sacrifice -> {
-                    findMatchingPermanents(state, playerId, cost.filter).size >= cost.count
+            return when (val atom = (cost as? PayCost.Atom)?.atom) {
+                is CostAtom.Sacrifice -> {
+                    findMatchingPermanents(state, playerId, atom.filter).size >= atom.count
                 }
-                is PayCost.Discard -> {
+                is CostAtom.Discard -> {
                     val handZone = ZoneKey(playerId, Zone.HAND)
                     val hand = state.getZone(handZone)
-                    hand.size >= cost.count
+                    hand.size >= atom.count
                 }
                 else -> true
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import java.util.UUID
 import kotlin.reflect.KClass
@@ -96,16 +97,16 @@ class AnyPlayerMayPayExecutor(
         }
 
         val playerId = playerOrder[index]
-        return when (val cost = effect.cost) {
-            is PayCost.Sacrifice -> askPlayerToSacrifice(
-                state, effect, context, cost, sourceId, sourceName,
+        return when (val atom = (effect.cost as? PayCost.Atom)?.atom) {
+            is CostAtom.Sacrifice -> askPlayerToSacrifice(
+                state, effect, context, atom, sourceId, sourceName,
                 playerId, playerOrder, index
             )
-            is PayCost.PayLife -> askPlayerToPayLife(
-                state, effect, context, cost, sourceId, sourceName,
+            is CostAtom.PayLife -> askPlayerToPayLife(
+                state, effect, context, atom, sourceId, sourceName,
                 playerId, playerOrder, index
             )
-            else -> EffectResult.error(state, "Unsupported cost type for AnyPlayerMayPay: ${cost::class.simpleName}")
+            else -> EffectResult.error(state, "Unsupported cost type for AnyPlayerMayPay: ${effect.cost::class.simpleName}")
         }
     }
 
@@ -115,15 +116,15 @@ class AnyPlayerMayPayExecutor(
         cost: PayCost,
         sourceId: EntityId
     ): Boolean {
-        return when (cost) {
-            is PayCost.Sacrifice -> {
-                val validPermanents = findValidPermanentsOnBattlefield(state, playerId, cost.filter, sourceId)
-                validPermanents.size >= cost.count
+        return when (val atom = (cost as? PayCost.Atom)?.atom) {
+            is CostAtom.Sacrifice -> {
+                val validPermanents = findValidPermanentsOnBattlefield(state, playerId, atom.filter, sourceId)
+                validPermanents.size >= atom.count
             }
             // CR 119.4: a player may pay life only if their life total is at least the amount.
-            is PayCost.PayLife -> {
+            is CostAtom.PayLife -> {
                 val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
-                life >= cost.amount
+                life >= atom.amount
             }
             else -> false
         }
@@ -133,7 +134,7 @@ class AnyPlayerMayPayExecutor(
         state: GameState,
         effect: AnyPlayerMayPayEffect,
         context: EffectContext,
-        cost: PayCost.Sacrifice,
+        cost: CostAtom.Sacrifice,
         sourceId: EntityId,
         sourceName: String,
         playerId: EntityId,
@@ -182,7 +183,7 @@ class AnyPlayerMayPayExecutor(
         state: GameState,
         effect: AnyPlayerMayPayEffect,
         context: EffectContext,
-        cost: PayCost.PayLife,
+        cost: CostAtom.PayLife,
         sourceId: EntityId,
         sourceName: String,
         playerId: EntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
@@ -65,20 +66,22 @@ class PayOrSufferExecutor(
             ?: return EffectResult.error(state, "Source has no card component")
 
         return when (val cost = effect.cost) {
-            is PayCost.Discard -> handleDiscardCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.Sacrifice -> handleSacrificeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.PayLife -> handlePayLifeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.Mana -> handleManaCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
+            is PayCost.Choice -> handleChoiceCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             // "...pay its mana cost": pay the affected permanent's own mana cost. A permanent
             // with no mana cost (a land, a token) has an empty ManaCost, which resolves to {0}
             // and is trivially payable, so such a permanent is always kept.
             is PayCost.OwnManaCost ->
-                handleManaCost(state, effect, context, PayCost.Mana(sourceCard.manaCost), sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.Exile -> handleExileCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.Choice -> handleChoiceCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.Tap -> handleTapCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
-            is PayCost.ReturnToHand -> EffectResult.error(state, "ReturnToHand payment for PayOrSuffer not yet implemented")
-            is PayCost.RevealCard -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
+                handleManaCost(state, effect, context, CostAtom.Mana(sourceCard.manaCost), sourceId, sourceCard.name, payingPlayerId)
+            is PayCost.Atom -> when (val atom = cost.atom) {
+                is CostAtom.Discard -> handleDiscardCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.Sacrifice -> handleSacrificeCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.PayLife -> handlePayLifeCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.Mana -> handleManaCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.ExileFrom -> handleExileCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.TapPermanents -> handleTapCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
+                is CostAtom.ReturnToHand -> EffectResult.error(state, "ReturnToHand payment for PayOrSuffer not yet implemented")
+                is CostAtom.RevealFromHand -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
+            }
         }
     }
 
@@ -89,7 +92,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Discard,
+        cost: CostAtom.Discard,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -157,7 +160,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Discard,
+        cost: CostAtom.Discard,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -226,7 +229,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Sacrifice,
+        cost: CostAtom.Sacrifice,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -294,7 +297,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Tap,
+        cost: CostAtom.TapPermanents,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -357,7 +360,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.PayLife,
+        cost: CostAtom.PayLife,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -428,7 +431,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Exile,
+        cost: CostAtom.ExileFrom,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -487,7 +490,7 @@ class PayOrSufferExecutor(
         state: GameState,
         effect: PayOrSufferEffect,
         context: EffectContext,
-        cost: PayCost.Mana,
+        cost: CostAtom.Mana,
         sourceId: EntityId,
         sourceName: String,
         controllerId: EntityId
@@ -635,24 +638,26 @@ class PayOrSufferExecutor(
         sourceId: EntityId
     ): Boolean {
         return when (cost) {
-            is PayCost.Discard -> findValidCardsInHand(state, playerId, cost.filter).size >= cost.count
-            is PayCost.Sacrifice -> findValidPermanentsOnBattlefield(state, playerId, cost.filter, sourceId).size >= cost.count
-            is PayCost.PayLife -> {
-                val life = state.getEntity(playerId)?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
-                life > cost.amount
-            }
-            is PayCost.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, cost.cost)
             is PayCost.OwnManaCost -> {
                 // Null only when the source entity/CardComponent is missing; an empty mana cost
                 // (lands, tokens) is {0} and always payable — see the execute branch above.
                 val ownCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost
                 ownCost != null && ManaSolver(cardRegistry).canPay(state, playerId, ownCost)
             }
-            is PayCost.Exile -> findValidCardsInZone(state, playerId, cost.filter, cost.zone).size >= cost.count
             is PayCost.Choice -> cost.options.any { canPayCost(state, playerId, it, sourceId) }
-            is PayCost.Tap -> findValidUntappedPermanentsOnBattlefield(state, playerId, cost.filter, sourceId).size >= cost.count
-            is PayCost.ReturnToHand -> false
-            is PayCost.RevealCard -> false
+            is PayCost.Atom -> when (val atom = cost.atom) {
+                is CostAtom.Discard -> findValidCardsInHand(state, playerId, atom.filter).size >= atom.count
+                is CostAtom.Sacrifice -> findValidPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
+                is CostAtom.PayLife -> {
+                    val life = state.getEntity(playerId)?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                    life > atom.amount
+                }
+                is CostAtom.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, atom.cost)
+                is CostAtom.ExileFrom -> findValidCardsInZone(state, playerId, atom.filter, atom.zone).size >= atom.count
+                is CostAtom.TapPermanents -> findValidUntappedPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
+                is CostAtom.ReturnToHand -> false
+                is CostAtom.RevealFromHand -> false
+            }
         }
     }
 
@@ -801,7 +806,7 @@ class PayOrSufferExecutor(
     /**
      * Build prompt for discard cost.
      */
-    private fun buildDiscardPrompt(cost: PayCost.Discard, sourceName: String, sufferEffect: Effect): String {
+    private fun buildDiscardPrompt(cost: CostAtom.Discard, sourceName: String, sufferEffect: Effect): String {
         val desc = cost.filter.description
         val typeText = if (cost.count == 1) {
             val article = if (desc == "card") "a" else if (desc.first().lowercaseChar() in "aeiou") "an" else "a"
@@ -816,7 +821,7 @@ class PayOrSufferExecutor(
     /**
      * Build prompt for sacrifice cost.
      */
-    private fun buildSacrificePrompt(cost: PayCost.Sacrifice, sourceName: String, sufferEffect: Effect): String {
+    private fun buildSacrificePrompt(cost: CostAtom.Sacrifice, sourceName: String, sufferEffect: Effect): String {
         val desc = cost.filter.description
         val typeText = if (cost.count == 1) {
             "${if (desc.first().lowercaseChar() in "aeiou") "an" else "a"} $desc"
@@ -830,7 +835,7 @@ class PayOrSufferExecutor(
     /**
      * Build prompt for tap cost.
      */
-    private fun buildTapPrompt(cost: PayCost.Tap, sourceName: String, sufferEffect: Effect): String {
+    private fun buildTapPrompt(cost: CostAtom.TapPermanents, sourceName: String, sufferEffect: Effect): String {
         val desc = cost.filter.description
         val typeText = if (cost.count == 1) {
             // The article always precedes "untapped", so it is always "an".
@@ -845,7 +850,7 @@ class PayOrSufferExecutor(
     /**
      * Build prompt for exile cost.
      */
-    private fun buildExilePrompt(cost: PayCost.Exile, sourceName: String, sufferEffect: Effect): String {
+    private fun buildExilePrompt(cost: CostAtom.ExileFrom, sourceName: String, sufferEffect: Effect): String {
         val desc = cost.filter.description
         val typeText = if (cost.count == 1) {
             "${if (desc.first().lowercaseChar() in "aeiou") "an" else "a"} $desc"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -269,7 +269,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.ExileFromGraveyard -> {
                         val targets = context.costUtils.findExileTargets(
                             state, playerId, effectiveCost.filter,
-                            com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD
+                            com.wingedsheep.sdk.core.Zone.GRAVEYARD
                         )
                         if (targets.size < effectiveCost.count) continue
                         exileCost = effectiveCost
@@ -405,7 +405,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     // graveyard" cost).
                                     val targets = context.costUtils.findExileTargets(
                                         state, playerId, subCost.filter,
-                                        com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD
+                                        com.wingedsheep.sdk.core.Zone.GRAVEYARD
                                     )
                                     if (targets.size < subCost.count) {
                                         costCanBePaid = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.MayCastFromGraveyard
 import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
@@ -1774,17 +1775,17 @@ class CastFromZoneEnumerator : ActionEnumerator {
             var kickerCostInfo: AdditionalCostData? = null
             var canPayKickerAdditionalCost = true
             if (additionalCostKicker?.additionalCost != null) {
-                when (val cost = additionalCostKicker.additionalCost) {
-                    is AdditionalCost.SacrificePermanent -> {
-                        val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, cost)
-                        if (validSacTargets.size < cost.count) {
+                when (val atom = (additionalCostKicker.additionalCost as? AdditionalCost.Atom)?.atom) {
+                    is CostAtom.Sacrifice -> {
+                        val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, atom)
+                        if (validSacTargets.size < atom.count) {
                             canPayKickerAdditionalCost = false
                         } else {
                             kickerCostInfo = AdditionalCostData(
-                                description = cost.description,
+                                description = atom.description.replaceFirstChar { it.uppercase() },
                                 costType = "SacrificePermanent",
                                 validSacrificeTargets = validSacTargets,
-                                sacrificeCount = cost.count
+                                sacrificeCount = atom.count
                             )
                         }
                     }
@@ -1891,17 +1892,17 @@ class CastFromZoneEnumerator : ActionEnumerator {
         component: PlayWithAdditionalCostComponent
     ): AdditionalCostData? {
         val cost = component.additionalCosts.firstOrNull() ?: return null
-        return when (cost) {
-            is com.wingedsheep.sdk.scripting.AdditionalCost.DiscardCards -> {
-                val handCards = state.getZone(ZoneKey(playerId, Zone.HAND))
-                AdditionalCostData(
-                    description = cost.description,
-                    costType = "DiscardCard",
-                    validDiscardTargets = handCards.toList(),
-                    discardCount = cost.count
-                )
-            }
-            else -> AdditionalCostData(
+        val discardAtom = (cost as? AdditionalCost.Atom)?.atom as? CostAtom.Discard
+        return if (discardAtom != null) {
+            val handCards = state.getZone(ZoneKey(playerId, Zone.HAND))
+            AdditionalCostData(
+                description = discardAtom.description.replaceFirstChar { it.uppercase() },
+                costType = "DiscardCard",
+                validDiscardTargets = handCards.toList(),
+                discardCount = discardAtom.count
+            )
+        } else {
+            AdditionalCostData(
                 description = cost.description,
                 costType = "Other"
             )
@@ -1914,10 +1915,10 @@ class CastFromZoneEnumerator : ActionEnumerator {
         component: PlayWithAdditionalCostComponent
     ): Boolean {
         for (cost in component.additionalCosts) {
-            when (cost) {
-                is com.wingedsheep.sdk.scripting.AdditionalCost.DiscardCards -> {
+            when (val atom = (cost as? AdditionalCost.Atom)?.atom) {
+                is CostAtom.Discard -> {
                     val handSize = state.getZone(ZoneKey(playerId, Zone.HAND)).size
-                    if (handSize < cost.count) return false
+                    if (handSize < atom.count) return false
                 }
                 else -> {} // Other cost types can be added as needed
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardFace
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
@@ -143,12 +144,40 @@ class CastSpellEnumerator : ActionEnumerator {
             }
             for (cost in flattenedCosts) {
                 when (cost) {
-                    is AdditionalCost.SacrificePermanent -> {
-                        val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, cost)
-                        if (validSacTargets.size < cost.count) {
-                            canPayAdditionalCosts = false
+                    is AdditionalCost.Atom -> when (val atom = cost.atom) {
+                        is CostAtom.Sacrifice -> {
+                            val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, atom)
+                            if (validSacTargets.size < atom.count) {
+                                canPayAdditionalCosts = false
+                            }
+                            sacrificeTargets.addAll(validSacTargets)
                         }
-                        sacrificeTargets.addAll(validSacTargets)
+                        is CostAtom.ExileFrom -> {
+                            val validExileTargets = context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
+                            if (validExileTargets.size < atom.count) {
+                                canPayAdditionalCosts = false
+                            }
+                            exileTargets = validExileTargets
+                            exileMinCount = atom.count
+                        }
+                        is CostAtom.Discard -> {
+                            val handZone = ZoneKey(playerId, Zone.HAND)
+                            val handCards = state.getZone(handZone)
+                                .filter { it != cardId } // Exclude the card being cast
+                            val predicateContext = PredicateContext(controllerId = playerId)
+                            val validDiscards = if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
+                                handCards
+                            } else {
+                                handCards.filter { context.predicateEvaluator.matches(state, state.projectedState, it, atom.filter, predicateContext) }
+                            }
+                            if (validDiscards.size < atom.count) {
+                                canPayAdditionalCosts = false
+                            }
+                            discardTargets = validDiscards
+                            discardCount = atom.count
+                        }
+                        // Mana / tap / return / reveal aren't produced as spell additional costs today.
+                        else -> {}
                     }
                     is AdditionalCost.SacrificeCreaturesForCostReduction -> {
                         // Always payable (0 sacrifices is valid)
@@ -157,20 +186,12 @@ class CastSpellEnumerator : ActionEnumerator {
                         variableSacrificeReduction = cost.costReductionPerCreature
                     }
                     is AdditionalCost.ExileVariableCards -> {
-                        val validExileTargets = context.costUtils.findExileTargets(state, playerId, cost.filter, cost.fromZone)
+                        val validExileTargets = context.costUtils.findExileTargets(state, playerId, cost.filter, cost.fromZone.toZone())
                         if (validExileTargets.size < cost.minCount) {
                             canPayAdditionalCosts = false
                         }
                         exileTargets = validExileTargets
                         exileMinCount = cost.minCount
-                    }
-                    is AdditionalCost.ExileCards -> {
-                        val validExileTargets = context.costUtils.findExileTargets(state, playerId, cost.filter, cost.fromZone)
-                        if (validExileTargets.size < cost.count) {
-                            canPayAdditionalCosts = false
-                        }
-                        exileTargets = validExileTargets
-                        exileMinCount = cost.count
                     }
                     is AdditionalCost.Behold -> {
                         // Find matching permanents on battlefield (projected) + matching cards in hand
@@ -192,22 +213,6 @@ class CastSpellEnumerator : ActionEnumerator {
                     }
                     is AdditionalCost.ExileFromStorage -> {
                         // Payability determined by the preceding Behold cost
-                    }
-                    is AdditionalCost.DiscardCards -> {
-                        val handZone = ZoneKey(playerId, Zone.HAND)
-                        val handCards = state.getZone(handZone)
-                            .filter { it != cardId } // Exclude the card being cast
-                        val predicateContext = PredicateContext(controllerId = playerId)
-                        val validDiscards = if (cost.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
-                            handCards
-                        } else {
-                            handCards.filter { context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext) }
-                        }
-                        if (validDiscards.size < cost.count) {
-                            canPayAdditionalCosts = false
-                        }
-                        discardTargets = validDiscards
-                        discardCount = cost.count
                     }
                     is AdditionalCost.BlightOrPay -> {
                         // Always payable: player can always choose the "pay mana" path
@@ -357,9 +362,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 val selfAltEffective = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, selfAltMana, playerId)
                 val canPayMana = context.manaSolver.canPay(state, playerId, selfAltEffective, precomputedSources = cachedSources)
                 val canPayAdditional = selfAltCost.additionalCosts.all { cost ->
-                    when (cost) {
-                        is AdditionalCost.TapPermanents -> {
-                            context.costUtils.findAbilityTapTargets(state, playerId, cost.filter).size >= cost.count
+                    when (val atom = (cost as? AdditionalCost.Atom)?.atom) {
+                        is CostAtom.TapPermanents -> {
+                            context.costUtils.findAbilityTapTargets(state, playerId, atom.filter).size >= atom.count
                         }
                         else -> true
                     }
@@ -520,7 +525,7 @@ class CastSpellEnumerator : ActionEnumerator {
                     context.manaSolver.solve(state, playerId, selfAltEffective, precomputedSources = cachedSources)
                         ?.sources?.map { it.entityId }
                 }
-                val tapCost = selfAltCost.additionalCosts.filterIsInstance<AdditionalCost.TapPermanents>().firstOrNull()
+                val tapCost = selfAltCost.additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.TapPermanents }
                 val tapTargets = if (tapCost != null) context.costUtils.findAbilityTapTargets(state, playerId, tapCost.filter) else null
                 val addlCostInfo = if (tapTargets != null && tapCost != null) {
                     AdditionalCostData(
@@ -1358,18 +1363,21 @@ class CastSpellEnumerator : ActionEnumerator {
             var canPayKickerAdditionalCost = true
             if (additionalCostKicker?.additionalCost != null) {
                 when (val cost = additionalCostKicker.additionalCost) {
-                    is AdditionalCost.SacrificePermanent -> {
-                        val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, cost)
-                        if (validSacTargets.size < cost.count) {
-                            canPayKickerAdditionalCost = false
-                        } else {
-                            kickerCostInfo = AdditionalCostData(
-                                description = cost.description,
-                                costType = "SacrificePermanent",
-                                validSacrificeTargets = validSacTargets,
-                                sacrificeCount = cost.count
-                            )
+                    is AdditionalCost.Atom -> when (val atom = cost.atom) {
+                        is CostAtom.Sacrifice -> {
+                            val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, atom)
+                            if (validSacTargets.size < atom.count) {
+                                canPayKickerAdditionalCost = false
+                            } else {
+                                kickerCostInfo = AdditionalCostData(
+                                    description = atom.description.replaceFirstChar { it.uppercase() },
+                                    costType = "SacrificePermanent",
+                                    validSacrificeTargets = validSacTargets,
+                                    sacrificeCount = atom.count
+                                )
+                            }
                         }
+                        else -> {}
                     }
                     is AdditionalCost.Behold -> {
                         // Behold a matching permanent you control or reveal a matching
@@ -1535,9 +1543,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 sacrificeCount = 0 // min 0 — sacrifice is optional
             )
         } else if (sacrificeTargets.isNotEmpty()) {
-            val sacCost = additionalCosts.filterIsInstance<AdditionalCost.SacrificePermanent>().firstOrNull()
+            val sacCost = additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.Sacrifice }
             AdditionalCostData(
-                description = sacCost?.description ?: "Sacrifice a creature",
+                description = sacCost?.description?.replaceFirstChar { it.uppercase() } ?: "Sacrifice a creature",
                 costType = "SacrificePermanent",
                 validSacrificeTargets = sacrificeTargets,
                 sacrificeCount = sacCost?.count ?: 1
@@ -1547,8 +1555,8 @@ class CastSpellEnumerator : ActionEnumerator {
                 .filterIsInstance<AdditionalCost.ExileVariableCards>()
                 .firstOrNull()?.description
                 ?: additionalCosts
-                    .filterIsInstance<AdditionalCost.ExileCards>()
-                    .firstOrNull()?.description
+                    .firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.ExileFrom }
+                    ?.description?.replaceFirstChar { it.uppercase() }
                 ?: "Exile cards from your graveyard"
             AdditionalCostData(
                 description = exileCostDesc,
@@ -1558,9 +1566,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 exileMaxCount = exileTargets.size
             )
         } else if (discardTargets.isNotEmpty()) {
-            val discardCost = additionalCosts.filterIsInstance<AdditionalCost.DiscardCards>().firstOrNull()
+            val discardCost = additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.Discard }
             AdditionalCostData(
-                description = discardCost?.description ?: "Discard a card",
+                description = discardCost?.description?.replaceFirstChar { it.uppercase() } ?: "Discard a card",
                 costType = "DiscardCard",
                 validDiscardTargets = discardTargets,
                 discardCount = discardCount
@@ -1677,29 +1685,40 @@ class CastSpellEnumerator : ActionEnumerator {
         if (modeAdditionalCosts != null) {
             for (cost in modeAdditionalCosts) {
                 when (cost) {
-                    is AdditionalCost.SacrificePermanent -> {
-                        val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, cost)
-                        if (validSacTargets.size < cost.count) canPayAdditionalCosts = false
-                        modeSacrificeTargets.addAll(validSacTargets)
-                    }
-                    is AdditionalCost.ExileCards -> {
-                        val validExileTargets = context.costUtils.findExileTargets(state, playerId, cost.filter, cost.fromZone)
-                        if (validExileTargets.size < cost.count) canPayAdditionalCosts = false
-                        modeExileTargets = validExileTargets
-                        modeExileMinCount = cost.count
-                    }
-                    is AdditionalCost.DiscardCards -> {
-                        val handZone = ZoneKey(playerId, Zone.HAND)
-                        val handCards = state.getZone(handZone).filter { it != cardId }
-                        val predicateContext = PredicateContext(controllerId = playerId)
-                        val validDiscards = if (cost.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
-                            handCards
-                        } else {
-                            handCards.filter { context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext) }
+                    is AdditionalCost.Atom -> when (val atom = cost.atom) {
+                        is CostAtom.Sacrifice -> {
+                            val validSacTargets = context.costUtils.findSacrificeTargets(state, playerId, atom)
+                            if (validSacTargets.size < atom.count) canPayAdditionalCosts = false
+                            modeSacrificeTargets.addAll(validSacTargets)
                         }
-                        if (validDiscards.size < cost.count) canPayAdditionalCosts = false
-                        modeDiscardTargets = validDiscards
-                        modeDiscardCount = cost.count
+                        is CostAtom.ExileFrom -> {
+                            val validExileTargets = context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
+                            if (validExileTargets.size < atom.count) canPayAdditionalCosts = false
+                            modeExileTargets = validExileTargets
+                            modeExileMinCount = atom.count
+                        }
+                        is CostAtom.Discard -> {
+                            val handZone = ZoneKey(playerId, Zone.HAND)
+                            val handCards = state.getZone(handZone).filter { it != cardId }
+                            val predicateContext = PredicateContext(controllerId = playerId)
+                            val validDiscards = if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
+                                handCards
+                            } else {
+                                handCards.filter { context.predicateEvaluator.matches(state, state.projectedState, it, atom.filter, predicateContext) }
+                            }
+                            if (validDiscards.size < atom.count) canPayAdditionalCosts = false
+                            modeDiscardTargets = validDiscards
+                            modeDiscardCount = atom.count
+                        }
+                        is CostAtom.PayLife -> {
+                            // Per CR 119.4 you can't pay life unless you have that much. Mode-level
+                            // affordability gate so "discard a card or pay 3 life" modes don't
+                            // surface a Pay-3-Life action when the caster has fewer than 3 life
+                            // (Bitter Triumph). Validation in CastSpellHandler still backstops.
+                            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                            if (life < atom.amount) canPayAdditionalCosts = false
+                        }
+                        else -> {}
                     }
                     is AdditionalCost.Forage -> {
                         val graveyardSize = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD)).size
@@ -1710,14 +1729,6 @@ class CastSpellEnumerator : ActionEnumerator {
                                 projected.hasSubtype(permId, com.wingedsheep.sdk.core.Subtype.FOOD.value)
                         }
                         if (graveyardSize < 3 && !hasFood) canPayAdditionalCosts = false
-                    }
-                    is AdditionalCost.PayLife -> {
-                        // Per CR 119.4 you can't pay life unless you have that much. Mode-level
-                        // affordability gate so "discard a card or pay 3 life" modes don't
-                        // surface a Pay-3-Life action when the caster has fewer than 3 life
-                        // (Bitter Triumph). Validation in CastSpellHandler still backstops.
-                        val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
-                        if (life < cost.amount) canPayAdditionalCosts = false
                     }
                     else -> {}
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 
 /**
@@ -40,9 +41,11 @@ class TurnFaceUpEnumerator : ActionEnumerator {
 
             // Check if player can afford the morph cost (including any morph cost increases)
             val morphCostIncrease = context.costCalculator.calculateMorphCostIncrease(state)
-            when (val cost = morphData.morphCost) {
-                is PayCost.Mana -> {
-                    val effectiveCost = context.costCalculator.increaseGenericCost(cost.cost, morphCostIncrease)
+            val cost = morphData.morphCost
+            val manaMorph = (cost as? PayCost.Atom)?.atom as? CostAtom.Mana
+            when {
+                manaMorph != null -> {
+                    val effectiveCost = context.costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
                     if (effectiveCost.hasX) {
                         // X morph cost (e.g., {X}{X}{R}) — always show as available with X selection
                         val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = context.availableManaSources)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -29,6 +29,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.CostZone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 
@@ -47,7 +48,7 @@ class CostEnumerationUtils(
     fun findSacrificeTargets(
         state: GameState,
         playerId: EntityId,
-        cost: AdditionalCost.SacrificePermanent
+        cost: CostAtom.Sacrifice
     ): List<EntityId> {
         val predicateContext = PredicateContext(controllerId = playerId)
         val projected = state.projectedState
@@ -127,14 +128,8 @@ class CostEnumerationUtils(
         state: GameState,
         playerId: EntityId,
         filter: GameObjectFilter,
-        fromZone: CostZone
+        zone: Zone
     ): List<EntityId> {
-        val zone = when (fromZone) {
-            CostZone.GRAVEYARD -> Zone.GRAVEYARD
-            CostZone.HAND -> Zone.HAND
-            CostZone.LIBRARY -> Zone.LIBRARY
-            CostZone.BATTLEFIELD -> Zone.BATTLEFIELD
-        }
         val zoneKey = ZoneKey(playerId, zone)
         val predicateContext = PredicateContext(controllerId = playerId)
         return state.getZone(zoneKey).filter { entityId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -34,6 +34,7 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import java.util.UUID
 
@@ -103,30 +104,32 @@ class CostPaymentService(private val services: EngineServices) {
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "the source"
 
         return when (resolved) {
-            is PayCost.Mana ->
-                yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${resolved.cost}?", "Pay ${resolved.cost}")
-            is PayCost.PayLife ->
-                yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${resolved.amount} life?", "Pay ${resolved.amount} life")
-            is PayCost.Discard ->
-                if (resolved.random) {
-                    val word = if (resolved.count == 1) "a card" else "${resolved.count} cards"
-                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Discard $word at random?", "Discard")
-                } else {
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, resolved.filter), resolved.count, useTargetingUI = false)
-                }
-            is PayCost.Exile ->
-                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInZone(state, payerId, resolved.filter, resolved.zone), resolved.count, useTargetingUI = resolved.zone == Zone.BATTLEFIELD)
-            is PayCost.RevealCard ->
-                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, resolved.filter), resolved.count, useTargetingUI = false)
-            is PayCost.Sacrifice ->
-                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
-            is PayCost.ReturnToHand ->
-                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
-            is PayCost.Tap ->
-                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
             is PayCost.Choice -> choicePrompt(state, payerId, resolved, sourceId, sourceName, ctx)
             // resolve() only yields OwnManaCost when unresolvable, and canAfford already rejected it.
             is PayCost.OwnManaCost -> PaymentResult.Unaffordable(state)
+            is PayCost.Atom -> when (val atom = resolved.atom) {
+                is CostAtom.Mana ->
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${atom.cost}?", "Pay ${atom.cost}")
+                is CostAtom.PayLife ->
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${atom.amount} life?", "Pay ${atom.amount} life")
+                is CostAtom.Discard ->
+                    if (atom.random) {
+                        val word = if (atom.count == 1) "a card" else "${atom.count} cards"
+                        yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Discard $word at random?", "Discard")
+                    } else {
+                        selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, atom.filter), atom.count, useTargetingUI = false)
+                    }
+                is CostAtom.ExileFrom ->
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInZone(state, payerId, atom.filter, atom.zone), atom.count, useTargetingUI = atom.zone == Zone.BATTLEFIELD)
+                is CostAtom.RevealFromHand ->
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, atom.filter), atom.count, useTargetingUI = false)
+                is CostAtom.Sacrifice ->
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                is CostAtom.ReturnToHand ->
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                is CostAtom.TapPermanents ->
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+            }
         }
     }
 
@@ -244,7 +247,7 @@ class CostPaymentService(private val services: EngineServices) {
      * selection cost (empty for yes/no costs and random discard). Returns the new state, the emitted
      * events, and whether the payment actually completed (mana solving can still fail defensively).
      *
-     * [cost] must already be resolved ([PayCost.OwnManaCost] mapped to [PayCost.Mana]) and, for
+     * [cost] must already be resolved ([PayCost.OwnManaCost] mapped to a [PayCost.Atom] CostAtom.Mana) and, for
      * [PayCost.Choice], a single chosen sub-cost — the resumer never calls this with a Choice.
      */
     fun performPayment(
@@ -254,18 +257,20 @@ class CostPaymentService(private val services: EngineServices) {
         sourceId: EntityId,
         selected: List<EntityId>
     ): CostPaymentExecution = when (cost) {
-        is PayCost.Mana -> payMana(state, payerId, cost.cost, sourceId)
-        is PayCost.PayLife -> payLife(state, payerId, cost.amount)
-        is PayCost.Discard ->
-            if (cost.random) discardRandom(state, payerId, cost.filter, cost.count)
-            else discardSelected(state, payerId, selected)
-        is PayCost.Exile -> exileSelected(state, payerId, selected, cost.zone)
-        is PayCost.RevealCard -> revealSelected(state, payerId, selected)
-        is PayCost.Sacrifice -> sacrificeSelected(state, payerId, selected)
-        is PayCost.ReturnToHand -> returnSelected(state, selected)
-        is PayCost.Tap -> tapSelected(state, selected)
         is PayCost.OwnManaCost -> CostPaymentExecution(state, emptyList(), success = false)
         is PayCost.Choice -> CostPaymentExecution(state, emptyList(), success = false)
+        is PayCost.Atom -> when (val atom = cost.atom) {
+            is CostAtom.Mana -> payMana(state, payerId, atom.cost, sourceId)
+            is CostAtom.PayLife -> payLife(state, payerId, atom.amount)
+            is CostAtom.Discard ->
+                if (atom.random) discardRandom(state, payerId, atom.filter, atom.count)
+                else discardSelected(state, payerId, selected)
+            is CostAtom.ExileFrom -> exileSelected(state, payerId, selected, atom.zone)
+            is CostAtom.RevealFromHand -> revealSelected(state, payerId, selected)
+            is CostAtom.Sacrifice -> sacrificeSelected(state, payerId, selected)
+            is CostAtom.ReturnToHand -> returnSelected(state, selected)
+            is CostAtom.TapPermanents -> tapSelected(state, selected)
+        }
     }
 
     private fun payMana(state: GameState, payerId: EntityId, manaCost: ManaCost, sourceId: EntityId): CostPaymentExecution {
@@ -428,13 +433,8 @@ class CostPaymentService(private val services: EngineServices) {
 
     /** How many entities a selection cost requires; 0 for non-selection costs. */
     fun requiredCount(cost: PayCost): Int = when (cost) {
-        is PayCost.Discard -> cost.count
-        is PayCost.Exile -> cost.count
-        is PayCost.RevealCard -> cost.count
-        is PayCost.Sacrifice -> cost.count
-        is PayCost.ReturnToHand -> cost.count
-        is PayCost.Tap -> cost.count
-        else -> 0
+        is PayCost.Atom -> cost.atom.selectionCount
+        is PayCost.OwnManaCost, is PayCost.Choice -> 0
     }
 
     /**
@@ -452,24 +452,26 @@ class CostPaymentService(private val services: EngineServices) {
          */
         fun canAfford(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId, manaSolver: ManaSolver): Boolean {
             return when (val c = resolve(state, cost, sourceId)) {
-                is PayCost.Mana -> manaSolver.canPay(state, payerId, c.cost)
                 // Only unresolvable own-mana-costs reach here (missing source/card component) — unpayable.
                 is PayCost.OwnManaCost -> false
-                // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
-                // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
-                is PayCost.PayLife -> life(state, payerId) >= c.amount
-                is PayCost.Discard -> cardsInHand(state, payerId, c.filter).size >= c.count
-                is PayCost.Exile -> cardsInZone(state, payerId, c.filter, c.zone).size >= c.count
-                is PayCost.RevealCard -> cardsInHand(state, payerId, c.filter).size >= c.count
-                is PayCost.Sacrifice -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
-                is PayCost.ReturnToHand -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
-                is PayCost.Tap -> controlledUntapped(state, payerId, c.filter, sourceId).size >= c.count
                 is PayCost.Choice -> c.options.any { canAfford(state, payerId, it, sourceId, manaSolver) }
+                is PayCost.Atom -> when (val atom = c.atom) {
+                    is CostAtom.Mana -> manaSolver.canPay(state, payerId, atom.cost)
+                    // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
+                    // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
+                    is CostAtom.PayLife -> life(state, payerId) >= atom.amount
+                    is CostAtom.Discard -> cardsInHand(state, payerId, atom.filter).size >= atom.count
+                    is CostAtom.ExileFrom -> cardsInZone(state, payerId, atom.filter, atom.zone).size >= atom.count
+                    is CostAtom.RevealFromHand -> cardsInHand(state, payerId, atom.filter).size >= atom.count
+                    is CostAtom.Sacrifice -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
+                    is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
+                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, sourceId).size >= atom.count
+                }
             }
         }
 
         /**
-         * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Mana] against the source's printed cost so
+         * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Atom] (CostAtom.Mana) against the source's printed cost so
          * every other code path sees a uniform shape. A source with no mana cost (a land, a token) has an
          * empty [ManaCost] — which is `{0}` and trivially payable. Returns the cost unchanged if the
          * source/card component is missing (unresolvable → reported unaffordable).
@@ -477,7 +479,7 @@ class CostPaymentService(private val services: EngineServices) {
         fun resolve(state: GameState, cost: PayCost, sourceId: EntityId): PayCost {
             if (cost !is PayCost.OwnManaCost) return cost
             val manaCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost ?: return cost
-            return PayCost.Mana(manaCost)
+            return PayCost.Atom(CostAtom.Mana(manaCost))
         }
 
         private fun life(state: GameState, playerId: EntityId): Int =

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CostHandlerPayLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CostHandlerPayLifeTest.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -72,7 +73,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 3)
             CostHandler().canPayAdditionalCost(
                 state = driver.state,
-                cost = AdditionalCost.PayLife(3),
+                cost = Costs.additional.PayLife(3),
                 controllerId = player
             ) shouldBe true
         }
@@ -81,7 +82,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 20)
             CostHandler().canPayAdditionalCost(
                 state = driver.state,
-                cost = AdditionalCost.PayLife(3),
+                cost = Costs.additional.PayLife(3),
                 controllerId = player
             ) shouldBe true
         }
@@ -90,7 +91,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 2)
             CostHandler().canPayAdditionalCost(
                 state = driver.state,
-                cost = AdditionalCost.PayLife(3),
+                cost = Costs.additional.PayLife(3),
                 controllerId = player
             ) shouldBe false
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/SelfAlternativeCostPayLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/SelfAlternativeCostPayLifeTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.SelfAlternativeCost
 import io.kotest.core.spec.style.FunSpec
@@ -31,7 +32,7 @@ class SelfAlternativeCostPayLifeTest : FunSpec({
         toughness = 4
         selfAlternativeCost = SelfAlternativeCost(
             manaCost = ManaCost.parse("{0}"),
-            additionalCosts = listOf(AdditionalCost.PayLife(5))
+            additionalCosts = listOf(Costs.additional.PayLife(5))
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.CostZone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import io.kotest.core.spec.style.FunSpec
@@ -131,7 +132,7 @@ class CostEnumerationUtilsTest : FunSpec({
             )
 
             val targets = utils(driver).findExileTargets(
-                driver.game.state, driver.player1, GameObjectFilter.Creature, CostZone.GRAVEYARD
+                driver.game.state, driver.player1, GameObjectFilter.Creature, Zone.GRAVEYARD
             )
 
             targets shouldHaveSize 2  // two Grizzly Bears, Forest excluded
@@ -143,7 +144,7 @@ class CostEnumerationUtilsTest : FunSpec({
             )
 
             val targets = utils(driver).findExileTargets(
-                driver.game.state, driver.player1, GameObjectFilter.Creature, CostZone.HAND
+                driver.game.state, driver.player1, GameObjectFilter.Creature, Zone.HAND
             )
 
             targets shouldHaveSize 1

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -56,10 +57,10 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val forest = bfCardByName(game.state, game.player1Id, "Forest")
 
-            service.canAfford(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source).shouldBeTrue()
-            service.canAfford(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{U}")), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{G}")), source).shouldBeTrue()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{U}")), source).shouldBeFalse()
 
-            val pending = service.pay(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source)
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{G}")), source)
             pending.shouldBeInstanceOf<PaymentResult.Pending>()
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
@@ -78,7 +79,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val forest = bfCardByName(game.state, game.player1Id, "Forest")
 
             val pending = service.pay(
-                game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source,
+                game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{G}")), source,
                 CostPaymentContext(onDeclined = Effects.DrawCards(1))
             ) as PaymentResult.Pending
             game.state = pending.state
@@ -133,10 +134,10 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
 
-            service.canAfford(game.state, game.player1Id, PayCost.PayLife(5), source).shouldBeTrue() // exactly enough
-            service.canAfford(game.state, game.player1Id, PayCost.PayLife(6), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.PayLife(5), source).shouldBeTrue() // exactly enough
+            service.canAfford(game.state, game.player1Id, Costs.pay.PayLife(6), source).shouldBeFalse()
 
-            val pending = service.pay(game.state, game.player1Id, PayCost.PayLife(3), source) as PaymentResult.Pending
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.PayLife(3), source) as PaymentResult.Pending
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
 
@@ -150,7 +151,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
 
-            val pending = service.pay(game.state, game.player1Id, PayCost.PayLife(3), source) as PaymentResult.Pending
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.PayLife(3), source) as PaymentResult.Pending
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, false))
 
@@ -169,7 +170,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getHand(game.player1Id).first()
-            val cost = PayCost.Discard(GameObjectFilter.Any, 1)
+            val cost = Costs.pay.Discard(GameObjectFilter.Any, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
 
@@ -190,7 +191,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getHand(game.player1Id).first()
 
-            val pending = service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source) as PaymentResult.Pending
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.Discard(GameObjectFilter.Any, 1), source) as PaymentResult.Pending
             game.state = pending.state
             game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, emptyList()))
             game.state.getHand(game.player1Id) shouldContain card
@@ -200,8 +201,8 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source).shouldBeFalse()
-            service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source)
+            service.canAfford(game.state, game.player1Id, Costs.pay.Discard(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.pay(game.state, game.player1Id, Costs.pay.Discard(GameObjectFilter.Any, 1), source)
                 .shouldBeInstanceOf<PaymentResult.Unaffordable>()
         }
 
@@ -214,7 +215,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getHand(game.player1Id).first()
 
-            val pending = service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1, random = true), source) as PaymentResult.Pending
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.Discard(GameObjectFilter.Any, 1, random = true), source) as PaymentResult.Pending
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
             game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain card
@@ -232,7 +233,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)).first()
-            val cost = PayCost.Exile(GameObjectFilter.Any, Zone.GRAVEYARD, 1)
+            val cost = Costs.pay.Exile(GameObjectFilter.Any, Zone.GRAVEYARD, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
             val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
@@ -253,7 +254,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getHand(game.player1Id).first()
-            val cost = PayCost.RevealCard(GameObjectFilter.Any, 1)
+            val cost = Costs.pay.RevealCard(GameObjectFilter.Any, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
             val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
@@ -276,7 +277,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
-            val cost = PayCost.Sacrifice(GameObjectFilter.Any, 1)
+            val cost = Costs.pay.Sacrifice(GameObjectFilter.Any, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
             val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
@@ -291,7 +292,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, PayCost.Sacrifice(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Sacrifice(GameObjectFilter.Any, 1), source).shouldBeFalse()
         }
 
         // -----------------------------------------------------------------------------------------
@@ -306,7 +307,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
-            val cost = PayCost.ReturnToHand(GameObjectFilter.Any, 1)
+            val cost = Costs.pay.ReturnToHand(GameObjectFilter.Any, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
             val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
@@ -329,7 +330,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
-            val cost = PayCost.Tap(GameObjectFilter.Any, 1)
+            val cost = Costs.pay.Tap(GameObjectFilter.Any, 1)
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
             val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
@@ -346,7 +347,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
                 .build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, PayCost.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
         }
 
         // -----------------------------------------------------------------------------------------
@@ -361,7 +362,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             val card = game.state.getHand(game.player1Id).first()
-            val cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1)))
+            val cost = Costs.pay.Choice(listOf(Costs.pay.PayLife(3), Costs.pay.Discard(GameObjectFilter.Any, 1)))
 
             service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
 
@@ -385,7 +386,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
                 .build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            val cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1)))
+            val cost = Costs.pay.Choice(listOf(Costs.pay.PayLife(3), Costs.pay.Discard(GameObjectFilter.Any, 1)))
 
             val pending = service.pay(
                 game.state, game.player1Id, cost, source,
@@ -414,7 +415,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
 
             val pending = service.pay(
-                game.state, game.player1Id, PayCost.Sacrifice(GameObjectFilter.Any, 1), source,
+                game.state, game.player1Id, Costs.pay.Sacrifice(GameObjectFilter.Any, 1), source,
                 CostPaymentContext(onPaid = Effects.DrawCards(1))
             ) as PaymentResult.Pending
             game.state = pending.state
@@ -439,7 +440,7 @@ class CostPaymentServiceTest : ScenarioTestBase() {
                     payerId = EntityId.of("player-1"),
                     sourceId = EntityId.of("src"),
                     sourceName = "Goblin Guide",
-                    cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1))),
+                    cost = Costs.pay.Choice(listOf(Costs.pay.PayLife(3), Costs.pay.Discard(GameObjectFilter.Any, 1))),
                     onPaid = Effects.DrawCards(1),
                     onDeclined = Effects.GainLife(2)
                 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExileUnlessExileTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExileUnlessExileTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
@@ -43,7 +44,7 @@ class ExileUnlessExileTest : FunSpec({
                 trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
                 binding = TriggerBinding.SELF,
                 effect = PayOrSufferEffect(
-                    cost = PayCost.Exile(
+                    cost = Costs.pay.Exile(
                         filter = GameObjectFilter.Any,
                         zone = Zone.GRAVEYARD,
                         count = 1
@@ -66,7 +67,7 @@ class ExileUnlessExileTest : FunSpec({
                 trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
                 binding = TriggerBinding.SELF,
                 effect = PayOrSufferEffect(
-                    cost = PayCost.Exile(
+                    cost = Costs.pay.Exile(
                         filter = GameObjectFilter.Any.withColor(Color.BLUE),
                         zone = Zone.HAND,
                         count = 1

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalPerModeAdditionalCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalPerModeAdditionalCostTest.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -86,7 +87,7 @@ class ModalPerModeAdditionalCostTest : FunSpec({
                         effect = GainLifeEffect(DynamicAmount.Fixed(3), EffectTarget.Controller),
                         description = "Sacrifice a creature; Gain 3 life",
                         additionalCosts = listOf(
-                            AdditionalCost.SacrificePermanent(
+                            Costs.additional.SacrificePermanent(
                                 filter = GameObjectFilter.Creature,
                                 count = 1
                             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -40,7 +41,7 @@ class MorphCostPaymentTest : FunSpec({
         typeLine = "Creature — Wizard"
         power = 2
         toughness = 2
-        morphCost = PayCost.Tap(GameObjectFilter.Land, count = 1)
+        morphCost = Costs.pay.Tap(GameObjectFilter.Land, count = 1)
     }
 
     // A plain Bird for Raven Guild Initiate's "return a Bird" cost to target.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProwlingPangolinTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProwlingPangolinTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -41,7 +42,7 @@ class ProwlingPangolinTest : FunSpec({
                 trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
                 binding = TriggerBinding.SELF,
                 effect = AnyPlayerMayPayEffect(
-                    cost = PayCost.Sacrifice(GameObjectFilter.Creature, count = 2),
+                    cost = Costs.pay.Sacrifice(GameObjectFilter.Creature, count = 2),
                     consequence = SacrificeSelfEffect
                 )
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SacrificeUnlessSacrificeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SacrificeUnlessSacrificeTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
@@ -43,7 +44,7 @@ class SacrificeUnlessSacrificeTest : FunSpec({
                 trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
                 binding = TriggerBinding.SELF,
                 effect = PayOrSufferEffect(
-                    cost = PayCost.Sacrifice(filter = GameObjectFilter.Any.withSubtype("Forest")),
+                    cost = Costs.pay.Sacrifice(filter = GameObjectFilter.Any.withSubtype("Forest")),
                     suffer = SacrificeSelfEffect
                 )
             )
@@ -62,7 +63,7 @@ class SacrificeUnlessSacrificeTest : FunSpec({
                 trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
                 binding = TriggerBinding.SELF,
                 effect = PayOrSufferEffect(
-                    cost = PayCost.Sacrifice(filter = GameObjectFilter.Any.withSubtype("Forest"), count = 3),
+                    cost = Costs.pay.Sacrifice(filter = GameObjectFilter.Any.withSubtype("Forest"), count = 3),
                     suffer = SacrificeSelfEffect
                 )
             )


### PR DESCRIPTION
## What

Implements **§3.2 "One cost language"** from `backlog/sdk-analysis-2026-06-revised.md` — the first two of the three cost wrappers, per the doc's *one-wrapper-per-PR, smallest-first* sequencing (PayCost → AdditionalCost → AbilityCost).

Three parallel cost hierarchies (`AbilityCost`, `AdditionalCost`, `PayCost`) each redefined the same payable things — sacrifice, discard, pay-life, exile-from-zone, tap, … — so a new payable thing had to be implemented per-hierarchy. This PR extracts a single **`CostAtom`** vocabulary and has each context carry it via a thin `Atom(atom: CostAtom)` wrapper.

## Shape

`CostAtom` (new, `scripting/costs/CostAtom.kt`): `Mana`, `PayLife`, `Sacrifice`, `Discard`, `ExileFrom`, `TapPermanents`, `ReturnToHand`, `RevealFromHand`.

- **`PayCost`** → `PayCost.Atom(atom)` + context-specific `OwnManaCost`, `Choice`.
- **`AdditionalCost`** → `AdditionalCost.Atom(atom)` + casting-specific members kept (Behold, Blight*, Forage, ChooseEntity, ExileFromStorage, PayLifePerTarget, ExileVariableCards, Composite, SacrificeCreaturesForCostReduction, RemoveCountersFromYourCreatures).

## Why this is safe / what reviewers should look at

- **`Costs.pay.*` / `Costs.additional.*` facade signatures are unchanged** — card authoring is identical, and the mtgish emitter (which emits facade calls) needs **zero** changes. `EmitterGoldenTest` stays green.
- Engine consumers (CostPaymentService, the cost continuations, PayOrSuffer/AnyPlayerMayPay/ChainCopy, CastSpellHandler validate+pay, the cast/morph/ability enumerators) now dispatch on the unwrapped `CostAtom`. Candidate-finding/affordability logic per context is **unchanged** (kept each context's existing helpers — no behavior shift in the most sensitive engine path).
- The `when (atom)` payment blocks are **exhaustive (no `else`)**, so adding a `CostAtom` is a compile error until every payment branch handles it. New `CostAtomSerializationTest` is the SDK-side coverage net (round-trips every subtype + `sealedSubclasses` completeness).
- **Snapshot golden re-blessed** — the diff is *purely* the cost re-encoding (`SacrificePermanent` → `AdditionalAtom`/`AtomSacrifice`, `PayMana` → `PayAtom`/`AtomMana`, …). No semantic field changes — this diff is the behavior-preservation artifact.

## Decisions / deviations from the doc sketch

- Counts use `Int`, not `DynamicAmount`: every current shared cost is fixed-count, and `DynamicAmount` would add resolution plumbing through ~10 enumerator/handler branches for zero current benefit. Variable/X costs and context oddities stay off `CostAtom` deliberately.
- Carrier is a singular `Atom(atom)` (not `atoms: List`): each wrapper already owns its composition construct (`PayCost.Choice`, `AdditionalCost.Composite`), so a singular carrier preserves current single-step payment exactly.

## Tests
`mtg-sdk`, `rules-engine`, `game-server` suites all green; `CardDefinitionSnapshotTest` re-blessed; mtgish `EmitterGoldenTest` green. Net **−247 LOC**.

## Follow-up
`AbilityCost` is the next (largest) wrapper to fold onto `CostAtom`, per the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)