### PR TITLE
AI: stop aiming two "can't block" effects at the same creature

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -86,11 +86,12 @@ class Strategist(
 
         val best = finalScored.maxByOrNull { it.second }
         return if (best != null && best.second > adjustedPassScore) {
-            // Fill in targets on the returned action so the processor can execute it
+            // Fill in targets on the returned action so the processor can execute it.
+            // The committed target is chosen by simulation (not just the heuristic) so the
+            // AI sees the real resolved board, including effects already on the stack.
             val chosen = best.first
             if (chosen.requiresTargets) {
-                val resolvedAction = resolveTargetsForSimulation(state, chosen, playerId)
-                chosen.copy(action = resolvedAction)
+                chosen.copy(action = chooseCommittedTargets(state, chosen, playerId))
             } else {
                 chosen
             }
@@ -142,10 +143,13 @@ class Strategist(
     }
 
     private fun evaluate1Ply(state: GameState, action: LegalAction, playerId: EntityId, passScore: Double? = null): Double {
-        // For targeted spells, fill in heuristic targets before simulating.
-        // Without this, the CastSpellHandler rejects the action ("No valid targets")
-        // and the spell always scores the same as passing.
-        val simulationAction = resolveTargetsForSimulation(state, action, playerId)
+        // For targeted spells, fill in the best target by simulation before scoring. Without a
+        // target the CastSpellHandler rejects the action ("No valid targets") and the spell always
+        // scores the same as passing; with only a *heuristic* target, an ability whose ideal target
+        // is already taken by something on the stack (e.g. a second "can't block" when the first is
+        // still resolving) would be scored at that redundant target and look worthless — so the AI
+        // would never play it. Scoring at the best target makes the action's real upside visible.
+        val simulationAction = chooseCommittedTargets(state, action, playerId)
         val result = simulator.simulate(state, simulationAction)
         val defaultScore = evaluator.evaluate(result.state, result.state.projectedState, playerId)
 
@@ -173,8 +177,9 @@ class Strategist(
      * opponent creature (or lowest-value own creature, depending on context).
      * Single-target spells: pick the best target by creature value.
      *
-     * The advisor's [CardAdvisor.respondToDecision] refines target selection
-     * during actual gameplay — this is just for scoring purposes.
+     * This is the cheap path used while *scoring* candidate actions (one heuristic target
+     * per requirement, no extra simulation). The action the AI actually commits routes through
+     * [chooseCommittedTargets], which refines the target by simulation.
      */
     private fun resolveTargetsForSimulation(
         state: GameState,
@@ -187,17 +192,82 @@ class Strategist(
         // here is submitted with no target, rejected by the engine ("requires a target"), and the
         // AI re-picks it forever — an infinite loop.
         val baseAction = action.action
-        val existingTargets = when (baseAction) {
-            is CastSpell -> baseAction.targets
-            is ActivateAbility -> baseAction.targets
-            else -> return action.action
+        if (targetsAlreadyFilled(baseAction) != false) return action.action
+        val targetInfos = targetInfosFor(action) ?: return action.action
+        if (targetInfos.any { it.validTargets.isEmpty() }) return action.action
+
+        val chosenTargets = targetInfos.map { info ->
+            val best = info.validTargets.maxByOrNull { heuristicTargetRank(state, it, playerId) }
+                ?: info.validTargets.first()
+            toChosenTarget(state, info, best, playerId)
         }
-        if (existingTargets.isNotEmpty()) return action.action
+        return applyTargets(baseAction, chosenTargets)
+    }
 
-        val projected = state.projectedState
+    /**
+     * Pick the targets the AI actually commits to for a chosen targeted action, by simulation
+     * rather than the static [heuristicTargetRank]. Simulating each candidate resolves the stack —
+     * including spells/abilities already on it — so the evaluator scores the *real* board.
+     *
+     * This is what stops the classic blunder of aiming two "target creature can't block" effects
+     * at the same creature: while the first is still on the stack the heuristic sees that creature
+     * at full value and re-picks it, but a simulation that resolves both effects shows re-hitting it
+     * gains nothing over neutralizing a second, still-able blocker (which [BoardPresence] now prices
+     * lower). Requirements are resolved greedily — others held at their heuristic best — and only the
+     * top [MAX_TARGET_CANDIDATES] candidates per requirement are simulated to bound cost. Falls back
+     * to [resolveTargetsForSimulation] when the action carries no usable target metadata.
+     */
+    private fun chooseCommittedTargets(
+        state: GameState,
+        action: LegalAction,
+        playerId: EntityId
+    ): com.wingedsheep.engine.core.GameAction {
+        val baseAction = action.action
+        if (targetsAlreadyFilled(baseAction) != false) return baseAction
+        val targetInfos = targetInfosFor(action)
+            ?: return resolveTargetsForSimulation(state, action, playerId)
+        if (targetInfos.any { it.validTargets.isEmpty() }) {
+            return resolveTargetsForSimulation(state, action, playerId)
+        }
 
-        // Build target info list: prefer targetRequirements (multi-target), fall back to validTargets
-        val targetInfos: List<TargetInfo> = action.targetRequirements
+        // Heuristic baseline for every requirement, then refine each one by simulation.
+        val chosenTargets = targetInfos.map { info ->
+            val best = info.validTargets.maxByOrNull { heuristicTargetRank(state, it, playerId) }
+                ?: info.validTargets.first()
+            toChosenTarget(state, info, best, playerId)
+        }.toMutableList()
+
+        for (i in targetInfos.indices) {
+            val info = targetInfos[i]
+            val candidates = info.validTargets
+                .sortedByDescending { heuristicTargetRank(state, it, playerId) }
+                .take(MAX_TARGET_CANDIDATES)
+            if (candidates.size <= 1) continue
+            val best = candidates.maxByOrNull { candidate ->
+                val trial = chosenTargets.toMutableList()
+                trial[i] = toChosenTarget(state, info, candidate, playerId)
+                val result = simulator.simulate(state, applyTargets(baseAction, trial))
+                evaluator.evaluate(result.state, result.state.projectedState, playerId)
+            } ?: continue
+            chosenTargets[i] = toChosenTarget(state, info, best, playerId)
+        }
+        return applyTargets(baseAction, chosenTargets)
+    }
+
+    /**
+     * Whether [baseAction]'s targets are already filled. `null` = the action type carries no
+     * AI-filled target list (only CastSpell / ActivateAbility do), `true`/`false` otherwise.
+     */
+    private fun targetsAlreadyFilled(baseAction: com.wingedsheep.engine.core.GameAction): Boolean? =
+        when (baseAction) {
+            is CastSpell -> baseAction.targets.isNotEmpty()
+            is ActivateAbility -> baseAction.targets.isNotEmpty()
+            else -> null
+        }
+
+    /** Normalize an action's target metadata into requirements (multi-target or single-target). */
+    private fun targetInfosFor(action: LegalAction): List<TargetInfo>? =
+        action.targetRequirements
             ?: action.validTargets?.let { targets ->
                 listOf(TargetInfo(
                     index = 0,
@@ -208,55 +278,60 @@ class Strategist(
                     targetZone = null
                 ))
             }
-            ?: return action.action
 
-        if (targetInfos.any { it.validTargets.isEmpty() }) return action.action
+    /** Heuristic desirability of a target: higher = better. Opponent removal targets rank highest. */
+    private fun heuristicTargetRank(state: GameState, entityId: EntityId, playerId: EntityId): Double {
+        val projected = state.projectedState
+        val controller = projected.getController(entityId)
+        val isOpponent = controller != null && controller != playerId
+        val isPlayer = state.getEntity(entityId)
+            ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>() != null
 
-        // For each requirement, pick the best target using a heuristic
-        val chosenTargets = targetInfos.map { info ->
-            val best = info.validTargets.maxByOrNull { entityId ->
-                val controller = projected.getController(entityId)
-                val isOpponent = controller != null && controller != playerId
-                val isPlayer = state.getEntity(entityId)?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>() != null
-
-                if (isPlayer) {
-                    // Player target — prefer opponent
-                    if (isOpponent) 5.0 else -5.0
-                } else if (projected.isCreature(entityId)) {
-                    val card = state.getEntity(entityId)?.get<CardComponent>()
-                    val value = if (card != null) {
-                        BoardPresence.permanentValue(state, projected, entityId, card)
-                    } else 0.0
-                    // Opponent creatures: higher value = better target for removal
-                    // Own creatures: higher value = better target for pump/bite source
-                    if (isOpponent) value + 10.0 else -value
-                } else {
-                    0.0
-                }
-            } ?: info.validTargets.first()
-
-            // Build the right ChosenTarget variant based on zone
-            when (info.targetZone) {
-                "GRAVEYARD" -> {
-                    val ownerId = state.getEntity(best)
-                        ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
-                        ?: playerId
-                    ChosenTarget.Card(best, ownerId, Zone.GRAVEYARD)
-                }
-                "STACK" -> ChosenTarget.Spell(best)
-                else -> {
-                    val isPlayer = state.getEntity(best)?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>() != null
-                    if (isPlayer) ChosenTarget.Player(best)
-                    else ChosenTarget.Permanent(best)
-                }
-            }
+        return if (isPlayer) {
+            // Player target — prefer opponent
+            if (isOpponent) 5.0 else -5.0
+        } else if (projected.isCreature(entityId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>()
+            val value = if (card != null) {
+                BoardPresence.permanentValue(state, projected, entityId, card)
+            } else 0.0
+            // Opponent creatures: higher value = better target for removal
+            // Own creatures: higher value = better target for pump/bite source
+            if (isOpponent) value + 10.0 else -value
+        } else {
+            0.0
         }
+    }
 
-        return when (baseAction) {
-            is CastSpell -> baseAction.copy(targets = chosenTargets)
-            is ActivateAbility -> baseAction.copy(targets = chosenTargets)
-            else -> action.action
+    /** Build the right [ChosenTarget] variant for [entityId] given the requirement's zone. */
+    private fun toChosenTarget(
+        state: GameState,
+        info: TargetInfo,
+        entityId: EntityId,
+        playerId: EntityId
+    ): ChosenTarget = when (info.targetZone) {
+        "GRAVEYARD" -> {
+            val ownerId = state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+                ?: playerId
+            ChosenTarget.Card(entityId, ownerId, Zone.GRAVEYARD)
         }
+        "STACK" -> ChosenTarget.Spell(entityId)
+        else -> {
+            val isPlayer = state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>() != null
+            if (isPlayer) ChosenTarget.Player(entityId) else ChosenTarget.Permanent(entityId)
+        }
+    }
+
+    /** Return [baseAction] with its target list replaced. */
+    private fun applyTargets(
+        baseAction: com.wingedsheep.engine.core.GameAction,
+        targets: List<ChosenTarget>
+    ): com.wingedsheep.engine.core.GameAction = when (baseAction) {
+        is CastSpell -> baseAction.copy(targets = targets)
+        is ActivateAbility -> baseAction.copy(targets = targets)
+        else -> baseAction
     }
 
     /**
@@ -297,5 +372,10 @@ class Strategist(
             else -> return null
         }
         return state.getEntity(entityId)?.get<CardComponent>()?.name
+    }
+
+    private companion object {
+        /** Cap on candidate targets simulated per requirement when committing a targeted action. */
+        const val MAX_TARGET_CANDIDATES = 8
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -147,6 +147,15 @@ object BoardPresence : BoardFeature {
         // ── Drawbacks ──
         if (Keyword.DEFENDER.name in keywords) value -= power * 0.8 // can't attack, power mostly wasted
 
+        // ── Combat restrictions (Pacifism, "can't block this turn", etc.) ──
+        // A creature that can't block has lost its defensive value; one that can't attack can't
+        // pressure. Pricing these keeps the AI from stacking redundant "target creature can't
+        // block / can't attack" effects on a creature already under that restriction: hitting a
+        // fresh target strictly lowers the opponent's board value, re-hitting a restricted one
+        // does not. (DEFENDER's can't-attack is already priced just above — don't double-count.)
+        if (projected.cantBlock(entityId)) value *= 0.85
+        if (projected.cantAttack(entityId) && Keyword.DEFENDER.name !in keywords) value *= 0.85
+
         // ── Speed ──
         if (Keyword.HASTE.name in keywords && container.has<SummoningSicknessComponent>()) {
             value += 0.5 // haste is most valuable the turn it enters

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.MtgSetCatalog
@@ -459,5 +461,77 @@ class AIPlayerTest : FunSpec({
 
         // The decisive anti-loop guarantee: the AI's chosen action is actually legal.
         driver.submit(chosen).isSuccess shouldBe true
+    }
+
+    // Regression: given two "target creature can't block" abilities and two opponent blockers,
+    // the AI used to aim BOTH at the same creature. Activated-ability targets are filled by a
+    // static heuristic (highest board value); while the first ability is still ON THE STACK the
+    // first blocker looks just as valuable as the second, so the heuristic re-picked it. The
+    // committed target now goes through simulation — which resolves the pending ability — and
+    // BoardPresence prices a creature that already can't block lower, so neutralizing a second,
+    // still-able blocker strictly wins. This reproduces the hard case: the first ability is left
+    // unresolved on the stack when the second one's target is chosen.
+    test("AI targets a distinct blocker with a second can't-block ability") {
+        val stopper = card("Test Stopper") {
+            manaCost = "{1}"
+            typeLine = "Creature — Wizard"
+            power = 1
+            toughness = 1
+            activatedAbility {
+                cost = Costs.Tap
+                val t = target("target creature", Targets.Creature)
+                effect = Effects.CantBlock(t)
+            }
+        }
+        // Big blockers so neutralizing one is clearly worth a tap — keeps the AI activating
+        // (rather than passing) in the main phase, isolating the target-choice behavior we test.
+        val ogre = card("Test Ogre") {
+            manaCost = "{4}{G}"
+            typeLine = "Creature — Ogre"
+            power = 5
+            toughness = 5
+        }
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(stopper, ogre))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val aiId = driver.activePlayer!!
+        val opp = driver.getOpponent(aiId)
+
+        val stopper1 = driver.putCreatureOnBattlefield(aiId, "Test Stopper")
+        val stopper2 = driver.putCreatureOnBattlefield(aiId, "Test Stopper")
+        driver.removeSummoningSickness(stopper1)
+        driver.removeSummoningSickness(stopper2)
+        val ogreA = driver.putCreatureOnBattlefield(opp, "Test Ogre")
+        val ogreB = driver.putCreatureOnBattlefield(opp, "Test Ogre")
+        driver.passPriorityUntil(Phase.PRECOMBAT_MAIN)
+
+        val simulator = GameSimulator(driver.cardRegistry)
+        val ai = AIPlayer.create(driver.cardRegistry, aiId)
+
+        fun targetOf(action: GameAction): EntityId {
+            (action is ActivateAbility).shouldBeTrue() // AI should activate the stopper, not pass
+            return ((action as ActivateAbility).targets.single() as ChosenTarget.Permanent).entityId
+        }
+
+        // First activation: the AI picks one blocker. Leave it UNRESOLVED on the stack.
+        val act1 = simulator.getLegalActions(driver.state, aiId)
+            .first { (it.action as? ActivateAbility)?.sourceId == stopper1 }
+        val pass = simulator.getLegalActions(driver.state, aiId).first { it.actionType == "PassPriority" }
+        val chosen1 = ai.chooseFrom(driver.state, listOf(act1, pass)).action
+        val firstTarget = targetOf(chosen1)
+        (firstTarget == ogreA || firstTarget == ogreB).shouldBeTrue()
+        driver.submitSuccess(chosen1)
+        // The first ability is on the stack but has not resolved — bearA/bearB can both still block.
+        driver.state.stack.shouldNotBeEmpty()
+        driver.state.projectedState.cantBlock(firstTarget) shouldBe false
+
+        // Second activation while the first is still pending: the AI must hit the OTHER blocker.
+        val act2 = simulator.getLegalActions(driver.state, aiId)
+            .first { (it.action as? ActivateAbility)?.sourceId == stopper2 }
+        val pass2 = simulator.getLegalActions(driver.state, aiId).first { it.actionType == "PassPriority" }
+        val chosen2 = ai.chooseFrom(driver.state, listOf(act2, pass2)).action
+        val secondTarget = targetOf(chosen2)
+        (secondTarget != firstTarget).shouldBeTrue()
     }
 })


### PR DESCRIPTION
## Problem

The engine AI can play two *"target creature can't block"* abilities and points **both at the same creature**, leaving every other blocker free. The effect is wasted — not very smart.

## Root causes

**1. Target choice was a static heuristic.** Activated-ability / spell targets are filled by `Strategist.resolveTargetsForSimulation`, which just picks the highest board-value creature. While the first ability is still on the stack, the already-targeted creature still looks fully valuable, so the heuristic re-picks it.

**2. The evaluator was blind to combat restrictions.** `BoardPresence` scored a creature that can't block identically to one that can — so even a simulation couldn't distinguish the redundant target from a fresh one (the difference only surfaced at the `ThreatAssessment` lethal threshold).

## Fix

- **`chooseCommittedTargets` (new):** the target the AI commits to is now chosen by **simulation** rather than the static heuristic. Simulating each candidate resolves the stack — including the pending first ability — so the evaluator scores the *real* board and a still-able blocker beats re-hitting a neutralized one. Requirements are resolved greedily; candidates are pre-ranked and capped at the top 8 per requirement to bound cost.
- **`BoardPresence` combat-restriction discount:** a creature that can't block (×0.85) / can't attack (×0.85, not double-counting `DEFENDER`) is now worth less, mirroring the existing `DEFENDER` and tapped discounts. Neutralizing a *second* blocker becomes a strict board improvement.
- **`evaluate1Ply` scores at the best simulated target** (not the heuristic one), so an ability whose ideal target is already taken by something on the stack no longer looks worthless and get passed over — it's the reason the AI now bothers to fire the second ability at all.

The bulk of the Strategist diff is extracting shared helpers (`targetInfosFor`, `heuristicTargetRank`, `toChosenTarget`, `applyTargets`, `targetsAlreadyFilled`) so the cheap heuristic path and the new simulation path share one implementation.

## Test

`AIPlayerTest > "AI targets a distinct blocker with a second can't-block ability"` reproduces the **hard case**: two stoppers, two opponent blockers, and the first ability left **unresolved on the stack** when the second's target is chosen. Verified load-bearing — it fails when the simulation step is disabled. Full `:ai` suite passes.

## Notes

- Scoring a targeted action now runs up to ~8 simulations to pick its best target (bounded by `MAX_TARGET_CANDIDATES`). The AI already simulates heavily, but worth noting.
- AI-only change; no SDK/engine/server signatures touched, so dependent modules are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)