### PR TITLE
Fold AbilityCost onto CostAtom (§3.2 one cost language — final wrapper)

### DIFF
--- a/backlog/sdk-analysis-2026-06-revised.md
+++ b/backlog/sdk-analysis-2026-06-revised.md
@@ -215,7 +215,13 @@ Family-specific notes:
 - **Review rule, enforced in `add-feature`:** a new `Effect` subtype must include one sentence in
   the PR description proving it cannot be a parameter of an existing family.
 
-### 3.2 One cost language — [HIGH]
+### 3.2 One cost language — [HIGH] — ✅ DONE
+
+> Landed across multiple PRs: `CostAtom` extracted for `PayCost` + `AdditionalCost` (commit
+> 87b71bf2e), then `AbilityCost` folded onto `AbilityCost.Atom(CostAtom)` (this PR). All three cost
+> contexts now carry one shared `CostAtom` vocabulary; the `Costs.*` facades are unchanged.
+> Counter-removal, X-variable, and named-mechanic costs stay as context-specific wrapper members by
+> design.
 
 **Problem.** Three parallel cost hierarchies — `AbilityCost`, `AdditionalCost` (591 lines),
 `PayCost` — share ~70% of their constructors. Each new payable thing (Blight, waterbend fodder, …)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -147,15 +147,16 @@ excluded.
 
 > **One cost vocabulary (`CostAtom`).** The payable things shared across cost *contexts* — mana, life,
 > sacrifice, discard, exile-from-zone, tap, return-to-hand, reveal — are defined **once** in the
-> `CostAtom` sealed hierarchy (`scripting/costs/CostAtom.kt`). The context wrappers carry them: a
-> `PayCost.Atom(atom)` and an `AdditionalCost.Atom(atom)` each hold one `CostAtom`, leaving only their
-> genuinely context-specific members on the wrapper (`PayCost.OwnManaCost` / `PayCost.Choice`;
-> `AdditionalCost`'s Behold / Blight / Forage / ChooseEntity / per-target life / variable exile). The
-> `Costs.*` facades below are unchanged — they construct the right `…Atom(CostAtom.X(…))` for you, so
-> card authoring is identical. A *new* payable thing is one `CostAtom` variant + one engine payment
-> branch, available in every context. (`AbilityCost` — the activated-ability cost hierarchy — is the
-> next wrapper slated to fold onto `CostAtom`; until then its `Costs.*` top-level members are still its
-> own subtypes.)
+> `CostAtom` sealed hierarchy (`scripting/costs/CostAtom.kt`). All three context wrappers carry them via
+> an `Atom(atom)` member: `PayCost.Atom`, `AdditionalCost.Atom`, and `AbilityCost.Atom` each hold one
+> `CostAtom`, leaving only their genuinely context-specific members on the wrapper
+> (`PayCost.OwnManaCost` / `PayCost.Choice`; `AdditionalCost`'s Behold / Blight / Forage / ChooseEntity
+> / per-target life / variable exile; `AbilityCost`'s `Free`, `Tap`/`Untap`, the X-variable costs
+> (`PayXLife`, `ExileXFromGraveyard`, `TapXPermanents`), the self-referential `SacrificeSelf` /
+> `ExileSelf` / `ExileGrantingPermanent`, counter-removal, `Loyalty`, `Composite`, and named mechanics
+> `Forage` / `Blight` / `Craft`). The `Costs.*` facades below are unchanged — they construct the right
+> `…Atom(CostAtom.X(…))` for you, so card authoring is identical. A *new* payable thing is one
+> `CostAtom` variant + one engine payment branch, available in every context.
 
 - `Costs.Free` — costs nothing (`{0}`).
 - `Costs.Tap` — `{T}`; tap this permanent.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -721,7 +721,7 @@ class CardBuilder(private val name: String) {
         val renewEffect = requireNotNull(builder.effect) { "renew requires an effect" }
         activatedAbilities.add(
             ActivatedAbility(
-                cost = AbilityCost.Composite(listOf(AbilityCost.Mana(ManaCost.parse(cost)), AbilityCost.ExileSelf)),
+                cost = AbilityCost.Composite(listOf(AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))), AbilityCost.ExileSelf)),
                 effect = renewEffect,
                 targetRequirements = builder.targetRequirements,
                 timing = TimingRule.SorcerySpeed,
@@ -768,7 +768,7 @@ class CardBuilder(private val name: String) {
         activatedAbilities.add(
             ActivatedAbility(
                 cost = AbilityCost.Composite(
-                    listOf(AbilityCost.Mana(ManaCost.parse(cost)), AbilityCost.Craft(filter))
+                    listOf(AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))), AbilityCost.Craft(filter))
                 ),
                 effect = com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect,
                 targetRequirements = emptyList(),
@@ -882,11 +882,11 @@ class CardBuilder(private val name: String) {
         activatedAbilities.add(
             ActivatedAbility(
                 id = AbilityId.generate(),
-                cost = AbilityCost.TapPermanents(
+                cost = AbilityCost.Atom(CostAtom.TapPermanents(
                     count = 1,
                     filter = GameObjectFilter.Creature,
                     excludeSelf = true
-                ),
+                )),
                 effect = Effects.AddDynamicCounters(
                     counterType = Counters.CHARGE,
                     amount = DynamicAmount.StationCharge,
@@ -943,7 +943,7 @@ class CardBuilder(private val name: String) {
         activatedAbilities.add(
             ActivatedAbility(
                 id = AbilityId.generate(),
-                cost = AbilityCost.Mana(ManaCost.parse(cost)),
+                cost = AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))),
                 effect = AttachEquipmentEffect(EffectTarget.BoundVariable("creature you control")),
                 targetRequirements = listOf(
                     TargetCreature(filter = TargetFilter.CreatureYouControl, id = "creature you control")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -56,13 +56,13 @@ object Costs {
      * Pay mana cost from string (e.g., "{2}{B}").
      */
     fun Mana(cost: String): AbilityCost =
-        AbilityCost.Mana(ManaCost.parse(cost))
+        AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost)))
 
     /**
      * Pay mana cost from ManaCost object.
      */
     fun Mana(cost: ManaCost): AbilityCost =
-        AbilityCost.Mana(cost)
+        AbilityCost.Atom(CostAtom.Mana(cost))
 
     // =========================================================================
     // Life Costs
@@ -72,7 +72,7 @@ object Costs {
      * Pay life.
      */
     fun PayLife(amount: Int): AbilityCost =
-        AbilityCost.PayLife(amount)
+        AbilityCost.Atom(CostAtom.PayLife(amount))
 
     /**
      * Pay X life, where X is the value chosen for the ability's `{X}` mana cost
@@ -88,19 +88,19 @@ object Costs {
      * Sacrifice a permanent matching the filter.
      */
     fun Sacrifice(filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.Sacrifice(filter)
+        AbilityCost.Atom(CostAtom.Sacrifice(filter))
 
     /**
      * Sacrifice another permanent matching the filter (excludes the source permanent).
      */
     fun SacrificeAnother(filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.Sacrifice(filter, excludeSelf = true)
+        AbilityCost.Atom(CostAtom.Sacrifice(filter, excludeSelf = true))
 
     /**
      * Sacrifice multiple permanents matching the filter.
      */
     fun SacrificeMultiple(count: Int, filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.Sacrifice(filter, count = count)
+        AbilityCost.Atom(CostAtom.Sacrifice(filter, count = count))
 
     // =========================================================================
     // Discard Costs
@@ -109,7 +109,7 @@ object Costs {
     /**
      * Discard a card (any card).
      */
-    val DiscardCard: AbilityCost = AbilityCost.Discard()
+    val DiscardCard: AbilityCost = AbilityCost.Atom(CostAtom.Discard())
 
     /**
      * Discard one or more cards matching the filter.
@@ -121,13 +121,13 @@ object Costs {
         filter: GameObjectFilter = GameObjectFilter.Any,
         count: Int = 1,
         atRandom: Boolean = false
-    ): AbilityCost = AbilityCost.Discard(filter, count, atRandom)
+    ): AbilityCost = AbilityCost.Atom(CostAtom.Discard(count, filter, random = atRandom))
 
     /**
      * Discard [count] cards chosen at random (e.g. Meteor Storm's "Discard two cards at random").
      */
     fun DiscardAtRandom(count: Int, filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.Discard(filter, count, atRandom = true)
+        AbilityCost.Atom(CostAtom.Discard(count, filter, random = true))
 
     /**
      * Discard your entire hand.
@@ -183,7 +183,7 @@ object Costs {
      * Exile cards from graveyard.
      */
     fun ExileFromGraveyard(count: Int, filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.ExileFromGraveyard(count, filter)
+        AbilityCost.Atom(CostAtom.ExileFrom(Zone.GRAVEYARD, filter, count))
 
     /**
      * Exile X cards from graveyard, where X is the ability's X value.
@@ -207,9 +207,13 @@ object Costs {
 
     /**
      * Tap permanents you control (e.g., "Tap five untapped Clerics you control").
+     * Set [excludeSelf] for "tap N other untapped … you control" (excludes the source permanent).
      */
-    fun TapPermanents(count: Int, filter: GameObjectFilter = GameObjectFilter.Creature): AbilityCost =
-        AbilityCost.TapPermanents(count, filter)
+    fun TapPermanents(
+        count: Int,
+        filter: GameObjectFilter = GameObjectFilter.Creature,
+        excludeSelf: Boolean = false
+    ): AbilityCost = AbilityCost.Atom(CostAtom.TapPermanents(count, filter, excludeSelf))
 
     /**
      * Tap another untapped permanent you control (e.g., "Tap another untapped permanent you control").
@@ -217,7 +221,7 @@ object Costs {
      * Pass `GameObjectFilter.Creature` to restrict to creatures, etc.
      */
     fun TapAnotherPermanent(filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.TapPermanents(count = 1, filter = filter, excludeSelf = true)
+        AbilityCost.Atom(CostAtom.TapPermanents(count = 1, filter = filter, excludeSelf = true))
 
     /**
      * Tap X permanents you control, where X is the ability's chosen X value.
@@ -234,7 +238,7 @@ object Costs {
      * Return a permanent you control matching the filter to its owner's hand.
      */
     fun ReturnToHand(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): AbilityCost =
-        AbilityCost.ReturnToHand(filter, count)
+        AbilityCost.Atom(CostAtom.ReturnToHand(filter, count))
 
     // =========================================================================
     // Counter Removal Costs

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
@@ -121,6 +122,25 @@ data class ActivatedAbility(
 sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     val description: String
 
+    /**
+     * A single shared payable thing — see [CostAtom]. Carries the payable concepts that mean the
+     * same in any cost context (pay mana, pay life, sacrifice/tap/return permanents, discard cards,
+     * exile from a zone). The activated-ability-specific costs — [Free], [Tap]/[Untap], the
+     * X-variable costs, the self-referential sacrifice/exile costs, counter removal, [Loyalty],
+     * [Composite], and named mechanics ([Forage], [Blight], [Craft]) — stay as their own subtypes.
+     * Ability-cost text leads a clause, so the description is the atom's phrase capitalized.
+     */
+    @SerialName("CostAtomWrapper")
+    @Serializable
+    data class Atom(val atom: CostAtom) : AbilityCost {
+        override val description: String get() = atom.description.replaceFirstChar { it.uppercase() }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
+            val newAtom = atom.applyTextReplacement(replacer)
+            return if (newAtom !== atom) copy(atom = newAtom) else this
+        }
+    }
+
     /** No cost ({0}) — the ability is free to activate */
     @SerialName("CostFree")
     @Serializable
@@ -142,20 +162,6 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         override val description: String = "{Q}"
     }
 
-    /** Pay mana */
-    @SerialName("CostMana")
-    @Serializable
-    data class Mana(val cost: ManaCost) : AbilityCost {
-        override val description: String = cost.toString()
-    }
-
-    /** Pay life */
-    @SerialName("CostPayLife")
-    @Serializable
-    data class PayLife(val amount: Int) : AbilityCost {
-        override val description: String = "Pay $amount life"
-    }
-
     /**
      * Pay X life, where X is the value chosen for the ability's `{X}` mana cost.
      *
@@ -170,88 +176,6 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     @Serializable
     data object PayXLife : AbilityCost {
         override val description: String = "Pay X life"
-    }
-
-    /**
-     * Sacrifice a permanent
-     *
-     * @property filter Which permanents can be sacrificed
-     */
-    @SerialName("CostSacrifice")
-    @Serializable
-    data class Sacrifice(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val excludeSelf: Boolean = false,
-        val count: Int = 1
-    ) : AbilityCost {
-        override val description: String = buildString {
-            append("Sacrifice ")
-            if (count == 1) {
-                append(if (excludeSelf) "another " else "a ")
-            } else {
-                append("$count ")
-            }
-            append(filter.description)
-            if (count > 1) append("s")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Discard one or more cards.
-     *
-     * @property filter Which cards can be discarded
-     * @property count How many cards to discard
-     * @property atRandom When true, the engine chooses the discarded cards at random
-     *   (no player selection); otherwise the player picks which cards to discard.
-     */
-    @SerialName("CostDiscard")
-    @Serializable
-    data class Discard(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val count: Int = 1,
-        val atRandom: Boolean = false
-    ) : AbilityCost {
-        override val description: String = buildString {
-            append("Discard ")
-            if (count == 1) append("a ") else append("$count ")
-            append(filter.description)
-            if (count != 1) append("s")
-            if (atRandom) append(" at random")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Exile cards from graveyard
-     *
-     * @property count Number of cards to exile
-     * @property filter Which cards can be exiled
-     */
-    @SerialName("CostExileFromGraveyard")
-    @Serializable
-    data class ExileFromGraveyard(
-        val count: Int,
-        val filter: GameObjectFilter = GameObjectFilter.Any
-    ) : AbilityCost {
-        override val description: String = buildString {
-            append("Exile $count ${filter.description}")
-            if (count > 1) append("s")
-            append(" from your graveyard")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
     }
 
     /**
@@ -344,38 +268,6 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
-     * Tap permanents you control.
-     * Example: "Tap five untapped Clerics you control"
-     *
-     * @property count Number of permanents to tap
-     * @property filter Which permanents can be tapped
-     */
-    @SerialName("CostTapPermanents")
-    @Serializable
-    data class TapPermanents(
-        val count: Int,
-        val filter: GameObjectFilter = GameObjectFilter.Creature,
-        val excludeSelf: Boolean = false
-    ) : AbilityCost {
-        override val description: String = buildString {
-            append("Tap ")
-            if (count == 1) {
-                append(if (excludeSelf) "another untapped " else "an untapped ")
-            } else {
-                append("$count untapped ")
-            }
-            append(filter.description)
-            if (count != 1) append("s")
-            append(" you control")
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
      * Tap a variable number of permanents you control, where the count equals the ability's X value.
      * Example: "Tap X untapped Knights you control" for Aryel, Knight of Windgrace.
      *
@@ -416,30 +308,6 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     @Serializable
     data object TapAttachedCreature : AbilityCost {
         override val description: String = "{T} enchanted creature"
-    }
-
-    /**
-     * Return a permanent you control to its owner's hand.
-     * Example: "Return an Elf you control to its owner's hand"
-     *
-     * @property filter Which permanents can be returned
-     */
-    @SerialName("CostReturnToHand")
-    @Serializable
-    data class ReturnToHand(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val count: Int = 1
-    ) : AbilityCost {
-        override val description: String = if (count == 1) {
-            "Return a ${filter.description} you control to its owner's hand"
-        } else {
-            "Return $count ${filter.description}s you control to their owner's hand"
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
     }
 
     /** Loyalty cost for planeswalker abilities */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/AbilityCostAtoms.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/AbilityCostAtoms.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.sdk.scripting.costs
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.scripting.AbilityCost
+
+/**
+ * Read-side helpers for the atom-backed [AbilityCost.Atom]. Since the shared payable things
+ * (mana, life, sacrifice, tap, return, discard, exile) now live on [CostAtom] and are carried
+ * by [AbilityCost.Atom], engine consumers that used to match `is AbilityCost.Mana` (etc.) read
+ * the wrapped atom through these accessors instead of unwrapping by hand at every call site.
+ */
+
+/** The wrapped [CostAtom] when this ability cost is atom-backed, else null. */
+val AbilityCost.atomOrNull: CostAtom?
+    get() = (this as? AbilityCost.Atom)?.atom
+
+/** The mana cost when this ability cost is an atom-backed [CostAtom.Mana], else null. */
+val AbilityCost.manaCostOrNull: ManaCost?
+    get() = (atomOrNull as? CostAtom.Mana)?.cost

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -58,15 +58,26 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
         override val description: String get() = "pay $amount life"
     }
 
-    /** Sacrifice [count] permanents matching [filter]. */
+    /**
+     * Sacrifice [count] permanents matching [filter].
+     *
+     * @property excludeSelf when true the cost's source permanent is excluded from the candidate
+     *   pool — "sacrifice another [filter]" (an activated-ability shape; spell additional costs
+     *   have no single source permanent to exclude, so they leave this false).
+     */
     @SerialName("AtomSacrifice")
     @Serializable
     data class Sacrifice(
         val filter: GameObjectFilter = GameObjectFilter.Any,
-        val count: Int = 1
+        val count: Int = 1,
+        val excludeSelf: Boolean = false
     ) : CostAtom {
         override val selectionCount: Int get() = count
-        override val description: String get() = "sacrifice ${quantify(count, filter.description)}"
+        override val description: String get() = buildString {
+            append("sacrifice ")
+            if (excludeSelf && count == 1) append("another ${filter.description}")
+            else append(quantify(count, filter.description))
+        }
 
         override fun applyTextReplacement(replacer: TextReplacer): CostAtom {
             val newFilter = filter.applyTextReplacement(replacer)
@@ -118,17 +129,23 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
         }
     }
 
-    /** Tap [count] untapped permanents matching [filter] you control. */
+    /**
+     * Tap [count] untapped permanents matching [filter] you control.
+     *
+     * @property excludeSelf when true the cost's source permanent is excluded from the candidate
+     *   pool — "tap another untapped [filter] you control".
+     */
     @SerialName("AtomTapPermanents")
     @Serializable
     data class TapPermanents(
         val count: Int = 1,
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val excludeSelf: Boolean = false
     ) : CostAtom {
         override val selectionCount: Int get() = count
         override val description: String get() = buildString {
             append("tap ")
-            if (count == 1) append("an untapped ${filter.description}")
+            if (count == 1) append(if (excludeSelf) "another untapped ${filter.description}" else "an untapped ${filter.description}")
             else append("$count untapped ${filter.description}s")
             append(" you control")
         }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/StationDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/StationDslTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.sdk.dsl
 
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.conditions.Compare
@@ -35,10 +36,11 @@ class StationDslTest : DescribeSpec({
             rammer.activatedAbilities.size shouldBe 1
             val station = rammer.activatedAbilities.single()
 
-            val cost = station.cost.shouldBeInstanceOf<AbilityCost.TapPermanents>()
-            cost.count shouldBe 1
-            cost.excludeSelf shouldBe true
-            cost.filter shouldBe GameObjectFilter.Creature
+            val cost = station.cost.shouldBeInstanceOf<AbilityCost.Atom>()
+            val atom = cost.atom.shouldBeInstanceOf<CostAtom.TapPermanents>()
+            atom.count shouldBe 1
+            atom.excludeSelf shouldBe true
+            atom.filter shouldBe GameObjectFilter.Creature
 
             station.timing shouldBe TimingRule.SorcerySpeed
 

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.serialization
 
 import com.wingedsheep.sdk.core.*
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
@@ -422,7 +423,7 @@ class CardSerializationRoundTripTest : DescribeSpec({
                 toughness = 5
 
                 activatedAbility {
-                    cost = AbilityCost.TapPermanents(
+                    cost = Costs.TapPermanents(
                         count = 5,
                         filter = GameObjectFilter.Creature.withSubtype("Cleric")
                     )
@@ -434,7 +435,7 @@ class CardSerializationRoundTripTest : DescribeSpec({
             }
 
             val serialized = CardLoader.toJson(card)
-            serialized shouldContain "CostTapPermanents"
+            serialized shouldContain "AtomTapPermanents"
             serialized shouldContain "GainLife"
 
             val deserialized = CardLoader.fromJson(serialized)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BaylenTheHaymaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BaylenTheHaymaker.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.blb.cards
 
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -28,19 +29,19 @@ val BaylenTheHaymaker = card("Baylen, the Haymaker") {
     oracleText = "Tap two untapped tokens you control: Add one mana of any color.\nTap three untapped tokens you control: Draw a card.\nTap four untapped tokens you control: Put three +1/+1 counters on Baylen. It gains trample until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(2, GameObjectFilter.Token)
+        cost = Costs.TapPermanents(2, GameObjectFilter.Token)
         effect = Effects.AddAnyColorMana()
         manaAbility = true
         timing = TimingRule.ManaAbility
     }
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(3, GameObjectFilter.Token)
+        cost = Costs.TapPermanents(3, GameObjectFilter.Token)
         effect = Effects.DrawCards(1)
     }
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(4, GameObjectFilter.Token)
+        cost = Costs.TapPermanents(4, GameObjectFilter.Token)
         effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self)
             .then(Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self))
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkirkProspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkirkProspector.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -24,7 +25,7 @@ val SkirkProspector = card("Skirk Prospector") {
     oracleText = "Sacrifice a Goblin: Add {R}."
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
+        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
         effect = AddManaEffect(Color.RED)
         manaAbility = true
         timing = TimingRule.ManaAbility

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TheDominionBracelet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TheDominionBracelet.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.eoe.cards
 
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.card
@@ -48,7 +49,7 @@ val TheDominionBracelet = card("The Dominion Bracelet") {
                 id = AbilityId.generate(),
                 cost = AbilityCost.Composite(
                     listOf(
-                        AbilityCost.Mana(ManaCost.parse("{15}")),
+                        Costs.Mana(ManaCost.parse("{15}")),
                         AbilityCost.ExileGrantingPermanent
                     )
                 ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DefilingTears.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DefilingTears.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.inv.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
@@ -32,7 +33,7 @@ val DefilingTears = card("Defiling Tears") {
             GrantActivatedAbilityEffect(
                 ability = ActivatedAbility(
                     id = AbilityId.generate(),
-                    cost = AbilityCost.Mana(ManaCost.parse("{B}")),
+                    cost = Costs.Mana(ManaCost.parse("{B}")),
                     effect = RegenerateEffect(EffectTarget.Self)
                 ),
                 target = t

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/Clickslither.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/Clickslither.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -27,7 +28,7 @@ val Clickslither = card("Clickslither") {
     keywords(Keyword.HASTE)
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
+        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
         effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
             .then(Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self))
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/FlamewaveInvoker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/FlamewaveInvoker.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -23,7 +24,7 @@ val FlamewaveInvoker = card("Flamewave Invoker") {
     oracleText = "{7}{R}: Flamewave Invoker deals 5 damage to target player or planeswalker."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{7}{R}"))
+        cost = Costs.Mana(ManaCost.parse("{7}{R}"))
         val t = target("target player or planeswalker", TargetPlayer())
         effect = DealDamageEffect(5, t)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/GoblinClearcutter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/GoblinClearcutter.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -28,7 +29,7 @@ val GoblinClearcutter = card("Goblin Clearcutter") {
         cost = AbilityCost.Composite(
             listOf(
                 AbilityCost.Tap,
-                AbilityCost.Sacrifice(GameObjectFilter.Land.withSubtype("Forest"))
+                Costs.Sacrifice(GameObjectFilter.Land.withSubtype("Forest"))
             )
         )
         effect = AddDynamicManaEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/RiptideMangler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/RiptideMangler.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
@@ -26,7 +27,7 @@ val RiptideMangler = card("Riptide Mangler") {
     oracleText = "{1}{U}: Change this creature's base power to target creature's power. (This effect lasts indefinitely.)"
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{1}{U}"))
+        cost = Costs.Mana(ManaCost.parse("{1}{U}"))
         target("target creature", Targets.Creature)
         effect = Effects.SetBasePower(
             target = EffectTarget.Self,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/SmokespewInvoker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/SmokespewInvoker.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -23,7 +24,7 @@ val SmokespewInvoker = card("Smokespew Invoker") {
     oracleText = "{7}{B}: Target creature gets -3/-3 until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{7}{B}"))
+        cost = Costs.Mana(ManaCost.parse("{7}{B}"))
         val t = target("target creature", TargetCreature())
         effect = Effects.ModifyStats(-3, -3, t)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/StarlightInvoker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/StarlightInvoker.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -23,7 +24,7 @@ val StarlightInvoker = card("Starlight Invoker") {
     oracleText = "{7}{W}: You gain 5 life."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{7}{W}"))
+        cost = Costs.Mana(ManaCost.parse("{7}{W}"))
         effect = GainLifeEffect(5, EffectTarget.Controller)
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/StonewoodInvoker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/StonewoodInvoker.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -23,7 +24,7 @@ val StonewoodInvoker = card("Stonewood Invoker") {
     oracleText = "{7}{G}: This creature gets +5/+5 until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{7}{G}"))
+        cost = Costs.Mana(ManaCost.parse("{7}{G}"))
         effect = Effects.ModifyStats(5, 5, EffectTarget.Self)
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/WitheredWretch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/WitheredWretch.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -23,7 +24,7 @@ val WitheredWretch = card("Withered Wretch") {
     oracleText = "{1}: Exile target card from a graveyard."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{1}"))
+        cost = Costs.Mana(ManaCost.parse("{1}"))
         val t = target("target card in a graveyard", Targets.CardInGraveyard)
         effect = Effects.Move(t, Zone.EXILE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainBlade.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.card
@@ -36,7 +37,7 @@ val DunedainBlade = card("Dúnedain Blade") {
 
     // Equip Human {1}: attach only to a Human creature you control, sorcery speed.
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{1}"))
+        cost = Costs.Mana(ManaCost.parse("{1}"))
         timing = TimingRule.SorcerySpeed
         val creature = target(
             "Human creature you control",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HauntOfTheDeadMarshes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HauntOfTheDeadMarshes.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -39,7 +40,7 @@ val HauntOfTheDeadMarshes = card("Haunt of the Dead Marshes") {
     }
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{2}{B}"))
+        cost = Costs.Mana(ManaCost.parse("{2}{B}"))
         activateFromZone = Zone.GRAVEYARD
         restrictions = listOf(
             ActivationRestriction.OnlyIfCondition(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HornOfGondor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HornOfGondor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
@@ -40,7 +41,7 @@ val HornOfGondor = card("Horn of Gondor") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{3}")),
+                Costs.Mana(ManaCost.parse("{3}")),
                 AbilityCost.Tap
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SaradocMasterOfBuckland.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SaradocMasterOfBuckland.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
@@ -48,7 +49,7 @@ val SaradocMasterOfBuckland = card("Saradoc, Master of Buckland") {
     }
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(
+        cost = Costs.TapPermanents(
             count = 2,
             filter = GameObjectFilter.Creature.withSubtype("Halfling").youControl(),
             excludeSelf = true

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/MossfireValley.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/MossfireValley.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ody.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -20,7 +21,7 @@ val MossfireValley = card("Mossfire Valley") {
 
     activatedAbility {
         cost = AbilityCost.Composite(listOf(
-            AbilityCost.Mana(ManaCost.parse("{1}")),
+            Costs.Mana(ManaCost.parse("{1}")),
             AbilityCost.Tap,
         ))
         effect = Effects.AddMana(Color.RED).then(Effects.AddMana(Color.GREEN))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SkrelvDefectorMite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SkrelvDefectorMite.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.one.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -39,7 +40,7 @@ val SkrelvDefectorMite = card("Skrelv, Defector Mite") {
     }
 
     activatedAbility {
-        cost = AbilityCost.Composite(listOf(AbilityCost.Mana(ManaCost.parse("{W}")), AbilityCost.Tap))
+        cost = AbilityCost.Composite(listOf(Costs.Mana(ManaCost.parse("{W}")), AbilityCost.Tap))
         val t = target("another target creature you control", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
         effect = Effects.ChooseColorThen(
             Effects.Composite(listOf(
@@ -51,7 +52,7 @@ val SkrelvDefectorMite = card("Skrelv, Defector Mite") {
     }
 
     activatedAbility {
-        cost = AbilityCost.Composite(listOf(AbilityCost.PayLife(2), AbilityCost.Tap))
+        cost = AbilityCost.Composite(listOf(Costs.PayLife(2), AbilityCost.Tap))
         val t = target("another target creature you control", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
         effect = Effects.ChooseColorThen(
             Effects.Composite(listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CatapultSquad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CatapultSquad.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -24,7 +25,7 @@ val CatapultSquad = card("Catapult Squad") {
     oracleText = "Tap two untapped Soldiers you control: Catapult Squad deals 2 damage to target attacking or blocking creature."
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(
+        cost = Costs.TapPermanents(
             count = 2,
             filter = GameObjectFilter.Creature.withSubtype("Soldier")
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/GoblinSledder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/GoblinSledder.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -24,7 +25,7 @@ val GoblinSledder = card("Goblin Sledder") {
     oracleText = "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
+        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
         val t = target("target", Targets.Creature)
         effect = ModifyStatsEffect(
             powerModifier = 1,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/NantukoHusk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/NantukoHusk.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -24,7 +25,7 @@ val NantukoHusk = card("Nantuko Husk") {
     oracleText = "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature)
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
         effect = ModifyStatsEffect(
             powerModifier = 2,
             toughnessModifier = 2,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RavenousBaloth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RavenousBaloth.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -22,7 +23,7 @@ val RavenousBaloth = card("Ravenous Baloth") {
     oracleText = "Sacrifice a Beast: You gain 4 life."
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature.withSubtype("Beast"))
+        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Beast"))
         effect = GainLifeEffect(4)
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RummagingWizard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RummagingWizard.kt
@@ -1,8 +1,9 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
 import com.wingedsheep.sdk.core.ManaCost
-import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
 
@@ -23,7 +24,7 @@ val RummagingWizard = card("Rummaging Wizard") {
     oracleText = "{2}{U}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)"
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{2}{U}"))
+        cost = Costs.Mana(ManaCost.parse("{2}{U}"))
         effect = Patterns.Library.surveil(1)
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RunWild.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RunWild.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ons.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -32,7 +33,7 @@ val RunWild = card("Run Wild") {
         ) then GrantActivatedAbilityEffect(
             ability = ActivatedAbility(
                 id = AbilityId.generate(),
-                cost = AbilityCost.Mana(ManaCost.parse("{G}")),
+                cost = Costs.Mana(ManaCost.parse("{G}")),
                 effect = RegenerateEffect(EffectTarget.Self)
             ),
             target = t

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/ShadesBreath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/ShadesBreath.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -33,7 +34,7 @@ val ShadesBreath = card("Shade's Breath") {
         ) then GrantActivatedAbilityToGroupEffect(
             ability = ActivatedAbility(
                 id = AbilityId.generate(),
-                cost = AbilityCost.Mana(ManaCost.parse("{B}")),
+                cost = Costs.Mana(ManaCost.parse("{B}")),
                 effect = ModifyStatsEffect(
                     powerModifier = 1,
                     toughnessModifier = 1,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SkirkProspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SkirkProspector.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -24,7 +25,7 @@ val SkirkProspector = card("Skirk Prospector") {
     oracleText = "Sacrifice a Goblin: Add {R}."
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
+        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
         effect = AddManaEffect(Color.RED)
         manaAbility = true
         timing = TimingRule.ManaAbility

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SpurredWolverine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SpurredWolverine.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.ons.cards
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -24,10 +25,7 @@ val SpurredWolverine = card("Spurred Wolverine") {
     oracleText = "Tap two untapped Beasts you control: Target creature gains first strike until end of turn."
 
     activatedAbility {
-        cost = AbilityCost.TapPermanents(
-            count = 2,
-            filter = GameObjectFilter.Creature.withSubtype("Beast")
-        )
+        cost = Costs.TapPermanents(2, GameObjectFilter.Creature.withSubtype("Beast"))
         val t = target("target", TargetCreature())
         effect = GrantKeywordEffect(Keyword.FIRST_STRIKE, t)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/CarrionFeeder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/CarrionFeeder.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.scg.cards
 
 import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityCost
@@ -30,7 +31,7 @@ val CarrionFeeder = card("Carrion Feeder") {
     }
 
     activatedAbility {
-        cost = AbilityCost.Sacrifice(GameObjectFilter.Creature)
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
         effect = AddCountersEffect(
             counterType = Counters.PLUS_ONE_PLUS_ONE,
             count = 1,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/ConsumptiveGoo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/ConsumptiveGoo.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.scg.cards
 
 import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.core.ManaCost
@@ -27,7 +28,7 @@ val ConsumptiveGoo = card("Consumptive Goo") {
     oracleText = "{2}{B}{B}: Target creature gets -1/-1 until end of turn. Put a +1/+1 counter on Consumptive Goo."
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{2}{B}{B}"))
+        cost = Costs.Mana(ManaCost.parse("{2}{B}{B}"))
         val t = target("target creature", Targets.Creature)
         effect = ModifyStatsEffect(
             powerModifier = -1,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GreatArashinCity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GreatArashinCity.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -53,9 +54,9 @@ val GreatArashinCity = card("Great Arashin City") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{1}{B}")),
+                Costs.Mana(ManaCost.parse("{1}{B}")),
                 AbilityCost.Tap,
-                AbilityCost.ExileFromGraveyard(count = 1, filter = GameObjectFilter.Creature)
+                Costs.ExileFromGraveyard(count = 1, filter = GameObjectFilter.Creature)
             )
         )
         effect = Effects.CreateToken(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiMonument.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.tdm.cards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
@@ -54,7 +55,7 @@ val JeskaiMonument = card("Jeskai Monument") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{1}{U}{R}{W}")),
+                Costs.Mana(ManaCost.parse("{1}{U}{R}{W}")),
                 AbilityCost.Tap,
                 AbilityCost.SacrificeSelf
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaVillage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaVillage.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.model.Rarity
@@ -54,7 +55,7 @@ val KishlaVillage = card("Kishla Village") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{3}{G}")),
+                Costs.Mana(ManaCost.parse("{3}{G}")),
                 AbilityCost.Tap
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MaelstromOfTheSpiritDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MaelstromOfTheSpiritDragon.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.tdm.cards
 
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
@@ -56,7 +57,7 @@ val MaelstromOfTheSpiritDragon = card("Maelstrom of the Spirit Dragon") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{4}")),
+                Costs.Mana(ManaCost.parse("{4}")),
                 AbilityCost.Tap,
                 AbilityCost.SacrificeSelf
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MistriseVillage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MistriseVillage.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -53,7 +54,7 @@ val MistriseVillage = card("Mistrise Village") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{U}")),
+                Costs.Mana(ManaCost.parse("{U}")),
                 AbilityCost.Tap
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SultaiMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SultaiMonument.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.tdm.cards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
@@ -55,7 +56,7 @@ val SultaiMonument = card("Sultai Monument") {
     activatedAbility {
         cost = AbilityCost.Composite(
             listOf(
-                AbilityCost.Mana(ManaCost.parse("{2}{B}{G}{U}")),
+                Costs.Mana(ManaCost.parse("{2}{B}{G}{U}")),
                 AbilityCost.Tap,
                 AbilityCost.SacrificeSelf
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SleepCursedFaerie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SleepCursedFaerie.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.woe.cards
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -42,7 +43,7 @@ val SleepCursedFaerie = card("Sleep-Cursed Faerie") {
     ))
 
     activatedAbility {
-        cost = AbilityCost.Mana(ManaCost.parse("{1}{U}"))
+        cost = Costs.Mana(ManaCost.parse("{1}{U}"))
         effect = Effects.Untap(EffectTarget.Self)
     }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/5DN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/5DN.json
@@ -59,8 +59,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -74,8 +77,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -94,8 +100,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -124,8 +133,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -153,8 +165,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{7}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/APC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/APC.json
@@ -16,8 +16,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -46,8 +49,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -107,8 +113,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -155,8 +164,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -227,8 +239,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -287,8 +302,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -340,8 +358,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -377,8 +398,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -423,8 +447,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -522,8 +549,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -559,8 +589,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -620,8 +653,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -733,12 +769,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
                         }
                     ]
                 },
@@ -796,8 +838,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -923,8 +968,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -942,8 +990,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1181,8 +1232,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -1257,8 +1311,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1352,8 +1409,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "land"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land"
+                    }
                 },
                 "effect": {
                     "type": "GainLife",
@@ -1730,13 +1790,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -1838,8 +1904,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2005,8 +2074,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2159,8 +2231,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -2202,8 +2277,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -16,8 +16,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -70,8 +73,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{8}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -120,8 +126,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -339,8 +348,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -737,8 +749,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -776,8 +791,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1083,8 +1101,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1325,8 +1346,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1516,8 +1540,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostDiscardLastDrawnThisTurn"
@@ -1565,8 +1592,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2538,8 +2568,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "Modal",
@@ -2705,8 +2738,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -97,8 +100,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
                         }
                     ]
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -333,8 +333,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{W}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -25,8 +25,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -176,8 +179,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{8}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -882,8 +882,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -931,9 +934,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "token"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "token"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "timing": "ManaAbility",
@@ -942,9 +948,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 3,
-                    "filter": "token"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "token"
+                    }
                 },
                 "effect": {
                     "type": "DrawCards",
@@ -957,9 +966,12 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 4,
-                    "filter": "token"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 4,
+                        "filter": "token"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1460,8 +1472,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -1519,8 +1534,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -1731,8 +1749,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2109,8 +2130,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2728,8 +2752,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostForage"
                     ]
@@ -3043,8 +3070,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -3164,8 +3194,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B/R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B/R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -4955,8 +4988,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6352,8 +6388,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": "SacrificeSelf",
                 "descriptionOverride": "{1}{R}: Sacrifice this enchantment."
@@ -6756,10 +6795,16 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
-                        "CostDiscard"
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
                     ]
                 },
                 "effect": {
@@ -6955,13 +7000,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "token"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "token"
+                            }
                         }
                     ]
                 },
@@ -6979,13 +7030,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -7008,8 +7065,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7094,8 +7154,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -8108,8 +8171,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -8260,8 +8326,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8487,8 +8556,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8619,8 +8691,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -8802,8 +8877,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -9958,8 +10036,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -10314,8 +10395,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -10621,8 +10705,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -10736,8 +10823,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -11317,12 +11407,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         }
                     ]
                 },
@@ -11386,8 +11482,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -11819,8 +11918,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U/B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U/B}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -12513,8 +12615,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -12718,8 +12823,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -12964,8 +13072,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14859,8 +14970,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -15086,8 +15200,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17167,8 +17284,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -17292,8 +17412,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -18036,8 +18159,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -18611,8 +18737,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -18922,8 +19051,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostTap",
                             "CostSacrificeSelf"
@@ -19114,8 +19246,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -19297,8 +19432,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -19325,9 +19463,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "token"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "token"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreature",
@@ -19877,8 +20018,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -19948,8 +20092,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -20193,8 +20340,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -20250,8 +20400,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "timing": "ManaAbility",
@@ -21758,8 +21911,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -22520,12 +22676,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{B}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{B}{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Snail"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Snail"
+                            }
                         }
                     ]
                 },
@@ -22840,8 +23002,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostTap",
                             "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -919,8 +919,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2061,8 +2064,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2321,8 +2327,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2852,8 +2861,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}{U}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",

--- a/mtg-sets/src/test/resources/snapshots/cards/C14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C14.json
@@ -25,8 +25,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/CMR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CMR.json
@@ -158,13 +158,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{W}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{W}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "enchantment"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "enchantment"
+                            }
                         }
                     ]
                 },
@@ -220,13 +226,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
                         }
                     ]
                 },
@@ -374,8 +386,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap",
                         {
@@ -383,8 +398,11 @@
                             "costs": [
                                 "CostSacrificeSelf",
                                 {
-                                    "type": "CostSacrifice",
-                                    "filter": "creature green"
+                                    "type": "CostAtomWrapper",
+                                    "atom": {
+                                        "type": "AtomSacrifice",
+                                        "filter": "creature green"
+                                    }
                                 }
                             ]
                         }

--- a/mtg-sets/src/test/resources/snapshots/cards/CON.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/DIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DIS.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -352,8 +352,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -709,8 +712,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -736,8 +742,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap",
                         {
@@ -1061,8 +1070,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1092,8 +1104,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1388,8 +1403,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1700,8 +1718,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3237,8 +3258,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3282,8 +3306,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -3459,8 +3486,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": "ExchangeLifeAndPower"
             }
@@ -4039,8 +4069,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4198,13 +4231,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         {
-                            "type": "CostExileFromGraveyard",
-                            "count": 1,
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -4224,9 +4263,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Saproling",
-                    "count": 2
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Saproling",
+                        "count": 2
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -5562,8 +5604,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -6422,8 +6467,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -6897,8 +6945,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",
@@ -7524,8 +7575,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "isManaAbility": true
@@ -7774,8 +7828,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -7840,8 +7897,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -7895,8 +7955,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -7959,8 +8022,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -8057,8 +8123,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -8415,13 +8484,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         {
-                            "type": "CostReturnToHand",
-                            "filter": "land",
-                            "count": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomReturnToHand",
+                                "filter": "land",
+                                "count": 2
+                            }
                         }
                     ]
                 },
@@ -8820,8 +8895,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
                         }
                     ]
                 },
@@ -9100,8 +9178,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -9699,8 +9780,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -9841,8 +9925,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
                         }
                     ]
                 },
@@ -9886,21 +9973,24 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostDiscard",
-                    "filter": {
-                        "cardPredicates": [
-                            {
-                                "type": "Or",
-                                "predicates": [
-                                    "IsArtifact",
-                                    "IsLegendary",
-                                    {
-                                        "type": "HasSubtype",
-                                        "subtype": "Saga"
-                                    }
-                                ]
-                            }
-                        ]
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsArtifact",
+                                        "IsLegendary",
+                                        {
+                                            "type": "HasSubtype",
+                                            "subtype": "Saga"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
                     }
                 },
                 "effect": {
@@ -10447,8 +10537,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -10551,8 +10644,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -10667,8 +10763,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -10751,12 +10850,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -10813,8 +10918,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "AddMana",
@@ -10956,8 +11064,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -11188,8 +11299,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -12167,13 +12281,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -12243,12 +12363,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -12970,8 +13096,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13913,8 +14042,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14650,9 +14782,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "count": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "count": 2
+                            }
                         }
                     ]
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -88,8 +88,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1060,9 +1060,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1083,8 +1086,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -156,8 +156,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{R}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}{G}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreature",

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -1077,8 +1077,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1136,8 +1139,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2162,8 +2168,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -2309,8 +2318,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2859,8 +2871,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -3496,8 +3511,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         {
                             "type": "CostBlight",
@@ -4196,8 +4214,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -4578,8 +4599,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -6656,8 +6680,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         {
                             "type": "CostBlight",
@@ -6874,8 +6901,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G/W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G/W}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreature",
@@ -6891,8 +6921,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G/W}{G/W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G/W}{G/W}"
+                    }
                 },
                 "effect": {
                     "type": "Gated",
@@ -6918,8 +6951,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{G/W}{G/W}{G/W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G/W}{G/W}{G/W}"
+                    }
                 },
                 "effect": {
                     "type": "Gated",
@@ -6993,8 +7029,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreature",
@@ -7038,8 +7077,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -7328,8 +7370,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -7505,8 +7550,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -7641,8 +7689,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8342,8 +8393,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -8648,8 +8702,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -8807,8 +8864,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -9989,9 +10049,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 3,
-                    "filter": "creature Elf"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature Elf"
+                    }
                 },
                 "effect": "Proliferate",
                 "timing": "SorcerySpeed"
@@ -10028,8 +10091,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R/W}{R/W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R/W}{R/W}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -10221,7 +10287,10 @@
         "activatedAbilities": [
             {
                 "id": "ability_1",
-                "cost": "CostDiscard",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -10652,8 +10721,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "CopyTargetTriggeredAbility",
@@ -10758,8 +10831,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 3
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -11204,13 +11281,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B/G}{B/G}{B/G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B/G}{B/G}{B/G}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostDiscard",
-                            "filter": "land"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "land"
+                            }
                         }
                     ]
                 },
@@ -11267,8 +11350,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -11290,8 +11376,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -11859,8 +11948,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -12147,8 +12239,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -12408,8 +12503,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -12582,8 +12680,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{G}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}{G}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -14021,8 +14122,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14267,8 +14371,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W/B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W/B}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -14595,8 +14702,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -15055,8 +15165,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -15271,8 +15384,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -16366,8 +16482,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -16651,8 +16770,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         {
                             "type": "CostBlight",
@@ -16945,8 +17067,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -17031,8 +17156,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostTap",
                         {
@@ -17086,8 +17214,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B/G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B/G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -18577,8 +18708,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -20018,14 +20152,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 1,
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -18,9 +18,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -36,8 +39,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -146,8 +152,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{7}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -801,9 +810,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -963,8 +975,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1050,8 +1065,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1246,8 +1264,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{8}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1934,8 +1955,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2584,8 +2608,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2916,9 +2943,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -3105,9 +3135,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -3120,8 +3153,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3825,8 +3861,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -3981,8 +4020,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4002,8 +4044,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4565,9 +4610,12 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -4788,9 +4836,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -4806,8 +4857,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5011,9 +5065,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -5428,9 +5485,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -5979,9 +6039,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -6111,10 +6174,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 1,
-                            "filter": {},
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -7045,8 +7109,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{W}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}{W}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -7161,8 +7228,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -7437,8 +7507,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -7565,8 +7638,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -7712,9 +7788,12 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -7926,8 +8005,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -8258,9 +8340,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -8276,13 +8361,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
                         }
                     ]
                 },
@@ -8515,9 +8606,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -9020,9 +9114,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -9504,8 +9601,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -9631,8 +9731,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -9799,9 +9902,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -10767,8 +10873,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -11235,9 +11344,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -11384,8 +11496,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{6}{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -11940,13 +12055,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "Food"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "Food"
+                            }
                         }
                     ]
                 },
@@ -11981,8 +12102,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostTap",
                             "CostSacrificeSelf"
@@ -12419,9 +12543,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -12713,14 +12840,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostExileFromGraveyard",
-                            "count": 1,
-                            "filter": "artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "artifact"
+                            }
                         }
                     ]
                 },
@@ -13331,8 +13464,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
@@ -13370,8 +13506,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13500,8 +13639,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{B}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}{G}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -14047,14 +14189,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact|land",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact|land",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -14134,9 +14282,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -14494,9 +14645,12 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -14627,8 +14781,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -15023,8 +15180,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -15406,8 +15566,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
                             "type": "CostRemovePlusOnePlusOneCounters",
@@ -15605,8 +15768,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{10}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{10}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -15707,9 +15873,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -15725,17 +15894,26 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -15835,9 +16013,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -16126,9 +16307,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -17442,8 +17626,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -17644,8 +17831,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -17681,8 +17871,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{15}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{15}"
+                                }
                             },
                             "CostExileGrantingPermanent"
                         ]
@@ -17860,9 +18053,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -17992,9 +18188,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -18340,9 +18539,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature|artifact",
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature|artifact",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -18594,9 +18796,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -18697,9 +18902,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -18715,8 +18923,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -19121,9 +19332,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -19303,9 +19517,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -19675,9 +19892,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 1,
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AddDynamicCounters",
@@ -20008,8 +20228,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{6}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/EXO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EXO.json
@@ -120,8 +120,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -189,8 +192,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "DrawCards",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -657,8 +657,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreature",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -152,12 +152,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature|artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|artifact"
+                            }
                         }
                     ]
                 },
@@ -429,8 +435,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -667,8 +676,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{B}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -1263,8 +1275,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1390,8 +1405,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1492,8 +1510,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1554,8 +1575,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1687,8 +1711,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1920,13 +1947,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -2077,8 +2110,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -2429,8 +2465,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2479,8 +2518,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -143,8 +143,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -307,8 +310,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -396,8 +402,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -450,8 +459,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/HML.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HML.json
@@ -16,8 +16,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -439,8 +439,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeColor",
@@ -536,8 +539,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -852,8 +858,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ChooseColorThen",
@@ -879,8 +888,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1047,8 +1059,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1455,8 +1470,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1557,8 +1575,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1799,8 +1820,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "ChooseColorThen",
@@ -1918,8 +1942,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddMana",
@@ -2262,8 +2289,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2599,8 +2629,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2636,8 +2669,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2691,8 +2727,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -2713,8 +2752,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3036,8 +3078,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -3088,8 +3133,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3227,8 +3275,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3247,8 +3298,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -3452,8 +3506,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3683,8 +3740,11 @@
                     "ability": {
                         "id": "ability_1",
                         "cost": {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "effect": {
                             "type": "Regenerate",
@@ -3834,8 +3894,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -4214,8 +4277,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -4607,8 +4673,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5117,8 +5186,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5246,8 +5318,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -5505,8 +5580,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -5626,8 +5704,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -5727,8 +5808,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5830,8 +5914,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -5925,8 +6012,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -6003,8 +6093,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6452,8 +6545,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeColorToChosen",
@@ -6770,13 +6866,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -6941,8 +7043,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -7552,8 +7657,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{X}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{X}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -7637,8 +7745,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeColor",
@@ -7703,8 +7814,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -7737,13 +7851,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}{G}"
+                            }
                         },
                         {
-                            "type": "CostDiscard",
-                            "count": 2,
-                            "atRandom": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "count": 2,
+                                "random": true
+                            }
                         }
                     ]
                 },
@@ -7794,8 +7914,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -7878,8 +8001,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -7931,8 +8057,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7962,8 +8091,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8016,8 +8148,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8046,8 +8181,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8101,8 +8239,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -8140,8 +8281,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "isManaAbility": true
@@ -8225,8 +8369,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -8679,8 +8826,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "isManaAbility": true
@@ -8713,8 +8863,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -8825,8 +8978,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "ExchangeControl",
@@ -8874,8 +9030,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -9231,8 +9390,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -9383,8 +9545,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -9712,12 +9877,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -9953,8 +10124,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -10159,8 +10333,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -10238,8 +10415,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeColorToChosen",
@@ -10275,8 +10455,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": "ForceBlock",
                 "targetRequirements": [
@@ -10340,12 +10523,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         }
                     ]
                 },
@@ -10923,8 +11112,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -12069,8 +12261,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -12102,8 +12297,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -12226,12 +12424,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -12493,8 +12697,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -12914,8 +13121,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -13165,8 +13375,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13194,8 +13407,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13393,8 +13609,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -13479,8 +13698,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13508,8 +13730,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13562,8 +13787,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13594,8 +13822,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13810,8 +14041,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13847,8 +14081,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13902,8 +14139,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13933,8 +14173,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14167,12 +14410,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "enchantment"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "enchantment"
+                            }
                         }
                     ]
                 },
@@ -14198,8 +14447,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}{U}"
+                    }
                 },
                 "effect": "Counter",
                 "targetRequirements": [
@@ -14599,8 +14851,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14629,8 +14884,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14682,8 +14940,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14715,8 +14976,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14772,8 +15036,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14802,8 +15069,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14863,8 +15133,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -14905,8 +15178,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -15174,8 +15450,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -15310,8 +15589,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -15367,8 +15649,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -15432,8 +15717,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -16137,8 +16425,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "PreventDamageShield",
@@ -16234,8 +16525,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -16581,8 +16875,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -16790,8 +17087,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17464,8 +17764,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -13,8 +13,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -209,8 +209,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}{B}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{B}{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -257,8 +260,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -404,8 +410,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -553,8 +562,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -866,8 +878,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1650,8 +1665,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1733,8 +1751,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -1887,8 +1908,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
@@ -2089,9 +2113,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature",
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "Modal",
@@ -2402,8 +2429,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -2539,8 +2569,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3055,8 +3088,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3135,8 +3171,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -3171,8 +3210,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostTap"
                         ]
@@ -3623,8 +3665,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -3909,8 +3954,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -4181,8 +4229,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4212,8 +4263,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4494,8 +4548,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4610,8 +4667,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4672,8 +4732,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -5509,8 +5572,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{R}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{R}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -5972,13 +6038,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -6024,13 +6096,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -6378,8 +6456,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -6447,8 +6528,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -6523,8 +6607,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6699,8 +6786,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{W}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{W}{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -6927,8 +7017,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -7472,8 +7565,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7642,8 +7738,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{2}{B}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}{B}"
+                        }
                     },
                     "effect": {
                         "type": "Regenerate",
@@ -8015,8 +8114,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
                         },
                         "CostTap",
                         "CostExileXFromGraveyard"
@@ -8221,9 +8323,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostReturnToHand",
-                    "filter": "land",
-                    "count": 3
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomReturnToHand",
+                        "filter": "land",
+                        "count": 3
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -8526,8 +8631,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -8545,8 +8653,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -8811,8 +8922,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostRemoveXPlusOnePlusOneCounters"
                     ]
@@ -9474,8 +9588,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -9729,8 +9846,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -9751,8 +9871,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -9763,8 +9886,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -9896,8 +10022,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -9949,8 +10078,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -10787,8 +10919,11 @@
                 "ability": {
                     "id": "ability_2",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{6}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{6}"
+                        }
                     },
                     "effect": {
                         "type": "TapUntap",
@@ -10867,8 +11002,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "LookAtFaceDown",
@@ -11245,8 +11383,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{G}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{G}{U}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -12072,8 +12213,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}{U}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{U}{R}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -12536,8 +12680,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -12919,8 +13066,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -13002,8 +13152,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -13656,8 +13809,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -13948,8 +14104,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -820,8 +820,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
                         },
                         {
                             "type": "CostCraft",

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -438,8 +438,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -629,8 +632,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{B}"
+                    }
                 },
                 "effect": "Counter",
                 "targetRequirements": [
@@ -761,8 +767,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -1073,8 +1082,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1217,8 +1229,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1301,8 +1316,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1450,8 +1468,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1648,8 +1669,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1754,8 +1778,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1939,8 +1966,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}{G}"
+                    }
                 },
                 "effect": "Counter",
                 "targetRequirements": [
@@ -2020,8 +2050,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2375,8 +2408,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2465,8 +2501,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2944,8 +2983,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3232,8 +3274,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3819,8 +3864,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3885,8 +3933,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3925,8 +3976,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3965,8 +4019,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -4088,8 +4145,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -4337,8 +4397,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",

--- a/mtg-sets/src/test/resources/snapshots/cards/LEG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEG.json
@@ -52,8 +52,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -451,12 +451,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -1022,8 +1028,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1141,13 +1150,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -1324,9 +1339,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Bird"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Bird"
+                    }
                 },
                 "effect": {
                     "type": "DrawCards",
@@ -1339,9 +1357,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Wizard"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Wizard"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1443,9 +1464,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Cleric",
-                            "count": 3
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Cleric",
+                                "count": 3
+                            }
                         }
                     ]
                 },
@@ -1723,13 +1747,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Zombie"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Zombie"
+                            }
                         }
                     ]
                 },
@@ -1901,8 +1931,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "PreventDamageShield",
@@ -2194,13 +2227,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -2548,8 +2587,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{R}"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",
@@ -2986,8 +3028,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -3162,8 +3207,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land Forest"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land Forest"
+                            }
                         }
                     ]
                 },
@@ -3235,8 +3283,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{R}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -3427,8 +3478,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -3479,8 +3533,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -4005,9 +4062,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 2,
-                            "filter": "creature Bird"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "count": 2,
+                                "filter": "creature Bird"
+                            }
                         }
                     ]
                 },
@@ -4601,8 +4661,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -4638,8 +4701,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{1}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{1}"
+                        }
                     },
                     "effect": {
                         "type": "BecomeCreatureType",
@@ -4706,8 +4772,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -4720,8 +4789,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5077,8 +5149,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -5362,8 +5437,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5406,8 +5484,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "SetBasePower",
@@ -6118,8 +6199,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -6212,8 +6296,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{2}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "effect": {
                         "type": "ModifyStats",
@@ -6261,8 +6348,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GainLife",
@@ -6346,8 +6436,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -6472,8 +6565,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "RemoveKeyword",
@@ -7019,8 +7115,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "TurnFaceDown",
@@ -7311,8 +7410,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantAttackBlockTaxPerCreatureType",
@@ -7640,8 +7742,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -88,8 +88,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -301,8 +304,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -452,8 +458,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -126,8 +126,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -489,8 +492,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{G}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -685,8 +691,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
                             "type": "CostRemoveCounterFromSelf",
@@ -972,8 +981,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -996,8 +1008,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1561,8 +1576,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1866,14 +1884,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -2225,13 +2249,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -2491,8 +2521,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2516,8 +2549,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -3826,8 +3862,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3917,8 +3956,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{7}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}{R}"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",
@@ -4807,8 +4849,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -5443,8 +5488,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -5770,8 +5818,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact Treasure"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact Treasure"
+                            }
                         }
                     ]
                 },
@@ -5869,8 +5920,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -6142,9 +6196,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -6342,8 +6399,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -6566,8 +6626,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7547,8 +7610,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -8461,8 +8527,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8607,13 +8676,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostExileFromGraveyard",
-                            "count": 3
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "count": 3
+                            }
                         }
                     ]
                 },
@@ -8854,8 +8930,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -9018,8 +9097,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -9310,8 +9392,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "Food"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "Food"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -10101,8 +10186,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -10801,8 +10889,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -11147,9 +11238,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "Food",
-                    "count": 3
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "Food",
+                        "count": 3
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -11304,10 +11398,13 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Halfling ctrl:you",
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Halfling ctrl:you",
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -11499,8 +11596,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -11963,8 +12063,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "timing": "ManaAbility",
@@ -12094,8 +12197,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -12739,8 +12845,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -13563,14 +13672,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 1,
-                            "filter": "creature ctrl:you"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature ctrl:you"
+                            }
                         }
                     ]
                 },
@@ -14553,8 +14667,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -14604,8 +14721,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}{G}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -25,8 +25,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"

--- a/mtg-sets/src/test/resources/snapshots/cards/MIR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MIR.json
@@ -173,8 +173,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -210,8 +213,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -452,8 +458,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land Swamp"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land Swamp"
+                            }
                         }
                     ]
                 },
@@ -489,8 +498,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -609,8 +621,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -776,8 +791,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -816,8 +834,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -998,8 +1019,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1035,8 +1059,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1239,8 +1266,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1364,8 +1394,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1505,8 +1538,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{8}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1776,8 +1812,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1856,8 +1895,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -2028,12 +2070,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land Forest"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land Forest"
+                            }
                         }
                     ]
                 },
@@ -2106,13 +2154,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -2234,8 +2288,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -2319,8 +2376,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -2452,8 +2512,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2463,8 +2526,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2544,8 +2610,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2938,8 +3007,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -2977,8 +3049,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3076,13 +3151,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -3272,8 +3353,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3392,8 +3476,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -3487,8 +3574,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3530,8 +3620,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -3601,12 +3694,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -3660,8 +3759,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3690,8 +3792,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3754,8 +3859,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4205,8 +4313,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4318,8 +4429,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -4370,12 +4484,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -4460,8 +4580,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -4709,8 +4832,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4879,8 +5005,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -5019,8 +5148,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -5108,8 +5240,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -103,8 +103,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostPayLife",
-                    "amount": 2
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 2
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -139,8 +142,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -175,8 +181,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -12,8 +12,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -42,8 +45,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -192,8 +198,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -312,8 +321,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -403,8 +415,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -552,8 +567,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -681,8 +699,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -781,8 +802,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -834,8 +858,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -978,8 +1005,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1057,8 +1087,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "artifact"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1111,8 +1144,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "artifact"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -1235,8 +1271,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -1331,8 +1370,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1407,8 +1449,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -1454,8 +1499,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{0}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{0}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1561,8 +1609,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1749,8 +1800,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1815,8 +1869,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "artifact"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1916,8 +1973,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2066,8 +2126,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2129,8 +2192,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2167,8 +2233,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2224,8 +2293,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2301,8 +2373,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2458,8 +2533,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2488,8 +2566,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -2807,8 +2888,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2865,8 +2949,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3019,8 +3106,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3093,8 +3183,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3113,8 +3206,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3645,8 +3741,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3685,8 +3784,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3753,8 +3855,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -3789,8 +3894,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{8}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3846,8 +3954,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{8}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3886,8 +3997,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{8}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4008,8 +4122,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -4254,8 +4371,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4308,8 +4428,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4391,8 +4514,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostPayLife",
-                    "amount": 1
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 1
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/NEM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEM.json
@@ -16,8 +16,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -111,8 +111,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -321,8 +324,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -376,8 +382,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ONE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONE.json
@@ -435,8 +435,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -488,8 +491,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostPayLife",
-                            "amount": 2
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -95,8 +95,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{R}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -178,12 +181,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -312,9 +321,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Cleric"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Cleric"
+                    }
                 },
                 "effect": {
                     "type": "GainLife",
@@ -587,9 +599,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Wizard"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Wizard"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -703,8 +718,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -1063,8 +1081,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1192,8 +1213,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1253,8 +1277,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
                 },
                 "effect": {
                     "type": "LookAtFaceDown",
@@ -1551,9 +1578,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Elf"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Elf"
+                    }
                 },
                 "effect": "AddManaOfChoice",
                 "isManaAbility": true
@@ -1824,8 +1854,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -1904,8 +1937,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -2104,12 +2140,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Cleric"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Cleric"
+                            }
                         }
                     ]
                 },
@@ -2361,9 +2403,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Soldier"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Soldier"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -2412,9 +2457,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Soldier"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Soldier"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",
@@ -2475,8 +2523,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -2928,8 +2979,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "PreventDamageShield",
@@ -3113,8 +3167,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3336,8 +3393,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -3359,8 +3419,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3739,8 +3802,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -3966,8 +4033,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4597,12 +4667,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "permanent"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent"
+                            }
                         }
                     ]
                 },
@@ -4780,8 +4856,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeChosenCreatureType"
@@ -4841,8 +4920,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4943,8 +5025,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}{R}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{R}{R}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -5034,8 +5119,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5253,8 +5341,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -5372,8 +5463,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -5871,8 +5965,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6390,8 +6487,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6506,8 +6606,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -6659,8 +6762,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6756,9 +6862,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 3,
-                    "filter": "creature Cleric"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature Cleric"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -6802,8 +6911,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -6960,8 +7072,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{W}"
+                    }
                 },
                 "effect": {
                     "type": "RedirectNextDamage",
@@ -7067,8 +7182,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7126,8 +7244,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -7421,8 +7542,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -7489,8 +7613,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -7820,9 +7947,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Zombie"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Zombie"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -9060,8 +9190,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "TurnFaceUp",
@@ -9137,8 +9270,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ChooseColorThen",
@@ -9297,8 +9433,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "AnimateLand",
@@ -9320,8 +9459,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -9422,8 +9564,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -10013,8 +10158,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10045,8 +10193,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10087,8 +10238,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10154,8 +10308,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10193,8 +10350,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10230,8 +10390,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10241,8 +10404,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -10295,8 +10461,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "BecomeCreatureType",
@@ -10350,8 +10519,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -10489,8 +10661,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -10626,8 +10801,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -10956,8 +11134,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -11203,8 +11384,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -11502,8 +11686,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeSpellTarget",
@@ -11548,8 +11735,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Beast"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Beast"
+                    }
                 },
                 "effect": {
                     "type": "GainLife",
@@ -11930,8 +12120,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -12076,8 +12269,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -12127,8 +12323,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -12213,8 +12412,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -12431,8 +12633,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -12520,8 +12725,11 @@
                     "ability": {
                         "id": "ability_1",
                         "cost": {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "effect": {
                             "type": "Regenerate",
@@ -12900,13 +13108,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{U}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Bird"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Bird"
+                            }
                         }
                     ]
                 },
@@ -13077,8 +13291,11 @@
                     "ability": {
                         "id": "ability_1",
                         "cost": {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "effect": {
                             "type": "ModifyStats",
@@ -13259,9 +13476,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Cleric"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Cleric"
+                    }
                 },
                 "effect": {
                     "type": "PreventDamageShield",
@@ -13284,9 +13504,12 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Wizard"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Wizard"
+                    }
                 },
                 "effect": {
                     "type": "PreventDamageShield",
@@ -13504,8 +13727,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{X}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{X}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -13551,8 +13777,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -13664,9 +13893,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -13728,8 +13960,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Goblin"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Goblin"
+                    }
                 },
                 "effect": {
                     "type": "AddMana",
@@ -13818,8 +14053,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostDiscardHand"
@@ -14094,8 +14332,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -14368,8 +14609,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -14451,9 +14695,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 2,
-                    "filter": "creature Beast"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature Beast"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -14696,13 +14943,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Cleric"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Cleric"
+                            }
                         }
                     ]
                 },
@@ -14721,13 +14974,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Cleric"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Cleric"
+                            }
                         }
                     ]
                 },
@@ -14939,9 +15198,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Wizard"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Wizard"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -15859,8 +16121,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -16147,10 +16412,16 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
-                        "CostDiscard"
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
                     ]
                 },
                 "effect": {
@@ -16213,8 +16484,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -16338,8 +16612,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -16558,9 +16835,12 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostTapPermanents",
-                    "count": 5,
-                    "filter": "creature Elf"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Elf"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -16622,12 +16902,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Wizard"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Wizard"
+                            }
                         }
                     ]
                 },
@@ -16673,8 +16959,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -16734,12 +17023,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Wall"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Wall"
+                            }
                         }
                     ]
                 },
@@ -16830,8 +17125,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17105,8 +17403,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17157,8 +17458,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -17344,8 +17648,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17566,8 +17873,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -17630,8 +17940,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ReplaceNextDrawWith",
@@ -17680,8 +17993,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ReplaceNextDrawWith",
@@ -17748,8 +18064,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ReplaceNextDrawWith",
@@ -17791,8 +18110,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ReplaceNextDrawWith",
@@ -17825,8 +18147,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "ReplaceNextDrawWith",

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -263,8 +263,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -779,8 +782,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{G}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -967,8 +973,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1148,8 +1157,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1548,8 +1560,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2467,8 +2482,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2621,8 +2639,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -3232,8 +3253,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -3876,8 +3900,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -3933,13 +3960,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "land"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
                         }
                     ]
                 },
@@ -3999,8 +4032,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "GrantCantBeBlockedExceptBy",
@@ -5146,8 +5182,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5575,13 +5614,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostPayLife",
-                            "amount": 1
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
                         }
                     ]
                 },
@@ -5793,8 +5838,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/PCY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PCY.json
@@ -13,8 +13,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "land"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -108,8 +111,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -192,8 +198,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "land"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -238,8 +247,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/PLS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PLS.json
@@ -13,8 +13,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -210,12 +213,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Zombie"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Zombie"
+                            }
                         }
                     ]
                 },
@@ -471,13 +480,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature|enchantment"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|enchantment"
+                            }
                         }
                     ]
                 },
@@ -520,8 +535,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -860,8 +878,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -924,8 +945,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1007,8 +1031,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -1025,8 +1052,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature Saproling"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature Saproling"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -1259,8 +1289,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1314,8 +1347,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1333,8 +1369,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1439,8 +1478,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1562,8 +1604,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -115,8 +115,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -167,8 +170,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -236,8 +242,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -260,8 +269,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -334,8 +346,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -411,8 +426,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostPayLife",
-                    "amount": 1
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 1
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -792,8 +810,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -936,8 +957,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1136,8 +1160,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1193,12 +1220,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -1464,12 +1497,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -1495,8 +1534,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -1549,12 +1591,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -1604,8 +1652,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1704,8 +1755,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -2136,8 +2190,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "MustBeBlocked",
@@ -2243,12 +2300,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -2489,8 +2552,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -2577,8 +2643,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
                 },
                 "effect": {
                     "type": "CreateToken",
@@ -2595,8 +2664,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -2645,8 +2717,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2868,8 +2943,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2969,8 +3047,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3009,8 +3090,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3054,8 +3138,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3239,8 +3326,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3336,8 +3426,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{G}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -3384,8 +3477,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -3424,8 +3520,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -25,8 +25,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -147,8 +150,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -183,8 +189,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{8}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -50,8 +50,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -200,12 +200,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Elf"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Elf"
+                            }
                         }
                     ]
                 },
@@ -368,8 +374,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -595,8 +604,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -945,8 +957,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1161,8 +1176,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -1217,8 +1235,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -1461,8 +1482,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{B}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}{B}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -2458,8 +2482,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -2777,8 +2804,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -3157,8 +3187,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}{W}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -4325,8 +4358,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -4841,8 +4877,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "TurnFaceDown",
@@ -5229,8 +5268,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -5242,8 +5284,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -5255,8 +5300,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -5268,8 +5316,11 @@
             {
                 "id": "ability_4",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "Modal",
@@ -6148,12 +6199,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature Goblin"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin"
+                            }
                         }
                     ]
                 },
@@ -6327,8 +6384,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -6370,8 +6430,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "GainControl",
@@ -6843,8 +6906,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -6860,8 +6926,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -6982,8 +7051,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7010,17 +7082,20 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": {
-                        "cardPredicates": [
-                            "IsLand"
-                        ],
-                        "statePredicates": [
-                            {
-                                "type": "HasCounter",
-                                "counterType": "trap"
-                            }
-                        ]
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsLand"
+                            ],
+                            "statePredicates": [
+                                {
+                                    "type": "HasCounter",
+                                    "counterType": "trap"
+                                }
+                            ]
+                        }
                     }
                 },
                 "effect": {
@@ -7135,8 +7210,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "Regenerate",
@@ -7333,8 +7411,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostPayLife",
-                    "amount": 3
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 3
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -7586,8 +7667,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostReturnToHand",
-                    "filter": "creature Elf"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomReturnToHand",
+                        "filter": "creature Elf"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",
@@ -7739,8 +7823,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "RedirectNextDamage",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -142,8 +142,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -16,8 +16,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -615,8 +618,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -170,8 +170,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{R}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -472,8 +475,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
                             "type": "CostRemovePlusOnePlusOneCounters",
@@ -816,8 +822,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/STH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STH.json
@@ -85,8 +85,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -34,8 +34,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -13,8 +13,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddManaOfChoice",
@@ -36,8 +39,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -132,8 +138,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{W}{B}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}{B}{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -223,8 +232,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -393,8 +405,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -647,8 +662,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -1028,8 +1046,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1502,8 +1523,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",
@@ -2365,8 +2389,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -2559,8 +2586,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -2708,8 +2738,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2905,8 +2938,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -3182,8 +3218,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -4176,9 +4215,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostTapPermanents",
-                            "count": 1,
-                            "filter": "creature ctrl:you"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature ctrl:you"
+                            }
                         }
                     ]
                 },
@@ -4192,8 +4233,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{W}{U}{B}{R}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}{U}{B}{R}{G}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -4339,8 +4383,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4499,8 +4546,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5816,8 +5866,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -6591,14 +6644,20 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostExileFromGraveyard",
-                            "count": 1,
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -6839,12 +6898,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "token"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "token"
+                            }
                         }
                     ]
                 },
@@ -7689,8 +7754,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -7824,8 +7892,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddManaOfChoice",
@@ -7929,8 +8000,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{U}{R}{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}{R}{W}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -8202,8 +8276,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}{G}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{G}{U}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -8527,8 +8604,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -8821,8 +8901,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
                 },
                 "effect": "CanAttackDespiteDefenderThisTurn",
                 "descriptionOverride": "{2}{G}: This creature can attack this turn as though it didn't have defender."
@@ -8858,8 +8941,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{B}"
+                            }
                         },
                         "CostTap",
                         "CostPayXLife"
@@ -8975,8 +9061,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -9378,8 +9467,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -9786,8 +9878,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddManaOfChoice",
@@ -9891,8 +9986,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}{W}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}{W}{B}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -10267,8 +10365,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -10469,8 +10570,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -11610,8 +11714,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -12446,8 +12553,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostDiscardHand",
                         "CostSacrificeSelf"
@@ -12675,8 +12785,11 @@
                 "ability": {
                     "id": "ability_2",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{5}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{5}"
+                        }
                     },
                     "effect": {
                         "type": "TapUntap",
@@ -13211,8 +13324,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}{B}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{B}{B}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -13392,8 +13508,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -13516,8 +13635,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}"
+                            }
                         },
                         "CostExileSelf"
                     ]
@@ -14574,9 +14696,12 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -14890,8 +15015,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}{U}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{U}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -15194,8 +15322,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -15587,8 +15718,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -15754,8 +15888,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -15969,8 +16106,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddManaOfChoice",
@@ -16076,8 +16216,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{B}{G}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{G}{U}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -16270,8 +16413,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -16712,8 +16858,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AddManaOfChoice",
@@ -16819,8 +16968,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{G}{U}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}{U}{R}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -17768,13 +17920,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -17839,8 +17997,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -17897,8 +18058,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -18059,13 +18223,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -19194,8 +19364,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -16,8 +16,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -32,8 +32,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -128,8 +131,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -430,8 +436,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -933,8 +942,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{R}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}{R}"
+                    }
                 },
                 "effect": {
                     "type": "AddCounters",
@@ -991,8 +1003,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1041,8 +1056,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -1485,8 +1503,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1647,8 +1668,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1715,8 +1739,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1791,8 +1818,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1857,8 +1887,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -1987,8 +2020,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2238,8 +2274,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{3}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2403,8 +2442,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -2457,8 +2499,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2579,8 +2624,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2882,8 +2930,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{5}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
                 },
                 "effect": {
                     "type": "ForEachInGroup",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -9,8 +9,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -128,8 +131,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{2}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "effect": {
                         "type": "ModifyStats",
@@ -179,8 +185,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{2}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "effect": {
                         "type": "ModifyStats",
@@ -380,12 +389,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostDiscard",
-                            "atRandom": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "random": true
+                            }
                         }
                     ]
                 },
@@ -533,8 +548,11 @@
                 "ability": {
                     "id": "ability_1",
                     "cost": {
-                        "type": "CostMana",
-                        "cost": "{2}"
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
                     },
                     "effect": {
                         "type": "Regenerate",
@@ -727,8 +745,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -785,8 +806,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -829,8 +853,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -884,8 +911,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "ChangeColor",
@@ -959,8 +989,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{0}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{0}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -996,8 +1029,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "DealDamage",
@@ -1124,8 +1160,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "GiveControlToTargetPlayer",
@@ -1229,8 +1268,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1268,8 +1310,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{W}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -1391,8 +1436,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostSacrificeSelf"
                         ]
@@ -1482,8 +1530,11 @@
                         "type": "CostComposite",
                         "costs": [
                             {
-                                "type": "CostMana",
-                                "cost": "{2}"
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
                             },
                             "CostSacrificeSelf"
                         ]
@@ -1663,7 +1714,10 @@
         "activatedAbilities": [
             {
                 "id": "ability_1",
-                "cost": "CostDiscard",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
                 "effect": {
                     "type": "Regenerate",
                     "target": "Self"
@@ -1808,8 +1862,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -19,8 +19,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{6}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
                         },
                         "CostDiscardSelf"
                     ]
@@ -161,8 +164,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -607,8 +613,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -1914,8 +1923,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -1997,8 +2009,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2143,8 +2158,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -2274,8 +2292,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{3}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -2335,13 +2356,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature|token",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|token",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -2360,8 +2387,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -2461,16 +2491,22 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}"
+                    }
                 },
                 "effect": "CreateTokenCopyOfSource"
             },
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{R}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -3019,8 +3055,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -3326,13 +3365,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "artifact",
-                            "excludeSelf": true
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
                         }
                     ]
                 },
@@ -3661,8 +3706,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]
@@ -4171,8 +4219,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{W}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -4237,8 +4288,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4254,8 +4308,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -4509,8 +4566,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -4902,8 +4962,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{R}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -5353,16 +5416,19 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": {
-                        "cardPredicates": [
-                            {
-                                "type": "Not",
-                                "predicate": "IsLand"
-                            }
-                        ]
-                    },
-                    "excludeSelf": true
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsLand"
+                                }
+                            ]
+                        },
+                        "excludeSelf": true
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -5709,8 +5775,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
                 },
                 "effect": {
                     "type": "AttachEquipment",
@@ -5932,8 +6001,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -6083,8 +6155,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "GrantKeyword",
@@ -6763,8 +6838,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{4}{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{B}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -6983,8 +7061,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{5}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/UDS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/UDS.json
@@ -17,8 +17,11 @@
                     "costs": [
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -69,13 +72,19 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{4}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
                         },
                         "CostTap",
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
                         }
                     ]
                 },
@@ -216,8 +225,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{U}{U}{U}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}{U}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -319,8 +331,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{2}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
                         },
                         "CostSacrificeSelf"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ULG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ULG.json
@@ -87,8 +87,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "MoveToZone",
@@ -223,8 +226,11 @@
             {
                 "id": "ability_2",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",

--- a/mtg-sets/src/test/resources/snapshots/cards/USG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/USG.json
@@ -354,8 +354,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
                         },
                         "CostTap"
                     ]
@@ -474,8 +477,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{G}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
                         },
                         "CostTap",
                         "CostSacrificeSelf"
@@ -554,8 +560,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostSacrifice",
-                    "filter": "creature"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "effect": {
                     "type": "Composite",
@@ -725,8 +734,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{B}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
                 },
                 "effect": {
                     "type": "ModifyStats",
@@ -803,8 +815,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{B}{B}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -26,8 +26,11 @@
             {
                 "id": "ability_1",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{1}{U}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
                 },
                 "effect": {
                     "type": "TapUntap",

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -99,8 +99,11 @@
             {
                 "id": "ability_3",
                 "cost": {
-                    "type": "CostMana",
-                    "cost": "{2}{R}{G}"
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}{G}"
+                    }
                 },
                 "effect": {
                     "type": "Composite",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -133,12 +133,18 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{1}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
                         },
                         {
-                            "type": "CostSacrifice",
-                            "filter": "creature|artifact"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|artifact"
+                            }
                         }
                     ]
                 },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -74,30 +74,17 @@ class CostHandler(
     ): Boolean {
         return when (cost) {
             is AbilityCost.Free -> true
+            is AbilityCost.Atom -> canPayAtom(state, cost.atom, sourceId, controllerId, manaPool, abilityContext)
             is AbilityCost.Tap -> {
                 !state.getEntity(sourceId)!!.has<TappedComponent>()
             }
             is AbilityCost.Untap -> {
                 state.getEntity(sourceId)!!.has<TappedComponent>()
             }
-            is AbilityCost.Mana -> {
-                canPayManaCost(manaPool, cost.cost, abilityContext)
-            }
-            is AbilityCost.PayLife -> {
-                val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
-                // CR 119.4 — a player may pay life only if their life total is >= the payment.
-                // Paying down to exactly 0 is legal; the state-based action checker handles the loss.
-                life >= cost.amount
-            }
             is AbilityCost.PayXLife -> {
                 // X can be 0, so this is always payable as long as the player has a life total.
                 // maxAffordableX is capped by life total in calculateMaxAffordableX.
                 state.getEntity(controllerId)?.has<LifeTotalComponent>() == true
-            }
-            is AbilityCost.Sacrifice -> {
-                val candidates = findMatchingPermanentsUnified(state, controllerId, cost.filter)
-                val eligible = if (cost.excludeSelf) candidates.filter { it != sourceId } else candidates
-                eligible.size >= cost.count
             }
             is AbilityCost.SacrificeChosenCreatureType -> {
                 val chosenType = state.getEntity(sourceId)?.chosenCreatureType()
@@ -105,17 +92,9 @@ class CostHandler(
                 val filter = GameObjectFilter.Creature.withSubtype(chosenType)
                 findMatchingPermanentsUnified(state, controllerId, filter).isNotEmpty()
             }
-            is AbilityCost.Discard -> {
-                val handZone = ZoneKey(controllerId, Zone.HAND)
-                findMatchingCardsUnified(state, state.getZone(handZone), cost.filter, controllerId).size >= cost.count
-            }
             is AbilityCost.DiscardHand -> {
                 // You can always discard your hand, even if it's empty
                 true
-            }
-            is AbilityCost.ExileFromGraveyard -> {
-                val graveyardZone = ZoneKey(controllerId, Zone.GRAVEYARD)
-                findMatchingCardsUnified(state, state.getZone(graveyardZone), cost.filter, controllerId).size >= cost.count
             }
             is AbilityCost.ExileXFromGraveyard -> {
                 // X can be 0, so this is always payable as long as graveyard exists
@@ -149,11 +128,6 @@ class CostHandler(
                 // since left, ActivateAbilityHandler's lookup would have failed before payment.
                 true
             }
-            is AbilityCost.TapPermanents -> {
-                val candidates = findUntappedMatchingPermanentsUnified(state, controllerId, cost.filter)
-                    .let { targets -> if (cost.excludeSelf) targets.filter { it != sourceId } else targets }
-                candidates.size >= cost.count
-            }
             is AbilityCost.TapXPermanents -> {
                 // X can be 0, so this is always payable
                 // maxAffordableX is capped by untapped permanent count in LegalActionsCalculator
@@ -173,9 +147,6 @@ class CostHandler(
                     if (hasSummoningSickness && !hasHaste) return false
                 }
                 true
-            }
-            is AbilityCost.ReturnToHand -> {
-                findMatchingPermanentsUnified(state, controllerId, cost.filter).size >= cost.count
             }
             is AbilityCost.RemoveXPlusOnePlusOneCounters -> {
                 // X can be 0, so this is always payable as long as there are creatures
@@ -257,6 +228,7 @@ class CostHandler(
             is AbilityCost.Free -> {
                 CostPaymentResult.success(state, manaPool)
             }
+            is AbilityCost.Atom -> payAtom(state, cost.atom, sourceId, controllerId, manaPool, choices, abilityContext)
             is AbilityCost.Tap -> {
                 val newState = state.updateEntity(sourceId) { it.with(TappedComponent) }
                 CostPaymentResult.success(newState, manaPool)
@@ -264,16 +236,6 @@ class CostHandler(
             is AbilityCost.Untap -> {
                 val newState = state.updateEntity(sourceId) { it.without<TappedComponent>() }
                 CostPaymentResult.success(newState, manaPool)
-            }
-            is AbilityCost.Mana -> {
-                val newPool = payManaCost(manaPool, cost.cost, abilityContext)
-                    ?: return CostPaymentResult.failure("Cannot pay mana cost")
-                CostPaymentResult.success(state, newPool)
-            }
-            is AbilityCost.PayLife -> {
-                val (newState, event) = DamageUtils.loseLife(state, controllerId, cost.amount, LifeChangeReason.PAYMENT)
-                if (event == null) return CostPaymentResult.failure("Player has no life total")
-                CostPaymentResult.success(newState, manaPool, events = listOf(event))
             }
             is AbilityCost.PayXLife -> {
                 val amount = choices.xValue
@@ -285,94 +247,14 @@ class CostHandler(
                     CostPaymentResult.success(newState, manaPool, events = listOf(event))
                 }
             }
-            is AbilityCost.Sacrifice, is AbilityCost.SacrificeChosenCreatureType -> {
-                val requiredCount = when (cost) {
-                    is AbilityCost.Sacrifice -> cost.count
-                    else -> 1
-                }
-                val toSacrificeList = choices.sacrificeChoices.take(requiredCount)
-                if (toSacrificeList.size < requiredCount) {
-                    return CostPaymentResult.failure("Not enough sacrifice targets chosen (need $requiredCount, got ${toSacrificeList.size})")
-                }
-
-                // Validate the chosen sacrifice matches the required filter
-                val sacrificeFilter = when (cost) {
-                    is AbilityCost.Sacrifice -> cost.filter
-                    is AbilityCost.SacrificeChosenCreatureType -> {
-                        val chosenType = state.getEntity(sourceId)?.chosenCreatureType()
-                            ?: return CostPaymentResult.failure("No creature type chosen")
-                        GameObjectFilter.Creature.withSubtype(chosenType)
-                    }
-                }
-
-                val context = PredicateContext(controllerId = controllerId)
-                val projected = state.projectedState
-
-                var newState = state
-                val events = mutableListOf<GameEvent>()
-
-                for (toSacrifice in toSacrificeList) {
-                    val sacrificeContainer = newState.getEntity(toSacrifice)
-                        ?: return CostPaymentResult.failure("Sacrifice target not found")
-                    val sacrificeController = sacrificeContainer.get<ControllerComponent>()?.playerId
-                        ?: return CostPaymentResult.failure("Sacrifice target has no controller")
-                    val sacrificeName = sacrificeContainer.get<CardComponent>()?.name ?: "Unknown"
-
-                    if (!predicateEvaluator.matches(state, projected, toSacrifice, sacrificeFilter, context)) {
-                        return CostPaymentResult.failure("Sacrifice target does not match the required filter")
-                    }
-                    // Validate excludeSelf: "sacrifice another creature" cannot sacrifice the source
-                    if (cost is AbilityCost.Sacrifice && cost.excludeSelf && toSacrifice == sourceId) {
-                        return CostPaymentResult.failure("Sacrifice target does not match the required filter")
-                    }
-
-                    // Capture AttachedToComponent before zone transition — needed by effects that
-                    // read the enchanted creature from the sacrificed aura at resolution time.
-                    val attachedTo = sacrificeContainer.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
-
-                    // Track Food sacrifice before zone transition
-                    newState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.trackFoodSacrifice(newState, listOf(toSacrifice), sacrificeController)
-
-                    // Delegate zone movement to ZoneTransitionService for full cleanup
-                    val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
-                        newState, toSacrifice, Zone.GRAVEYARD
-                    )
-                    newState = transitionResult.state
-
-                    // Restore AttachedToComponent for effects that need it at resolution time
-                    if (attachedTo != null) {
-                        newState = newState.updateEntity(toSacrifice) { c -> c.with(attachedTo) }
-                    }
-
-                    events.add(PermanentsSacrificedEvent(sacrificeController, listOf(toSacrifice), listOf(sacrificeName)))
-                    events.addAll(transitionResult.events)
-                }
-
-                CostPaymentResult.success(newState, manaPool, events)
-            }
-            is AbilityCost.Discard -> {
-                var workState = state
-                val toDiscard: List<EntityId> = if (cost.atRandom) {
-                    // Engine chooses the discarded cards at random — no player selection.
-                    val eligible = findMatchingCardsUnified(
-                        state, state.getZone(ZoneKey(controllerId, Zone.HAND)), cost.filter, controllerId
-                    )
-                    if (eligible.size < cost.count) {
-                        return CostPaymentResult.failure("Not enough cards to discard at random")
-                    }
-                    val (shuffled, advanced) = state.nextRandom { shuffle(eligible) }
-                    workState = advanced
-                    shuffled.take(cost.count)
-                } else {
-                    if (choices.discardChoices.size < cost.count) {
-                        return CostPaymentResult.failure("Must choose ${cost.count} card(s) to discard")
-                    }
-                    choices.discardChoices.take(cost.count)
-                }
-
-                val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .discardCards(workState, controllerId, toDiscard)
-                CostPaymentResult.success(result.state, manaPool, result.events)
+            is AbilityCost.SacrificeChosenCreatureType -> {
+                val chosenType = state.getEntity(sourceId)?.chosenCreatureType()
+                    ?: return CostPaymentResult.failure("No creature type chosen")
+                val sacrificeFilter = GameObjectFilter.Creature.withSubtype(chosenType)
+                paySacrificeList(
+                    state, choices.sacrificeChoices, sacrificeFilter,
+                    requiredCount = 1, excludeSelf = false, sourceId, controllerId, manaPool
+                )
             }
             is AbilityCost.DiscardHand -> {
                 val cardsInHand = state.getZone(ZoneKey(controllerId, Zone.HAND))
@@ -383,15 +265,12 @@ class CostHandler(
                     .discardCards(state, controllerId, cardsInHand)
                 CostPaymentResult.success(result.state, manaPool, result.events)
             }
-            is AbilityCost.ExileFromGraveyard -> {
-                exileCardsFromGraveyard(state, controllerId, cost.count, cost.filter, choices.exileChoices, manaPool)
-            }
             is AbilityCost.ExileXFromGraveyard -> {
                 val xCount = choices.xValue
                 if (xCount == 0) {
                     CostPaymentResult.success(state, manaPool)
                 } else {
-                    exileCardsFromGraveyard(state, controllerId, xCount, cost.filter, choices.exileChoices, manaPool)
+                    exileCardsFromZone(state, controllerId, Zone.GRAVEYARD, xCount, cost.filter, choices.exileChoices, manaPool)
                 }
             }
             is AbilityCost.DiscardSelf -> {
@@ -480,79 +359,10 @@ class CostHandler(
 
                 CostPaymentResult.success(transitionResult.state, manaPool, transitionResult.events)
             }
-            is AbilityCost.ReturnToHand -> {
-                if (choices.bounceChoices.size < cost.count) {
-                    return CostPaymentResult.failure("Not enough permanents chosen to bounce (need ${cost.count}, got ${choices.bounceChoices.size})")
-                }
-
-                val toBounceList = choices.bounceChoices.take(cost.count)
-                val context = PredicateContext(controllerId = controllerId)
-                var newState = state
-                val allEvents = mutableListOf<GameEvent>()
-
-                for (toBounce in toBounceList) {
-                    newState.getEntity(toBounce)
-                        ?: return CostPaymentResult.failure("Bounce target not found")
-
-                    // Validate the chosen bounce target matches the required filter
-                    if (!predicateEvaluator.matches(newState, newState.projectedState, toBounce, cost.filter, context)) {
-                        return CostPaymentResult.failure("Bounce target does not match the required filter")
-                    }
-
-                    // Delegate zone movement to ZoneTransitionService for full cleanup
-                    val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
-                        newState, toBounce, Zone.HAND
-                    )
-                    newState = transitionResult.state
-                    allEvents.addAll(transitionResult.events)
-                }
-
-                CostPaymentResult.success(newState, manaPool, allEvents)
-            }
             is AbilityCost.TapAttachedCreature -> {
                 val attachedId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
                     ?: return CostPaymentResult.failure("Source is not attached to a creature")
                 val newState = state.updateEntity(attachedId) { it.with(TappedComponent) }
-                CostPaymentResult.success(newState, manaPool)
-            }
-            is AbilityCost.TapPermanents -> {
-                val toTap = choices.tapChoices
-                if (toTap.size < cost.count) {
-                    return CostPaymentResult.failure("Not enough permanents chosen to tap (need ${cost.count}, got ${toTap.size})")
-                }
-                if (cost.excludeSelf && sourceId in toTap) {
-                    return CostPaymentResult.failure("Cannot tap self for this cost")
-                }
-
-                // Defense in depth: the enumerator only offers untapped, controlled, matching
-                // permanents (CostEnumerationUtils.findAbilityTapTargets), but the chosen ids
-                // arrive on the action from the client — re-validate here so a malformed action
-                // can't "pay" a tap cost by re-tapping an already-tapped or ineligible permanent
-                // (Station, Cryptic Gateway). Filter matching uses projected state (CR 613).
-                val projected = state.projectedState
-                val context = PredicateContext(controllerId = controllerId)
-                for (permanentId in toTap) {
-                    val entity = state.getEntity(permanentId)
-                        ?: return CostPaymentResult.failure("Permanent to tap no longer exists")
-                    if (permanentId !in state.getBattlefield()) {
-                        return CostPaymentResult.failure("Permanent to tap is not on the battlefield")
-                    }
-                    if (projected.getController(permanentId) != controllerId) {
-                        return CostPaymentResult.failure("Can only tap permanents you control")
-                    }
-                    if (entity.has<TappedComponent>()) {
-                        return CostPaymentResult.failure("Permanent to tap is already tapped")
-                    }
-                    if (!predicateEvaluator.matches(state, projected, permanentId, cost.filter, context)) {
-                        return CostPaymentResult.failure("Permanent to tap does not match ${cost.filter.description}")
-                    }
-                }
-
-                var newState = state
-                for (permanentId in toTap) {
-                    newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
-                }
-
                 CostPaymentResult.success(newState, manaPool)
             }
             is AbilityCost.TapXPermanents -> {
@@ -725,6 +535,258 @@ class CostHandler(
         }
     }
 
+    // =============================================================================================
+    // Shared CostAtom payment — the one place activated-ability costs and (eventually) other cost
+    // contexts dispatch the payable things that mean the same everywhere (§3.2 "one cost language").
+    // =============================================================================================
+
+    /** Affordability check for a single [CostAtom] paid as an activated-ability cost. */
+    private fun canPayAtom(
+        state: GameState,
+        atom: CostAtom,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        abilityContext: SpellPaymentContext?,
+    ): Boolean = when (atom) {
+        is CostAtom.Mana -> canPayManaCost(manaPool, atom.cost, abilityContext)
+        is CostAtom.PayLife -> {
+            val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
+            // CR 119.4 — a player may pay life only if their life total is >= the payment.
+            // Paying down to exactly 0 is legal; the state-based action checker handles the loss.
+            life >= atom.amount
+        }
+        is CostAtom.Sacrifice -> {
+            val candidates = findMatchingPermanentsUnified(state, controllerId, atom.filter)
+            val eligible = if (atom.excludeSelf) candidates.filter { it != sourceId } else candidates
+            eligible.size >= atom.count
+        }
+        is CostAtom.Discard -> {
+            val handZone = ZoneKey(controllerId, Zone.HAND)
+            findMatchingCardsUnified(state, state.getZone(handZone), atom.filter, controllerId).size >= atom.count
+        }
+        is CostAtom.ExileFrom -> {
+            val zone = ZoneKey(controllerId, atom.zone)
+            findMatchingCardsUnified(state, state.getZone(zone), atom.filter, controllerId).size >= atom.count
+        }
+        is CostAtom.TapPermanents -> {
+            val candidates = findUntappedMatchingPermanentsUnified(state, controllerId, atom.filter)
+                .let { targets -> if (atom.excludeSelf) targets.filter { it != sourceId } else targets }
+            candidates.size >= atom.count
+        }
+        is CostAtom.ReturnToHand ->
+            findMatchingPermanentsUnified(state, controllerId, atom.filter).size >= atom.count
+        is CostAtom.RevealFromHand -> {
+            val handZone = ZoneKey(controllerId, Zone.HAND)
+            findMatchingCardsUnified(state, state.getZone(handZone), atom.filter, controllerId).size >= atom.count
+        }
+    }
+
+    /** Perform payment for a single [CostAtom] paid as an activated-ability cost. */
+    private fun payAtom(
+        state: GameState,
+        atom: CostAtom,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        choices: CostPaymentChoices,
+        abilityContext: SpellPaymentContext?,
+    ): CostPaymentResult = when (atom) {
+        is CostAtom.Mana -> {
+            val newPool = payManaCost(manaPool, atom.cost, abilityContext)
+                ?: return CostPaymentResult.failure("Cannot pay mana cost")
+            CostPaymentResult.success(state, newPool)
+        }
+        is CostAtom.PayLife -> {
+            val (newState, event) = DamageUtils.loseLife(state, controllerId, atom.amount, LifeChangeReason.PAYMENT)
+            if (event == null) return CostPaymentResult.failure("Player has no life total")
+            CostPaymentResult.success(newState, manaPool, events = listOf(event))
+        }
+        is CostAtom.Sacrifice -> paySacrificeList(
+            state, choices.sacrificeChoices, atom.filter,
+            requiredCount = atom.count, excludeSelf = atom.excludeSelf, sourceId, controllerId, manaPool
+        )
+        is CostAtom.Discard -> {
+            var workState = state
+            val toDiscard: List<EntityId> = if (atom.random) {
+                // Engine chooses the discarded cards at random — no player selection.
+                val eligible = findMatchingCardsUnified(
+                    state, state.getZone(ZoneKey(controllerId, Zone.HAND)), atom.filter, controllerId
+                )
+                if (eligible.size < atom.count) {
+                    return CostPaymentResult.failure("Not enough cards to discard at random")
+                }
+                val (shuffled, advanced) = state.nextRandom { shuffle(eligible) }
+                workState = advanced
+                shuffled.take(atom.count)
+            } else {
+                if (choices.discardChoices.size < atom.count) {
+                    return CostPaymentResult.failure("Must choose ${atom.count} card(s) to discard")
+                }
+                choices.discardChoices.take(atom.count)
+            }
+            val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                .discardCards(workState, controllerId, toDiscard)
+            CostPaymentResult.success(result.state, manaPool, result.events)
+        }
+        is CostAtom.ExileFrom ->
+            exileCardsFromZone(state, controllerId, atom.zone, atom.count, atom.filter, choices.exileChoices, manaPool)
+        is CostAtom.TapPermanents -> payTapPermanents(state, atom, sourceId, controllerId, manaPool, choices)
+        is CostAtom.ReturnToHand -> payReturnToHand(state, atom, controllerId, manaPool, choices)
+        is CostAtom.RevealFromHand ->
+            // No activated-ability cost reveals from hand today; revealing changes no zone, so this
+            // is a no-op success kept for atom exhaustiveness (the PayCost reveal path emits the
+            // CardsRevealedEvent through CostPaymentService).
+            CostPaymentResult.success(state, manaPool)
+    }
+
+    /**
+     * Sacrifice [requiredCount] permanents from [sacrificeChoices], each validated against [filter]
+     * (and excluded from being the source when [excludeSelf]). Shared by the [CostAtom.Sacrifice]
+     * atom and the chosen-creature-type sacrifice cost so both go through one cleanup path.
+     */
+    private fun paySacrificeList(
+        state: GameState,
+        sacrificeChoices: List<EntityId>,
+        filter: GameObjectFilter,
+        requiredCount: Int,
+        excludeSelf: Boolean,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+    ): CostPaymentResult {
+        val toSacrificeList = sacrificeChoices.take(requiredCount)
+        if (toSacrificeList.size < requiredCount) {
+            return CostPaymentResult.failure("Not enough sacrifice targets chosen (need $requiredCount, got ${toSacrificeList.size})")
+        }
+        val context = PredicateContext(controllerId = controllerId)
+        val projected = state.projectedState
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        for (toSacrifice in toSacrificeList) {
+            val sacrificeContainer = newState.getEntity(toSacrifice)
+                ?: return CostPaymentResult.failure("Sacrifice target not found")
+            val sacrificeController = sacrificeContainer.get<ControllerComponent>()?.playerId
+                ?: return CostPaymentResult.failure("Sacrifice target has no controller")
+            val sacrificeName = sacrificeContainer.get<CardComponent>()?.name ?: "Unknown"
+
+            if (!predicateEvaluator.matches(state, projected, toSacrifice, filter, context)) {
+                return CostPaymentResult.failure("Sacrifice target does not match the required filter")
+            }
+            // Validate excludeSelf: "sacrifice another creature" cannot sacrifice the source.
+            if (excludeSelf && toSacrifice == sourceId) {
+                return CostPaymentResult.failure("Sacrifice target does not match the required filter")
+            }
+
+            // Capture AttachedToComponent before zone transition — needed by effects that
+            // read the enchanted creature from the sacrificed aura at resolution time.
+            val attachedTo = sacrificeContainer.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+
+            // Track Food sacrifice before zone transition
+            newState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.trackFoodSacrifice(newState, listOf(toSacrifice), sacrificeController)
+
+            // Delegate zone movement to ZoneTransitionService for full cleanup
+            val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                newState, toSacrifice, Zone.GRAVEYARD
+            )
+            newState = transitionResult.state
+
+            // Restore AttachedToComponent for effects that need it at resolution time
+            if (attachedTo != null) {
+                newState = newState.updateEntity(toSacrifice) { c -> c.with(attachedTo) }
+            }
+
+            events.add(PermanentsSacrificedEvent(sacrificeController, listOf(toSacrifice), listOf(sacrificeName)))
+            events.addAll(transitionResult.events)
+        }
+        return CostPaymentResult.success(newState, manaPool, events)
+    }
+
+    /** Pay a [CostAtom.TapPermanents] atom from the chosen tap targets, re-validating each. */
+    private fun payTapPermanents(
+        state: GameState,
+        atom: CostAtom.TapPermanents,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        choices: CostPaymentChoices,
+    ): CostPaymentResult {
+        val toTap = choices.tapChoices
+        if (toTap.size < atom.count) {
+            return CostPaymentResult.failure("Not enough permanents chosen to tap (need ${atom.count}, got ${toTap.size})")
+        }
+        if (atom.excludeSelf && sourceId in toTap) {
+            return CostPaymentResult.failure("Cannot tap self for this cost")
+        }
+
+        // Defense in depth: the enumerator only offers untapped, controlled, matching
+        // permanents (CostEnumerationUtils.findAbilityTapTargets), but the chosen ids
+        // arrive on the action from the client — re-validate here so a malformed action
+        // can't "pay" a tap cost by re-tapping an already-tapped or ineligible permanent
+        // (Station, Cryptic Gateway). Filter matching uses projected state (CR 613).
+        val projected = state.projectedState
+        val context = PredicateContext(controllerId = controllerId)
+        for (permanentId in toTap) {
+            val entity = state.getEntity(permanentId)
+                ?: return CostPaymentResult.failure("Permanent to tap no longer exists")
+            if (permanentId !in state.getBattlefield()) {
+                return CostPaymentResult.failure("Permanent to tap is not on the battlefield")
+            }
+            if (projected.getController(permanentId) != controllerId) {
+                return CostPaymentResult.failure("Can only tap permanents you control")
+            }
+            if (entity.has<TappedComponent>()) {
+                return CostPaymentResult.failure("Permanent to tap is already tapped")
+            }
+            if (!predicateEvaluator.matches(state, projected, permanentId, atom.filter, context)) {
+                return CostPaymentResult.failure("Permanent to tap does not match ${atom.filter.description}")
+            }
+        }
+
+        var newState = state
+        for (permanentId in toTap) {
+            newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
+        }
+        return CostPaymentResult.success(newState, manaPool)
+    }
+
+    /** Pay a [CostAtom.ReturnToHand] atom from the chosen bounce targets, validating each. */
+    private fun payReturnToHand(
+        state: GameState,
+        atom: CostAtom.ReturnToHand,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        choices: CostPaymentChoices,
+    ): CostPaymentResult {
+        if (choices.bounceChoices.size < atom.count) {
+            return CostPaymentResult.failure("Not enough permanents chosen to bounce (need ${atom.count}, got ${choices.bounceChoices.size})")
+        }
+
+        val toBounceList = choices.bounceChoices.take(atom.count)
+        val context = PredicateContext(controllerId = controllerId)
+        var newState = state
+        val allEvents = mutableListOf<GameEvent>()
+
+        for (toBounce in toBounceList) {
+            newState.getEntity(toBounce)
+                ?: return CostPaymentResult.failure("Bounce target not found")
+
+            // Validate the chosen bounce target matches the required filter
+            if (!predicateEvaluator.matches(newState, newState.projectedState, toBounce, atom.filter, context)) {
+                return CostPaymentResult.failure("Bounce target does not match the required filter")
+            }
+
+            // Delegate zone movement to ZoneTransitionService for full cleanup
+            val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                newState, toBounce, Zone.HAND
+            )
+            newState = transitionResult.state
+            allEvents.addAll(transitionResult.events)
+        }
+
+        return CostPaymentResult.success(newState, manaPool, allEvents)
+    }
+
     /**
      * Check if additional costs can be paid.
      */
@@ -861,22 +923,25 @@ class CostHandler(
     }
 
     /**
-     * Exile a specified number of cards from the controller's graveyard.
-     * Uses provided exile choices if available, otherwise auto-selects.
+     * Exile a specified number of cards matching [filter] from the controller's [fromZone].
+     * Uses provided exile choices if available, otherwise auto-selects. Ability exile costs are
+     * graveyard-only today (Costs.ExileFromGraveyard → CostAtom.ExileFrom(GRAVEYARD)); the zone
+     * parameter keeps the helper honest for any future non-graveyard ability exile.
      */
-    private fun exileCardsFromGraveyard(
+    private fun exileCardsFromZone(
         state: GameState,
         controllerId: EntityId,
+        fromZone: Zone,
         count: Int,
         filter: GameObjectFilter,
         exileChoices: List<EntityId>,
         manaPool: ManaPool
     ): CostPaymentResult {
-        val graveyardZone = ZoneKey(controllerId, Zone.GRAVEYARD)
-        val validCards = findMatchingCardsUnified(state, state.getZone(graveyardZone), filter, controllerId)
+        val sourceZone = ZoneKey(controllerId, fromZone)
+        val validCards = findMatchingCardsUnified(state, state.getZone(sourceZone), filter, controllerId)
 
         if (validCards.size < count) {
-            return CostPaymentResult.failure("Not enough cards in graveyard to exile")
+            return CostPaymentResult.failure("Not enough cards in ${fromZone.name.lowercase()} to exile")
         }
 
         // Use exile choices if provided, otherwise auto-select
@@ -892,13 +957,13 @@ class CostHandler(
 
         for (cardId in toExile) {
             val cardName = newState.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-            newState = newState.removeFromZone(graveyardZone, cardId)
+            newState = newState.removeFromZone(sourceZone, cardId)
             newState = newState.addToZone(exileZone, cardId)
             events.add(
                 ZoneChangeEvent(
                     entityId = cardId,
                     entityName = cardName,
-                    fromZone = Zone.GRAVEYARD,
+                    fromZone = fromZone,
                     toZone = Zone.EXILE,
                     ownerId = controllerId
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -48,6 +48,8 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
@@ -263,7 +265,7 @@ class ActivateAbilityHandler(
         // account for the reduced cost.
         val costAfterConvokeReduction = if ((ability.hasConvoke || ability.hasWaterbend) && action.alternativePayment != null && !action.alternativePayment.isEmpty) {
             val mc = extractManaCost(effectiveCost) ?: effectiveCost
-            if (mc is ManaCost || effectiveCost is AbilityCost.Mana || effectiveCost is AbilityCost.Composite) {
+            if (mc is ManaCost || effectiveCost.manaCostOrNull != null || effectiveCost is AbilityCost.Composite) {
                 val reducedManaCost = extractManaCost(effectiveCost)?.let {
                     var reduced = it
                     if (ability.hasConvoke) reduced = alternativePaymentHandler.calculateReducedCostForAbility(reduced, action.alternativePayment)
@@ -272,9 +274,9 @@ class ActivateAbilityHandler(
                 }
                 if (reducedManaCost != null) {
                     when (effectiveCost) {
-                        is AbilityCost.Mana -> AbilityCost.Mana(reducedManaCost)
+                        is AbilityCost.Atom -> AbilityCost.Atom(CostAtom.Mana(reducedManaCost))
                         is AbilityCost.Composite -> AbilityCost.Composite(effectiveCost.costs.map { subCost ->
-                            if (subCost is AbilityCost.Mana) AbilityCost.Mana(reducedManaCost) else subCost
+                            if (subCost.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(reducedManaCost)) else subCost
                         })
                         else -> effectiveCost
                     }
@@ -295,8 +297,11 @@ class ActivateAbilityHandler(
                         "Cannot pay loyalty cost"
                     }
                 }
-                is AbilityCost.Mana -> "Not enough mana to activate this ability"
-                is AbilityCost.PayLife -> "Not enough life to activate this ability"
+                is AbilityCost.Atom -> when (effectiveCost.atom) {
+                    is CostAtom.Mana -> "Not enough mana to activate this ability"
+                    is CostAtom.PayLife -> "Not enough life to activate this ability"
+                    else -> "Cannot pay ability cost"
+                }
                 else -> "Cannot pay ability cost"
             }
         }
@@ -616,9 +621,9 @@ class ActivateAbilityHandler(
             // Convoke/waterbend reduced the mana cost — update the cost structure so payAbilityCost
             // deducts the reduced amount from the pool instead of the original full amount
             when (effectiveCost) {
-                is AbilityCost.Mana -> AbilityCost.Mana(manaCost)
+                is AbilityCost.Atom -> AbilityCost.Atom(CostAtom.Mana(manaCost))
                 is AbilityCost.Composite -> AbilityCost.Composite(effectiveCost.costs.map { subCost ->
-                    if (subCost is AbilityCost.Mana) AbilityCost.Mana(manaCost) else subCost
+                    if (subCost.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(manaCost)) else subCost
                 })
                 else -> effectiveCost
             }
@@ -1125,15 +1130,18 @@ class ActivateAbilityHandler(
             restrictedMana = poolComponent.restrictedMana,
         )
         return when (cost) {
-            is AbilityCost.Mana -> manaSolver.canPay(state, playerId, cost.cost, spellContext = abilityContext)
+            is AbilityCost.Atom -> {
+                val mana = cost.manaCostOrNull
+                if (mana != null) manaSolver.canPay(state, playerId, mana, spellContext = abilityContext)
+                else costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext)
+            }
             is AbilityCost.Composite -> {
                 // If composite cost includes Tap, the source itself can't also be used as a mana source
                 val excludeSources = if (hasTapCost(cost)) setOf(sourceId) else emptySet()
                 cost.costs.all { subCost ->
-                    when (subCost) {
-                        is AbilityCost.Mana -> manaSolver.canPay(state, playerId, subCost.cost, excludeSources = excludeSources, spellContext = abilityContext)
-                        else -> costHandler.canPayAbilityCost(state, subCost, sourceId, playerId, manaPool, abilityContext)
-                    }
+                    val subMana = subCost.manaCostOrNull
+                    if (subMana != null) manaSolver.canPay(state, playerId, subMana, excludeSources = excludeSources, spellContext = abilityContext)
+                    else costHandler.canPayAbilityCost(state, subCost, sourceId, playerId, manaPool, abilityContext)
                 }
             }
             else -> costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext)
@@ -1180,13 +1188,15 @@ class ActivateAbilityHandler(
     }
 
     private fun reduceGenericInCost(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {
-        is AbilityCost.Mana -> AbilityCost.Mana(cost.cost.reduceGeneric(amount))
+        is AbilityCost.Atom -> cost.manaCostOrNull
+            ?.let { AbilityCost.Atom(CostAtom.Mana(it.reduceGeneric(amount))) } ?: cost
         is AbilityCost.Composite -> {
             var applied = false
             AbilityCost.Composite(cost.costs.map { sub ->
-                if (!applied && sub is AbilityCost.Mana) {
+                val subMana = sub.manaCostOrNull
+                if (!applied && subMana != null) {
                     applied = true
-                    AbilityCost.Mana(sub.cost.reduceGeneric(amount))
+                    AbilityCost.Atom(CostAtom.Mana(subMana.reduceGeneric(amount)))
                 } else sub
             })
         }
@@ -1197,8 +1207,8 @@ class ActivateAbilityHandler(
      * Extract the ManaCost from an ability cost, if present.
      */
     private fun extractManaCost(cost: AbilityCost): ManaCost? = when (cost) {
-        is AbilityCost.Mana -> cost.cost
-        is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost
+        is AbilityCost.Atom -> cost.manaCostOrNull
+        is AbilityCost.Composite -> cost.costs.firstNotNullOfOrNull { it.manaCostOrNull }
         else -> null
     }
 
@@ -1316,9 +1326,9 @@ class ActivateAbilityHandler(
      * tapped the required sources, so the mana pool deduction should be skipped.
      */
     private fun stripManaCost(cost: AbilityCost): AbilityCost = when (cost) {
-        is AbilityCost.Mana -> AbilityCost.Free
+        is AbilityCost.Atom -> if (cost.manaCostOrNull != null) AbilityCost.Free else cost
         is AbilityCost.Composite -> {
-            val nonManaCosts = cost.costs.filter { it !is AbilityCost.Mana }
+            val nonManaCosts = cost.costs.filter { it.manaCostOrNull == null }
             when (nonManaCosts.size) {
                 0 -> AbilityCost.Free
                 1 -> nonManaCosts.single()
@@ -1768,7 +1778,7 @@ class ActivateAbilityHandler(
         val levelAbility = cardDef.classLevels.find { it.level == targetLevel } ?: return null
         return ActivatedAbility(
             id = AbilityId.classLevelUp(targetLevel),
-            cost = AbilityCost.Mana(levelAbility.cost),
+            cost = AbilityCost.Atom(CostAtom.Mana(levelAbility.cost)),
             effect = LevelUpClassEffect(targetLevel),
             timing = TimingRule.SorcerySpeed,
             descriptionOverride = "Level up to level $targetLevel"
@@ -1902,14 +1912,16 @@ class ActivateAbilityHandler(
     }
 
     /**
-     * Pull the [AbilityCost.ExileFromGraveyard] sub-cost out of an ability cost (top-level or
+     * Pull the graveyard-exile [CostAtom.ExileFrom] sub-cost out of an ability cost (top-level or
      * inside a [AbilityCost.Composite]), or null if none. Used by the legal-actions submission
      * path to detect that an activation needs to pause for a card-selection decision when the
      * player has more matching graveyard cards than the cost requires.
      */
-    private fun extractExileFromGraveyardCost(cost: AbilityCost): AbilityCost.ExileFromGraveyard? = when (cost) {
-        is AbilityCost.ExileFromGraveyard -> cost
-        is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.ExileFromGraveyard>().firstOrNull()
+    private fun extractExileFromGraveyardCost(cost: AbilityCost): CostAtom.ExileFrom? = when (cost) {
+        is AbilityCost.Atom -> (cost.atom as? CostAtom.ExileFrom)?.takeIf { it.zone == Zone.GRAVEYARD }
+        is AbilityCost.Composite -> cost.costs.firstNotNullOfOrNull {
+            ((it as? AbilityCost.Atom)?.atom as? CostAtom.ExileFrom)?.takeIf { ex -> ex.zone == Zone.GRAVEYARD }
+        }
         else -> null
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.ModifyDrawAmount
 import com.wingedsheep.sdk.scripting.PreventDraw
 import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
@@ -280,9 +281,9 @@ class DrawReplacementDispatcher(
                 if (!ability.promptOnDraw) continue
 
                 val manaCost = when (val cost = ability.cost) {
-                    is AbilityCost.Mana -> cost.cost
+                    is AbilityCost.Atom -> cost.manaCostOrNull
                     is AbilityCost.Composite ->
-                        cost.costs.filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost
+                        cost.costs.firstNotNullOfOrNull { it.manaCostOrNull }
                     else -> null
                 } ?: continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -29,6 +29,8 @@ import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.effects.AnimateLandEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureTypeEffect
@@ -172,21 +174,21 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
 
                 // Check cost requirements and gather sacrifice/tap/bounce targets if needed
                 var sacrificeTargets: List<EntityId>? = null
-                var sacrificeCost: AbilityCost.Sacrifice? = null
+                var sacrificeCost: CostAtom.Sacrifice? = null
                 var tapTargets: List<EntityId>? = null
-                var tapCost: AbilityCost.TapPermanents? = null
+                var tapCost: CostAtom.TapPermanents? = null
                 var bounceTargets: List<EntityId>? = null
-                var bounceCost: AbilityCost.ReturnToHand? = null
+                var bounceCost: CostAtom.ReturnToHand? = null
                 var hasForageCost = false
                 var forageGraveyardCards: List<EntityId> = emptyList()
                 var forageFoodTargets: List<EntityId> = emptyList()
                 var blightCost: AbilityCost.Blight? = null
                 var blightCreatures: List<EntityId> = emptyList()
-                var discardCost: AbilityCost.Discard? = null
+                var discardCost: CostAtom.Discard? = null
                 var discardTargets: List<EntityId>? = null
                 var craftCost: AbilityCost.Craft? = null
                 var craftMaterials: List<EntityId> = emptyList()
-                var exileCost: AbilityCost.ExileFromGraveyard? = null
+                var exileCost: CostAtom.ExileFrom? = null
                 var exileTargets: List<EntityId>? = null
                 var costAffordable = true
 
@@ -210,52 +212,75 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             if (hasSummoningSickness && !hasHaste) continue
                         }
                     }
-                    is AbilityCost.Mana -> {
-                        if (!context.manaSolver.canPay(state, playerId, effectiveCost.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
-                            // If the ability has convoke or waterbend, check if the tap-to-pay
-                            // helpers close the affordability gap.
-                            val affordableViaConvoke = ability.hasConvoke &&
-                                context.costUtils.canAffordWithConvoke(
-                                    state, playerId, effectiveCost.cost,
-                                    context.costUtils.findConvokeCreatures(state, playerId),
-                                    precomputedSources = context.availableManaSources
-                                )
-                            val affordableViaWaterbend = ability.hasWaterbend &&
-                                context.costUtils.canAffordWithWaterbend(
-                                    state, playerId, effectiveCost.cost,
-                                    context.costUtils.findWaterbendPermanents(state, playerId),
-                                    precomputedSources = context.availableManaSources
-                                )
-                            if (!affordableViaConvoke && !affordableViaWaterbend) {
-                                costAffordable = false
+                    is AbilityCost.Atom -> when (val atom = effectiveCost.atom) {
+                        is CostAtom.Mana -> {
+                            if (!context.manaSolver.canPay(state, playerId, atom.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
+                                // If the ability has convoke or waterbend, check if the tap-to-pay
+                                // helpers close the affordability gap.
+                                val affordableViaConvoke = ability.hasConvoke &&
+                                    context.costUtils.canAffordWithConvoke(
+                                        state, playerId, atom.cost,
+                                        context.costUtils.findConvokeCreatures(state, playerId),
+                                        precomputedSources = context.availableManaSources
+                                    )
+                                val affordableViaWaterbend = ability.hasWaterbend &&
+                                    context.costUtils.canAffordWithWaterbend(
+                                        state, playerId, atom.cost,
+                                        context.costUtils.findWaterbendPermanents(state, playerId),
+                                        precomputedSources = context.availableManaSources
+                                    )
+                                if (!affordableViaConvoke && !affordableViaWaterbend) {
+                                    costAffordable = false
+                                }
                             }
                         }
-                    }
-                    is AbilityCost.Sacrifice -> {
-                        sacrificeCost = effectiveCost
-                        sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
-                            state, playerId, sacrificeCost.filter, if (sacrificeCost.excludeSelf) entityId else null
-                        )
-                        if (sacrificeTargets.size < sacrificeCost.count) continue
-                    }
-                    is AbilityCost.ReturnToHand -> {
-                        bounceCost = effectiveCost
-                        bounceTargets = context.costUtils.findAbilityBounceTargets(state, playerId, bounceCost.filter)
-                        if (bounceTargets.size < bounceCost.count) continue
+                        is CostAtom.Sacrifice -> {
+                            sacrificeCost = atom
+                            sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
+                                state, playerId, atom.filter, if (atom.excludeSelf) entityId else null
+                            )
+                            if (sacrificeTargets.size < atom.count) continue
+                        }
+                        is CostAtom.ReturnToHand -> {
+                            bounceCost = atom
+                            bounceTargets = context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                            if (bounceTargets.size < atom.count) continue
+                        }
+                        is CostAtom.TapPermanents -> {
+                            tapCost = atom
+                            tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                                .let { targets -> if (atom.excludeSelf) targets.filter { it != entityId } else targets }
+                            if (tapTargets.size < atom.count) continue
+                        }
+                        is CostAtom.Discard -> {
+                            val targets = context.costUtils.findDiscardTargets(state, playerId, atom.filter)
+                            if (targets.size < atom.count) continue
+                            // Random discard is paid automatically at cost time — no player selection.
+                            if (!atom.random) {
+                                discardCost = atom
+                                discardTargets = targets
+                            }
+                        }
+                        is CostAtom.ExileFrom -> {
+                            val targets = context.costUtils.findExileTargets(
+                                state, playerId, atom.filter, atom.zone
+                            )
+                            if (targets.size < atom.count) continue
+                            exileCost = atom
+                            exileTargets = targets
+                        }
+                        // Pay-life / reveal carry no enumeration-time selection or affordability gate
+                        // here (life payability is validated at payment time, matching the prior
+                        // fall-through behavior for these costs).
+                        is CostAtom.PayLife, is CostAtom.RevealFromHand -> {}
                     }
                     is AbilityCost.SacrificeChosenCreatureType -> {
                         val chosenType = container.chosenCreatureType()
                         if (chosenType == null) continue
                         val dynamicFilter = GameObjectFilter.Creature.withSubtype(chosenType)
-                        sacrificeCost = AbilityCost.Sacrifice(dynamicFilter)
+                        sacrificeCost = CostAtom.Sacrifice(dynamicFilter)
                         sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(state, playerId, dynamicFilter)
                         if (sacrificeTargets.isEmpty()) continue
-                    }
-                    is AbilityCost.TapPermanents -> {
-                        tapCost = effectiveCost
-                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, tapCost.filter)
-                            .let { targets -> if (tapCost.excludeSelf) targets.filter { it != entityId } else targets }
-                        if (tapTargets.size < tapCost.count) continue
                     }
                     is AbilityCost.SacrificeSelf -> {
                         // Source must be on battlefield (always true when iterating battlefield)
@@ -266,24 +291,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         blightCreatures = projected.getBattlefieldControlledBy(playerId)
                             .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                         if (blightCreatures.isEmpty()) continue
-                    }
-                    is AbilityCost.Discard -> {
-                        val targets = context.costUtils.findDiscardTargets(state, playerId, effectiveCost.filter)
-                        if (targets.size < effectiveCost.count) continue
-                        // Random discard is paid automatically at cost time — no player selection.
-                        if (!effectiveCost.atRandom) {
-                            discardCost = effectiveCost
-                            discardTargets = targets
-                        }
-                    }
-                    is AbilityCost.ExileFromGraveyard -> {
-                        val targets = context.costUtils.findExileTargets(
-                            state, playerId, effectiveCost.filter,
-                            com.wingedsheep.sdk.core.Zone.GRAVEYARD
-                        )
-                        if (targets.size < effectiveCost.count) continue
-                        exileCost = effectiveCost
-                        exileTargets = targets
                     }
                     is AbilityCost.DiscardLastDrawnThisTurn -> {
                         // No player choice — engine picks the tracked entity at payment. Gate the
@@ -320,36 +327,87 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         }
                                     }
                                 }
-                                is AbilityCost.Mana -> {
-                                    if (!context.manaSolver.canPay(state, playerId, subCost.cost, excludeSources = excludeFromMana, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
-                                        // If the ability has convoke or waterbend, check with the tap-to-pay helpers.
-                                        val affordableViaConvoke = ability.hasConvoke &&
-                                            context.costUtils.canAffordWithConvoke(
-                                                state, playerId, subCost.cost,
-                                                context.costUtils.findConvokeCreatures(state, playerId),
-                                                precomputedSources = context.availableManaSources
-                                            )
-                                        val affordableViaWaterbend = ability.hasWaterbend &&
-                                            context.costUtils.canAffordWithWaterbend(
-                                                state, playerId, subCost.cost,
-                                                context.costUtils.findWaterbendPermanents(state, playerId),
-                                                precomputedSources = context.availableManaSources
-                                            )
-                                        if (!affordableViaConvoke && !affordableViaWaterbend) {
+                                is AbilityCost.Atom -> when (val atom = subCost.atom) {
+                                    is CostAtom.Mana -> {
+                                        if (!context.manaSolver.canPay(state, playerId, atom.cost, excludeSources = excludeFromMana, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
+                                            // If the ability has convoke or waterbend, check with the tap-to-pay helpers.
+                                            val affordableViaConvoke = ability.hasConvoke &&
+                                                context.costUtils.canAffordWithConvoke(
+                                                    state, playerId, atom.cost,
+                                                    context.costUtils.findConvokeCreatures(state, playerId),
+                                                    precomputedSources = context.availableManaSources
+                                                )
+                                            val affordableViaWaterbend = ability.hasWaterbend &&
+                                                context.costUtils.canAffordWithWaterbend(
+                                                    state, playerId, atom.cost,
+                                                    context.costUtils.findWaterbendPermanents(state, playerId),
+                                                    precomputedSources = context.availableManaSources
+                                                )
+                                            if (!affordableViaConvoke && !affordableViaWaterbend) {
+                                                costCanBePaid = false
+                                                break
+                                            }
+                                        }
+                                    }
+                                    is CostAtom.Sacrifice -> {
+                                        sacrificeCost = atom
+                                        sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
+                                            state, playerId, atom.filter, if (atom.excludeSelf) entityId else null
+                                        )
+                                        if (sacrificeTargets.size < atom.count) {
                                             costCanBePaid = false
                                             break
                                         }
                                     }
-                                }
-                                is AbilityCost.Sacrifice -> {
-                                    sacrificeCost = subCost
-                                    sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
-                                        state, playerId, subCost.filter, if (subCost.excludeSelf) entityId else null
-                                    )
-                                    if (sacrificeTargets.size < subCost.count) {
-                                        costCanBePaid = false
-                                        break
+                                    is CostAtom.TapPermanents -> {
+                                        tapCost = atom
+                                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                                            .let { targets -> if (atom.excludeSelf) targets.filter { it != entityId } else targets }
+                                        if (tapTargets.size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
                                     }
+                                    is CostAtom.ReturnToHand -> {
+                                        bounceCost = atom
+                                        bounceTargets = context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                                        if (bounceTargets.size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                    }
+                                    is CostAtom.ExileFrom -> {
+                                        // Filter the source zone by the cost's GameObjectFilter so the
+                                        // payability check matches what CostHandler will see, and so
+                                        // we can surface the matching cards to the UI via
+                                        // AdditionalCostData.validExileTargets (the picker prompt
+                                        // for Rust Harvester's "Exile an artifact card from your
+                                        // graveyard" cost).
+                                        val targets = context.costUtils.findExileTargets(
+                                            state, playerId, atom.filter, atom.zone
+                                        )
+                                        if (targets.size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                        exileCost = atom
+                                        exileTargets = targets
+                                    }
+                                    is CostAtom.Discard -> {
+                                        val targets = context.costUtils.findDiscardTargets(state, playerId, atom.filter)
+                                        if (targets.size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                        // Random discard is paid automatically at cost time — no player selection.
+                                        if (!atom.random) {
+                                            discardCost = atom
+                                            discardTargets = targets
+                                        }
+                                    }
+                                    // Pay-life / reveal carry no enumeration-time gate here (matching
+                                    // the prior else fall-through for these sub-costs).
+                                    is CostAtom.PayLife, is CostAtom.RevealFromHand -> {}
                                 }
                                 is AbilityCost.SacrificeChosenCreatureType -> {
                                     val chosenType = container.chosenCreatureType()
@@ -358,7 +416,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         break
                                     }
                                     val dynamicFilter = GameObjectFilter.Creature.withSubtype(chosenType)
-                                    sacrificeCost = AbilityCost.Sacrifice(dynamicFilter)
+                                    sacrificeCost = CostAtom.Sacrifice(dynamicFilter)
                                     sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(state, playerId, dynamicFilter)
                                     if (sacrificeTargets.isEmpty()) {
                                         costCanBePaid = false
@@ -389,41 +447,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         }
                                     }
                                 }
-                                is AbilityCost.TapPermanents -> {
-                                    tapCost = subCost
-                                    tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, subCost.filter)
-                                        .let { targets -> if (subCost.excludeSelf) targets.filter { it != entityId } else targets }
-                                    if (tapTargets.size < subCost.count) {
-                                        costCanBePaid = false
-                                        break
-                                    }
-                                }
-                                is AbilityCost.ReturnToHand -> {
-                                    bounceCost = subCost
-                                    bounceTargets = context.costUtils.findAbilityBounceTargets(state, playerId, subCost.filter)
-                                    if (bounceTargets.size < subCost.count) {
-                                        costCanBePaid = false
-                                        break
-                                    }
-                                }
-                                is AbilityCost.ExileFromGraveyard -> {
-                                    // Filter the graveyard by the cost's GameObjectFilter so the
-                                    // payability check matches what CostHandler will see, and so
-                                    // we can surface the matching cards to the UI via
-                                    // AdditionalCostData.validExileTargets (the picker prompt
-                                    // for Rust Harvester's "Exile an artifact card from your
-                                    // graveyard" cost).
-                                    val targets = context.costUtils.findExileTargets(
-                                        state, playerId, subCost.filter,
-                                        com.wingedsheep.sdk.core.Zone.GRAVEYARD
-                                    )
-                                    if (targets.size < subCost.count) {
-                                        costCanBePaid = false
-                                        break
-                                    }
-                                    exileCost = subCost
-                                    exileTargets = targets
-                                }
                                 is AbilityCost.Forage -> {
                                     // Forage: can exile 3 from graveyard OR sacrifice a Food
                                     val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
@@ -449,18 +472,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     if (blightCreatures.isEmpty()) {
                                         costCanBePaid = false
                                         break
-                                    }
-                                }
-                                is AbilityCost.Discard -> {
-                                    val targets = context.costUtils.findDiscardTargets(state, playerId, subCost.filter)
-                                    if (targets.size < subCost.count) {
-                                        costCanBePaid = false
-                                        break
-                                    }
-                                    // Random discard is paid automatically at cost time — no player selection.
-                                    if (!subCost.atRandom) {
-                                        discardCost = subCost
-                                        discardTargets = targets
                                     }
                                 }
                                 is AbilityCost.DiscardLastDrawnThisTurn -> {
@@ -543,12 +554,9 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
 
                 // If cost is unaffordable, add as greyed-out option and skip expensive computations
                 if (!costAffordable) {
-                    val abilityManaCostString = when (effectiveCost) {
-                        is AbilityCost.Mana -> effectiveCost.cost.toString()
-                        is AbilityCost.Composite -> effectiveCost.costs
-                            .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost?.toString()
-                        else -> null
-                    }
+                    val abilityManaCostString = (effectiveCost.manaCostOrNull
+                        ?: (effectiveCost as? AbilityCost.Composite)?.costs?.firstNotNullOfOrNull { it.manaCostOrNull })
+                        ?.toString()
                     result.add(LegalAction(
                         actionType = "ActivateAbility",
                         description = displayDescription,
@@ -607,9 +615,9 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // Use [effectiveCost] so generic-cost reductions (e.g., The Dominion Bracelet,
                 // Starport Security) flow through to the displayed [manaCostString].
                 val abilityManaCost = when (effectiveCost) {
-                    is AbilityCost.Mana -> effectiveCost.cost
+                    is AbilityCost.Atom -> effectiveCost.manaCostOrNull
                     is AbilityCost.Composite -> effectiveCost.costs
-                        .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost
+                        .firstNotNullOfOrNull { it.manaCostOrNull }
                     else -> null
                 }
                 // A mana cost reduced all the way to {0} (e.g. Forge Anew's free first equip)
@@ -639,7 +647,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // and the effect must "stack" when activated multiple times (e.g., +1/+0 modifiers).
                 // Effects that REPLACE base characteristics (BecomeCreature, SetBasePowerToughness, etc.)
                 // are excluded — repeating them only re-applies the same end state, so the prompt is meaningless.
-                val isRepeatEligible = ability.cost is AbilityCost.Mana
+                val isRepeatEligible = ability.cost.manaCostOrNull != null
                     && !abilityHasXCost
                     && ability.effect !is LevelUpClassEffect
                     && effectStacksOnRepeat(ability.effect)
@@ -810,9 +818,12 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 val anyPlayerAbilityContext = com.wingedsheep.engine.mechanics.mana.buildAbilityPaymentContext(cardComponent, projected, entityId)
                 val anyPlayerManaCostString = when (effectiveCost) {
                     is AbilityCost.Free -> null
-                    is AbilityCost.Mana -> {
-                        if (!context.manaSolver.canPay(state, playerId, effectiveCost.cost, precomputedSources = context.availableManaSources, spellContext = anyPlayerAbilityContext)) continue
-                        effectiveCost.cost.toString()
+                    is AbilityCost.Atom -> {
+                        // Only mana costs on opponents' permanents are supported ("any player may
+                        // activate"); other atoms (sacrifice/discard/…) fall through to continue.
+                        val mana = effectiveCost.manaCostOrNull ?: continue
+                        if (!context.manaSolver.canPay(state, playerId, mana, precomputedSources = context.availableManaSources, spellContext = anyPlayerAbilityContext)) continue
+                        mana.toString()
                     }
                     else -> continue // Other costs on opponent's permanents not yet supported
                 }
@@ -877,7 +888,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         return listOf(
             ActivatedAbility(
                 id = AbilityId.classLevelUp(nextLevel),
-                cost = AbilityCost.Mana(nextLevelAbility.cost),
+                cost = AbilityCost.Atom(CostAtom.Mana(nextLevelAbility.cost)),
                 effect = LevelUpClassEffect(nextLevel),
                 timing = TimingRule.SorcerySpeed,
                 descriptionOverride = "Level up to level $nextLevel"
@@ -891,23 +902,23 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
     private fun buildAdditionalCostInfo(
         ability: ActivatedAbility,
         tapTargets: List<EntityId>?,
-        tapCost: AbilityCost.TapPermanents?,
+        tapCost: CostAtom.TapPermanents?,
         hasTapXPermanentsCost: Boolean,
         sacrificeTargets: List<EntityId>?,
-        sacrificeCost: AbilityCost.Sacrifice?,
+        sacrificeCost: CostAtom.Sacrifice?,
         bounceTargets: List<EntityId>?,
-        bounceCost: AbilityCost.ReturnToHand?,
+        bounceCost: CostAtom.ReturnToHand?,
         counterRemovalCreatures: List<CounterRemovalCreatureData>,
         hasForageCost: Boolean = false,
         forageGraveyardCards: List<EntityId> = emptyList(),
         forageFoodTargets: List<EntityId> = emptyList(),
         blightCost: AbilityCost.Blight? = null,
         blightCreatures: List<EntityId> = emptyList(),
-        discardCost: AbilityCost.Discard? = null,
+        discardCost: CostAtom.Discard? = null,
         discardTargets: List<EntityId>? = null,
         craftCost: AbilityCost.Craft? = null,
         craftMaterials: List<EntityId> = emptyList(),
-        exileCost: AbilityCost.ExileFromGraveyard? = null,
+        exileCost: CostAtom.ExileFrom? = null,
         exileTargets: List<EntityId>? = null
     ): AdditionalCostData? {
         if (craftCost != null) {
@@ -929,7 +940,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         }
         if (tapTargets != null && tapCost != null) {
             return AdditionalCostData(
-                description = tapCost.description,
+                description = tapCost.description.replaceFirstChar { it.uppercase() },
                 costType = "TapPermanents",
                 validTapTargets = tapTargets,
                 tapCount = tapCost.count,
@@ -955,7 +966,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         }
         if (sacrificeTargets != null && sacrificeCost != null) {
             return AdditionalCostData(
-                description = sacrificeCost.description,
+                description = sacrificeCost.description.replaceFirstChar { it.uppercase() },
                 costType = "SacrificePermanent",
                 validSacrificeTargets = sacrificeTargets,
                 sacrificeCount = sacrificeCost.count,
@@ -973,7 +984,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         }
         if (discardCost != null && discardTargets != null && discardTargets.isNotEmpty()) {
             return AdditionalCostData(
-                description = discardCost.description,
+                description = discardCost.description.replaceFirstChar { it.uppercase() },
                 costType = "DiscardCard",
                 validDiscardTargets = discardTargets,
                 discardCount = discardCost.count,
@@ -982,7 +993,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         }
         if (bounceTargets != null && bounceCost != null) {
             return AdditionalCostData(
-                description = bounceCost.description,
+                description = bounceCost.description.replaceFirstChar { it.uppercase() },
                 costType = "BouncePermanent",
                 validBounceTargets = bounceTargets,
                 bounceCount = bounceCost.count,
@@ -1012,7 +1023,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             // renders a card-picker; ActivateAbilityHandler's matching fast-path pauses for a
             // SelectCardsDecision when candidate count > required count.
             return AdditionalCostData(
-                description = exileCost.description,
+                description = exileCost.description.replaceFirstChar { it.uppercase() },
                 costType = "ExileFromGraveyard",
                 validExileTargets = exileTargets,
                 exileMinCount = exileCost.count,
@@ -1149,13 +1160,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
     }
 
     private fun reduceGenericInAbilityCost(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {
-        is AbilityCost.Mana -> AbilityCost.Mana(cost.cost.reduceGeneric(amount))
+        is AbilityCost.Atom -> cost.manaCostOrNull
+            ?.let { AbilityCost.Atom(CostAtom.Mana(it.reduceGeneric(amount))) } ?: cost
         is AbilityCost.Composite -> {
             var applied = false
             AbilityCost.Composite(cost.costs.map { sub ->
-                if (!applied && sub is AbilityCost.Mana) {
+                val subMana = sub.manaCostOrNull
+                if (!applied && subMana != null) {
                     applied = true
-                    AbilityCost.Mana(sub.cost.reduceGeneric(amount))
+                    AbilityCost.Atom(CostAtom.Mana(subMana.reduceGeneric(amount)))
                 } else sub
             })
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
@@ -10,6 +10,8 @@ import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.TimingRule
 
@@ -71,12 +73,16 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                 )
 
                 when (effectiveCost) {
-                    is AbilityCost.Mana -> {
-                        if (!context.manaSolver.canPay(state, playerId, effectiveCost.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) costCanBePaid = false
-                    }
-                    is AbilityCost.Discard -> {
-                        hasDiscardCost = true
-                        if (handCards.isEmpty()) costCanBePaid = false
+                    is AbilityCost.Atom -> when (val atom = effectiveCost.atom) {
+                        is CostAtom.Mana -> {
+                            if (!context.manaSolver.canPay(state, playerId, atom.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) costCanBePaid = false
+                        }
+                        is CostAtom.Discard -> {
+                            hasDiscardCost = true
+                            if (handCards.isEmpty()) costCanBePaid = false
+                        }
+                        // Other atoms — engine validates at payment.
+                        else -> {}
                     }
                     is AbilityCost.Blight -> {
                         blightCost = effectiveCost
@@ -87,22 +93,26 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.Composite -> {
                         for (subCost in effectiveCost.costs) {
                             when (subCost) {
-                                is AbilityCost.Mana -> {
-                                    if (!context.manaSolver.canPay(state, playerId, subCost.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
-                                        costCanBePaid = false; break
+                                is AbilityCost.Atom -> when (val atom = subCost.atom) {
+                                    is CostAtom.Mana -> {
+                                        if (!context.manaSolver.canPay(state, playerId, atom.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
+                                            costCanBePaid = false; break
+                                        }
                                     }
-                                }
-                                is AbilityCost.Discard -> {
-                                    hasDiscardCost = true
-                                    if (handCards.isEmpty()) {
-                                        costCanBePaid = false; break
+                                    is CostAtom.Discard -> {
+                                        hasDiscardCost = true
+                                        if (handCards.isEmpty()) {
+                                            costCanBePaid = false; break
+                                        }
                                     }
-                                }
-                                is AbilityCost.ReturnToHand -> {
-                                    val targets = context.costUtils.findAbilityBounceTargets(state, playerId, subCost.filter)
-                                    if (targets.size < subCost.count) {
-                                        costCanBePaid = false; break
+                                    is CostAtom.ReturnToHand -> {
+                                        val targets = context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                                        if (targets.size < atom.count) {
+                                            costCanBePaid = false; break
+                                        }
                                     }
+                                    // Other atoms — engine validates at payment.
+                                    else -> {}
                                 }
                                 is AbilityCost.ExileSelf -> {
                                     // Always payable — the card is in the graveyard
@@ -124,10 +134,10 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                 if (!costCanBePaid) continue
 
                 // Build cost info for bounce or discard costs
-                val bounceCostFromGraveyard = when (effectiveCost) {
+                val bounceCostFromGraveyard: CostAtom.ReturnToHand? = when (effectiveCost) {
                     is AbilityCost.Composite -> effectiveCost.costs
-                        .filterIsInstance<AbilityCost.ReturnToHand>().firstOrNull()
-                    is AbilityCost.ReturnToHand -> effectiveCost
+                        .firstNotNullOfOrNull { (it as? AbilityCost.Atom)?.atom as? CostAtom.ReturnToHand }
+                    is AbilityCost.Atom -> effectiveCost.atom as? CostAtom.ReturnToHand
                     else -> null
                 }
                 val costInfo = if (bounceCostFromGraveyard != null) {
@@ -135,7 +145,7 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                         state, playerId, bounceCostFromGraveyard.filter
                     )
                     AdditionalCostData(
-                        description = bounceCostFromGraveyard.description,
+                        description = bounceCostFromGraveyard.description.replaceFirstChar { it.uppercase() },
                         costType = "BouncePermanent",
                         validBounceTargets = bounceTargets,
                         bounceCount = bounceCostFromGraveyard.count
@@ -157,10 +167,9 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                 } else null
 
                 // Calculate X cost info
-                val abilityManaCost = when (ability.cost) {
-                    is AbilityCost.Mana -> (ability.cost as AbilityCost.Mana).cost
-                    is AbilityCost.Composite -> (ability.cost as AbilityCost.Composite).costs
-                        .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost
+                val abilityManaCost = when (val c = ability.cost) {
+                    is AbilityCost.Atom -> c.manaCostOrNull
+                    is AbilityCost.Composite -> c.costs.firstNotNullOfOrNull { it.manaCostOrNull }
                     else -> null
                 }
                 val graveyardManaCostString = abilityManaCost?.toString()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -23,6 +23,8 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.OverrideEnchantedLandManaColor
@@ -111,9 +113,9 @@ class ManaAbilityEnumerator : ActionEnumerator {
 
                 // Check if the ability can be activated and gather cost info
                 var tapTargets: List<EntityId>? = null
-                var tapCost: AbilityCost.TapPermanents? = null
+                var tapCost: CostAtom.TapPermanents? = null
                 var sacrificeTargets: List<EntityId>? = null
-                var sacrificeCost: AbilityCost.Sacrifice? = null
+                var sacrificeCost: CostAtom.Sacrifice? = null
                 var affordable = true
 
                 when (effectiveCost) {
@@ -123,18 +125,22 @@ class ManaAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.TapAttachedCreature -> {
                         if (!context.costUtils.canPayTapAttachedCreatureCost(state, entityId)) affordable = false
                     }
-                    is AbilityCost.TapPermanents -> {
-                        tapCost = effectiveCost
-                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, tapCost.filter)
-                        if (tapTargets.size < tapCost.count) affordable = false
-                    }
-                    is AbilityCost.Sacrifice -> {
-                        sacrificeCost = effectiveCost
-                        sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
-                            state, playerId, sacrificeCost.filter,
-                            if (sacrificeCost.excludeSelf) entityId else null
-                        )
-                        if (sacrificeTargets.size < sacrificeCost.count) affordable = false
+                    is AbilityCost.Atom -> when (val atom = effectiveCost.atom) {
+                        is CostAtom.TapPermanents -> {
+                            tapCost = atom
+                            tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                            if (tapTargets.size < atom.count) affordable = false
+                        }
+                        is CostAtom.Sacrifice -> {
+                            sacrificeCost = atom
+                            sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
+                                state, playerId, atom.filter,
+                                if (atom.excludeSelf) entityId else null
+                            )
+                            if (sacrificeTargets.size < atom.count) affordable = false
+                        }
+                        // Other atoms (mana, life, discard, …) — engine validates at payment.
+                        else -> {}
                     }
                     is AbilityCost.SacrificeChosenCreatureType -> {
                         val chosenType = container.chosenCreatureType()
@@ -142,7 +148,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
                             affordable = false
                         } else {
                             val dynamicFilter = GameObjectFilter.Creature.withSubtype(chosenType)
-                            sacrificeCost = AbilityCost.Sacrifice(dynamicFilter)
+                            sacrificeCost = CostAtom.Sacrifice(dynamicFilter)
                             sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(state, playerId, dynamicFilter)
                             if (sacrificeTargets.isEmpty()) affordable = false
                         }
@@ -166,20 +172,34 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                         }
                                     }
                                 }
-                                is AbilityCost.Mana -> {
-                                    if (!context.manaSolver.canPay(state, playerId, subCost.cost, excludeSources = excludeFromMana, precomputedSources = context.availableManaSources, spellContext = manaAbilityContext)) {
-                                        affordable = false; break
+                                is AbilityCost.Atom -> when (val atom = subCost.atom) {
+                                    is CostAtom.Mana -> {
+                                        if (!context.manaSolver.canPay(state, playerId, atom.cost, excludeSources = excludeFromMana, precomputedSources = context.availableManaSources, spellContext = manaAbilityContext)) {
+                                            affordable = false; break
+                                        }
                                     }
-                                }
-                                is AbilityCost.Sacrifice -> {
-                                    sacrificeCost = subCost
-                                    sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
-                                        state, playerId, subCost.filter,
-                                        if (subCost.excludeSelf) entityId else null
-                                    )
-                                    if (sacrificeTargets.size < subCost.count) {
-                                        affordable = false; break
+                                    is CostAtom.Sacrifice -> {
+                                        sacrificeCost = atom
+                                        sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(
+                                            state, playerId, atom.filter,
+                                            if (atom.excludeSelf) entityId else null
+                                        )
+                                        if (sacrificeTargets.size < atom.count) {
+                                            affordable = false; break
+                                        }
                                     }
+                                    is CostAtom.TapPermanents -> {
+                                        tapCost = atom
+                                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                                        if (tapTargets.size < atom.count) {
+                                            affordable = false; break
+                                        }
+                                    }
+                                    is CostAtom.ReturnToHand -> {
+                                        // Bounce costs not typical for mana abilities but handle for completeness
+                                    }
+                                    // Other atoms (life, discard, exile, reveal) — engine validates at payment.
+                                    else -> {}
                                 }
                                 is AbilityCost.SacrificeChosenCreatureType -> {
                                     val chosenType = container.chosenCreatureType()
@@ -187,7 +207,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                         affordable = false; break
                                     }
                                     val dynamicFilter = GameObjectFilter.Creature.withSubtype(chosenType)
-                                    sacrificeCost = AbilityCost.Sacrifice(dynamicFilter)
+                                    sacrificeCost = CostAtom.Sacrifice(dynamicFilter)
                                     sacrificeTargets = context.costUtils.findAbilitySacrificeTargets(state, playerId, dynamicFilter)
                                     if (sacrificeTargets.isEmpty()) {
                                         affordable = false; break
@@ -200,16 +220,6 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     if (!context.costUtils.canPayTapAttachedCreatureCost(state, entityId)) {
                                         affordable = false; break
                                     }
-                                }
-                                is AbilityCost.TapPermanents -> {
-                                    tapCost = subCost
-                                    tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, subCost.filter)
-                                    if (tapTargets.size < subCost.count) {
-                                        affordable = false; break
-                                    }
-                                }
-                                is AbilityCost.ReturnToHand -> {
-                                    // Bounce costs not typical for mana abilities but handle for completeness
                                 }
                                 is AbilityCost.Forage -> {
                                     val graveyardSize = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD)).size
@@ -244,14 +254,14 @@ class ManaAbilityEnumerator : ActionEnumerator {
 
                 val costInfo = if (tapTargets != null && tapCost != null) {
                     AdditionalCostData(
-                        description = tapCost.description,
+                        description = tapCost.description.replaceFirstChar { it.uppercase() },
                         costType = "TapPermanents",
                         validTapTargets = tapTargets,
                         tapCount = tapCost.count
                     )
                 } else if (sacrificeTargets != null && sacrificeCost != null) {
                     AdditionalCostData(
-                        description = sacrificeCost.description,
+                        description = sacrificeCost.description.replaceFirstChar { it.uppercase() },
                         costType = "SacrificePermanent",
                         validSacrificeTargets = sacrificeTargets,
                         sacrificeCount = sacrificeCost.count
@@ -259,9 +269,9 @@ class ManaAbilityEnumerator : ActionEnumerator {
                 } else null
 
                 val manaAbilityManaCostString = when (effectiveCost) {
-                    is AbilityCost.Mana -> effectiveCost.cost.toString()
+                    is AbilityCost.Atom -> effectiveCost.manaCostOrNull?.toString()
                     is AbilityCost.Composite -> effectiveCost.costs
-                        .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost?.toString()
+                        .firstNotNullOfOrNull { it.manaCostOrNull }?.toString()
                     else -> null
                 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -18,6 +18,8 @@ import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnCompone
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
@@ -454,9 +456,10 @@ class CastPermissionUtils(
         if (activations > 0) return cost
         if (!hasFreeFirstEquip(state, playerId)) return cost
         return when (cost) {
-            is AbilityCost.Mana -> AbilityCost.Mana(ManaCost.ZERO)
+            is AbilityCost.Atom ->
+                if (cost.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(ManaCost.ZERO)) else cost
             is AbilityCost.Composite -> AbilityCost.Composite(cost.costs.map {
-                if (it is AbilityCost.Mana) AbilityCost.Mana(ManaCost.ZERO) else it
+                if (it.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(ManaCost.ZERO)) else it
             })
             else -> cost
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -25,6 +25,8 @@ import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.effects.AddAnyColorManaSpendOnChosenTypeEffect
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
@@ -930,10 +932,13 @@ class ManaSolver(
                 var abilityTapPermanentsSubCost: TapPermanentsSubCost? = null
                 val abilityCanBeUsed = when (val cost = ability.cost) {
                     is AbilityCost.Tap -> true
-                    is AbilityCost.PayLife -> {
-                        abilityHasPainCost = true
-                        abilityPainAmount = cost.amount
-                        true
+                    is AbilityCost.Atom -> when (val atom = cost.atom) {
+                        is CostAtom.PayLife -> {
+                            abilityHasPainCost = true
+                            abilityPainAmount = atom.amount
+                            true
+                        }
+                        else -> false // Non-pain atom-only cost: skip like other non-tap mana abilities.
                     }
                     is AbilityCost.Composite -> {
                         var hasTap = false
@@ -941,30 +946,35 @@ class ManaSolver(
                         for (subCost in cost.costs) {
                             when (subCost) {
                                 is AbilityCost.Tap -> hasTap = true
-                                is AbilityCost.PayLife -> {
-                                    abilityHasPainCost = true
-                                    abilityPainAmount = maxOf(abilityPainAmount, subCost.amount)
-                                }
-                                is AbilityCost.Mana -> {
-                                    abilityActivationManaCost += subCost.cost.cmc
+                                is AbilityCost.Atom -> when (val atom = subCost.atom) {
+                                    is CostAtom.PayLife -> {
+                                        abilityHasPainCost = true
+                                        abilityPainAmount = maxOf(abilityPainAmount, atom.amount)
+                                    }
+                                    is CostAtom.Mana -> {
+                                        abilityActivationManaCost += atom.cost.cmc
+                                    }
+                                    // TapPermanents as a sub-cost (Springleaf Drum:
+                                    // "{T}, Tap an untapped creature you control: Add …"). Same
+                                    // treatment as SacrificeSelf — auto-pay refuses to silently
+                                    // consume the secondary tap target; manual menus offer the
+                                    // source and the resumer prompts for the creature.
+                                    is CostAtom.TapPermanents -> {
+                                        abilityTapPermanentsSubCost = TapPermanentsSubCost(
+                                            count = atom.count,
+                                            filter = atom.filter,
+                                            excludeSelf = atom.excludeSelf
+                                        )
+                                    }
+                                    // Other choice atoms (sacrifice-something-else, discard, …) still
+                                    // require explicit ActivateAbility entry.
+                                    else -> hasUnsupportedSubCost = true
                                 }
                                 // SacrificeSelf (Treasure: "{T}, Sacrifice this artifact: Add …").
                                 // Auto-tap won't pick these (filtered in solve()), but they appear
                                 // in `findAvailableManaSources` so manual-selection UIs can offer
                                 // them; selecting one triggers an explicit sacrifice in the resumer.
                                 is AbilityCost.SacrificeSelf -> abilityRequiresSacrifice = true
-                                // TapPermanents as a sub-cost (Springleaf Drum:
-                                // "{T}, Tap an untapped creature you control: Add …"). Same
-                                // treatment as SacrificeSelf — auto-pay refuses to silently
-                                // consume the secondary tap target; manual menus offer the
-                                // source and the resumer prompts for the creature.
-                                is AbilityCost.TapPermanents -> {
-                                    abilityTapPermanentsSubCost = TapPermanentsSubCost(
-                                        count = subCost.count,
-                                        filter = subCost.filter,
-                                        excludeSelf = subCost.excludeSelf
-                                    )
-                                }
                                 // Other choice costs (Forage, sacrifice-something-else, etc.) still
                                 // require explicit ActivateAbility entry.
                                 else -> hasUnsupportedSubCost = true
@@ -1780,7 +1790,7 @@ class ManaSolver(
 
             for (ability in cardDef.script.activatedAbilities) {
                 if (!ability.isManaAbility) continue
-                val tapCost = ability.cost as? AbilityCost.TapPermanents ?: continue
+                val tapCost = (ability.cost as? AbilityCost.Atom)?.atom as? CostAtom.TapPermanents ?: continue
 
                 // Find untapped permanents matching the filter that are NOT regular mana sources
                 // and haven't been consumed by another TapPermanents activation.
@@ -1878,7 +1888,7 @@ class ManaSolver(
                 // when the pool has mana, but counting their net production here would
                 // double-count and complicate color resolution. Treasure / Food (mana) / etc.
                 // have a flat tap+sac shape; we cover the canonical case.
-                if (composite.costs.any { it is AbilityCost.Mana }) continue
+                if (composite.costs.any { it.manaCostOrNull != null }) continue
 
                 // Honor activation restrictions (e.g. "only during your turn").
                 if (!activationRestrictionsSatisfied(state, playerId, entityId, ability)) continue
@@ -1995,12 +2005,12 @@ class ManaSolver(
                 val composite = ability.cost as? AbilityCost.Composite ?: continue
                 val hasTap = composite.costs.any { it is AbilityCost.Tap }
                 val tapPermanentsCost = composite.costs
-                    .firstOrNull { it is AbilityCost.TapPermanents } as? AbilityCost.TapPermanents
+                    .firstNotNullOfOrNull { (it as? AbilityCost.Atom)?.atom as? CostAtom.TapPermanents }
                 if (!hasTap || tapPermanentsCost == null) continue
                 // Skip composites that also bundle SacrificeSelf or a mana sub-cost — those are
                 // handled by other helpers (calculateSacrificeSelfBonusMana) and would
                 // double-count or complicate color resolution here.
-                if (composite.costs.any { it is AbilityCost.SacrificeSelf || it is AbilityCost.Mana }) continue
+                if (composite.costs.any { it is AbilityCost.SacrificeSelf || it.manaCostOrNull != null }) continue
 
                 if (!activationRestrictionsSatisfied(state, playerId, entityId, ability)) continue
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CostHandlerPayLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CostHandlerPayLifeTest.kt
@@ -38,7 +38,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 3)
             CostHandler().canPayAbilityCost(
                 state = driver.state,
-                cost = AbilityCost.PayLife(3),
+                cost = Costs.PayLife(3),
                 sourceId = player,
                 controllerId = player,
                 manaPool = ManaPool()
@@ -49,7 +49,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 20)
             CostHandler().canPayAbilityCost(
                 state = driver.state,
-                cost = AbilityCost.PayLife(3),
+                cost = Costs.PayLife(3),
                 sourceId = player,
                 controllerId = player,
                 manaPool = ManaPool()
@@ -60,7 +60,7 @@ class CostHandlerPayLifeTest : FunSpec({
             val (driver, player) = createDriver(initialLife = 2)
             CostHandler().canPayAbilityCost(
                 state = driver.state,
-                cost = AbilityCost.PayLife(3),
+                cost = Costs.PayLife(3),
                 sourceId = player,
                 controllerId = player,
                 manaPool = ManaPool()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/SurveilNTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/SurveilNTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -39,7 +40,7 @@ class SurveilNTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = surveilAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{2}{U}")),
+                cost = Costs.Mana(ManaCost.parse("{2}{U}")),
                 effect = Patterns.Library.surveil(2)
             )
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.CostZone
@@ -326,7 +327,7 @@ class CostEnumerationUtilsTest : FunSpec({
             val maxX = u.calculateMaxAffordableX(
                 driver.game.state,
                 driver.player1,
-                AbilityCost.Mana(manaCost),
+                Costs.Mana(manaCost),
                 manaCost
             )
 
@@ -340,7 +341,7 @@ class CostEnumerationUtilsTest : FunSpec({
             )
             val manaCost = ManaCost.parse("{X}")
             val compositeCost = AbilityCost.Composite(listOf(
-                AbilityCost.Mana(manaCost),
+                Costs.Mana(manaCost),
                 AbilityCost.ExileXFromGraveyard()
             ))
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/SmartTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/SmartTapTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.core.*
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.scripting.*
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
@@ -86,7 +87,7 @@ class SmartTapTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = AbilityId(UUID.randomUUID().toString()),
-                cost = AbilityCost.Composite(listOf(AbilityCost.Tap, AbilityCost.PayLife(1))),
+                cost = AbilityCost.Composite(listOf(AbilityCost.Tap, Costs.PayLife(1))),
                 effect = Effects.AddAnyColorMana(1),
                 isManaAbility = true
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwarvenBlastminerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwarvenBlastminerTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.*
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.*
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
@@ -45,7 +46,7 @@ class DwarvenBlastminerTest : FunSpec({
             ActivatedAbility(
                 id = blastminerAbilityId,
                 cost = AbilityCost.Composite(
-                    listOf(AbilityCost.Mana(ManaCost.parse("{2}{R}")), AbilityCost.Tap)
+                    listOf(Costs.Mana(ManaCost.parse("{2}{R}")), AbilityCost.Tap)
                 ),
                 effect = MoveToZoneEffect(EffectTarget.BoundVariable("target"), Zone.GRAVEYARD, byDestruction = true),
                 targetRequirement = TargetPermanent(id = "target",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinMachinistTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinMachinistTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
@@ -56,7 +57,7 @@ class GoblinMachinistTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = machinistAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{2}{R}")),
+                cost = Costs.Mana(ManaCost.parse("{2}{R}")),
                 effect = CompositeEffect(
                     listOf(
                         GatherUntilMatchEffect(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiddenGrottoTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiddenGrottoTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -55,7 +56,7 @@ class HiddenGrottoTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = pumpAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{G}{G}")),
+                cost = Costs.Mana(ManaCost.parse("{G}{G}")),
                 effect = Effects.ModifyStats(1, 1, EffectTarget.Self),
             )
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MakeNextSpellUncounterableTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MakeNextSpellUncounterableTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -38,7 +39,7 @@ class MakeNextSpellUncounterableTest : FunSpec({
     val mistriseVillage = card("Mistrise Village") {
         typeLine = "Land"
         activatedAbility {
-            cost = AbilityCost.Composite(listOf(AbilityCost.Mana(ManaCost.parse("{U}")), AbilityCost.Tap))
+            cost = AbilityCost.Composite(listOf(Costs.Mana(ManaCost.parse("{U}")), AbilityCost.Tap))
             effect = Effects.MakeNextSpellUncounterable()
         }
     }
@@ -48,7 +49,7 @@ class MakeNextSpellUncounterableTest : FunSpec({
     val creatureOnlyVillage = card("Creature Village") {
         typeLine = "Land"
         activatedAbility {
-            cost = AbilityCost.Composite(listOf(AbilityCost.Mana(ManaCost.parse("{U}")), AbilityCost.Tap))
+            cost = AbilityCost.Composite(listOf(Costs.Mana(ManaCost.parse("{U}")), AbilityCost.Tap))
             effect = Effects.MakeNextSpellUncounterable(GameObjectFilter.Creature)
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformDreamerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformDreamerTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -45,7 +46,7 @@ class MistformDreamerTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = mistformDreamerAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{1}")),
+                cost = Costs.Mana(ManaCost.parse("{1}")),
                 effect = BecomeCreatureTypeEffect(
                     target = EffectTarget.Self
                 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformMutantTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformMutantTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -44,7 +45,7 @@ class MistformMutantTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = mutantAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{1}{U}")),
+                cost = Costs.Mana(ManaCost.parse("{1}{U}")),
                 effect = BecomeCreatureTypeEffect(
                     target = EffectTarget.BoundVariable("target"),
                     excludedTypes = listOf("Wall")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformShriekerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformShriekerTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -46,7 +47,7 @@ class MistformShriekerTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = mistformShriekerAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{1}")),
+                cost = Costs.Mana(ManaCost.parse("{1}")),
                 effect = BecomeCreatureTypeEffect(
                     target = EffectTarget.Self
                 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformStalkerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformStalkerTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -45,14 +46,14 @@ class MistformStalkerTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = changeTypeAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{1}")),
+                cost = Costs.Mana(ManaCost.parse("{1}")),
                 effect = BecomeCreatureTypeEffect(
                     target = EffectTarget.Self
                 )
             ),
             ActivatedAbility(
                 id = pumpAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{2}{U}{U}")),
+                cost = Costs.Mana(ManaCost.parse("{2}{U}{U}")),
                 effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
                     .then(Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self))
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformWallTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistformWallTest.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -47,7 +48,7 @@ class MistformWallTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = mistformWallAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{1}")),
+                cost = Costs.Mana(ManaCost.parse("{1}")),
                 effect = BecomeCreatureTypeEffect(
                     target = EffectTarget.Self
                 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuicksilverDragonTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuicksilverDragonTest.kt
@@ -48,7 +48,7 @@ class QuicksilverDragonTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = abilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{U}")),
+                cost = Costs.Mana(ManaCost.parse("{U}")),
                 effect = Effects.ChangeSpellTarget(targetMustBeSource = true),
                 targetRequirement = Targets.Spell
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RummagingWizardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RummagingWizardTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -42,7 +43,7 @@ class RummagingWizardTest : FunSpec({
         script = CardScript.permanent(
             ActivatedAbility(
                 id = wizardAbilityId,
-                cost = AbilityCost.Mana(ManaCost.parse("{2}{U}")),
+                cost = Costs.Mana(ManaCost.parse("{2}{U}")),
                 effect = Patterns.Library.surveil(1)
             )
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StationMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StationMechanicTest.kt
@@ -9,12 +9,14 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
@@ -50,7 +52,7 @@ class StationMechanicTest : ScenarioTestBase() {
     private val tapCollector = card("Test Tap Collector") {
         typeLine = "Artifact"
         activatedAbility {
-            cost = AbilityCost.TapPermanents(count = 1, filter = GameObjectFilter.Creature, excludeSelf = true)
+            cost = Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature, excludeSelf = true)
             effect = Effects.AddDynamicCounters(
                 counterType = Counters.CHARGE,
                 amount = DynamicAmount.EntityProperty(EntityReference.TappedAsCost(), EntityNumericProperty.Power),
@@ -72,7 +74,7 @@ class StationMechanicTest : ScenarioTestBase() {
     }
 
     private fun stationAbilityId(cardName: String) =
-        cardRegistry.getCard(cardName)!!.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }.id
+        cardRegistry.getCard(cardName)!!.activatedAbilities.first { (it.cost as? AbilityCost.Atom)?.atom is CostAtom.TapPermanents }.id
 
     init {
         cardRegistry.register(testWall)


### PR DESCRIPTION
Completes the **§3.2 "one cost language"** unification from `backlog/sdk-analysis-2026-06-revised.md`. `CostAtom` already backed `PayCost` and `AdditionalCost` (commit `87b71bf2e`); this PR folds the third and largest cost hierarchy — `AbilityCost` — onto a thin `AbilityCost.Atom(atom: CostAtom)` wrapper, mirroring the other two.

## SDK
- Deleted `AbilityCost.Mana / PayLife / Sacrifice / Discard / ExileFromGraveyard / TapPermanents / ReturnToHand`; all now flow through `AbilityCost.Atom`. Context-specific members stay on the wrapper (`Free`, `Tap`/`Untap`, X-variable costs, `SacrificeSelf`/`ExileSelf`/`ExileGrantingPermanent`, counter removal, `Loyalty`, `Composite`, `Forage`/`Blight`/`Craft`).
- `CostAtom.Sacrifice` and `CostAtom.TapPermanents` gain `excludeSelf` so "sacrifice/tap another" survives the fold.
- `Costs.*` facades unchanged for card authors (they now build `AbilityCost.Atom(CostAtom.X(...))`); `Costs.TapPermanents` gains an `excludeSelf` param. New read helpers `AbilityCost.atomOrNull` / `manaCostOrNull`.

## Engine
`CostHandler` dispatches `AbilityCost.Atom` through one shared `canPayAtom`/`payAtom` (sacrifice/tap/return execution extracted to helpers). The three ability enumerators, `ManaSolver`, `CastPermissionUtils`, `ActivateAbilityHandler`, and `DrawReplacementDispatcher` all read the wrapped atom. Exhaustive `when (atom)` makes a new atom a compile error in every payment branch — behavior is preserved.

## Content
Card defs + scenario tests that constructed raw `AbilityCost.*` switched to the `Costs.*` facade. Card snapshot golden re-blessed — diff is **purely** the cost re-encoding (`CostX` → `CostAtomWrapper`/`AtomX`, `atRandom` → `random`, defaulted `count` omitted), no semantic field changes.

## Verification
- `:mtg-sdk`, `:rules-engine`, `:mtg-sets`, `:game-server`, `:mtgish-tooling` test suites green.
- `EmitterGoldenTest` green; `just coverage-verify POR` = **158/158, 0-mismatch** (§6 same-PR rule satisfied — the emitter emits facade calls, so no dictionary changes were needed).
- Docs: `card-sdk-language-reference.md` §3 cost note updated; §3.2 marked done in the revised SDK plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)