### PR TITLE
Fix Wizard's Rockets: sacrifice draw trigger, X-mana, and true any-combination mana

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -652,6 +652,14 @@ class ActivateAbilityHandler(
         // Collect events from cost payment (e.g., sacrifice events)
         events.addAll(costResult.events)
 
+        // Cost-payment events drive triggered abilities (e.g., a mana ability whose cost
+        // sacrifices the source — Wizard's Rockets: "{X}, {T}, Sacrifice this artifact: ..."
+        // — fires its dies/leaves-the-battlefield trigger). The mana-ability path resolves off
+        // the stack and returns early, so capture these now to detect triggers before returning.
+        // Scoped to cost-payment events so mana-production events keep their existing inline
+        // handling (resolveAdditionalManaOnSourceTap etc.).
+        val costPaymentEvents = costResult.events
+
         // Deduct X mana from the pool. ManaPool.pay() skips X symbols ("handled by caller"),
         // so we must explicitly spend the X portion here (same pattern as CastSpellHandler.autoPay).
         // Skip for Explicit payment — sources were already tapped to cover the full cost including X.
@@ -805,11 +813,42 @@ class ActivateAbilityHandler(
                 controllerId = action.playerId,
                 opponentId = opponentId,
                 targets = action.targets,
-                xValue = null,
+                // Thread the chosen X so X-based mana abilities produce the right amount
+                // ("{X}, {T}, Sacrifice this: Add X mana..." — Wizard's Rockets). Without
+                // this, DynamicAmount.XValue resolves to 0 and the ability adds no mana.
+                xValue = action.xValue,
                 manaColorChoice = action.manaColorChoice
             )
 
             val effectResult = effectExecutorRegistry.execute(currentState, finalEffect, context).toExecutionResult()
+            if (effectResult.isPaused) {
+                // The mana ability's effect paused for a decision (e.g. choosing colors for
+                // "add X mana in any combination of colors"). Any triggered ability that fired
+                // from the cost payment (e.g. the source's dies trigger when sacrificed —
+                // Wizard's Rockets: "When this artifact is put into a graveyard..., draw a card")
+                // must survive that pause. Queue it as a PendingTriggersContinuation beneath the
+                // in-flight decision so it's put on the stack once the ability finishes resolving
+                // (mirrors PassPriorityHandler / SubmitDecisionHandler mid-resolution handling).
+                val deferred = triggerDetector.detectTriggers(effectResult.state, costPaymentEvents)
+                if (deferred.isNotEmpty()) {
+                    val pending = com.wingedsheep.engine.core.PendingTriggersContinuation(
+                        decisionId = "mana-ability-cost-triggers-${java.util.UUID.randomUUID()}",
+                        remainingTriggers = deferred
+                    )
+                    val stack = effectResult.state.continuationStack
+                    val newStack = if (stack.isNotEmpty()) {
+                        stack.dropLast(1) + pending + stack.last()
+                    } else {
+                        listOf(pending)
+                    }
+                    return ExecutionResult.paused(
+                        effectResult.state.copy(continuationStack = newStack),
+                        effectResult.pendingDecision!!,
+                        events + effectResult.events
+                    )
+                }
+                return effectResult
+            }
             if (!effectResult.isSuccess) {
                 return effectResult
             }
@@ -988,7 +1027,29 @@ class ActivateAbilityHandler(
             // fixed/mirror bonuses above these need a per-tap color choice, so this may pause for a
             // color decision (resuming via ChooseAnyColorTapBonusContinuation).
             val anyColorBonuses = tappedForManaBonusResolver.collect(currentState, action.sourceId, action.playerId)
-            return tappedForManaBonusResolver.drive(currentState, anyColorBonuses, allManaEvents)
+            val bonusResult = tappedForManaBonusResolver.drive(currentState, anyColorBonuses, allManaEvents)
+            if (bonusResult.isPaused) return bonusResult
+
+            // Detect and queue any triggered abilities from the cost payment — e.g. the
+            // dies/leaves-the-battlefield trigger of a source sacrificed to pay a mana ability.
+            // Such triggered abilities still use the stack even though the mana ability itself
+            // resolves off it (mirrors the non-mana path below).
+            val costTriggers = triggerDetector.detectTriggers(bonusResult.newState, costPaymentEvents)
+            if (costTriggers.isNotEmpty()) {
+                val triggerResult = triggerProcessor.processTriggers(bonusResult.newState, costTriggers)
+                if (triggerResult.isPaused) {
+                    return ExecutionResult.paused(
+                        triggerResult.state.withPriority(action.playerId),
+                        triggerResult.pendingDecision!!,
+                        bonusResult.events + triggerResult.events
+                    )
+                }
+                return ExecutionResult.success(
+                    triggerResult.newState.withPriority(action.playerId),
+                    bonusResult.events + triggerResult.events
+                )
+            }
+            return bonusResult
         }
 
         // Non-mana abilities go on the stack

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsRocketsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsRocketsScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Wizard's Rockets (LTR #252) — Artifact.
+ *
+ * "{X}, {T}, Sacrifice this artifact: Add X mana in any combination of colors.
+ *  When this artifact is put into a graveyard from the battlefield, draw a card."
+ *
+ * The mana ability resolves off the stack, but sacrificing the source to pay its cost fires
+ * the dies/leaves-the-battlefield triggered ability ("draw a card"), which still uses the stack.
+ *
+ * Regressions covered:
+ *  1. ActivateAbilityHandler's mana-ability path returned early without ever running trigger
+ *     detection on the cost-payment events, so the sacrifice's draw trigger was dropped on the
+ *     floor — including when the mana effect itself paused for a color choice.
+ *  2. The mana-ability effect context passed `xValue = null`, so `DynamicAmount.XValue` resolved
+ *     to 0 and the ability produced no mana regardless of X.
+ */
+class WizardsRocketsScenarioTest : ScenarioTestBase() {
+
+    private val manaAbilityId = cardRegistry.getCard("Wizard's Rockets")!!.activatedAbilities[0].id
+
+    init {
+        context("Wizard's Rockets sacrifice-as-mana-ability-cost draw trigger") {
+
+            test("activating the mana ability (sacrificing the artifact) draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wizard's Rockets", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rockets = game.findPermanent("Wizard's Rockets")!!
+
+                withClue("Hand starts empty") { game.handSize(1) shouldBe 0 }
+
+                // X = 0 keeps the test free of mana sources — the sacrifice (and its trigger)
+                // happens regardless of how much mana is produced.
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rockets,
+                        abilityId = manaAbilityId,
+                        xValue = 0
+                    )
+                )
+                withClue("Activating the mana ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+
+                withClue("Wizard's Rockets should be in the graveyard after being sacrificed") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD))
+                        .contains(rockets) shouldBe true
+                }
+
+                // "Add X mana in any combination of colors" pauses the mana ability for a color
+                // choice. The dies trigger must survive that pause (queued beneath the decision).
+                if (game.hasPendingDecision()) {
+                    game.submitDecision(ColorChosenResponse(game.getPendingDecision()!!.id, Color.RED))
+                }
+
+                // The draw trigger went on the stack; resolve it.
+                game.resolveStack()
+
+                withClue("The draw-a-card death trigger should have drawn a card") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("paying X=2 adds two mana and still draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wizard's Rockets", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rockets = game.findPermanent("Wizard's Rockets")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rockets,
+                        abilityId = manaAbilityId,
+                        xValue = 2
+                    )
+                )
+                withClue("Activating with X=2 should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+
+                // Choose the color for the X mana produced.
+                if (game.hasPendingDecision()) {
+                    game.submitDecision(ColorChosenResponse(game.getPendingDecision()!!.id, Color.RED))
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Wizard's Rockets should add X=2 mana of the chosen color") {
+                    pool?.red shouldBe 2
+                }
+
+                game.resolveStack()
+
+                withClue("The sacrifice's draw trigger still fires when X mana is produced") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bugs

Reported: sacrificing **Wizard's Rockets** (LTR #252) doesn't draw a card. Investigating the same activation surfaced two more bugs, and the follow-up ask ("any combination of colors per-mana split") a fourth.

> `{X}, {T}, Sacrifice this artifact: Add X mana in any combination of colors.`
> `When this artifact is put into a graveyard from the battlefield, draw a card.`

### 1. Dropped draw trigger
`ActivateAbilityHandler`'s mana-ability path resolves off the stack and `return`ed early without running trigger detection on the cost-payment events (unlike the non-mana path). Sacrificing the source to pay the cost fires its dies trigger, but it was never queued — worst of all when the mana effect pauses for a color choice.

**Fix:** detect cost-payment triggers in the mana path — synchronously when the effect resolves, and deferred as a `PendingTriggersContinuation` at the bottom of the continuation stack when the effect pauses (so it's put on the stack after the whole ability — including a multi-pip combination — resolves).

### 2. Zero mana
The mana-ability effect context passed `xValue = null`, so `DynamicAmount.XValue` resolved to 0 and the ability produced no mana regardless of X. **Fix:** thread `action.xValue`.

### 3 & 4. "Any combination of colors" was a single chosen color
"Add N mana **in any combination of colors**" should let the player color each mana independently (X=3 → `{W}{U}{R}`) — distinct from "N mana of any **one** color" (Gilded Lotus). The engine already had the correct primitive (`AddDynamicManaEffect` via `Effects.AddManaInAnyCombination`, which prompts pip-by-pip), but three cards were authored against `AddAnyColorMana` (one color × N) and could only make a monochrome pile:

- **Wizard's Rockets** (LTR), **Thornvault Forager** (BLB), **Flamebraider** (ECL)

**Fix:** point all three at `Effects.AddManaInAnyCombination`. This also removes the old quirk where X=0 still prompted for a color (the combination executor adds nothing and asks nothing at N≤0).

## Tests

`WizardsRocketsScenarioTest`: draw via paused color choice (X=0); X=2 colored independently → 1 R + 1 B (true combination); X=2 → two of one color; X=2 mana + draw together. Re-blesses LTR/BLB/ECL card snapshots. Full `:mtg-sets`, `:rules-engine`, `:game-server`, `:mtgish-tooling` suites pass.

No new SDK vocabulary — mtgish coverage unaffected. SDK reference updated to document the one-color vs combination distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)