### PR TITLE
Structural card linter (sdk-analysis §1.1): CardLinter + corpus-wide CardLintTest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,11 @@ continuations, layer system, mana, priority): [`docs/architecture-principles.md`
   compiled JSON tree against a committed golden per set, so any SDK change shows up as a reviewable
   per-card diff across the whole corpus. After an *intentional* change, re-bless with
   `./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true`.
+- **Card lint net** — `CardLintTest` (in `mtg-sets`) runs `CardLinter` over every registered card:
+  pipeline-variable reads must have writers in scope, `ContextTarget`/`BoundVariable` must resolve
+  against the owning ability's requirements, choice-slot reads need declarations. A new SDK type
+  that reads/writes a named pipeline variable must be classified in `CardLinter.dataflowFields`
+  (the hygiene check fails otherwise). See `card-sdk-language-reference.md` §21.
 - **E2E tests** — Playwright in `e2e-scenarios/`, run against full stack. Patterns, scenario config, and `GamePage`
   helper reference: [`docs/e2e-test-patterns.md`](docs/e2e-test-patterns.md).
 - **Manual self-play** — drive a full game over the gym server's HTTP step loop to shake out new-set cards that

--- a/backlog/sdk-analysis-2026-06-revised.md
+++ b/backlog/sdk-analysis-2026-06-revised.md
@@ -48,7 +48,18 @@ and several items below are "apply that pattern to another contract."
 These are cheap, card-migration-free, and they're what makes every collapse in §3 safe. Highest ROI
 in the document.
 
-### 1.1 Card linter — grow `CardValidator` into structural validation — [HIGH]
+### 1.1 Card linter — grow `CardValidator` into structural validation — [HIGH] — ✅ DONE
+
+> Landed as `CardLinter` (mtg-sdk) + corpus gate `CardLintTest` (mtg-sets) with a burn-downable
+> `lint-allowlist.txt`. Took the stale-proof JSON-tree route; abilities are detected structurally
+> (no `type` discriminator + `effect` + trigger/cost/target member), and two registry-hygiene
+> checks keep the dataflow vocabulary honest (the executor-coverage pattern). Checks: pipeline
+> reads have in-scope writers (typo = error, cross-resolution = warning), orphan stores,
+> `ContextTarget`/`BoundVariable` per owning ability (count-expanded slots; modes, reflexive
+> triggers, delayed triggers, granted abilities all scoped), `ChoiceSlot` reads vs declarations,
+> `SourceChosenModeIs` mode ids. First corpus run: 48 errors → triaged to **one real shipped bug**
+> (Atmospheric Greenhouse's ETB was a silent no-op — `ContextTarget(0)` inside `ForEachInGroup`),
+> the rest were linter/registry gaps, fixed; corpus is now 0-error with 13 review-level warnings.
 
 **Problem.** `CardValidator` checks creature stats, target-index bounds, aura/equipment consistency,
 planeswalker loyalty — and nothing else. Not validated: pipeline variable references

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3304,6 +3304,43 @@ Card authors rarely reference these directly; they are created/updated by the ma
 - Server is authoritative; never compute legal actions in the client. Every state change emits a `GameEvent` so triggers
   and animations can react.
 
+## 21. Structural lint (`CardLinter`)
+
+Every registered card is structurally validated at build time: `CardValidator.validate` runs
+`CardLinter` (mtg-sdk `serialization/CardLinter.kt`), and the corpus-wide gate is
+`CardLintTest` in mtg-sets (beside `CardDefinitionSnapshotTest`). The linter walks the card's
+serialized JSON tree, so every container — composites, gates, modes, granted abilities, class
+levels, saga chapters, faces — is covered automatically. What it checks:
+
+- **Pipeline dataflow** — every read of a named pipeline variable (`MoveCollection.from`,
+  `CardSource.FromVariable`, `VariableReference`, `CollectionContainsMatch`, `chosenSubtypeKey`,
+  …) must have a writer (`storeAs` / `storeSelected` / `storeMatching` / `StoreNumber` /
+  `ChooseOption` / a cast-time additional cost, …) in the same resolution scope. A read written
+  *nowhere* on the card is an **error** (typo → silent no-op); read-before-write and
+  cross-resolution reads are warnings, as are stores nothing reads. A collection write `x`
+  also satisfies the numeric read `x_count`.
+- **Target bindings per owning ability** — `ContextTarget(i)` must fit the owning ability's
+  flattened target slots (a `count = 2` requirement spans two indices); `BoundVariable(name)`
+  must match a requirement `id` (indexed form `id[i]` allowed). Modes inherit the card-level
+  requirements unless they declare their own; `ReflexiveTriggerEffect.reflexiveEffect` resolves
+  against `reflexiveTargetRequirements`; `CreateDelayedTriggerEffect.effect` against its
+  `targetRequirement`; granted/token abilities against their own requirements only.
+- **Choice slots** — a `ChoiceSlot` read (`CastChoiceMade`, `DynamicAmount.CastChoice`,
+  `HasChosenColor`, `SourceChosenModeIs`, …) needs a declarer on the card (`EntersWithChoice`,
+  kicker, blight, sneak, `ChooseColorThen`/`ChooseColorForTarget`); `SourceChosenModeIs` ids
+  must match a declared `modeOptions` id.
+- **Registry hygiene** — a string field whose name follows the dataflow conventions (`store*`,
+  `from`, `collectionName`, `variableName`, …) on a node type the linter doesn't know is itself
+  an error: **when you add an SDK type that reads or writes a named pipeline variable, classify
+  it in `CardLinter.dataflowFields` in the same change** (and name the field conventionally so
+  the hygiene net sees it).
+
+Intentional exceptions go in `mtg-sets/src/test/resources/lint-allowlist.txt`
+(`ErrorType|Card Name`, stale entries fail). Inside `ForEachInGroup` / `ForEachInCollection`,
+address the iterated entity with `EffectTarget.Self` — `ContextTarget(0)` reads the cast-time
+target list, which is unrelated to the iteration (this exact bug shipped on a real card before
+the linter).
+
 ---
 
 ## Authoritative source files

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -1,0 +1,812 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.model.CardDefinition
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Structural lint for card definitions (sdk-analysis §1.1): catches the "silent no-op" bug class
+ * where a name-based reference — a pipeline collection, a stored number, a chosen value, a
+ * cast-time target binding, a [com.wingedsheep.sdk.scripting.ChoiceSlot] — doesn't resolve to
+ * anything because of a typo, a missing writer, or a reference into the wrong ability's scope.
+ *
+ * ## How it works
+ *
+ * The card is serialized to its JSON tree (the same machinery as the snapshot test) and the lint
+ * walks that tree, so every effect container — composites, gates, modes, granted abilities, class
+ * levels, saga chapters, card faces — is covered automatically, including containers added after
+ * this linter was written. Two registries supply the semantics the tree alone doesn't carry:
+ *
+ * - [dataflowFields]: which `(type, field)` pairs *write* a named pipeline variable
+ *   (`GatherCards.storeAs`) and which *read* one (`MoveCollection.from`), per namespace
+ *   (collections / numbers / chosen values / string lists / subtype groups / cast flags).
+ * - Slot readers/declarers: which node types read a [com.wingedsheep.sdk.scripting.ChoiceSlot]
+ *   (`CastChoiceMade`, `HasChosenColor`, …) and which declare one (`EntersWithChoice`, kicker,
+ *   blight, sneak).
+ *
+ * Both registries are kept honest by hygiene checks that run on every card: a string field whose
+ * *name* looks like a dataflow reference (`storeAs`, `from`, `collectionName`, …) but whose
+ * `(type, field)` is not classified fails with [CardValidationError.UnclassifiedDataflowField] —
+ * the same "classify it or the build breaks" contract as the executor-coverage test.
+ *
+ * ## Scopes
+ *
+ * Pipeline variables live in an `EffectContext`, which exists per resolution. Each top-level
+ * effect tree (the spell effect, each triggered/activated ability, each saga chapter) is its own
+ * scope; abilities nested inside effects (granted triggered/activated abilities, token abilities)
+ * start fresh scopes because they resolve later with a fresh context. Nested scopes are detected
+ * *structurally*: a JSON object without a polymorphic `type` discriminator that has an `effect`
+ * member plus a `trigger` / `cost` / target-requirement member is an ability. Modal `Mode`s are
+ * target-scopes only — their effects share the parent resolution's collections, but their
+ * `ContextTarget` indices are sliced per mode.
+ *
+ * Severities: a read whose name is written *nowhere* on the card is an [LintSeverity.ERROR]
+ * (it can only be a typo); a read satisfied only later in the same scope or only in a different
+ * scope is a [LintSeverity.WARNING] (cross-trigger flows are legal but worth eyeballing), as are
+ * writes that are never read.
+ */
+object CardLinter {
+
+    /**
+     * JSON encoder with defaults materialized: a defaulted writer (`ChooseOption.storeAs =
+     * "chosenOption"`) must still connect to an explicit reader of that name, and vice versa.
+     * [CardSerialization.json] encodes with `encodeDefaults = false`, which would hide them.
+     */
+    private val lintJson = Json(from = CardSerialization.json) { encodeDefaults = true }
+
+    fun lint(card: CardDefinition): List<CardValidationError> {
+        val findings = mutableListOf<CardValidationError>()
+        val fullTree = lintJson.encodeToJsonElement(CardDefinition.serializer(), card) as JsonObject
+        val explicitTree =
+            CardSerialization.json.encodeToJsonElement(CardDefinition.serializer(), card) as JsonObject
+
+        // Choice slots persist on the physical card (a DFC's back face reads what the front
+        // declared), so declarations and reads are collected across all faces before any check.
+        val slots = SlotUsage()
+        collectSlots(fullTree, slots)
+
+        lintDefinition(card.name, fullTree, explicitTree, slots, findings)
+        checkSlots(card.name, slots, findings)
+        return findings
+    }
+
+    // =========================================================================================
+    // Namespaces and registries
+    // =========================================================================================
+
+    internal enum class Space(val displayName: String) {
+        COLLECTION("collection"),
+        NUMBER("stored number"),
+        CHOSEN("chosen value"),
+        STRING_LIST("stored string list"),
+        SUBTYPE_GROUPS("stored subtype groups"),
+        CAST_FLAG("cast-time flag"),
+    }
+
+    private enum class Kind { READ, WRITE, IGNORE }
+
+    private data class Classification(val kind: Kind, val space: Space)
+
+    private fun read(space: Space) = Classification(Kind.READ, space)
+    private fun write(space: Space) = Classification(Kind.WRITE, space)
+    private val ignored = Classification(Kind.IGNORE, Space.COLLECTION)
+
+    /**
+     * `(type discriminator | null, field name)` → how that field participates in dataflow.
+     * A `null` type matches any node (for fields on non-polymorphic classes, which carry no
+     * discriminator — e.g. `CastTimeCapture.flag`, `GroupFilter.chosenSubtypeKey`). Type-keyed
+     * entries win over field-keyed ones.
+     */
+    private val dataflowFields: Map<Pair<String?, String>, Classification> = buildMap {
+        // --- Writers -------------------------------------------------------------------------
+        put("GatherCards" to "storeAs", write(Space.COLLECTION))
+        put("CaptureControllers" to "storeAs", write(Space.COLLECTION))
+        put("GatherSubtypes" to "storeAs", write(Space.SUBTYPE_GROUPS))
+        put("GatherUntilMatch" to "storeMatch", write(Space.COLLECTION))
+        put("GatherUntilMatch" to "storeRevealed", write(Space.COLLECTION))
+        put("SelectFromCollection" to "storeSelected", write(Space.COLLECTION))
+        put("SelectFromCollection" to "storeRemainder", write(Space.COLLECTION))
+        put("ChoosePile" to "storeChosenAs", write(Space.COLLECTION))
+        put("ChoosePile" to "storeOtherAs", write(Space.COLLECTION))
+        put("MoveCollection" to "storeMovedAs", write(Space.COLLECTION))
+        put("SelectTarget" to "storeAs", write(Space.COLLECTION))
+        put("FilterCollection" to "storeMatching", write(Space.COLLECTION))
+        put("FilterCollection" to "storeNonMatching", write(Space.COLLECTION))
+        put("ExileLibraryUntilManaValue" to "storeAs", write(Space.COLLECTION))
+        put("CopyCardIntoCollection" to "storeAs", write(Space.COLLECTION))
+        put("CounterAllOnStack" to "storeCountAs", write(Space.COLLECTION))
+        put("Behold" to "storeAs", write(Space.COLLECTION))
+        put("BeholdOrPay" to "storeAs", write(Space.COLLECTION))
+        put("ChooseEntity" to "storeAs", write(Space.COLLECTION))
+        put("StoreNumber" to "name", write(Space.NUMBER))
+        put("ForEachCapturedController" to "countVariable", write(Space.NUMBER))
+        put("DrawUpTo" to "storeNotDrawnAs", write(Space.NUMBER))
+        put("ChooseOption" to "storeAs", write(Space.CHOSEN))
+        put("NoteCreatureType" to "storeAs", write(Space.CHOSEN))
+        put("StoreCardName" to "storeAs", write(Space.CHOSEN))
+        put("EachPlayerChoosesCreatureType" to "storeAs", write(Space.STRING_LIST))
+        put(null to "flag", write(Space.CAST_FLAG)) // CastTimeCapture (no discriminator)
+
+        // --- Readers -------------------------------------------------------------------------
+        for (type in listOf(
+            "CaptureControllers", "GatherSubtypes", "RevealCollection", "SelectFromCollection",
+            "ChoosePile", "MoveCollection", "GrantMayPlayFromExile", "GrantPlayWithoutPayingCost",
+            "GrantPlayWithAdditionalCost", "GrantPlayWithCostIncrease", "FilterCollection",
+            "StoreCardName", "CastFromCollectionWithoutPayingCost",
+            "CastAnyNumberFromCollectionWithoutPayingCost", "ExileFromStorage",
+        )) put(type to "from", read(Space.COLLECTION))
+        put("ChoosePile" to "pileA", read(Space.COLLECTION))
+        put("ChoosePile" to "pileB", read(Space.COLLECTION))
+        put("ForEachCapturedController" to "collection", read(Space.COLLECTION))
+        put("ForEachCapturedController" to "originalCollection", read(Space.COLLECTION))
+        put("ForEachCapturedController" to "controllerSnapshot", read(Space.COLLECTION))
+        put("ForEachInCollection" to "collection", read(Space.COLLECTION))
+        put("ConditionalOnCollection" to "collection", read(Space.COLLECTION))
+        put("CollectionContainsMatch" to "collection", read(Space.COLLECTION))
+        put("SuccessCriterion.CollectionNonEmpty" to "name", read(Space.COLLECTION))
+        put("FromVariable" to "variableName", read(Space.COLLECTION))
+        put("PipelineTarget" to "collectionName", read(Space.COLLECTION))
+        put("ControllerOfPipelineTarget" to "collectionName", read(Space.COLLECTION))
+        put("StoredCardManaValue" to "collectionName", read(Space.COLLECTION))
+        put("FromCostStorage" to "collectionName", read(Space.COLLECTION))
+        put("RetargetChooser.OwnerOfStored" to "collectionName", read(Space.COLLECTION))
+        put("TapUntapCollection" to "collectionName", read(Space.COLLECTION))
+        put("AddCountersToCollection" to "collectionName", read(Space.COLLECTION))
+        put("DealDamagePerEntityInZone" to "collectionName", read(Space.COLLECTION))
+        put("DistinctEntitiesInCollections" to "collections", read(Space.COLLECTION))
+        put("ExcludeOtherCollection" to "otherCollectionName", read(Space.COLLECTION))
+        put("VariableReference" to "variableName", read(Space.NUMBER))
+        put("NameEqualsChosen" to "variableName", read(Space.CHOSEN))
+        put("HasSubtypeFromVariable" to "variableName", read(Space.CHOSEN))
+        put("YouControlMostOfChosenType" to "chosenValueKey", read(Space.CHOSEN))
+        put(null to "chosenSubtypeKey", read(Space.CHOSEN)) // GroupFilter (no discriminator)
+        put("HasSubtypeInStoredList" to "listName", read(Space.STRING_LIST))
+        put("ExcludeSubtypesFromStored" to "storedKey", read(Space.STRING_LIST))
+        put("HasSubtypeInEachStoredGroup" to "groupName", read(Space.SUBTYPE_GROUPS))
+        put("CastTimeFlagSet" to "flag", read(Space.CAST_FLAG))
+        // "becomes the chosen type/color" effects reading a ChooseOption result.
+        for (type in listOf("SetCreatureSubtypes", "AddCreatureType", "AddSubtype", "SetLandType")) {
+            put(type to "fromChosenValueKey", read(Space.CHOSEN))
+        }
+    }
+
+    /**
+     * Field names that *look like* dataflow references. A string-valued field with one of these
+     * names on a node whose `(type, field)` is not in [dataflowFields] is a hygiene error: either
+     * classify it (READ/WRITE) or list it as IGNORE. Deliberately narrow — generic names (`name`,
+     * `key`, `id`) are classified per-type only.
+     */
+    private val candidateFieldNames = setOf(
+        "from", "collection", "collectionName", "collections", "originalCollection",
+        "controllerSnapshot", "pileA", "pileB", "variableName", "otherCollectionName",
+        "storedKey", "groupName", "listName", "chosenValueKey", "chosenSubtypeKey",
+        "countVariable", "flag",
+    )
+
+    private fun isStoreField(field: String) =
+        field == "storeAs" || (field.startsWith("store") && field.length > 5 && field[5].isUpperCase())
+
+    /** Known non-dataflow uses of candidate names — `(type, field)` pairs that are fine as-is. */
+    private val hygieneExempt: Set<Pair<String, String>> = setOf(
+        // EventPattern zone fields ("from"/"to" zones on zone-change triggers) are Zone enums.
+        "ZoneChangeEvent" to "from",
+    )
+
+    /** Implicit accesses keyed by node type — participation not visible as a string field. */
+    private fun implicitAccesses(type: String?, obj: JsonObject): List<Pair<Kind, Pair<Space, String>>> =
+        when {
+            type == "ChooseCreatureType" ->
+                listOf(Kind.WRITE to (Space.CHOSEN to "chosenCreatureType"))
+            type == "SelectFromCollection" &&
+                (obj["matchChosenCreatureType"] as? JsonPrimitive)?.contentOrNull == "true" ->
+                listOf(Kind.READ to (Space.CHOSEN to "chosenCreatureType"))
+            // Token executors publish the created tokens' ids under this well-known name so
+            // sibling steps can address them via PipelineTarget(CREATED_TOKENS, i).
+            type == "CreateToken" || type == "CreatePredefinedToken" ->
+                listOf(Kind.WRITE to (Space.COLLECTION to "createdTokens"))
+            else -> emptyList()
+        }
+
+    // =========================================================================================
+    // Choice slots
+    // =========================================================================================
+
+    /** Node types that declare a slot just by being present. */
+    private val slotDeclarers: Map<String, String> = mapOf(
+        "Kicker" to "KICKED",
+        "Sneak" to "SNEAK",
+        "BlightVariable" to "BLIGHT_AMOUNT",
+        "BlightOrPay" to "BLIGHT_AMOUNT",
+        // Resolution-time color choices: ChooseColorThen sets EffectContext.chosenColor for its
+        // wrapped effect; ChooseColorForTarget stamps a ChosenColorComponent on the permanent.
+        // Both are what HasChosenColor / GrantChosenColor-style readers consume.
+        "ChooseColorThen" to "COLOR",
+        "ChooseColorForTarget" to "COLOR",
+    )
+
+    /** [com.wingedsheep.sdk.scripting.ReplacementEffect] `EntersWithChoice.choiceType` → slot. */
+    private val choiceTypeToSlot: Map<String, String> = mapOf(
+        "COLOR" to "COLOR",
+        "CREATURE_TYPE" to "CREATURE_TYPE",
+        "BASIC_LAND_TYPE" to "LAND_TYPE",
+        "MODE" to "MODE",
+        "CREATURE_ON_BATTLEFIELD" to "CREATURE",
+        "OPPONENT" to "OPPONENT",
+    )
+
+    /** Node types that read a slot without naming it in a field. */
+    private val slotReaders: Map<String, String> = mapOf(
+        "ChosenOpponent" to "OPPONENT",
+        "ChosenCreature" to "CREATURE",
+        "HasChosenColor" to "COLOR",
+        "SharesChosenColorWithSource" to "COLOR",
+        "GrantChosenColor" to "COLOR",
+        "GrantProtectionFromChosenColorToGroup" to "COLOR",
+        "GrantLandwalkOfChosenType" to "LAND_TYPE",
+        "NotOfSourceChosenType" to "CREATURE_TYPE",
+        "SneakCostWasPaid" to "SNEAK",
+        "SourceChosenModeIs" to "MODE",
+    )
+
+    /** Node types whose `slot` field names the slot they read. */
+    private val slotFieldReaders = setOf("CastChoice", "CastChoiceMade", "CastChoiceIs")
+
+    private class SlotUsage {
+        val declared = mutableSetOf<String>()
+        val declaredModeIds = mutableSetOf<String>()
+        val reads = mutableListOf<Pair<String, String>>() // slot to nodeType
+        val modeIdReads = mutableListOf<String>()
+    }
+
+    /** One pass over the whole card (all faces) collecting slot declarations and reads. */
+    private fun collectSlots(element: JsonElement, slots: SlotUsage) {
+        when (element) {
+            is JsonObject -> {
+                val type = element.typeName()
+                slotDeclarers[type]?.let { slots.declared.add(it) }
+                if (type == "EntersWithChoice") {
+                    val choiceType = (element["choiceType"] as? JsonPrimitive)?.contentOrNull
+                    choiceTypeToSlot[choiceType]?.let { slots.declared.add(it) }
+                    (element["modeOptions"] as? JsonArray)?.forEach { option ->
+                        ((option as? JsonObject)?.get("id") as? JsonPrimitive)?.contentOrNull
+                            ?.let { slots.declaredModeIds.add(it) }
+                    }
+                }
+                slotReaders[type]?.let { slots.reads.add(it to type.orEmpty()) }
+                if (type in slotFieldReaders) {
+                    (element["slot"] as? JsonPrimitive)?.contentOrNull
+                        ?.let { slots.reads.add(it to type.orEmpty()) }
+                }
+                if (type == "SourceChosenModeIs") {
+                    (element["modeId"] as? JsonPrimitive)?.contentOrNull
+                        ?.let { slots.modeIdReads.add(it) }
+                }
+                // A kicked resolution implies the KICKED slot even without the keyword object.
+                if (element["kickerSpellEffect"] != null && element["kickerSpellEffect"] !is JsonNull) {
+                    slots.declared.add("KICKED")
+                }
+                element.values.forEach { collectSlots(it, slots) }
+            }
+            is JsonArray -> element.forEach { collectSlots(it, slots) }
+            else -> {}
+        }
+    }
+
+    // =========================================================================================
+    // Scopes
+    // =========================================================================================
+
+    private data class Access(
+        val pos: Int,
+        val space: Space,
+        val name: String,
+        val nodeType: String?,
+        val field: String,
+    )
+
+    private data class TargetRef(
+        val nodeType: String,
+        val index: Int?, // ContextTarget / EntityReference.Target
+        val boundName: String?, // BoundVariable
+    )
+
+    private class Scope(
+        val label: String,
+        val targetCount: Int,
+        val targetIds: Set<String>,
+        /** Non-null for Mode scopes: collections resolve against this enclosing scope. */
+        val collectionParent: Scope?,
+    ) {
+        val reads = mutableListOf<Access>()
+        val writes = mutableListOf<Access>()
+        val targetRefs = mutableListOf<TargetRef>()
+
+        /** The scope whose pipeline context this scope's collection accesses belong to. */
+        val collectionScope: Scope get() = collectionParent?.collectionScope ?: this
+    }
+
+    private class LintState(val cardName: String, val findings: MutableList<CardValidationError>) {
+        var pos = 0
+        val scopes = mutableListOf<Scope>()
+
+        fun newScope(
+            label: String,
+            targetCount: Int = 0,
+            targetIds: Set<String> = emptySet(),
+            collectionParent: Scope? = null,
+        ): Scope = Scope(label, targetCount, targetIds, collectionParent).also { scopes.add(it) }
+    }
+
+    // =========================================================================================
+    // Definition walk
+    // =========================================================================================
+
+    private fun lintDefinition(
+        cardName: String,
+        defObj: JsonObject,
+        explicitDefObj: JsonObject?,
+        slots: SlotUsage,
+        findings: MutableList<CardValidationError>,
+    ) {
+        val state = LintState(cardName, findings)
+        walkDefinitionScopes(defObj, state)
+        checkDataflow(state, explicitDefObj, slots)
+        checkTargets(state)
+
+        // Faces are separate lint units: their scripts resolve in their own resolutions.
+        (defObj["backFace"] as? JsonObject)?.let { back ->
+            lintDefinition(
+                "$cardName (back face)",
+                back,
+                explicitDefObj?.get("backFace") as? JsonObject,
+                slots,
+                findings,
+            )
+        }
+        (defObj["cardFaces"] as? JsonArray)?.forEachIndexed { i, face ->
+            val faceObj = face as? JsonObject ?: return@forEachIndexed
+            val explicitFace = (explicitDefObj?.get("cardFaces") as? JsonArray)?.getOrNull(i) as? JsonObject
+            // CardFace wraps its behavior in a `script`; reuse the definition walk on a
+            // synthetic object so the same scope assembly applies.
+            lintDefinition(
+                "$cardName (face ${i + 1})",
+                JsonObject(faceObj.filterKeys { it == "script" || it == "keywordAbilities" }),
+                explicitFace?.let { JsonObject(it.filterKeys { k -> k == "script" || k == "keywordAbilities" }) },
+                slots,
+                findings,
+            )
+        }
+    }
+
+    /** Assembles the top-level scopes for one definition (card or face). */
+    private fun walkDefinitionScopes(defObj: JsonObject, state: LintState) {
+        val script = defObj["script"] as? JsonObject ?: return
+
+        val baseReqs = script["targetRequirements"] as? JsonArray ?: JsonArray(emptyList())
+        val kickerReqs = script["kickerTargetRequirements"] as? JsonArray ?: JsonArray(emptyList())
+        val spellScope = state.newScope(
+            label = "spell effect",
+            targetCount = maxOf(requirementSlotCount(baseReqs), requirementSlotCount(kickerReqs)),
+            targetIds = requirementIds(baseReqs) + requirementIds(kickerReqs),
+        )
+
+        // Spell-resolution scope, in execution order: cast-time writers (captures, additional
+        // costs, alternative-cost riders) come before the spell effect that reads them.
+        val abilityListFields = setOf(
+            "triggeredAbilities", "stateTriggeredAbilities", "activatedAbilities",
+            "staticAbilities", "replacementEffects", "sagaChapters", "classLevels",
+        )
+        val orderedSpellFields = listOf("castTimeCaptures", "additionalCosts", "selfAlternativeCost")
+        val deferredSpellFields = listOf("spellEffect", "kickerSpellEffect")
+
+        // A declared cast-time creature-type choice writes the chosen type before resolution.
+        if (script["castTimeCreatureTypeChoice"]?.takeIf { it !is JsonNull } != null) {
+            spellScope.writes.add(
+                Access(state.pos++, Space.CHOSEN, "chosenCreatureType", null, "castTimeCreatureTypeChoice")
+            )
+        }
+        defObj["keywordAbilities"]?.let { walk(it, spellScope, state) }
+        for (field in orderedSpellFields) script[field]?.let { walk(it, spellScope, state) }
+        for ((field, value) in script) {
+            if (field in abilityListFields || field in orderedSpellFields || field in deferredSpellFields) continue
+            walk(value, spellScope, state)
+        }
+        for (field in deferredSpellFields) script[field]?.let { walk(it, spellScope, state) }
+
+        // Each ability is its own resolution.
+        (script["triggeredAbilities"] as? JsonArray)?.forEachIndexed { i, ability ->
+            walkAbilityScope(ability, "triggered ability ${i + 1}", state)
+        }
+        (script["stateTriggeredAbilities"] as? JsonArray)?.forEachIndexed { i, ability ->
+            walkAbilityScope(ability, "state-triggered ability ${i + 1}", state)
+        }
+        (script["activatedAbilities"] as? JsonArray)?.forEachIndexed { i, ability ->
+            walkAbilityScope(ability, "activated ability ${i + 1}", state)
+        }
+        (script["sagaChapters"] as? JsonArray)?.forEachIndexed { i, chapter ->
+            walkAbilityScope(chapter, "saga chapter ${i + 1}", state)
+        }
+        (script["staticAbilities"] as? JsonArray)?.forEachIndexed { i, ability ->
+            walkInto(ability, state.newScope("static ability ${i + 1}"), state)
+        }
+        (script["replacementEffects"] as? JsonArray)?.forEachIndexed { i, replacement ->
+            walkInto(replacement, state.newScope("replacement effect ${i + 1}"), state)
+        }
+        (script["classLevels"] as? JsonArray)?.forEachIndexed { i, level ->
+            // The level object itself is just a holder; its nested ability objects are
+            // ability-shaped and start their own scopes via the structural rule.
+            walkInto(level, state.newScope("class level ${i + 1}"), state)
+        }
+    }
+
+    /** Starts a scope for an ability-shaped object and walks its members. */
+    private fun walkAbilityScope(
+        element: JsonElement,
+        label: String,
+        state: LintState,
+        collectionParent: Scope? = null,
+    ) {
+        val obj = element as? JsonObject ?: return
+        val reqs = JsonArray(
+            listOfNotNull(obj["targetRequirement"]?.takeIf { it !is JsonNull }) +
+                (obj["targetRequirements"] as? JsonArray ?: emptyList()) +
+                (obj["additionalTargetRequirements"] as? JsonArray ?: emptyList())
+        )
+        // A Mode with no target requirements of its own indexes into the card-level
+        // requirements (the engine slices the flat target list per mode only when modes
+        // declare their own).
+        val scope = if (reqs.isEmpty() && collectionParent != null) {
+            state.newScope(label, collectionParent.targetCount, collectionParent.targetIds, collectionParent)
+        } else {
+            state.newScope(label, requirementSlotCount(reqs), requirementIds(reqs), collectionParent)
+        }
+        walkInto(obj, scope, state)
+    }
+
+    private fun requirementIds(reqs: JsonArray): Set<String> =
+        reqs.mapNotNull { ((it as? JsonObject)?.get("id") as? JsonPrimitive)?.contentOrNull }.toSet()
+
+    /**
+     * Number of `ContextTarget` indices a requirement list spans. `ContextTarget(i)` indexes the
+     * *flattened* chosen-target list, so a requirement with `count = 2` ("two target creatures")
+     * contributes two indices; `unlimited` / `dynamicMaxCount` requirements contribute an
+     * unbounded number.
+     */
+    private fun requirementSlotCount(reqs: JsonArray): Int {
+        var total = 0
+        for (req in reqs) {
+            val obj = req as? JsonObject ?: continue
+            val unlimited = (obj["unlimited"] as? JsonPrimitive)?.contentOrNull == "true"
+            val dynamicMax = obj["dynamicMaxCount"]?.takeIf { it !is JsonNull } != null
+            if (unlimited || dynamicMax) return Int.MAX_VALUE
+            total += (obj["count"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull() ?: 1
+        }
+        return total
+    }
+
+    /**
+     * Structural ability detection. Abilities ([com.wingedsheep.sdk.scripting.TriggeredAbility],
+     * [com.wingedsheep.sdk.scripting.ActivatedAbility], modal `Mode`s, saga chapters) are concrete
+     * classes, so unlike effects they serialize *without* a `type` discriminator — an object with
+     * an `effect` member, no `type`, plus a trigger / cost / condition+id / target-requirement
+     * member is an embedded ability wherever it appears (granted abilities, token abilities).
+     */
+    private enum class AbilityShape { FULL, TARGETS_ONLY }
+
+    private fun abilityShape(obj: JsonObject): AbilityShape? {
+        if (obj.containsKey("type") || !obj.containsKey("effect")) return null
+        return when {
+            obj.containsKey("trigger") || obj.containsKey("cost") ||
+                (obj.containsKey("condition") && obj.containsKey("id")) -> AbilityShape.FULL
+            obj.containsKey("targetRequirement") || obj.containsKey("targetRequirements") ->
+                AbilityShape.TARGETS_ONLY
+            else -> null
+        }
+    }
+
+    /** Walks an object's members in declaration order without re-testing the object itself. */
+    private fun walkInto(element: JsonElement, scope: Scope, state: LintState) {
+        val obj = element as? JsonObject ?: return walk(element, scope, state)
+        visitNode(obj, scope, state)
+        obj.values.forEach { walk(it, scope, state) }
+    }
+
+    private fun walk(element: JsonElement, scope: Scope, state: LintState) {
+        when (element) {
+            is JsonObject -> {
+                when (abilityShape(element)) {
+                    AbilityShape.FULL ->
+                        return walkAbilityScope(element, "ability granted by ${scope.label}", state)
+                    AbilityShape.TARGETS_ONLY ->
+                        // A modal Mode: own target slice, parent's pipeline context.
+                        return walkAbilityScope(element, "mode of ${scope.label}", state, collectionParent = scope)
+                    null -> {}
+                }
+                when (element.typeName()) {
+                    "ReflexiveTrigger" -> return walkDeferredEffect(
+                        element, scope, state,
+                        effectField = "reflexiveEffect",
+                        reqFields = listOf("reflexiveTargetRequirements"),
+                        label = "reflexive trigger of ${scope.label}",
+                    )
+                    "CreateDelayedTrigger" -> return walkDeferredEffect(
+                        element, scope, state,
+                        effectField = "effect",
+                        reqFields = listOf("targetRequirement"),
+                        label = "delayed trigger of ${scope.label}",
+                    )
+                }
+                visitNode(element, scope, state)
+                element.values.forEach { walk(it, scope, state) }
+            }
+            is JsonArray -> element.forEach { walk(it, scope, state) }
+            else -> {}
+        }
+    }
+
+    /**
+     * Effects that *defer* a sub-effect into its own future trigger resolution with its own
+     * target requirements: a `ReflexiveTriggerEffect`'s reflexive effect targets via
+     * `reflexiveTargetRequirements` (chosen when the reflexive trigger goes on the stack —
+     * Foray of Orcs et al.), and a `CreateDelayedTriggerEffect`'s effect targets via its
+     * `targetRequirement` (chosen each time the delayed trigger fires — Rediscover the Way).
+     * `ContextTarget` indices inside the deferred effect are scoped to those requirements;
+     * when none are declared, they inherit the outer ability's targets ("exile target card …
+     * when you do, return it"). Pipeline collections flow through — the engine snapshots them
+     * at creation time.
+     */
+    private fun walkDeferredEffect(
+        obj: JsonObject,
+        scope: Scope,
+        state: LintState,
+        effectField: String,
+        reqFields: List<String>,
+        label: String,
+    ) {
+        visitNode(obj, scope, state)
+        for ((field, value) in obj) {
+            if (field == effectField) continue
+            walk(value, scope, state)
+        }
+        val reqs = JsonArray(
+            reqFields.flatMap { field ->
+                when (val value = obj[field]) {
+                    is JsonArray -> value
+                    is JsonObject -> listOf(value)
+                    else -> emptyList()
+                }
+            }
+        )
+        val child = if (reqs.isEmpty()) {
+            state.newScope(label, scope.targetCount, scope.targetIds, scope)
+        } else {
+            state.newScope(label, requirementSlotCount(reqs), requirementIds(reqs), collectionParent = scope)
+        }
+        obj[effectField]?.let { walk(it, child, state) }
+    }
+
+    /** Records this node's dataflow accesses and target references (not its children). */
+    private fun visitNode(obj: JsonObject, scope: Scope, state: LintState) {
+        val type = obj.typeName()
+
+        when (type) {
+            "ContextTarget" -> (obj["index"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+                ?.let { scope.targetRefs.add(TargetRef(type, it, null)) }
+            "Target" -> (obj["index"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+                ?.let { scope.targetRefs.add(TargetRef(type, it, null)) }
+            "BoundVariable" -> (obj["name"] as? JsonPrimitive)?.contentOrNull
+                ?.let { scope.targetRefs.add(TargetRef(type, null, it)) }
+        }
+
+        for ((kind, spaceAndName) in implicitAccesses(type, obj)) {
+            val (space, name) = spaceAndName
+            val access = Access(state.pos++, space, name, type, "(implicit)")
+            if (kind == Kind.READ) scope.collectionScope.reads.add(access)
+            else scope.collectionScope.writes.add(access)
+        }
+
+        for ((field, value) in obj) {
+            val names: List<String> = when {
+                value is JsonPrimitive && value.isString -> listOf(value.content)
+                value is JsonArray && dataflowFields[type to field]?.kind == Kind.READ ->
+                    value.mapNotNull { (it as? JsonPrimitive)?.takeIf(JsonPrimitive::isString)?.content }
+                else -> continue
+            }
+            val classification = dataflowFields[type to field] ?: dataflowFields[null to field]
+            if (classification == null) {
+                val suspicious = field in candidateFieldNames || isStoreField(field)
+                if (suspicious && (type.orEmpty() to field) !in hygieneExempt) {
+                    state.findings.add(
+                        CardValidationError.UnclassifiedDataflowField(
+                            cardName = state.cardName,
+                            message = "'${state.cardName}': field '$field' on node type " +
+                                "'${type ?: "(no discriminator)"}' looks like a pipeline-variable reference " +
+                                "but is not classified in CardLinter.dataflowFields. Classify it as a " +
+                                "READ/WRITE (with its namespace) or list it as a known non-dataflow field.",
+                        )
+                    )
+                }
+                continue
+            }
+            if (classification.kind == Kind.IGNORE) continue
+            for (name in names) {
+                val access = Access(state.pos++, classification.space, name, type, field)
+                if (classification.kind == Kind.READ) scope.collectionScope.reads.add(access)
+                else scope.collectionScope.writes.add(access)
+            }
+        }
+    }
+
+    // =========================================================================================
+    // Checks
+    // =========================================================================================
+
+    /** `x_count` numeric reads are satisfied by a collection write named `x`. */
+    private fun matches(read: Access, write: Access): Boolean {
+        if (write.space == read.space && write.name == read.name) return true
+        return read.space == Space.NUMBER && write.space == Space.COLLECTION &&
+            read.name == "${write.name}_count"
+    }
+
+    private fun checkDataflow(state: LintState, explicitDefObj: JsonObject?, slots: SlotUsage) {
+        val allWrites = state.scopes.flatMap { it.writes }
+
+        /**
+         * The default `chosenCreatureType` key doubles as the read path for the CREATURE_TYPE
+         * choice slot: statics like Cover of Darkness pair `EntersWithChoice(CREATURE_TYPE)` with
+         * a `chosenSubtypeKey = "chosenCreatureType"` group filter, no pipeline write involved.
+         */
+        fun satisfiedBySlot(read: Access): Boolean =
+            read.space == Space.CHOSEN && read.name == "chosenCreatureType" &&
+                "CREATURE_TYPE" in slots.declared
+
+        for (scope in state.scopes) {
+            if (scope.collectionParent != null) continue // merged into parent already
+            for (read in scope.reads) {
+                if (satisfiedBySlot(read)) continue
+                val inScope = scope.writes.filter { matches(read, it) }
+                when {
+                    inScope.any { it.pos <= read.pos } -> {}
+                    inScope.isNotEmpty() -> state.findings.add(
+                        CardValidationError.PipelineReadBeforeWrite(
+                            cardName = state.cardName,
+                            message = "'${state.cardName}' (${scope.label}): ${read.nodeType}.${read.field} " +
+                                "reads ${read.space.displayName} '${read.name}' before any step writes it " +
+                                "in the same resolution. Verify the pipeline ordering.",
+                        )
+                    )
+                    allWrites.any { matches(read, it) } -> state.findings.add(
+                        CardValidationError.CrossScopePipelineRead(
+                            cardName = state.cardName,
+                            message = "'${state.cardName}' (${scope.label}): ${read.nodeType}.${read.field} " +
+                                "reads ${read.space.displayName} '${read.name}', which is only written in a " +
+                                "different ability's resolution. Cross-resolution flows work only when the " +
+                                "engine snapshots the value (e.g. delayed-trigger creation) — verify this one.",
+                        )
+                    )
+                    else -> state.findings.add(
+                        CardValidationError.UnresolvedPipelineRead(
+                            cardName = state.cardName,
+                            message = "'${state.cardName}' (${scope.label}): ${read.nodeType}.${read.field} " +
+                                "reads ${read.space.displayName} '${read.name}', but nothing on this card " +
+                                "writes it — the step would silently no-op. " +
+                                suggestion(read, allWrites),
+                        )
+                    )
+                }
+            }
+        }
+
+        // Orphan writes: only explicitly-authored names (a defaulted storeAs nobody reads is
+        // just an unused convenience default, not a smell).
+        if (explicitDefObj != null) {
+            val explicitNames = mutableSetOf<Pair<String, String>>() // (field, name)
+            collectExplicitStrings(explicitDefObj, explicitNames)
+            val allReads = state.scopes.flatMap { it.reads }
+            for (write in allWrites) {
+                if ((write.field to write.name) !in explicitNames) continue
+                val isRead = allReads.any { read -> matches(read, write) }
+                if (!isRead) {
+                    state.findings.add(
+                        CardValidationError.OrphanPipelineWrite(
+                            cardName = state.cardName,
+                            message = "'${state.cardName}': ${write.nodeType}.${write.field} stores " +
+                                "${write.space.displayName} '${write.name}', but nothing reads it. " +
+                                "Drop the store or wire up the consumer.",
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun suggestion(read: Access, writes: List<Access>): String {
+        val sameSpace = writes.filter { it.space == read.space }.map { it.name }.distinct()
+        return if (sameSpace.isEmpty()) {
+            "No ${read.space.displayName} is written anywhere on the card."
+        } else {
+            "Written ${read.space.displayName}s on this card: ${sameSpace.joinToString(", ") { "'$it'" }}."
+        }
+    }
+
+    /** Collects every `(field, value)` string pair present in the defaults-omitted tree. */
+    private fun collectExplicitStrings(element: JsonElement, into: MutableSet<Pair<String, String>>) {
+        when (element) {
+            is JsonObject -> for ((field, value) in element) {
+                if (value is JsonPrimitive && value.isString) into.add(field to value.content)
+                collectExplicitStrings(value, into)
+            }
+            is JsonArray -> element.forEach { collectExplicitStrings(it, into) }
+            else -> {}
+        }
+    }
+
+    private fun checkTargets(state: LintState) {
+        for (scope in state.scopes) {
+            for (ref in scope.targetRefs) {
+                if (ref.index != null && ref.index >= scope.targetCount) {
+                    state.findings.add(
+                        CardValidationError.InvalidTargetIndex(
+                            cardName = state.cardName,
+                            index = ref.index,
+                            maxIndex = scope.targetCount - 1,
+                            message = "'${state.cardName}' (${scope.label}): ${ref.nodeType} references " +
+                                "target index ${ref.index} but the owning ability declares " +
+                                "${scope.targetCount} target requirement(s).",
+                        )
+                    )
+                }
+                if (ref.boundName != null) {
+                    val base = ref.boundName.substringBefore('[')
+                    if (base !in scope.targetIds) {
+                        state.findings.add(
+                            CardValidationError.UnknownTargetBinding(
+                                cardName = state.cardName,
+                                message = "'${state.cardName}' (${scope.label}): BoundVariable('${ref.boundName}') " +
+                                    "doesn't match any target requirement id in the owning ability " +
+                                    (if (scope.targetIds.isEmpty()) "(none are named)."
+                                    else "(named: ${scope.targetIds.joinToString(", ") { "'$it'" }})."),
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun checkSlots(cardName: String, slots: SlotUsage, findings: MutableList<CardValidationError>) {
+        for ((slot, nodeType) in slots.reads) {
+            if (slot !in slots.declared) {
+                findings.add(
+                    CardValidationError.UndeclaredChoiceSlotRead(
+                        cardName = cardName,
+                        message = "'$cardName': $nodeType reads choice slot $slot, but nothing on the card " +
+                            "declares it (EntersWithChoice / kicker / blight / sneak). The read would " +
+                            "always come back empty.",
+                    )
+                )
+            }
+        }
+        for (modeId in slots.modeIdReads) {
+            if (modeId !in slots.declaredModeIds) {
+                findings.add(
+                    CardValidationError.UnknownModeId(
+                        cardName = cardName,
+                        message = "'$cardName': SourceChosenModeIs('$modeId') doesn't match any " +
+                            "EntersWithChoice mode option id " +
+                            (if (slots.declaredModeIds.isEmpty()) "(no mode options declared)."
+                            else "(declared: ${slots.declaredModeIds.joinToString(", ") { "'$it'" }})."),
+                    )
+                )
+            }
+        }
+    }
+
+    private fun JsonObject.typeName(): String? = (this["type"] as? JsonPrimitive)?.contentOrNull
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -1,46 +1,8 @@
 package com.wingedsheep.sdk.serialization
 
 import com.wingedsheep.sdk.model.CardDefinition
-import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
-import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
-import com.wingedsheep.sdk.scripting.effects.BecomeCreatureTypeEffect
-import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
-import com.wingedsheep.sdk.scripting.effects.ChangeCreatureTypeTextEffect
-import com.wingedsheep.sdk.scripting.effects.CompositeEffect
-import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
-import com.wingedsheep.sdk.scripting.effects.ExileUntilLeavesEffect
-import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
-import com.wingedsheep.sdk.scripting.effects.LoseGameEffect
-import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
-import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
-import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
-import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
-import com.wingedsheep.sdk.scripting.effects.GainControlByMostEffect
-import com.wingedsheep.sdk.scripting.effects.GainControlEffect
-import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
-import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
-import com.wingedsheep.sdk.scripting.effects.LookAtFaceDownEffect
-import com.wingedsheep.sdk.scripting.effects.LoseAllCreatureTypesEffect
-import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
-import com.wingedsheep.sdk.scripting.effects.ModalEffect
-import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
-import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
-import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
-import com.wingedsheep.sdk.scripting.effects.Gate
-import com.wingedsheep.sdk.scripting.effects.GatedEffect
-import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
-import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
-import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
-import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
-import com.wingedsheep.sdk.scripting.effects.RemoveDamageShieldEffect
-import com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect
-import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
-import com.wingedsheep.sdk.scripting.effects.TransformEffect
-import com.wingedsheep.sdk.scripting.effects.TurnFaceDownEffect
-import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -52,10 +14,11 @@ import kotlinx.serialization.json.jsonPrimitive
  *
  * Catches errors that the type system can't, such as:
  * - Creatures without stats
- * - Target index out of bounds
  * - Aura/Equipment consistency
- * - Orphaned targets
  * - SuccessCriterion.Auto on action shapes it can't infer
+ * - Structural dataflow mistakes — see [CardLinter]: pipeline-variable reads with no writer,
+ *   target indices / `BoundVariable` names that don't resolve against the owning ability's
+ *   requirements, choice-slot reads with no declaration, unused stores.
  */
 object CardValidator {
 
@@ -63,11 +26,11 @@ object CardValidator {
         val errors = mutableListOf<CardValidationError>()
 
         validateCreatureStats(card, errors)
-        validateTargetIndices(card, errors)
         validateAuraConsistency(card, errors)
         validateEquipmentConsistency(card, errors)
         validatePlaneswalkerLoyalty(card, errors)
         validateSuccessCriteria(card, errors)
+        errors.addAll(CardLinter.lint(card))
 
         return errors
     }
@@ -132,43 +95,6 @@ object CardValidator {
         }
     }
 
-    private fun validateTargetIndices(card: CardDefinition, errors: MutableList<CardValidationError>) {
-        val maxIndex = card.script.targetRequirements.size - 1
-
-        // Check spell effect
-        card.script.spellEffect?.let { effect ->
-            collectContextTargetIndices(effect).forEach { index ->
-                if (index > maxIndex) {
-                    errors.add(
-                        CardValidationError.InvalidTargetIndex(
-                            cardName = card.name,
-                            index = index,
-                            maxIndex = maxIndex,
-                            message = "Spell effect references target index $index but only ${maxIndex + 1} target(s) declared in '${card.name}'"
-                        )
-                    )
-                }
-            }
-        }
-
-        // Check triggered ability effects
-        card.script.triggeredAbilities.forEach { ability ->
-            val abilityMaxIndex = if (ability.targetRequirement != null) 0 else -1
-            collectContextTargetIndices(ability.effect).forEach { index ->
-                if (index > abilityMaxIndex) {
-                    errors.add(
-                        CardValidationError.InvalidTargetIndex(
-                            cardName = card.name,
-                            index = index,
-                            maxIndex = abilityMaxIndex,
-                            message = "Triggered ability effect references target index $index but only ${abilityMaxIndex + 1} target(s) declared in '${card.name}'"
-                        )
-                    )
-                }
-            }
-        }
-    }
-
     private fun validateAuraConsistency(card: CardDefinition, errors: MutableList<CardValidationError>) {
         if (card.script.auraTarget != null && !card.typeLine.isAura) {
             errors.add(
@@ -209,95 +135,14 @@ object CardValidator {
             )
         }
     }
-
-    /**
-     * Recursively collect all ContextTarget indices from an effect tree.
-     */
-    private fun collectContextTargetIndices(effect: Effect): List<Int> {
-        val indices = mutableListOf<Int>()
-        collectIndicesRecursive(effect, indices)
-        return indices
-    }
-
-    private fun collectIndicesRecursive(effect: Effect, indices: MutableList<Int>) {
-        when (effect) {
-            is CompositeEffect -> effect.effects.forEach { collectIndicesRecursive(it, indices) }
-            is ForEachTargetEffect -> effect.effects.forEach { collectIndicesRecursive(it, indices) }
-            is GatedEffect -> {
-                when (val gate = effect.gate) {
-                    is Gate.MayPay -> collectIndicesRecursive(gate.cost, indices)
-                    is Gate.DoAction -> collectIndicesRecursive(gate.action, indices)
-                    is Gate.MayDecide -> {}
-                    is Gate.WhenCondition -> {}
-                    is Gate.MayPayX -> {}
-                }
-                collectIndicesRecursive(effect.then, indices)
-                effect.otherwise?.let { collectIndicesRecursive(it, indices) }
-            }
-            is ReflexiveTriggerEffect -> {
-                collectIndicesRecursive(effect.action, indices)
-                collectIndicesRecursive(effect.reflexiveEffect, indices)
-            }
-            is ModalEffect -> effect.modes.forEach { collectIndicesRecursive(it.effect, indices) }
-            is PayOrSufferEffect -> collectIndicesRecursive(effect.suffer, indices)
-            is AnyPlayerMayPayEffect -> {
-                effect.consequence?.let { collectIndicesRecursive(it, indices) }
-                effect.consequenceIfNonePaid?.let { collectIndicesRecursive(it, indices) }
-            }
-            is ForEachInGroupEffect -> collectIndicesRecursive(effect.effect, indices)
-            is FlipCoinEffect -> {
-                effect.wonEffect?.let { collectIndicesRecursive(it, indices) }
-                effect.lostEffect?.let { collectIndicesRecursive(it, indices) }
-            }
-            else -> {
-                // Check all EffectTarget fields for ContextTarget references
-                collectTargetIndicesFromEffect(effect, indices)
-            }
-        }
-    }
-
-    /**
-     * Extract ContextTarget indices from an effect's target fields via reflection-free approach.
-     * This checks common patterns — effects that have a `target: EffectTarget` property.
-     */
-    private fun collectTargetIndicesFromEffect(effect: Effect, indices: MutableList<Int>) {
-        // Use the effect's target field if accessible
-        val target = when (effect) {
-            is DealDamageEffect -> effect.target
-            is ModifyStatsEffect -> effect.target
-            is MoveToZoneEffect -> effect.target
-            is TapUntapEffect -> effect.target
-            is AddCountersEffect -> effect.target
-            is RemoveCountersEffect -> effect.target
-            is GrantKeywordEffect -> effect.target
-            is RegenerateEffect -> effect.target
-            is RemoveDamageShieldEffect -> effect.target
-            is CantBeRegeneratedEffect -> effect.target
-            is ExileUntilLeavesEffect -> effect.target
-            is MustBeBlockedEffect -> effect.target
-            is RemoveFromCombatEffect -> effect.target
-            is ForceSacrificeEffect -> effect.target
-            is MarkExileOnDeathEffect -> effect.target
-            is GainControlEffect -> effect.target
-            is TurnFaceDownEffect -> effect.target
-            is TurnFaceUpEffect -> effect.target
-            is BecomeCreatureTypeEffect -> effect.target
-            is ChangeCreatureTypeTextEffect -> effect.target
-            is GrantTriggeredAbilityEffect -> effect.target
-            is LoseAllCreatureTypesEffect -> effect.target
-            is LookAtFaceDownEffect -> effect.target
-            is TransformEffect -> effect.target
-            is GainControlByMostEffect -> effect.target
-            is SacrificeTargetEffect -> effect.target
-            is LoseGameEffect -> effect.target
-            else -> null
-        }
-
-        if (target is EffectTarget.ContextTarget) {
-            indices.add(target.index)
-        }
-    }
 }
+
+/**
+ * Severity of a validation finding. [ERROR]s are structural mistakes that make part of the card
+ * a silent no-op (the corpus gate fails on them); [WARNING]s are legal-but-suspicious patterns
+ * (cross-resolution reads, unused stores) surfaced for review without failing the build.
+ */
+enum class LintSeverity { ERROR, WARNING }
 
 /**
  * Validation errors found during card validation.
@@ -305,6 +150,7 @@ object CardValidator {
 sealed interface CardValidationError {
     val cardName: String
     val message: String
+    val severity: LintSeverity get() = LintSeverity.ERROR
 
     data class MissingCreatureStats(
         override val cardName: String,
@@ -339,6 +185,64 @@ sealed interface CardValidationError {
     ) : CardValidationError
 
     data class UninferableSuccessCriterion(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /** A pipeline-variable read whose name is written nowhere on the card — a typo / silent no-op. */
+    data class UnresolvedPipelineRead(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /** A read whose only writer comes later in the same resolution's pipeline. */
+    data class PipelineReadBeforeWrite(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError {
+        override val severity: LintSeverity get() = LintSeverity.WARNING
+    }
+
+    /** A read satisfied only by a writer in a different ability's resolution. */
+    data class CrossScopePipelineRead(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError {
+        override val severity: LintSeverity get() = LintSeverity.WARNING
+    }
+
+    /** An explicitly named store that no step on the card ever reads. */
+    data class OrphanPipelineWrite(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError {
+        override val severity: LintSeverity get() = LintSeverity.WARNING
+    }
+
+    /** A `BoundVariable` name that matches no target-requirement id in the owning ability. */
+    data class UnknownTargetBinding(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /** A choice-slot read (`CastChoiceMade`, `HasChosenColor`, …) with no declaring ability. */
+    data class UndeclaredChoiceSlotRead(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /** A `SourceChosenModeIs` id that matches no declared `EntersWithChoice` mode option. */
+    data class UnknownModeId(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /**
+     * A string field whose name follows the pipeline-variable naming conventions but whose
+     * `(type, field)` pair is not classified in [CardLinter]'s dataflow registry — classify
+     * it (READ/WRITE + namespace) or list it as a known non-dataflow field.
+     */
+    data class UnclassifiedDataflowField(
         override val cardName: String,
         override val message: String
     ) : CardValidationError

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
@@ -1,0 +1,277 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.conditions.CastChoiceMade
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unit tests for [CardLinter] — the structural dataflow lint (sdk-analysis §1.1).
+ * The corpus-wide gate lives in mtg-sets (`CardLintTest`); these tests pin the
+ * individual checks on minimal synthetic cards.
+ */
+class CardLinterTest : DescribeSpec({
+
+    fun instant(name: String, script: CardScript) = CardDefinition(
+        name = name,
+        manaCost = ManaCost.parse("{1}{U}"),
+        typeLine = TypeLine.instant(),
+        script = script,
+    )
+
+    fun gather(storeAs: String) =
+        GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(3)), storeAs = storeAs)
+
+    fun move(from: String) =
+        MoveCollectionEffect(from = from, destination = CardDestination.ToZone(Zone.HAND))
+
+    describe("pipeline dataflow") {
+
+        it("accepts a well-formed gather → select → move pipeline") {
+            val card = instant(
+                "Clean Pipeline",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            gather("looked"),
+                            SelectFromCollectionEffect(
+                                from = "looked",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                                storeSelected = "kept",
+                                storeRemainder = "rest",
+                            ),
+                            move("kept"),
+                            MoveCollectionEffect(
+                                from = "rest",
+                                destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            CardLinter.lint(card).shouldBeEmpty()
+        }
+
+        it("flags a typo'd collection read as an error with a suggestion") {
+            val card = instant(
+                "Typo Pipeline",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(gather("revealed"), move("revaeled")),
+                    ),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            // The unread write and the unresolved read are two views of the same typo.
+            val errors = findings.filter { it.severity == LintSeverity.ERROR }
+            errors.shouldHaveSize(1)
+            errors[0].shouldBeInstanceOf<CardValidationError.UnresolvedPipelineRead>()
+                .message shouldContain "'revealed'"
+        }
+
+        it("flags a read whose writer lives in a different ability as a warning") {
+            val card = CardDefinition(
+                name = "Split Flow",
+                manaCost = ManaCost.parse("{2}"),
+                typeLine = TypeLine.creature(),
+                creatureStats = CreatureStats(2, 2),
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility.create(
+                            trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
+                            effect = gather("stash"),
+                        ),
+                        TriggeredAbility.create(
+                            trigger = EventPattern.ZoneChangeEvent(
+                                from = Zone.BATTLEFIELD,
+                                to = Zone.GRAVEYARD,
+                            ),
+                            effect = move("stash"),
+                        ),
+                    ),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.filter { it.severity == LintSeverity.ERROR }.shouldBeEmpty()
+            findings.filterIsInstance<CardValidationError.CrossScopePipelineRead>().shouldHaveSize(1)
+        }
+
+        it("flags a store nothing reads as a warning") {
+            val card = instant(
+                "Hoarder",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            gather("looked"),
+                            SelectFromCollectionEffect(
+                                from = "looked",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                                storeSelected = "kept",
+                                storeRemainder = "forgotten",
+                            ),
+                            move("kept"),
+                        ),
+                    ),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.filter { it.severity == LintSeverity.ERROR }.shouldBeEmpty()
+            findings.filterIsInstance<CardValidationError.OrphanPipelineWrite>()
+                .shouldHaveSize(1).first().message shouldContain "'forgotten'"
+        }
+
+        it("connects cast-time additional-cost stores to the spell effect") {
+            val card = instant(
+                "Behold Payoff",
+                CardScript(
+                    spellEffect = move("beheld"),
+                    additionalCosts = listOf(AdditionalCost.Behold()),
+                ),
+            )
+            CardLinter.lint(card).filter { it.severity == LintSeverity.ERROR }.shouldBeEmpty()
+        }
+
+        it("bridges a collection write to its _count numeric read") {
+            val card = instant(
+                "Counter",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            gather("exiled"),
+                            move("exiled"),
+                            DealDamageEffect(
+                                DynamicAmount.VariableReference("exiled_count"),
+                                EffectTarget.PlayerRef(
+                                    com.wingedsheep.sdk.scripting.references.Player.EachOpponent
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            CardLinter.lint(card).filter { it.severity == LintSeverity.ERROR }.shouldBeEmpty()
+        }
+    }
+
+    describe("target bindings per owning scope") {
+
+        it("scopes a granted ability's ContextTarget to the granted ability") {
+            // The granted ability declares no targets; ContextTarget(0) inside it must NOT
+            // resolve against the outer spell's requirement.
+            val card = instant(
+                "Bad Grant",
+                CardScript(
+                    spellEffect = GrantTriggeredAbilityEffect(
+                        ability = TriggeredAbility.create(
+                            trigger = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+                            effect = DealDamageEffect(
+                                DynamicAmount.Fixed(1),
+                                EffectTarget.ContextTarget(0),
+                            ),
+                        ),
+                        target = EffectTarget.ContextTarget(0),
+                    ),
+                    targetRequirements = listOf(AnyTarget()),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.shouldHaveSize(1)
+            findings[0].shouldBeInstanceOf<CardValidationError.InvalidTargetIndex>()
+                .message shouldContain "granted"
+        }
+
+        it("flags a BoundVariable that matches no requirement id") {
+            val card = instant(
+                "Named Wrong",
+                CardScript(
+                    spellEffect = DealDamageEffect(
+                        DynamicAmount.Fixed(2),
+                        EffectTarget.BoundVariable("victim"),
+                    ),
+                    targetRequirements = listOf(AnyTarget(id = "target")),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.shouldHaveSize(1)
+            findings[0].shouldBeInstanceOf<CardValidationError.UnknownTargetBinding>()
+                .message shouldContain "'victim'"
+        }
+
+        it("accepts indexed BoundVariable names against the base id") {
+            val card = instant(
+                "Named Right",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.BoundVariable("creature[0]")),
+                            DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.BoundVariable("creature[1]")),
+                        ),
+                    ),
+                    targetRequirements = listOf(AnyTarget(id = "creature")),
+                ),
+            )
+            CardLinter.lint(card).shouldBeEmpty()
+        }
+    }
+
+    describe("choice slots") {
+
+        it("flags a slot read with no declaration") {
+            val card = instant(
+                "Unkicked",
+                CardScript(
+                    spellEffect = ConditionalEffect(
+                        condition = CastChoiceMade(ChoiceSlot.KICKED),
+                        effect = DealDamageEffect(DynamicAmount.Fixed(3), EffectTarget.ContextTarget(0)),
+                    ),
+                    targetRequirements = listOf(AnyTarget()),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.shouldHaveSize(1)
+            findings[0].shouldBeInstanceOf<CardValidationError.UndeclaredChoiceSlotRead>()
+                .message shouldContain "KICKED"
+        }
+
+        it("accepts a KICKED read when a kicker effect is declared") {
+            val card = instant(
+                "Kicked",
+                CardScript(
+                    spellEffect = ConditionalEffect(
+                        condition = CastChoiceMade(ChoiceSlot.KICKED),
+                        effect = DealDamageEffect(DynamicAmount.Fixed(3), EffectTarget.ContextTarget(0)),
+                    ),
+                    kickerSpellEffect = DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(AnyTarget()),
+                ),
+            )
+            CardLinter.lint(card).shouldBeEmpty()
+        }
+    }
+})

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardValidatorTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardValidatorTest.kt
@@ -12,7 +12,9 @@ import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
@@ -400,12 +402,17 @@ class CardValidatorTest : DescribeSpec({
                 manaCost = ManaCost.parse("{B}"),
                 typeLine = TypeLine.instant(),
                 script = CardScript(
-                    spellEffect = IfYouDoEffect(
-                        action = MoveCollectionEffect(
-                            from = "discarded",
-                            destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            GatherCardsEffect(CardSource.FromZone(Zone.HAND), storeAs = "discarded"),
+                            IfYouDoEffect(
+                                action = MoveCollectionEffect(
+                                    from = "discarded",
+                                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                                ),
+                                ifYouDo = DrawCardsEffect(1),
+                            ),
                         ),
-                        ifYouDo = DrawCardsEffect(1),
                     ),
                 ),
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AtmosphericGreenhouse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AtmosphericGreenhouse.kt
@@ -35,7 +35,7 @@ val AtmosphericGreenhouse = card("Atmospheric Greenhouse") {
         trigger = Triggers.EntersBattlefield
         effect = Effects.ForEachInGroup(
             filter = GroupFilter.AllCreaturesYouControl,
-            effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))
+            effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
         )
     }
 

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/CardLintTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/CardLintTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets
+
+import com.wingedsheep.sdk.serialization.CardLinter
+import com.wingedsheep.sdk.serialization.LintSeverity
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Corpus-wide gate for the structural card lint (sdk-analysis §1.1, [CardLinter]): every
+ * registered card's name-based references — pipeline collections/variables, target bindings,
+ * choice slots — must resolve. A typo'd `storeAs`/`from` pair, a `ContextTarget` index into the
+ * wrong ability, or a `CastChoiceMade` with no declaring kicker used to be a silent no-op found
+ * (at best) in playtesting; this test makes it a build failure naming the exact card and step.
+ *
+ * **Errors** fail the build unless the card is listed in
+ * `src/test/resources/lint-allowlist.txt` (one `ErrorType|Card Name` per line) — intentional
+ * exceptions become a visible, burn-downable file. Stale allowlist entries fail too, so the
+ * file can only shrink. **Warnings** (cross-resolution reads, unused stores) are printed for
+ * review but never fail.
+ */
+class CardLintTest : FunSpec({
+
+    val allowlist: Set<String> =
+        (javaClass.getResource("/lint-allowlist.txt")?.readText() ?: "")
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .toSet()
+
+    val findings = MtgSetCatalog.all.flatMap { set ->
+        set.cards.flatMap { card ->
+            CardLinter.lint(card).map { Triple(set.code, it::class.simpleName!!, it) }
+        }
+    }
+
+    test("every card's pipeline variables, target bindings, and choice slots resolve") {
+        val errors = findings.filter { (_, _, finding) -> finding.severity == LintSeverity.ERROR }
+        val keyed = errors.map { (setCode, type, finding) ->
+            "$type|${finding.cardName}" to "[$setCode] ${finding.message}"
+        }
+        val unexpected = keyed.filter { (key, _) -> key !in allowlist }.map { it.second }
+        if (unexpected.isNotEmpty()) {
+            println("=== CardLinter errors: ${unexpected.size} ===")
+            unexpected.forEach { println("  $it") }
+        }
+        unexpected.shouldBeEmpty()
+    }
+
+    test("the lint allowlist contains no stale entries") {
+        val errorKeys = findings
+            .filter { (_, _, finding) -> finding.severity == LintSeverity.ERROR }
+            .map { (_, type, finding) -> "$type|${finding.cardName}" }
+            .toSet()
+        allowlist.filter { it !in errorKeys }.shouldBeEmpty()
+    }
+
+    test("print lint warnings for review (never fails)") {
+        val warnings = findings.filter { (_, _, f) -> f.severity == LintSeverity.WARNING }
+        if (warnings.isNotEmpty()) {
+            val byType = warnings.groupBy { it.second }
+            println("=== CardLinter warnings: ${warnings.size} across ${byType.size} categories ===")
+            for ((type, entries) in byType) {
+                println("--- $type (${entries.size}) ---")
+                entries.forEach { (setCode, _, f) -> println("  [$setCode] ${f.message}") }
+            }
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/lint-allowlist.txt
+++ b/mtg-sets/src/test/resources/lint-allowlist.txt
@@ -1,0 +1,8 @@
+# CardLintTest allowlist — intentional exceptions to the structural card lint (CardLinter).
+#
+# One entry per line: <ErrorTypeSimpleName>|<Card Name>
+#   e.g.  UnresolvedPipelineRead|Some Card
+#
+# Entries here suppress an ERROR-severity finding for that card. Stale entries (no longer
+# matching any finding) fail the build, so this file can only shrink. Add an entry only with
+# a comment explaining why the pattern is legal.

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -798,10 +798,7 @@
                         "type": "AddCounters",
                         "counterType": "+1/+1",
                         "count": 1,
-                        "target": {
-                            "type": "ContextTarget",
-                            "index": 0
-                        }
+                        "target": "Self"
                     }
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtmosphericGreenhouseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtmosphericGreenhouseScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Atmospheric Greenhouse's ETB trigger.
+ *
+ * Oracle: "When this Spacecraft enters, put a +1/+1 counter on each creature you control."
+ *
+ * Regression for a bug found by the card linter (sdk-analysis §1.1): the ETB's
+ * `ForEachInGroup` inner effect targeted `ContextTarget(0)` — which reads the (empty)
+ * cast-time target list, not the iterated creature — so the trigger silently did nothing.
+ * The iteration entity is addressed with `EffectTarget.Self`.
+ */
+class AtmosphericGreenhouseScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val permanent = game.findPermanent(name)!!
+        return game.state.getEntity(permanent)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Atmospheric Greenhouse — ETB counters") {
+
+            test("ETB puts a +1/+1 counter on each creature you control, not the opponent's") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atmospheric Greenhouse")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .build()
+
+                game.castSpell(1, "Atmospheric Greenhouse")
+                game.resolveStack()
+
+                withClue("each of the controller's creatures gets a +1/+1 counter") {
+                    plusOneCounters(game, "Glory Seeker") shouldBe 1
+                    plusOneCounters(game, "Centaur Courser") shouldBe 1
+                }
+                withClue("the opponent's creature is untouched") {
+                    plusOneCounters(game, "Savannah Lions") shouldBe 0
+                }
+                withClue("the Spacecraft itself is not a creature yet (no charge counters)") {
+                    plusOneCounters(game, "Atmospheric Greenhouse") shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **sdk-analysis-2026-06-revised §1.1** — grows `CardValidator` into structural validation so the "typo'd name → silent no-op found in playtesting" bug class dies in CI.

### How it works

`CardLinter` (mtg-sdk) walks each card's **serialized JSON tree** — the plan's stale-proof alternative to a hand-maintained effect walker — so every container (composites, gates, modes, granted/token abilities, class levels, saga chapters, faces) is covered automatically, including ones added later. Embedded abilities are detected **structurally** (an object with no `type` discriminator + an `effect` member + a trigger/cost/target member), not by a field-name list.

### Checks

| Check | Severity |
|---|---|
| Pipeline read (`from`, `variableName`, `chosenSubtypeKey`, …) with no writer anywhere on the card | error |
| Read before its writer / satisfied only in another ability's resolution / store nothing reads | warning |
| `ContextTarget(i)` outside the owning ability's flattened slot count (`count = 2` spans two indices; modes inherit card-level reqs; reflexive triggers → `reflexiveTargetRequirements`; delayed triggers → `targetRequirement`) | error |
| `BoundVariable(name)` matching no requirement id | error |
| `ChoiceSlot` read (`CastChoiceMade`, `HasChosenColor`, …) with no declarer (`EntersWithChoice`, kicker, blight, sneak, `ChooseColorThen`/`ForTarget`) | error |
| `SourceChosenModeIs` id not among declared `modeOptions` | error |
| Dataflow-shaped string field on an unclassified `(type, field)` pair — the registry can't silently rot (PR #606 pattern) | error |

Dataflow is tracked across six namespaces (collections / numbers / chosen values / string lists / subtype groups / cast flags) with the `x` → `x_count` bridge, scoped per resolution (cast-time additional costs feed the spell scope, each ability is its own scope).

### Corpus gate

`CardLintTest` (mtg-sets, beside `CardDefinitionSnapshotTest`): errors fail unless listed in a burn-downable `lint-allowlist.txt` (stale entries fail too); warnings print for review. The `add-card` skill inherits the gate for free.

### First harvest

The initial corpus run surfaced 48 errors → triaged to registry/scope gaps (fixed in-linter) and **one real shipped bug**: **Atmospheric Greenhouse**'s ETB ("put a +1/+1 counter on each creature you control") was a complete silent no-op — `ContextTarget(0)` inside `ForEachInGroup` reads the empty cast-time target list, not the iterated creature. Fixed to `EffectTarget.Self` + pinned with a scenario test (first commit). Corpus is now **0 errors**, 13 review-level warnings, empty allowlist.

Also: `CardValidator`'s hand-maintained target-index walker is deleted (subsumed), findings gain ERROR/WARNING severity, docs updated (`card-sdk-language-reference.md` §21, CLAUDE.md testing nets, backlog §1.1 marked done).

### Tests

- `CardLinterTest` (mtg-sdk): per-check synthetic-card units
- `CardLintTest` (mtg-sets): corpus-wide zero-error gate + stale-allowlist guard
- `AtmosphericGreenhouseScenarioTest` (rules-engine): pins the bug fix
- Full `just test` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)