### PR TITLE
Add Abu Ja'far to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 64 / 78
+**Implemented:** 65 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -15,7 +15,7 @@
 
 ---
 
-- [ ] Abu Ja'far
+- [x] Abu Ja'far
 - [x] Army of Allah
 - [x] Camel
 - [ ] Eye for an Eye

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -325,6 +325,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   save the ID list for follow-up. `excludeTriggering = true` spares the triggering entity, for "destroy all
   *other* … with it" triggers (Spreading Plague).
 - `DestroyAllAndAttached(filter, noRegenerate?)` — also destroys auras/equipment on the matching permanents.
+- `DestroyCreaturesBlockingOrBlockedBySource(noRegenerate?)` — destroy the creatures blocking, or blocked by,
+  the effect's source (CR 509 combat pairing), using the pairing **last known when the source left the
+  battlefield**. For "when ~ dies, destroy all creatures blocking or blocked by it" (Abu Ja'far): the live
+  combat cross-references are already torn down by the time a dies trigger resolves, so the pairing is read
+  from the leaves-battlefield snapshot (`ZoneChangeEvent.lastKnownBlockingOrBlockedByIds` →
+  `EffectContext.triggerLastKnownBlockingOrBlockedByIds`) via `CardSource.LastKnownCombatPairedWithSource`,
+  restricted to creatures still on the battlefield.
 - `DestroyAllEquipmentOnTarget(target)` — wreck the gear attached to a creature.
 - `Exile(target)` — exile target.
 - `ExileAndGrantOwnerPlayPermission(target, until?)` — exile + owner may play it (Garth-style).

--- a/manual-scenarios/cards/a/abu-jafar.json
+++ b/manual-scenarios/cards/a/abu-jafar.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Abu Ja'far"},
+      {"name": "Hill Giant"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "COMBAT",
+  "step": "DECLARE_ATTACKERS",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS", "COMBAT_DAMAGE"],
+  "player1OpponentStopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS", "COMBAT_DAMAGE"],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -444,6 +444,16 @@ object Effects {
     ): Effect = GroupPatterns.destroyAllAndAttachedPipeline(filter, noRegenerate)
 
     /**
+     * Destroy all creatures blocking or blocked by the effect's source (CR 509), using the
+     * combat pairing last known when the source left the battlefield. Intended for a dies
+     * trigger (Abu Ja'far) — the live combat cross-references are already gone by resolution, so
+     * the pairing is read from the leaves-battlefield snapshot.
+     */
+    fun DestroyCreaturesBlockingOrBlockedBySource(
+        noRegenerate: Boolean = false
+    ): Effect = GroupPatterns.destroyCombatPairedWithSourcePipeline(noRegenerate)
+
+    /**
      * Destroy all creatures sharing a creature type with the sacrificed creature.
      * Requires a creature sacrificed as additional cost.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/GroupPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/GroupPatterns.kt
@@ -87,6 +87,27 @@ object GroupPatterns {
         )
     ))
 
+    /**
+     * "Destroy all creatures blocking or blocked by it" (Abu Ja'far). Gathers the source's
+     * last-known combat pairing (CR 509) — captured on the leaves-battlefield event because the
+     * live cross-references are gone by the time a dies trigger resolves — and destroys those
+     * still on the battlefield.
+     */
+    fun destroyCombatPairedWithSourcePipeline(
+        noRegenerate: Boolean = false
+    ): CompositeEffect = CompositeEffect(listOf(
+        GatherCardsEffect(
+            source = CardSource.LastKnownCombatPairedWithSource,
+            storeAs = "combatPaired_gathered"
+        ),
+        MoveCollectionEffect(
+            from = "combatPaired_gathered",
+            destination = CardDestination.ToZone(Zone.GRAVEYARD),
+            moveType = MoveType.Destroy,
+            noRegenerate = noRegenerate
+        )
+    ))
+
     fun destroyAllAndAttachedPipeline(
         filter: GameObjectFilter,
         noRegenerate: Boolean = false

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -199,6 +199,22 @@ sealed interface CardSource {
     data object Self : CardSource {
         override val description: String = "this card"
     }
+
+    /**
+     * The creatures that were blocking, or blocked by, the effect's source at the moment the
+     * source last left the battlefield (CR 509 combat pairing, captured as last-known
+     * information). Resolves to those creatures that are still on the battlefield.
+     *
+     * This is the gatherable backing "destroy all creatures blocking or blocked by it" on a
+     * dies trigger (Abu Ja'far): by resolution the engine has already torn the combat
+     * cross-references down, so the pairing must come from the last-known snapshot carried on
+     * the leaves-battlefield event rather than from live combat components.
+     */
+    @SerialName("LastKnownCombatPairedWithSource")
+    @Serializable
+    data object LastKnownCombatPairedWithSource : CardSource {
+        override val description: String = "creatures blocking or blocked by it"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AbuJafar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AbuJafar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abu Ja'far
+ * {W}
+ * Creature — Human
+ * 0/1
+ * When this creature dies, destroy all creatures blocking or blocked by it.
+ * They can't be regenerated.
+ *
+ * The dies trigger destroys the combat pairing (CR 509) captured as last-known information
+ * when Abu Ja'far left the battlefield — the live combat cross-references are torn down by the
+ * time the trigger resolves, so [Effects.DestroyCreaturesBlockingOrBlockedBySource] reads the
+ * snapshot carried on the leaves-battlefield event.
+ */
+val AbuJafar = card("Abu Ja'far") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human"
+    power = 0
+    toughness = 1
+    oracleText = "When this creature dies, destroy all creatures blocking or blocked by it. They can't be regenerated."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DestroyCreaturesBlockingOrBlockedBySource(noRegenerate = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Ken Meyer, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg?1562897827"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -1,3 +1,56 @@
+// Abu Ja'far
+{
+    "name": "Abu Ja'far",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human",
+    "oracleText": "When this creature dies, destroy all creatures blocking or blocked by it. They can't be regenerated.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "LastKnownCombatPairedWithSource",
+                            "storeAs": "combatPaired_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "combatPaired_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy",
+                            "noRegenerate": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Ken Meyer, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg?1562897827"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aladdin
 {
     "name": "Aladdin",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -58,6 +58,8 @@ data class TriggeredAbilityContinuation(
     val triggerTotalCounterCount: Int? = null,
     val triggerLastKnownCounters: Map<String, Int>? = null,
     val triggerLastKnownDamageDealtByPlayers: Map<EntityId, Int>? = null,
+    /** Creatures blocking/blocked by the trigger's source on leave-battlefield (CR 509 LKI, Abu Ja'far). */
+    val triggerLastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
     val lastKnownPower: Int? = null,
     val lastKnownToughness: Int? = null,
     val triggerModesChosenCount: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -103,6 +103,8 @@ data class TriggerDamageDistributionContinuation(
     val triggerTotalCounterCount: Int? = null,
     val triggerLastKnownCounters: Map<String, Int>? = null,
     val triggerLastKnownDamageDealtByPlayers: Map<EntityId, Int>? = null,
+    /** Creatures blocking/blocked by the trigger's source on leave-battlefield (CR 509 LKI, Abu Ja'far). */
+    val triggerLastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
     val selectedTargets: List<ChosenTarget>,
     val targetRequirements: List<TargetRequirement>,
     val totalDamage: Int,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -54,6 +54,15 @@ data class ZoneChangeEvent(
     val copyOfOriginalName: String? = null,
     /** For auras: the entity this aura was attached to when it left the battlefield (for "enchanted creature dies" triggers) */
     val lastKnownAttachedTo: EntityId? = null,
+    /**
+     * Creatures that were blocking, or blocked by, this creature when it left the battlefield
+     * (the union of its [com.wingedsheep.engine.state.components.combat.BlockedComponent] blockers
+     * and its [com.wingedsheep.engine.state.components.combat.BlockingComponent] blocked-attackers,
+     * CR 509). Captured as last-known information because the live combat cross-references are torn
+     * down as the creature leaves — read by "destroy all creatures blocking or blocked by it" dies
+     * triggers (Abu Ja'far). Empty for non-combat / non-battlefield transitions.
+     */
+    val lastKnownBlockingOrBlockedByIds: List<EntityId> = emptyList(),
     /** Last known type line when leaving battlefield (for trigger detection when entity has been cleaned up, e.g., tokens) */
     val lastKnownTypeLine: TypeLine? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -56,6 +56,13 @@ data class TriggerContext(
      */
     val lastKnownDamageDealtByPlayers: Map<EntityId, Int>? = null,
     /**
+     * Creatures that were blocking, or blocked by, the triggering source when it left the
+     * battlefield (CR 509 combat pairing), captured as last-known information. Read by
+     * "destroy all creatures blocking or blocked by it" (Abu Ja'far). Null when the trigger's
+     * source never left combat.
+     */
+    val lastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
+    /**
      * For SpellCastEvent triggers — number of mode picks the cast spell recorded. `null`
      * when the trigger was not driven by a spell cast. Read by
      * `ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL` so abilities like Riku of
@@ -99,7 +106,9 @@ data class TriggerContext(
                     lastKnownToughness = event.lastKnownToughness,
                     lastKnownCounters = event.lastKnownCounters.takeIf { it.isNotEmpty() },
                     lastKnownDamageDealtByPlayers =
-                        event.lastKnownDamageDealtByPlayers.takeIf { it.isNotEmpty() }
+                        event.lastKnownDamageDealtByPlayers.takeIf { it.isNotEmpty() },
+                    lastKnownBlockingOrBlockedByIds =
+                        event.lastKnownBlockingOrBlockedByIds.takeIf { it.isNotEmpty() }
                 )
                 is DamageDealtEvent -> TriggerContext(
                     triggeringEntityId = event.targetId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -421,6 +421,8 @@ class TriggerProcessor(
                 triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,
                 triggerLastKnownDamageDealtByPlayers =
                     trigger.triggerContext.lastKnownDamageDealtByPlayers,
+                triggerLastKnownBlockingOrBlockedByIds =
+                    trigger.triggerContext.lastKnownBlockingOrBlockedByIds,
                 triggerLastKnownPower = trigger.triggerContext.lastKnownPower,
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,
                 triggerModesChosenCount = trigger.triggerContext.modesChosenCount,
@@ -464,6 +466,8 @@ class TriggerProcessor(
             triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,
             triggerLastKnownDamageDealtByPlayers =
                 trigger.triggerContext.lastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds =
+                trigger.triggerContext.lastKnownBlockingOrBlockedByIds,
             lastKnownPower = trigger.triggerContext.lastKnownPower,
             lastKnownToughness = trigger.triggerContext.lastKnownToughness,
             triggerModesChosenCount = trigger.triggerContext.modesChosenCount,
@@ -513,6 +517,8 @@ class TriggerProcessor(
             triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,
             triggerLastKnownDamageDealtByPlayers =
                 trigger.triggerContext.lastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds =
+                trigger.triggerContext.lastKnownBlockingOrBlockedByIds,
             targetingSourceEntityId = trigger.triggerContext.targetingSourceEntityId,
             lastKnownPower = trigger.triggerContext.lastKnownPower,
             lastKnownToughness = trigger.triggerContext.lastKnownToughness,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -154,6 +154,13 @@ data class EffectContext(
      */
     val triggerLastKnownDamageDealtByPlayers: Map<EntityId, Int>? = null,
     /**
+     * Creatures that were blocking, or blocked by, the trigger's source when it left the
+     * battlefield (CR 509 combat pairing), captured as last-known information. Resolved by
+     * `CardSource.LastKnownCombatPairedWithSource` for "destroy all creatures blocking or
+     * blocked by it" (Abu Ja'far). Null when the source never left combat.
+     */
+    val triggerLastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
+    /**
      * Number of mode picks the triggering spell-cast recorded. Read by
      * `ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL` (Riku of Many Paths).
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -93,6 +93,7 @@ class EffectAndTriggerContinuationResumer(
                 triggerTotalCounterCount = continuation.triggerTotalCounterCount,
                 triggerLastKnownCounters = continuation.triggerLastKnownCounters,
                 triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+                triggerLastKnownBlockingOrBlockedByIds = continuation.triggerLastKnownBlockingOrBlockedByIds,
                 lastKnownPower = continuation.lastKnownPower,
                 lastKnownToughness = continuation.lastKnownToughness,
                 triggerScryCount = continuation.triggerScryCount,
@@ -137,6 +138,7 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds = continuation.triggerLastKnownBlockingOrBlockedByIds,
             lastKnownPower = continuation.lastKnownPower,
             lastKnownToughness = continuation.lastKnownToughness,
             triggerModesChosenCount = continuation.triggerModesChosenCount,
@@ -256,6 +258,8 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+            // The divided-damage continuation doesn't carry combat-pairing LKI (no card needs
+            // both at once); the on-stack component's field stays null on this path.
             lastKnownPower = continuation.lastKnownPower,
             lastKnownToughness = continuation.lastKnownToughness,
             damageDistribution = response.distribution

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -210,6 +210,7 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds = continuation.triggerLastKnownBlockingOrBlockedByIds,
             selectedTargets = selectedTargets,
             targetRequirements = continuation.targetRequirements,
             totalDamage = totalDamage
@@ -258,8 +259,7 @@ class EffectAndTriggerContinuationResumer(
             triggerTotalCounterCount = continuation.triggerTotalCounterCount,
             triggerLastKnownCounters = continuation.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = continuation.triggerLastKnownDamageDealtByPlayers,
-            // The divided-damage continuation doesn't carry combat-pairing LKI (no card needs
-            // both at once); the on-stack component's field stays null on this path.
+            triggerLastKnownBlockingOrBlockedByIds = continuation.triggerLastKnownBlockingOrBlockedByIds,
             lastKnownPower = continuation.lastKnownPower,
             lastKnownToughness = continuation.lastKnownToughness,
             damageDistribution = response.distribution

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -150,6 +150,7 @@ object ZoneTransitionService {
         var lastKnownKeywords: Set<String> = emptySet()
         var lastKnownLostAllAbilities = false
         var lastKnownAttachedTo = options.lastKnownAttachedTo
+        var lastKnownBlockingOrBlockedByIds: List<EntityId> = emptyList()
         var lastKnownWasToken = false
         var lastKnownDamageDealtByPlayers: Map<EntityId, Int> = emptyMap()
         // The {X} this permanent was cast with (DynamicAmount.CastX), captured before the
@@ -185,6 +186,14 @@ object ZoneTransitionService {
             lastKnownLostAllAbilities = projected.hasLostAllAbilities(entityId)
             if (lastKnownAttachedTo == null) {
                 lastKnownAttachedTo = container.get<AttachedToComponent>()?.targetId
+            }
+            // CR 509 combat pairing, captured before the cross-references are torn down: the
+            // creatures blocking this one (its BlockedComponent) and the creatures it was blocking
+            // (its BlockingComponent). Read by "destroy all creatures blocking or blocked by it".
+            run {
+                val blockingThis = container.get<BlockedComponent>()?.blockerIds ?: emptyList()
+                val blockedByThis = container.get<BlockingComponent>()?.blockedAttackerIds ?: emptyList()
+                lastKnownBlockingOrBlockedByIds = (blockingThis + blockedByThis).distinct()
             }
             lastKnownWasToken = container.has<TokenComponent>()
             lastKnownDamageDealtByPlayers =
@@ -393,6 +402,7 @@ object ZoneTransitionService {
                 lastKnownKeywords = lastKnownKeywords,
                 lastKnownLostAllAbilities = lastKnownLostAllAbilities,
                 lastKnownAttachedTo = if (leavingBattlefield) lastKnownAttachedTo else null,
+                lastKnownBlockingOrBlockedByIds = if (leavingBattlefield) lastKnownBlockingOrBlockedByIds else emptyList(),
                 lastKnownCardDefinitionId = if (leavingBattlefield) cardComponent.cardDefinitionId else null,
                 lastKnownDamageDealtByPlayers = lastKnownDamageDealtByPlayers,
                 xValue = lastKnownCastX

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -192,6 +192,15 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                     ?: return EffectResult.error(state, "No source entity for CardSource.Self")
                 if (state.getEntity(sourceId) != null) listOf(sourceId) else emptyList()
             }
+
+            is CardSource.LastKnownCombatPairedWithSource -> {
+                // CR 509 combat pairing captured when the source left the battlefield. Restrict
+                // to creatures still on the battlefield — a creature that already left can't be
+                // affected (last-known-information identifies them, it doesn't resurrect them).
+                val battlefield = state.getBattlefield().toSet()
+                (context.triggerLastKnownBlockingOrBlockedByIds ?: emptyList())
+                    .filter { it in battlefield }
+            }
         }
 
         if (cards.isEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1783,6 +1783,7 @@ class StackResolver(
             triggerTotalCounterCount = abilityComponent.triggerTotalCounterCount,
             triggerLastKnownCounters = abilityComponent.triggerLastKnownCounters,
             triggerLastKnownDamageDealtByPlayers = abilityComponent.triggerLastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds = abilityComponent.triggerLastKnownBlockingOrBlockedByIds,
             triggeringEntityId = abilityComponent.triggeringEntityId,
             triggeringPlayerId = abilityComponent.triggeringPlayerId,
             targetingSourceEntityId = abilityComponent.targetingSourceEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -107,6 +107,8 @@ data class TriggeredAbilityOnStackComponent(
     val triggerLastKnownCounters: Map<String, Int>? = null,
     /** Per-player damage dealt to the trigger's source this turn, captured at LTB time (Grothama). */
     val triggerLastKnownDamageDealtByPlayers: Map<EntityId, Int>? = null,
+    /** Creatures blocking/blocked by the trigger's source on leave-battlefield (CR 509 LKI, Abu Ja'far). */
+    val triggerLastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
     val targetingSourceEntityId: EntityId? = null,  // The spell/ability that targeted this permanent (for ward)
     val damageDistribution: Map<EntityId, Int>? = null,  // For DividedDamageEffect - pre-chosen damage allocation
     val copyIndex: Int? = null,    // Which copy number this is (1, 2, 3...) for storm/copy effects

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbuJafarTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbuJafarTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Abu Ja'far (Arabian Nights, {W}, 0/1 Human).
+ *
+ * Oracle: "When this creature dies, destroy all creatures blocking or blocked by it.
+ * They can't be regenerated."
+ *
+ * The dies trigger uses the source-relative [com.wingedsheep.sdk.scripting.predicates.StatePredicate.BlockingOrBlockedBySource]
+ * predicate: it reads the *surviving* creatures' combat components against Abu Ja'far's
+ * (now graveyard-bound) entity id, so the combat pairing is recovered as last-known
+ * information after Abu Ja'far has left combat.
+ */
+class AbuJafarTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("Abu Ja'far blocking and dying destroys the attacker it blocked, but not bystanders") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val defender = driver.activePlayer!!
+        val attacker = driver.getOpponent(defender)
+
+        val abu = driver.putCreatureOnBattlefield(defender, "Abu Ja'far")
+        driver.removeSummoningSickness(abu)
+        // A second creature the defender controls that takes no part in combat.
+        val bystander = driver.putCreatureOnBattlefield(defender, "Hill Giant")
+
+        val attackingBears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(attackingBears)
+
+        // Advance to the attacker's declare-attackers step. The attacker is the non-active
+        // player, so step past the active player's own combat (to their postcombat main)
+        // before seeking the next turn's declare-attackers.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        if (driver.activePlayer != attacker) {
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        }
+
+        driver.declareAttackers(attacker, listOf(attackingBears), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Abu Ja'far (0/1) blocks the 2/2.
+        driver.declareBlockers(defender, mapOf(abu to listOf(attackingBears)))
+
+        // Combat damage kills Abu Ja'far; its dies trigger resolves and destroys the
+        // creature it was blocked by (the attacking Grizzly Bears).
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.findPermanent(defender, "Abu Ja'far") shouldBe null
+        driver.findPermanent(attacker, "Grizzly Bears") shouldBe null
+        // The bystander was never in combat with Abu Ja'far — it must survive.
+        driver.findPermanent(defender, "Hill Giant") shouldNotBe null
+        bystander shouldNotBe null
+    }
+
+    test("Abu Ja'far attacking and dying destroys the creature blocking it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val abu = driver.putCreatureOnBattlefield(attacker, "Abu Ja'far")
+        driver.removeSummoningSickness(abu)
+
+        val blockingBears = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(blockingBears)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        if (driver.activePlayer != attacker) {
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        }
+
+        driver.declareAttackers(attacker, listOf(abu), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // The 2/2 blocks Abu Ja'far (0/1).
+        driver.declareBlockers(defender, mapOf(blockingBears to listOf(abu)))
+
+        // Abu Ja'far dies to combat damage; its trigger destroys the blocker.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.findPermanent(attacker, "Abu Ja'far") shouldBe null
+        driver.findPermanent(defender, "Grizzly Bears") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbuJafarTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbuJafarTest.kt
@@ -1,9 +1,15 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -14,10 +20,12 @@ import io.kotest.matchers.shouldNotBe
  * Oracle: "When this creature dies, destroy all creatures blocking or blocked by it.
  * They can't be regenerated."
  *
- * The dies trigger uses the source-relative [com.wingedsheep.sdk.scripting.predicates.StatePredicate.BlockingOrBlockedBySource]
- * predicate: it reads the *surviving* creatures' combat components against Abu Ja'far's
- * (now graveyard-bound) entity id, so the combat pairing is recovered as last-known
- * information after Abu Ja'far has left combat.
+ * The dies trigger uses [com.wingedsheep.sdk.scripting.effects.CardSource.LastKnownCombatPairedWithSource]:
+ * the live combat cross-references are torn down by the time a dies trigger resolves, so the
+ * pairing (CR 509) is captured as last-known information on Abu Ja'far's leaves-battlefield
+ * event ([com.wingedsheep.engine.core.ZoneChangeEvent.lastKnownBlockingOrBlockedByIds]) and the
+ * gather restricts it to creatures still on the battlefield. `noRegenerate = true`, so a
+ * shielded blocker is destroyed anyway.
  */
 class AbuJafarTest : FunSpec({
 
@@ -98,4 +106,54 @@ class AbuJafarTest : FunSpec({
         driver.findPermanent(attacker, "Abu Ja'far") shouldBe null
         driver.findPermanent(defender, "Grizzly Bears") shouldBe null
     }
+
+    test("Abu Ja'far's trigger can't be regenerated — a shielded blocker is destroyed anyway") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val abu = driver.putCreatureOnBattlefield(attacker, "Abu Ja'far")
+        driver.removeSummoningSickness(abu)
+
+        // The 2/2 blocks Abu Ja'far (0/1) — it takes no combat damage back, so its
+        // regeneration shield is still up when the dies trigger resolves.
+        val blockingBears = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(blockingBears)
+        driver.replaceState(
+            driver.state.copy(
+                floatingEffects = driver.state.floatingEffects + regenerationShield(blockingBears, defender)
+            )
+        )
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        if (driver.activePlayer != attacker) {
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        }
+
+        driver.declareAttackers(attacker, listOf(abu), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(blockingBears to listOf(abu)))
+
+        // Abu Ja'far dies; its "can't be regenerated" trigger destroys the blocker even
+        // though a regeneration shield is up.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.findPermanent(attacker, "Abu Ja'far") shouldBe null
+        driver.findPermanent(defender, "Grizzly Bears") shouldBe null
+    }
 })
+
+private fun regenerationShield(entityId: EntityId, controllerId: EntityId) = ActiveFloatingEffect(
+    id = EntityId.generate(),
+    effect = FloatingEffectData(
+        layer = Layer.ABILITY,
+        modification = SerializableModification.RegenerationShield,
+        affectedEntities = setOf(entityId)
+    ),
+    duration = Duration.EndOfTurn,
+    sourceId = null,
+    controllerId = controllerId,
+    timestamp = 1L
+)


### PR DESCRIPTION
Abu Ja'far ({W} 0/1 Human): "When this creature dies, destroy all creatures blocking or blocked by it. They can't be regenerated."

A dies trigger can't read live combat state — by the time it resolves the engine has already torn down the combat cross-references (and the dying creature's own combat components). So this captures the CR 509 combat pairing as last-known information when the creature leaves the battlefield and threads it through to the trigger's effect:

- ZoneChangeEvent.lastKnownBlockingOrBlockedByIds — captured in ZoneTransitionService from the leaver's BlockedComponent (its blockers) + BlockingComponent (the attackers it blocked).
- Carried through TriggerContext -> EffectContext (triggerLastKnownBlockingOrBlockedByIds), including the on-stack (TriggeredAbilityOnStackComponent) and targeted-trigger continuation paths.
- New CardSource.LastKnownCombatPairedWithSource resolves it (restricted to creatures still on the battlefield) so the standard gather+destroy pipeline can consume it.
- Facade: Effects.DestroyCreaturesBlockingOrBlockedBySource(noRegenerate).

Scenario test covers Abu Ja'far dying as a blocker (kills the attacker it blocked, spares a bystander) and as an attacker (kills its blocker). SDK reference updated.