### PR TITLE
Fix AI loop: "target spell" must not match abilities on the stack

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.sdk.core.Keyword
@@ -398,7 +399,12 @@ class TargetFinder(
         val filter = requirement.filter
         val predicateContext = PredicateContext(controllerId = controllerId)
         return state.stack.filter { spellId ->
-            predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, predicateContext)
+            // "Target spell" only matches actual spells — never triggered/activated abilities
+            // on the stack. The base filter is `Any` (zone = STACK), which would otherwise pass
+            // ability entities too, offering an illegal cast that TargetValidator then rejects
+            // ("Target must be a spell on the stack") — see CR 115.4.
+            state.getEntity(spellId)?.has<SpellOnStackComponent>() == true &&
+                predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, predicateContext)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.sdk.core.Keyword
@@ -400,10 +399,11 @@ class TargetFinder(
         val predicateContext = PredicateContext(controllerId = controllerId)
         return state.stack.filter { spellId ->
             // "Target spell" only matches actual spells — never triggered/activated abilities
-            // on the stack. The base filter is `Any` (zone = STACK), which would otherwise pass
-            // ability entities too, offering an illegal cast that TargetValidator then rejects
-            // ("Target must be a spell on the stack") — see CR 115.4.
-            state.getEntity(spellId)?.has<SpellOnStackComponent>() == true &&
+            // on the stack. A spell is a card on the stack (CR 112.1); an ability on the stack
+            // is an ability, not a spell (CR 113.3b/c, 113.7a). The base filter is `Any`
+            // (zone = STACK), which would otherwise pass ability entities too — so an
+            // empty-targets counterspell could be offered while only an ability is on the stack.
+            state.isSpellOnStack(spellId) &&
                 predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, predicateContext)
         }
     }
@@ -464,10 +464,9 @@ class TargetFinder(
             targets.add(entityId)
         }
 
-        // Add all spells on the stack
-        targets.addAll(state.stack.filter { spellId ->
-            state.getEntity(spellId)?.get<CardComponent>() != null
-        })
+        // Add all spells on the stack — only actual spells (CR 112.1), never abilities
+        // on the stack (CR 113.3b/c, 113.7a), consistent with findSpellTargets above.
+        targets.addAll(state.stack.filter { spellId -> state.isSpellOnStack(spellId) })
 
         return targets
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CounterEffectExecutor.kt
@@ -97,8 +97,7 @@ class CounterEffectExecutor(
         // a spell carries SpellOnStackComponent; activated/triggered abilities do not.
         val effectiveTarget = when (effect.target) {
             CounterTarget.SpellOrAbility -> {
-                val isSpell = state.getEntity(entityId)?.has<SpellOnStackComponent>() == true
-                if (isSpell) CounterTarget.Spell else CounterTarget.Ability
+                if (state.isSpellOnStack(entityId)) CounterTarget.Spell else CounterTarget.Ability
             }
             else -> effect.target
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -218,7 +219,13 @@ class TargetEnumerationUtils(
     ): List<EntityId> {
         val context = PredicateContext(controllerId = playerId)
         return state.stack.filter { spellId ->
-            predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, context)
+            // "Target spell" only matches actual spells — never triggered/activated abilities on
+            // the stack. The base filter is `Any` (zone = STACK) and would otherwise pass ability
+            // entities, surfacing a castable counterspell with an illegal target that
+            // TargetValidator then rejects ("Target must be a spell on the stack") — leaving the
+            // AI in an infinite re-pick loop (CR 115.4).
+            state.getEntity(spellId)?.has<SpellOnStackComponent>() == true &&
+                predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, context)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
-import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -220,11 +219,11 @@ class TargetEnumerationUtils(
         val context = PredicateContext(controllerId = playerId)
         return state.stack.filter { spellId ->
             // "Target spell" only matches actual spells — never triggered/activated abilities on
-            // the stack. The base filter is `Any` (zone = STACK) and would otherwise pass ability
-            // entities, surfacing a castable counterspell with an illegal target that
-            // TargetValidator then rejects ("Target must be a spell on the stack") — leaving the
-            // AI in an infinite re-pick loop (CR 115.4).
-            state.getEntity(spellId)?.has<SpellOnStackComponent>() == true &&
+            // the stack. A spell is a card on the stack (CR 112.1); an ability on the stack is an
+            // ability, not a spell (CR 113.3b/c, 113.7a). The base filter is `Any` (zone = STACK)
+            // and would otherwise pass ability entities, surfacing a castable counterspell whenever
+            // anything is on the stack — which previously left the AI in an infinite re-pick loop.
+            state.isSpellOnStack(spellId) &&
                 predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, context)
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.engine.state.components.battlefield.GraveyardEntryTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.StateProjector
@@ -370,6 +371,15 @@ data class GameState(
      * Get the top entity on the stack, or null if empty.
      */
     fun getTopOfStack(): EntityId? = stack.lastOrNull()
+
+    /**
+     * True if the stack entity is a *spell* (a card on the stack, CR 112.1), as opposed
+     * to an activated/triggered ability on the stack (CR 113.3b/c, 113.7a). The canonical
+     * marker is [SpellOnStackComponent]; ability entities never carry it. Use this for
+     * "target spell" enumeration/validation so abilities aren't offered as spell targets.
+     */
+    fun isSpellOnStack(entityId: EntityId): Boolean =
+        getEntity(entityId)?.has<SpellOnStackComponent>() == true
 
     /**
      * Remove a specific entity from the stack (for countering).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TargetSpellExcludesAbilitiesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TargetSpellExcludesAbilitiesTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
+import com.wingedsheep.engine.legalactions.support.shouldContainCastOf
+import com.wingedsheep.engine.legalactions.support.shouldNotContainCastOf
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression test for the "target spell" enumeration loop.
+ *
+ * A counterspell's target requirement is `TargetSpell()`, whose filter is
+ * `Any` with `zone = STACK`. The enumerator's stack-target finders used to
+ * return *every* stack object — including triggered/activated abilities — so a
+ * counterspell was offered as a legal cast whenever ANYTHING was on the stack.
+ * [com.wingedsheep.engine.mechanics.targeting.TargetValidator] then rejected the
+ * chosen ability ("Target must be a spell on the stack"), and an AI that re-picked
+ * the same enumerated action looped forever.
+ *
+ * "Target spell" must match only actual spells (entities with a
+ * `SpellOnStackComponent`), never abilities on the stack (CR 115.4 — a spell or
+ * ability that targets a spell can't target an ability).
+ */
+class TargetSpellExcludesAbilitiesTest : FunSpec({
+
+    val pingerAbility = AbilityId("test-life-pinger")
+
+    // Artifact with a NON-mana activated ability that uses the stack.
+    val LifePinger = CardDefinition(
+        name = "Life Pinger",
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.artifact(),
+        oracleText = "{T}: You gain 1 life.",
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = pingerAbility,
+                cost = AbilityCost.Tap,
+                effect = GainLifeEffect(1)
+            )
+        )
+    )
+
+    fun newDriver(): EnumerationTestDriver {
+        val driver = EnumerationTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(LifePinger))
+        driver.game.initMirrorMatch(
+            deck = Deck.of("Island" to 40, "Life Pinger" to 4, "Counterspell" to 4),
+            skipMulligans = true
+        )
+        driver.game.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("an activated ability on the stack does NOT make a counterspell castable") {
+        val driver = newDriver()
+        val p1 = driver.player1
+
+        // P1 controls the artifact and holds Counterspell with mana up.
+        val pinger = driver.game.putPermanentOnBattlefield(p1, "Life Pinger")
+        val counterspell = driver.game.putCardInHand(p1, "Counterspell")
+        driver.game.giveMana(p1, Color.BLUE, 2)
+
+        // Sanity: with an empty stack, Counterspell has no legal target → not castable.
+        driver.enumerateFor(p1) shouldNotContainCastOf "Counterspell"
+
+        // Activate the artifact's non-mana ability — it goes on the stack.
+        driver.game.submitSuccess(ActivateAbility(p1, pinger, pingerAbility))
+        driver.game.stackSize == 1 || error("expected the ability on the stack")
+
+        // The only stack object is an ability, not a spell. Counterspell must NOT be
+        // offered — this is the case that previously looped.
+        driver.enumerateFor(p1) shouldNotContainCastOf "Counterspell"
+    }
+
+    test("a spell on the stack DOES make a counterspell castable (positive control)") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        val counterspell = driver.game.putCardInHand(p1, "Counterspell")
+        driver.game.giveMana(p1, Color.BLUE, 2)
+
+        // Put a real spell on the stack: P1 casts Lightning Bolt at P2.
+        val bolt = driver.game.putCardInHand(p1, "Lightning Bolt")
+        driver.game.giveMana(p1, Color.RED, 1)
+        driver.game.castSpell(p1, bolt, listOf(p2))
+
+        // A genuine spell is on the stack → Counterspell can target it.
+        driver.enumerateFor(p1) shouldContainCastOf "Counterspell"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TargetSpellExcludesAbilitiesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TargetSpellExcludesAbilitiesTest.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.engine.legalactions
 
 import com.wingedsheep.engine.core.ActivateAbility
-import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
 import com.wingedsheep.engine.legalactions.support.shouldContainCastOf
 import com.wingedsheep.engine.legalactions.support.shouldNotContainCastOf
@@ -18,6 +17,7 @@ import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Regression test for the "target spell" enumeration loop.
@@ -25,14 +25,14 @@ import io.kotest.core.spec.style.FunSpec
  * A counterspell's target requirement is `TargetSpell()`, whose filter is
  * `Any` with `zone = STACK`. The enumerator's stack-target finders used to
  * return *every* stack object — including triggered/activated abilities — so a
- * counterspell was offered as a legal cast whenever ANYTHING was on the stack.
- * [com.wingedsheep.engine.mechanics.targeting.TargetValidator] then rejected the
- * chosen ability ("Target must be a spell on the stack"), and an AI that re-picked
- * the same enumerated action looped forever.
+ * counterspell was offered as a legal cast whenever ANYTHING was on the stack,
+ * and an AI that re-picked the same (ultimately illegal) enumerated action
+ * looped forever.
  *
- * "Target spell" must match only actual spells (entities with a
- * `SpellOnStackComponent`), never abilities on the stack (CR 115.4 — a spell or
- * ability that targets a spell can't target an ability).
+ * "Target spell" must match only actual spells (a spell is a card on the stack,
+ * CR 112.1), never abilities on the stack — an activated or triggered ability on
+ * the stack is an ability, not a spell (CR 113.3b/c, 113.7a). The canonical marker
+ * is `SpellOnStackComponent`, surfaced via `GameState.isSpellOnStack`.
  */
 class TargetSpellExcludesAbilitiesTest : FunSpec({
 
@@ -71,7 +71,7 @@ class TargetSpellExcludesAbilitiesTest : FunSpec({
 
         // P1 controls the artifact and holds Counterspell with mana up.
         val pinger = driver.game.putPermanentOnBattlefield(p1, "Life Pinger")
-        val counterspell = driver.game.putCardInHand(p1, "Counterspell")
+        driver.game.putCardInHand(p1, "Counterspell")
         driver.game.giveMana(p1, Color.BLUE, 2)
 
         // Sanity: with an empty stack, Counterspell has no legal target → not castable.
@@ -79,7 +79,7 @@ class TargetSpellExcludesAbilitiesTest : FunSpec({
 
         // Activate the artifact's non-mana ability — it goes on the stack.
         driver.game.submitSuccess(ActivateAbility(p1, pinger, pingerAbility))
-        driver.game.stackSize == 1 || error("expected the ability on the stack")
+        driver.game.stackSize shouldBe 1
 
         // The only stack object is an ability, not a spell. Counterspell must NOT be
         // offered — this is the case that previously looped.
@@ -91,7 +91,7 @@ class TargetSpellExcludesAbilitiesTest : FunSpec({
         val p1 = driver.player1
         val p2 = driver.player2
 
-        val counterspell = driver.game.putCardInHand(p1, "Counterspell")
+        driver.game.putCardInHand(p1, "Counterspell")
         driver.game.giveMana(p1, Color.BLUE, 2)
 
         // Put a real spell on the stack: P1 casts Lightning Bolt at P2.


### PR DESCRIPTION
A counterspell's TargetSpell() requirement uses TargetFilter.SpellOnStack (GameObjectFilter.Any, zone = STACK). Both stack-target finders filtered state.stack by the base filter alone, and Any matches every entity — so triggered/activated abilities on the stack were counted as valid "target spell" targets. The enumerator then offered an illegal counterspell cast that TargetValidator rejected ("Target must be a spell on the stack"), looping the AI forever when an opponent ability sat on the stack.

Restrict findSpellTargets / findValidSpellTargets to entities that are actually spells (carry SpellOnStackComponent); ability-on-stack entities have no such component. A spell is a card on the stack (CR 112.1), whereas an activated/triggered ability put on the stack is an ability, not a spell (CR 113.3b/c), and once on the stack it exists as its own object independent of its source (CR 113.7a) — so "target spell" can never select it.