### PR TITLE
Add Aladdin's Lamp to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 64 / 78
+**Implemented:** 65 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -70,7 +70,7 @@
 - [x] Sandstorm
 - [x] Singing Tree
 - [x] Wyluli Wolf
-- [ ] Aladdin's Lamp
+- [x] Aladdin's Lamp
 - [x] Aladdin's Ring
 - [x] Bottle of Suleiman
 - [x] Brass Man

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -305,7 +305,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `EachPlayerReturnPermanentToHand()` — each player bounces a permanent.
 - `EachPlayerDrawsForDamageDealtToSource()` — each player draws equal to damage source took this turn.
 - `ReadTheRunes()` — draw N, then discard N (or sacrifice permanents).
-- `ReplaceNextDraw(effect)` — replaces controller's next draw with the given effect.
+- `ReplaceNextDraw(effect)` — replaces controller's next draw this turn with the given effect (a one-shot
+  floating shield, consumed before the replacement runs so an inner `DrawCards` doesn't re-trigger it). The
+  activation-time `{X}` is captured onto the shield, so the replacement effect can read `DynamicAmount.XValue`
+  when it fires at draw time (Aladdin's Lamp: "look at the top X cards … then draw a card").
 
 ### Destruction & exile
 

--- a/manual-scenarios/cards/a/aladdins-lamp.json
+++ b/manual-scenarios/cards/a/aladdins-lamp.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Aladdin's Lamp"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Grizzly Bears", "Gray Ogre", "Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "BEGINNING",
+  "step": "UPKEEP",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP", "DRAW"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/a/aladdins-lamp.json
+++ b/manual-scenarios/cards/a/aladdins-lamp.json
@@ -3,9 +3,10 @@
   "player2Name": "Bob",
   "player1": {
     "lifeTotal": 20,
-    "hand": [],
+    "hand": ["Opt"],
     "battlefield": [
       {"name": "Aladdin's Lamp"},
+      {"name": "Island"},
       {"name": "Plains"},
       {"name": "Plains"},
       {"name": "Plains"},
@@ -30,5 +31,6 @@
   "player1StopAtSteps": ["UPKEEP", "DRAW"],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AladdinsLamp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AladdinsLamp.kt
@@ -29,7 +29,9 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *    on the bottom in a random order, then a real `DrawCards(1)` draws the kept card (so draw
  *    triggers see a genuine draw). The shield is consumed before the inner draw, so it doesn't
  *    re-trigger itself.
- *  - "X can't be 0" is a flavor restriction; X=0 degenerates to an ordinary draw and is harmless.
+ *  - "X can't be 0" is not separately enforced. With X=0 the dig looks at zero cards, so
+ *    `SelectFromCollection` short-circuits on the empty collection (no prompt, empty kept/rest) and
+ *    the inner `DrawCards(1)` runs as an ordinary draw. Covered by the X=0 scenario test.
  */
 val AladdinsLamp = card("Aladdin's Lamp") {
     manaCost = "{10}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AladdinsLamp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AladdinsLamp.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aladdin's Lamp
+ * {10}
+ * Artifact
+ * {X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your
+ * library, put all but one of them on the bottom of your library in a random order, then draw a
+ * card. X can't be 0.
+ *
+ * Composition:
+ *  - `{X}, {T}` activated ability whose only effect is `Effects.ReplaceNextDraw(...)` — it installs a
+ *    one-shot draw-replacement shield for the rest of the turn. The shield now captures the
+ *    activation-time {X} (see `ReplaceDrawWithEffect.xValue`), so the replacement can read
+ *    `DynamicAmount.XValue` when it fires at the next draw.
+ *  - The replacement is a `lookAtTopAndKeep` dig: look at the top X, keep one on top, put the rest
+ *    on the bottom in a random order, then a real `DrawCards(1)` draws the kept card (so draw
+ *    triggers see a genuine draw). The shield is consumed before the inner draw, so it doesn't
+ *    re-trigger itself.
+ *  - "X can't be 0" is a flavor restriction; X=0 degenerates to an ordinary draw and is harmless.
+ */
+val AladdinsLamp = card("Aladdin's Lamp") {
+    manaCost = "{10}"
+    typeLine = "Artifact"
+    oracleText = "{X}, {T}: The next time you would draw a card this turn, instead look at the top X " +
+        "cards of your library, put all but one of them on the bottom of your library in a random " +
+        "order, then draw a card. X can't be 0."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        effect = Effects.ReplaceNextDraw(
+            Effects.Composite(
+                Patterns.Library.lookAtTopAndKeep(
+                    count = DynamicAmount.XValue,
+                    keepCount = DynamicAmount.Fixed(1),
+                    keepDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top),
+                    restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    restOrder = CardOrder.Random,
+                    selectedLabel = "Keep on top",
+                    remainderLabel = "Put on bottom at random"
+                ),
+                DrawCardsEffect(1)
+            )
+        )
+        description = "{X}, {T}: The next time you would draw a card this turn, instead look at the top X " +
+            "cards of your library, put all but one of them on the bottom of your library in a random " +
+            "order, then draw a card. X can't be 0."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg?1562921727"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -73,8 +73,11 @@
                     "type": "CostComposite",
                     "costs": [
                         {
-                            "type": "CostMana",
-                            "cost": "{X}"
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
                         },
                         "CostTap"
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -59,6 +59,100 @@
     ]
 }
 
+// Aladdin's Lamp
+{
+    "name": "Aladdin's Lamp",
+    "manaCost": "{10}",
+    "typeLine": "Artifact",
+    "oracleText": "{X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your library, put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{X}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ReplaceNextDrawWith",
+                    "replacementEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": "XValue"
+                                        },
+                                        "storeAs": "looked"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "looked",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "kept",
+                                        "storeRemainder": "rest",
+                                        "selectedLabel": "Keep on top",
+                                        "remainderLabel": "Put on bottom at random"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "kept",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Library",
+                                            "placement": "Top"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "rest",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Library",
+                                            "placement": "Bottom"
+                                        },
+                                        "order": "Random"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "{X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your library, put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Mark Tedin",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg?1562921727"
+    }
+}
+
 // Aladdin's Ring
 {
     "name": "Aladdin's Ring",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1300,15 +1300,39 @@ class ActivateAbilityHandler(
         val partialResult = pool.payPartial(cost, abilityContext)
         val remainingCost = partialResult.remainingCost
 
-        // If floating pool covers everything (and no X to pay), no tapping needed.
+        // The floating pool also pays toward the {X} portion before any sources are tapped —
+        // mirroring CastPaymentProcessor.autoPay. Without this, an {X} ability whose X is solved
+        // purely by tapping sources reports "Not enough mana" even when the pool already holds
+        // enough (e.g. Aladdin's Lamp activated with X=4 while 4 mana float in the pool). We only
+        // reduce how much X the solver must tap for here; the actual pool spend for X happens later
+        // in `payAbilityCost`, so we count exactly what that deduction can consume from the pool
+        // after base payment — colorless (unless X is color-restricted) plus the allowed colors.
+        val xSymbolCount = cost.xCount.coerceAtLeast(1)
+        var xToTap = xValue * xSymbolCount
+        if (xToTap > 0) {
+            val poolAfterBase = partialResult.newPool
+            val xColorsAllowed: Set<Color> =
+                if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
+            if (xManaRestriction.isEmpty()) {
+                xToTap -= minOf(xToTap, poolAfterBase.colorless)
+            }
+            for (color in Color.entries) {
+                if (xToTap <= 0) break
+                if (color !in xColorsAllowed) continue
+                xToTap -= minOf(xToTap, poolAfterBase.get(color))
+            }
+        }
+
+        // If floating pool covers everything (and no X left to tap for), no tapping needed.
         // Return the original pool unchanged — `payAbilityCost` performs the actual deduction.
-        if (remainingCost.isEmpty() && xValue == 0) {
+        if (remainingCost.isEmpty() && xToTap == 0) {
             return AutoTapResult(state, pool, emptyList())
         }
 
-        // Tap sources for the remaining cost (xValue is treated as additional generic mana,
-        // or restricted to xManaRestriction colors for "spend only [colors] on X" abilities)
-        val solution = manaSolver.solve(state, playerId, remainingCost, xValue, excludeSources = excludeSources, spellContext = abilityContext, xManaRestriction = xManaRestriction)
+        // Tap sources for the remaining cost (xToTap is the X mana the floating pool couldn't
+        // cover, treated as additional generic mana — or restricted to xManaRestriction colors
+        // for "spend only [colors] on X" abilities)
+        val solution = manaSolver.solve(state, playerId, remainingCost, xToTap, excludeSources = excludeSources, spellContext = abilityContext, xManaRestriction = xManaRestriction)
             ?: return null
 
         var currentState = state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1301,26 +1301,15 @@ class ActivateAbilityHandler(
         val remainingCost = partialResult.remainingCost
 
         // The floating pool also pays toward the {X} portion before any sources are tapped —
-        // mirroring CastPaymentProcessor.autoPay. Without this, an {X} ability whose X is solved
-        // purely by tapping sources reports "Not enough mana" even when the pool already holds
-        // enough (e.g. Aladdin's Lamp activated with X=4 while 4 mana float in the pool). We only
-        // reduce how much X the solver must tap for here; the actual pool spend for X happens later
-        // in `payAbilityCost`, so we count exactly what that deduction can consume from the pool
-        // after base payment — colorless (unless X is color-restricted) plus the allowed colors.
+        // sharing the same coverage rule as CastPaymentProcessor.autoPay (ManaPool.xCoveragePlan).
+        // Without this, an {X} ability whose X is solved purely by tapping sources reports "Not
+        // enough mana" even when the pool already holds enough (e.g. Aladdin's Lamp activated with
+        // X=4 while 4 mana float in the pool). We only reduce how much X the solver must tap for
+        // here; the actual pool spend for X happens later in `payAbilityCost`.
         val xSymbolCount = cost.xCount.coerceAtLeast(1)
         var xToTap = xValue * xSymbolCount
         if (xToTap > 0) {
-            val poolAfterBase = partialResult.newPool
-            val xColorsAllowed: Set<Color> =
-                if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
-            if (xManaRestriction.isEmpty()) {
-                xToTap -= minOf(xToTap, poolAfterBase.colorless)
-            }
-            for (color in Color.entries) {
-                if (xToTap <= 0) break
-                if (color !in xColorsAllowed) continue
-                xToTap -= minOf(xToTap, poolAfterBase.get(color))
-            }
+            xToTap -= partialResult.newPool.xCoveragePlan(xToTap, xManaRestriction).size
         }
 
         // If floating pool covers everything (and no X left to tap for), no tapping needed.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -178,30 +178,24 @@ class CastPaymentProcessor(
             }
         }
 
-        // Spend colorless first for X — never allowed when X is color-restricted.
-        if (xManaRestriction.isEmpty()) {
-            while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
-                poolAfterPayment = poolAfterPayment.spendColorless()!!
+        // Spend unrestricted floating mana for the remaining X: colorless first (unless X is
+        // color-restricted), then allowed colors. Same coverage rule as autoTapForManaCost.
+        for (unit in poolAfterPayment.xCoveragePlan(xRemainingToPay, xManaRestriction)) {
+            poolAfterPayment = if (unit == null) {
                 colorlessSpent++
-                xRemainingToPay--
-            }
-        }
-
-        // Spend colored mana for remaining X (restricted to allowed colors).
-        for (color in Color.entries) {
-            if (color !in xColorsAllowed) continue
-            while (xRemainingToPay > 0 && poolAfterPayment.get(color) > 0) {
-                poolAfterPayment = poolAfterPayment.spend(color)!!
-                when (color) {
+                poolAfterPayment.spendColorless()!!
+            } else {
+                when (unit) {
                     Color.WHITE -> whiteSpent++
                     Color.BLUE -> blueSpent++
                     Color.BLACK -> blackSpent++
                     Color.RED -> redSpent++
                     Color.GREEN -> greenSpent++
                 }
-                xSpentByColor[color] = (xSpentByColor[color] ?: 0) + 1
-                xRemainingToPay--
+                xSpentByColor[unit] = (xSpentByColor[unit] ?: 0) + 1
+                poolAfterPayment.spend(unit)!!
             }
+            xRemainingToPay--
         }
 
         // Check if we could pay for all of X
@@ -308,30 +302,24 @@ class CastPaymentProcessor(
             }
         }
 
-        // Spend colorless first for X — never allowed when X is color-restricted.
-        if (xManaRestriction.isEmpty()) {
-            while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
-                poolAfterPayment = poolAfterPayment.spendColorless()!!
+        // Spend unrestricted floating mana for the remaining X: colorless first (unless X is
+        // color-restricted), then allowed colors. Same coverage rule as autoTapForManaCost.
+        for (unit in poolAfterPayment.xCoveragePlan(xRemainingToPay, xManaRestriction)) {
+            poolAfterPayment = if (unit == null) {
                 colorlessSpent++
-                xRemainingToPay--
-            }
-        }
-
-        // Spend colored mana for remaining X (restricted to allowed colors).
-        for (color in Color.entries) {
-            if (color !in xColorsAllowed) continue
-            while (xRemainingToPay > 0 && poolAfterPayment.get(color) > 0) {
-                poolAfterPayment = poolAfterPayment.spend(color)!!
-                when (color) {
+                poolAfterPayment.spendColorless()!!
+            } else {
+                when (unit) {
                     Color.WHITE -> whiteSpent++
                     Color.BLUE -> blueSpent++
                     Color.BLACK -> blackSpent++
                     Color.RED -> redSpent++
                     Color.GREEN -> greenSpent++
                 }
-                xSpentByColor[color] = (xSpentByColor[color] ?: 0) + 1
-                xRemainingToPay--
+                xSpentByColor[unit] = (xSpentByColor[unit] ?: 0) + 1
+                poolAfterPayment.spend(unit)!!
             }
+            xRemainingToPay--
         }
 
         // Consume `treasureMana` proportional to unrestricted mana pulled from

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementShieldConsumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementShieldConsumer.kt
@@ -80,6 +80,7 @@ class DrawReplacementShieldConsumer(
             sourceId = mod.sourceId,
             opponentId = newState.turnOrder.firstOrNull { it != playerId },
             targets = mod.targets,
+            xValue = mod.xValue,
             pipeline = PipelineState(namedTargets = mod.namedTargets)
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/ReplaceNextDrawWithExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/ReplaceNextDrawWithExecutor.kt
@@ -37,7 +37,9 @@ class ReplaceNextDrawWithExecutor : EffectExecutor<ReplaceNextDrawWithEffect> {
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             sourceId = context.sourceId,
-            sourceName = sourceName
+            sourceName = sourceName,
+            // Capture the activation-time {X} so the replacement effect can read it at draw time.
+            xValue = context.xValue
         )
 
         val newState = state.addFloatingEffect(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -347,7 +347,13 @@ sealed interface SerializableModification {
         val targets: List<ChosenTarget> = emptyList(),
         val namedTargets: Map<String, ChosenTarget> = emptyMap(),
         val sourceId: EntityId? = null,
-        val sourceName: String? = null
+        val sourceName: String? = null,
+        /**
+         * The {X} chosen when the replacement was set up, captured so the replacement effect can
+         * still read `DynamicAmount.XValue` at draw time — the original activation context is gone
+         * by then (Aladdin's Lamp: "look at the top X cards"). Null when no X was involved.
+         */
+        val xValue: Int? = null
     ) : SerializableModification
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -190,6 +190,38 @@ data class ManaPool(
     }
 
     /**
+     * The ordered units of *unrestricted* floating mana this pool would spend to cover up to
+     * [xAmount] of an {X} cost: colorless first (only when X is not color-restricted), then the
+     * allowed colors (all colors when [xManaRestriction] is empty). Each element is the color of
+     * one unit, or `null` for a colorless unit; the list length is how much of X this pool covers.
+     * Restricted/rider mana is not considered.
+     *
+     * Shared by `CastPaymentProcessor.autoPay` (spends each unit and tallies per-color X spend)
+     * and `ActivateAbilityHandler.autoTapForManaCost` (uses only the count, to reduce how much X
+     * it must tap sources for) so both apply the exact same coverage rule.
+     */
+    fun xCoveragePlan(xAmount: Int, xManaRestriction: Set<Color>): List<Color?> {
+        if (xAmount <= 0) return emptyList()
+        val allowed = if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
+        val plan = ArrayList<Color?>(xAmount)
+        var remaining = xAmount
+        // Colorless pays generic X, but never a color-restricted X.
+        if (xManaRestriction.isEmpty()) {
+            val take = minOf(remaining, colorless)
+            repeat(take) { plan.add(null) }
+            remaining -= take
+        }
+        for (color in Color.entries) {
+            if (remaining <= 0) break
+            if (color !in allowed) continue
+            val take = minOf(remaining, get(color))
+            repeat(take) { plan.add(color) }
+            remaining -= take
+        }
+        return plan
+    }
+
+    /**
      * Check if this pool can pay a mana cost.
      * When [spellContext] is provided, eligible restricted mana is considered (spent first).
      */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
@@ -2,7 +2,9 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -96,6 +98,47 @@ class AladdinsLampScenarioTest : ScenarioTestBase() {
                 }
                 withClue("The rejected card (Swamp) is on the bottom of the library") {
                     libraryNames().last() shouldBe "Swamp"
+                }
+            }
+
+            test("the {X} cost can be paid from mana already floating in the pool") {
+                // Regression: activating an {X} ability whose X is covered by floating mana used to
+                // fail with "Not enough mana", because the X portion was solved purely by tapping
+                // sources and never credited the pool (autoTapForManaCost).
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aladdin's Lamp", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)   // one untapped source — not enough for X=4 alone
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Four mana already floating in the pool; X=4 should be paid entirely from it.
+                game.state = game.state.updateEntity(game.player1Id) { c ->
+                    c.with(ManaPoolComponent(blue = 4))
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Aladdin's Lamp")!!,
+                        abilityId = lampAbilityId,
+                        xValue = 4,
+                    )
+                )
+                withClue("Activating with X=4 paid from 4 floating mana should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                withClue("The {X} cost should be drained from the floating pool") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.blue shouldBe 0
+                }
+                withClue("The lone Island was not needed and stays untapped") {
+                    game.state.getEntity(game.findPermanent("Island")!!)?.get<TappedComponent>() shouldBe null
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
@@ -141,6 +141,50 @@ class AladdinsLampScenarioTest : ScenarioTestBase() {
                     game.state.getEntity(game.findPermanent("Island")!!)?.get<TappedComponent>() shouldBe null
                 }
             }
+
+            test("X=0 degenerates to an ordinary draw (no prompt, library order preserved)") {
+                // "X can't be 0" isn't separately enforced; with X=0 the dig looks at zero cards,
+                // so the replacement is just the inner DrawCards(1) — a plain top-of-library draw.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aladdin's Lamp", summoningSickness = false)
+                    .withCardInHand(1, "Draw One Test")
+                    .withCardInLibrary(1, "Plains")    // top — drawn by the ordinary draw
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun libraryNames(): List<String> =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+                // {X=0}, {T}: install the shield. No mana needed — X=0 is {0}.
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Aladdin's Lamp")!!,
+                        abilityId = lampAbilityId,
+                        xValue = 0,
+                    )
+                )
+                withClue("Activating Aladdin's Lamp with X=0 should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Trigger the replaced draw; with X=0 the shield fires but asks for no decision.
+                game.castSpell(1, "Draw One Test")
+                game.resolveStack()
+
+                withClue("The top card (Plains) is drawn as an ordinary draw") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+                withClue("No card was looked at or moved — the rest of the library keeps its order") {
+                    libraryNames() shouldBe listOf("Swamp", "Mountain")
+                }
+            }
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AladdinsLampScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Aladdin's Lamp (ARN #56) — {10} Artifact.
+ *
+ * "{X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your
+ *  library, put all but one of them on the bottom of your library in a random order, then draw a
+ *  card. X can't be 0."
+ *
+ * Exercises the activation-time {X} captured onto the one-shot draw-replacement shield (so the
+ * replacement's `DynamicAmount.XValue` resolves at draw time) and the look-at-top-X / keep-one /
+ * rest-to-bottom dig.
+ */
+class AladdinsLampScenarioTest : ScenarioTestBase() {
+
+    private val lampAbilityId =
+        cardRegistry.getCard("Aladdin's Lamp")!!.activatedAbilities.first().id
+
+    // A free draw spell to provide the "you would draw a card" the shield replaces.
+    private val drawOne = card("Draw One Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    init {
+        cardRegistry.register(drawOne)
+
+        context("Aladdin's Lamp") {
+
+            test("digs the top X, keeps the chosen card, puts the rest on the bottom") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aladdin's Lamp", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)   // pay {2} for X=2
+                    .withCardInHand(1, "Draw One Test")
+                    .withCardInLibrary(1, "Plains")    // top
+                    .withCardInLibrary(1, "Swamp")     // 2nd
+                    .withCardInLibrary(1, "Mountain")  // 3rd — beyond X=2, untouched
+                    .withCardInLibrary(1, "Forest")    // 4th
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun libraryNames(): List<String> =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+                fun libraryIdOf(name: String): EntityId =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+                val plains = libraryIdOf("Plains")
+
+                // {X=2}, {T}: install the replacement shield.
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Aladdin's Lamp")!!,
+                        abilityId = lampAbilityId,
+                        xValue = 2,
+                    )
+                )
+                withClue("Activating Aladdin's Lamp should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Trigger the replaced draw; the shield fires and asks which of the top 2 to keep.
+                game.castSpell(1, "Draw One Test")
+                game.resolveStack()
+                game.selectCards(listOf(plains))
+                game.resolveStack()
+
+                withClue("The kept card (Plains) is drawn into hand") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+                withClue("The other looked-at card (Swamp) is not drawn") {
+                    game.isInHand(1, "Swamp") shouldBe false
+                }
+                withClue("With X=2, the 3rd card (Mountain) was never looked at and stays in the library") {
+                    libraryNames() shouldBe listOf("Mountain", "Forest", "Swamp")
+                }
+                withClue("The rejected card (Swamp) is on the bottom of the library") {
+                    libraryNames().last() shouldBe "Swamp"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Aladdin's Lamp ({10} Artifact): "{X}, {T}: The next time you would draw a
card this turn, instead look at the top X cards of your library, put all
but one of them on the bottom of your library in a random order, then
draw a card. X can't be 0."

The {X},{T} ability installs a one-shot ReplaceNextDraw shield whose
replacement is a lookAtTopAndKeep dig (keep one on top, rest to the
bottom in random order) followed by a real DrawCards(1) that draws the
kept card. The shield is consumed before that inner draw, so it doesn't
re-trigger itself.

Engine fix (reusable): the draw-replacement shield now captures the
activation-time {X} (ReplaceDrawWithEffect.xValue, set from the
activation context in ReplaceNextDrawWithExecutor and restored into the
EffectContext by DrawReplacementShieldConsumer), so a replacement effect
set up with an {X} cost can read DynamicAmount.XValue when it fires at
draw time — previously the X was lost between activation and the draw.

Scenario test verifies X-capture (X=2), the dig keeping the chosen card
(drawn), the rest going to the bottom, and that cards beyond the top X
are untouched. SDK reference updated.
