### PR TITLE
Add Effects.Pipeline { } — inline pipeline builder with typed slot handles

### DIFF
--- a/backlog/inline-pipeline-dsl.md
+++ b/backlog/inline-pipeline-dsl.md
@@ -1,6 +1,10 @@
 # Inline pipeline DSL — typed slot handles for card-file pipelines
 
-_Drafted 2026-06-12, out of the PR #630 (Drop of Honey) review discussion. Status: proposal._
+_Drafted 2026-06-12, out of the PR #630 (Drop of Honey) review discussion. Status: §5 step 1
+(builder core) + pilot migration implemented — `mtg-sdk/dsl/PipelineBuilder.kt`, entry point
+`Effects.Pipeline { }`, reference in `card-sdk-language-reference.md` §5.5; `inv/cards/Lobotomy.kt`
+migrated byte-identically. Steps 2–5 (new-card pilots, corpus migration, facade closure, emitter
+renderer) remain open._
 
 ## 0. The problem
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -830,6 +830,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 ## 5. Effect patterns (`Patterns.Library.*` / `Patterns.Hand.*` / `Patterns.Group.*` / `Patterns.Exile.*` / `Patterns.CreatureType.*` / `Patterns.Mechanic.*`)
 
 Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` shapes and similar).
+Named entries here are for named MTG mechanics and shapes with a demonstrated second user — a
+one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5.5) instead.
 
 **Library search & reveal**
 
@@ -912,6 +914,99 @@ Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` sh
 - `modifyStatsForAll(power, toughness, filter, duration?)` — give every match +X/+Y (`Int` or `DynamicAmount`).
 - `doublePowerAndToughnessForAll(filter, duration?)` — double each match's power and toughness. Resolves to a fixed +P/+T modification read per-entity from projected state via `DynamicAmount.EntityProperty(EntityReference.IterationEntity, …)`, so the bonus locks in at resolution (no re-doubling) and negative power doubles correctly. Roar of Endless Song, Unnatural Growth.
 - `grantKeywordToAll(keyword, filter, duration?)` / `removeKeywordFromAll(...)`; `tapAll(filter)` / `untapGroup(filter?)`; `dealDamageToAll(amount, filter)`; `destroyAll(filter, noRegenerate?)`; `gainControlOfGroup(filter?, duration?)`.
+
+---
+
+## 5.5 Inline pipelines (`Effects.Pipeline { }`)
+
+The facade-respecting way to compose a **one-off** Gather → Select → Move pipeline inside a card
+file (see `backlog/inline-pipeline-dsl.md`). Named `Patterns.*` entries are for named MTG mechanics
+and shapes with a demonstrated second user; one-off pipelines go inline via the builder instead of
+hand-threading string slot keys between raw step constructors.
+
+Each builder verb serializes to the existing pipeline step `Effect` — the result is the exact same
+`CompositeEffect` tree the raw constructors produce (zero engine change, zero JSON-contract change).
+Steps return **typed slot handles**; the only way to obtain a handle is from a step that produced
+it, so a read-without-write (the `CardLinter` dangling-slot error class) cannot be expressed.
+
+```kotlin
+effect = Effects.Pipeline {
+    val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(7)))
+    val (kept, rest) = chooseExactlySplit(2, from = looked)
+    toHand(kept)
+    toGraveyard(rest)
+}
+```
+
+**Slot handles** (one per `EffectContext` namespace, mirroring `CardLinter.Space`):
+
+| Handle | Backing store | Produced by | Consumed by |
+|---|---|---|---|
+| `CollectionSlot` | `storedCollections` | `gather`, `chooseExactly`, `filter`, `captureControllers`, `moveTracked`, … | `move`, `reveal`, the select/filter verbs, `forEachCaptured` |
+| `NumberSlot` | `storedNumbers` | `storeNumber`, `forEachCaptured`'s block param | `.amount` → `DynamicAmount.VariableReference` |
+| `ChosenSlot` | `chosenValues` | `storeCardName`, `chooseOption`, `noteCreatureType` | `GameObjectFilter.namedFromVariable(slot)` |
+| `SubtypeGroupsSlot` | `storedSubtypeGroups` | `gatherSubtypes` | subtype-matching filters |
+
+**Keys are auto-generated deterministically** — `"<verb><stepIndex>"` per builder instance
+(`gathered0`, `selected1`, `matching3`), so renaming a Kotlin `val` never churns the serialized
+JSON, while reordering steps changes keys (the tree changed anyway). Every producing step takes an
+optional `name = "..."` override: use it for readable goldens on gnarly cards and for **churn-free
+migration** of existing inline cards (keep the old hand-written keys → byte-identical JSON,
+untouched snapshot goldens; `inv/cards/Lobotomy.kt` is the worked example). Duplicate explicit
+names, empty pipelines, and empty branch blocks fail at card-load with `require`.
+
+**Step vocabulary** (one verb per existing step type — the vocabulary grows with step types, never
+with cards):
+
+| Builder verb | Serializes to |
+|---|---|
+| `gather(source)` / `gather(filter, player?, …)` (battlefield shorthand) | `GatherCardsEffect` |
+| `gatherUntilMatch(filter, …)` → `(match, revealed)` | `GatherUntilMatchEffect` |
+| `chooseExactly(n, from)` / `chooseUpTo` / `chooseAnyNumber` / `chooseRandom` / `selectAll` (+ `…Split` variants returning `(selected, remainder)`) | `SelectFromCollectionEffect` |
+| `filter(from, filter)` / `filterSplit(…)` → `(matching, rest)` | `FilterCollectionEffect` |
+| `move(from, destination, …)` / `moveTracked(…)` / sugar `destroy`, `sacrifice`, `exile`, `toHand`, `toGraveyard`, `toLibraryTop`, `toLibraryBottom` | `MoveCollectionEffect` |
+| `reveal(from, …)` | `RevealCollectionEffect` |
+| `captureControllers(from)` | `CaptureControllersEffect` |
+| `forEachCaptured(collection, original, controllers) { count -> … }` | `ForEachCapturedControllerEffect` |
+| `gatherSubtypes(from)` | `GatherSubtypesEffect` |
+| `storeCardName(from)` | `StoreCardNameEffect` |
+| `storeNumber(amount)` | `StoreNumberEffect` |
+| `chooseOption(optionType, …)` / `noteCreatureType(…)` | `ChooseOptionEffect` / `NoteCreatureTypeEffect` |
+| `choosePile(a, b, chooser?, …)` → `(chosen, other)` | `ChoosePileEffect` |
+| `selectTarget(requirement)` (resolution-time choice — never printed "target") | `SelectTargetEffect` |
+| `ifNotEmpty(slot, filter?, minSize?) { … } orElse { … }` | `ConditionalOnCollectionEffect` |
+| `whenMatches(slot, filter)` (returns a `Condition`, adds no step) | `CollectionContainsMatch` |
+| `run(effect)` | any other `Effect`, verbatim |
+
+`run(...)` keeps the builder open: non-pipeline effects (a `ShuffleLibraryEffect`, a damage effect)
+interleave without the builder needing a verb for everything. Optional secondary outputs
+(`storeRemainder`, `storeNonMatching`, `storeMovedAs`) are only serialized when the card actually
+requests the handle (`chooseExactlySplit`, `filterSplit`, `moveTracked`), keeping emitted JSON free
+of never-read writes.
+
+**Branch scoping** matches the engine's `EffectContext`: handles from the outer scope are visible
+inside `ifNotEmpty` / `forEachCaptured` blocks by plain lexical capture (branches don't start fresh
+scopes; nested *abilities* do). Branch bodies with one step stay bare; multiple steps wrap in a
+nested `CompositeEffect`. Nested scopes share the key counter, so auto-keys never collide.
+
+```kotlin
+// Branch-on-gathered (the PR #618 idiom):
+effect = Effects.Pipeline {
+    val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)))
+    reveal(drawn)
+    ifNotEmpty(drawn, filter = GameObjectFilter.Creature) {
+        toHand(drawn)
+    } orElse {
+        toGraveyard(drawn)
+    }
+}
+```
+
+A card needing a genuinely **new step semantic** (a new capture kind, a new decision shape) still
+adds the `Effect` + executor first (`add-feature`); the builder only composes the existing
+vocabulary. The JSON/custom-card authoring path is unchanged — raw step types stay `@Serializable`
+with string keys, and `CardLinter` remains the backstop for that path and for anything the builder
+can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside `ForEach`).
 
 ---
 
@@ -3357,6 +3452,7 @@ the linter).
 | Card DSL           | `mtg-sdk/src/main/kotlin/.../dsl/CardBuilder.kt`                |
 | Effects            | `mtg-sdk/src/main/kotlin/.../dsl/Effects.kt`                    |
 | Effect patterns    | `mtg-sdk/src/main/kotlin/.../dsl/{Library,Hand,Group,Exile,CreatureType,Misc}Patterns.kt` |
+| Inline pipelines   | `mtg-sdk/src/main/kotlin/.../dsl/PipelineBuilder.kt`            |
 | Triggers           | `mtg-sdk/src/main/kotlin/.../dsl/Triggers.kt`                   |
 | Costs              | `mtg-sdk/src/main/kotlin/.../dsl/Costs.kt`                      |
 | Conditions         | `mtg-sdk/src/main/kotlin/.../dsl/Conditions.kt`                 |

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1695,6 +1695,32 @@ object Effects {
     ): Effect = CompositeEffect(effects, stopOnError, descriptionOverride, descriptionAmounts)
 
     /**
+     * Compose an inline Gather → Select → Move pipeline with typed slot handles —
+     * the facade-respecting replacement for hand-threading string slot keys between
+     * raw pipeline step constructors. Serializes to the exact [CompositeEffect] tree
+     * the steps would produce by hand; see [PipelineBuilder] for the step vocabulary.
+     *
+     * ```kotlin
+     * effect = Effects.Pipeline {
+     *     val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(7)))
+     *     val (kept, rest) = chooseExactlySplit(2, from = looked)
+     *     toHand(kept)
+     *     toGraveyard(rest)
+     * }
+     * ```
+     *
+     * @param stopOnError when true, abort the remaining steps if one fails.
+     * @param descriptionOverride render a single hand-written sentence instead of joining steps.
+     * @param descriptionAmounts dynamic values interpolated into `{0}`, `{1}`, … of [descriptionOverride] at runtime.
+     */
+    fun Pipeline(
+        stopOnError: Boolean = false,
+        descriptionOverride: String? = null,
+        descriptionAmounts: List<DynamicAmount> = emptyList(),
+        block: PipelineBuilder.() -> Unit
+    ): Effect = PipelineBuilder.build(stopOnError, descriptionOverride, descriptionAmounts, block)
+
+    /**
      * Move [target] to [destination] zone — the foundational single-target zone-change effect.
      *
      * Prefer the named shortcuts ([Destroy], [Exile], [ReturnToHand], [PutOnTopOfLibrary],

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
@@ -1,0 +1,813 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.CollectionContainsMatch
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.effects.CaptureControllersEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChooseOptionEffect
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachCapturedControllerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GatherSubtypesEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.NoteCreatureTypeEffect
+import com.wingedsheep.sdk.scripting.effects.OptionType
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+import com.wingedsheep.sdk.scripting.effects.StoreCardNameEffect
+import com.wingedsheep.sdk.scripting.effects.StoreNumberEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+// =============================================================================
+// Typed slot handles
+// =============================================================================
+//
+// One handle type per pipeline variable namespace (mirroring CardLinter.Space).
+// A handle is only obtainable from a builder step that *wrote* the slot, so a
+// read-without-write cannot be expressed at the Kotlin authoring layer. The
+// handle is a thin wrapper over the generated key string — the serialized tree
+// is exactly the same string-keyed CompositeEffect the engine already executes.
+
+/** Handle to a named entry in `EffectContext.storedCollections` (a list of entity ids). */
+@JvmInline
+value class CollectionSlot(val key: String) {
+    /** Read this collection back as a [CardSource] for a downstream [PipelineBuilder.gather]. */
+    val asSource: CardSource get() = CardSource.FromVariable(key)
+}
+
+/** Handle to a named entry in `EffectContext.storedNumbers`. */
+@JvmInline
+value class NumberSlot(val key: String) {
+    /** Read this number as a [DynamicAmount] (`DynamicAmount.VariableReference`). */
+    val amount: DynamicAmount get() = DynamicAmount.VariableReference(key)
+}
+
+/** Handle to a named entry in `EffectContext.chosenValues` (a chosen name/type/color). */
+@JvmInline
+value class ChosenSlot(val key: String)
+
+/** Handle to a named entry in `EffectContext.storedSubtypeGroups` (`List<Set<String>>`). */
+@JvmInline
+value class SubtypeGroupsSlot(val key: String)
+
+/** Match cards whose name equals the name captured in [slot] (cross-namespace handle overload). */
+fun GameObjectFilter.namedFromVariable(slot: ChosenSlot): GameObjectFilter = namedFromVariable(slot.key)
+
+/** Selected + remainder pair returned by the `*Split` selection verbs. */
+data class SelectionSlots(val selected: CollectionSlot, val remainder: CollectionSlot)
+
+/** Matching + rest pair returned by [PipelineBuilder.filterSplit]. */
+data class FilterSlots(val matching: CollectionSlot, val rest: CollectionSlot)
+
+/** Match + all-revealed pair returned by [PipelineBuilder.gatherUntilMatch]. */
+data class UntilMatchSlots(val match: CollectionSlot, val revealed: CollectionSlot)
+
+/** Chosen + other pile pair returned by [PipelineBuilder.choosePile]. */
+data class PileSlots(val chosen: CollectionSlot, val other: CollectionSlot)
+
+@DslMarker
+annotation class PipelineDsl
+
+// =============================================================================
+// Builder
+// =============================================================================
+
+/**
+ * Inline pipeline builder — the facade-respecting way to compose a one-off
+ * Gather → Select → Move pipeline inside a card file without hand-threading
+ * string slot keys (see `backlog/inline-pipeline-dsl.md`).
+ *
+ * Each step verb serializes to the existing pipeline step `Effect` (one verb per
+ * step type — the vocabulary grows with step types, never with cards) and returns
+ * a typed slot handle. Keys are auto-generated deterministically per builder
+ * instance (`"<verb><stepIndex>"`, e.g. `gathered0`, `selected1`), so renaming a
+ * Kotlin `val` never churns the serialized JSON; every producing step also takes
+ * an optional `name =` override for readable goldens and byte-identical migration
+ * of existing inline cards.
+ *
+ * Entry point: [Effects.Pipeline]. Example (the spec's Drop of Honey shape):
+ *
+ * ```kotlin
+ * effect = Effects.Pipeline {
+ *     val tied = gather(GameObjectFilter.Creature.hasLeastPowerAmongAllCreatures())
+ *     val pick = chooseExactly(1, from = tied,
+ *         prompt = "Choose a creature with the least power to destroy",
+ *         useTargetingUI = true)
+ *     destroy(pick, noRegenerate = true)
+ * }
+ * ```
+ *
+ * Non-pipeline effects interleave via [run]; branch scopes ([ifNotEmpty]/[orElse],
+ * [forEachCaptured]) share the outer scope's handles by lexical capture, matching
+ * the engine's actual `EffectContext` scoping (branches don't start fresh scopes).
+ */
+@PipelineDsl
+class PipelineBuilder private constructor(private val shared: Shared) {
+
+    private val steps = mutableListOf<Effect>()
+
+    /** Key counter + name registry, shared across nested branch scopes so keys stay unique. */
+    private class Shared {
+        var stepIndex = 0
+        val usedKeys = mutableSetOf<String>()
+    }
+
+    private fun nextIndex(): Int = shared.stepIndex++
+
+    private fun slotKey(verb: String, index: Int, name: String?): String {
+        val key = name ?: "$verb$index"
+        require(shared.usedKeys.add(key)) {
+            "Duplicate pipeline slot name '$key' — explicit name= overrides must be unique within one pipeline { }"
+        }
+        return key
+    }
+
+    private fun nested(block: PipelineBuilder.() -> Unit): List<Effect> =
+        PipelineBuilder(shared).apply(block).steps.toList()
+
+    /** A nested branch body: a single step stays bare; multiple steps wrap in a [CompositeEffect]. */
+    private fun nestedAsEffect(block: PipelineBuilder.() -> Unit): Effect {
+        val body = nested(block)
+        require(body.isNotEmpty()) { "Pipeline branch block must add at least one step" }
+        return body.singleOrNull() ?: CompositeEffect(body)
+    }
+
+    // =========================================================================
+    // Gather
+    // =========================================================================
+
+    /** Gather cards from [source] into a new collection ([GatherCardsEffect]). */
+    fun gather(source: CardSource, revealed: Boolean = false, name: String? = null): CollectionSlot {
+        val slot = CollectionSlot(slotKey("gathered", nextIndex(), name))
+        steps += GatherCardsEffect(source = source, storeAs = slot.key, revealed = revealed)
+        return slot
+    }
+
+    /** Gather battlefield permanents matching [filter] ([CardSource.BattlefieldMatching] shorthand). */
+    fun gather(
+        filter: GameObjectFilter,
+        player: Player = Player.Each,
+        excludeSelf: Boolean = false,
+        includeAttachments: Boolean = false,
+        excludeTriggering: Boolean = false,
+        revealed: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = gather(
+        source = CardSource.BattlefieldMatching(
+            filter = filter,
+            player = player,
+            excludeSelf = excludeSelf,
+            includeAttachments = includeAttachments,
+            excludeTriggering = excludeTriggering
+        ),
+        revealed = revealed,
+        name = name
+    )
+
+    /**
+     * Walk [player]'s library top-down until [count] cards matching [filter] are found
+     * ([GatherUntilMatchEffect]). Returns both the matches and everything revealed along
+     * the way (including the matches). Does not emit a reveal event — pair with [reveal].
+     */
+    fun gatherUntilMatch(
+        filter: GameObjectFilter,
+        player: Player = Player.You,
+        count: DynamicAmount = DynamicAmount.Fixed(1),
+        matchName: String? = null,
+        revealedName: String? = null
+    ): UntilMatchSlots {
+        val index = nextIndex()
+        val match = CollectionSlot(slotKey("matched", index, matchName))
+        val revealed = CollectionSlot(slotKey("revealed", index, revealedName))
+        steps += GatherUntilMatchEffect(
+            player = player,
+            filter = filter,
+            storeMatch = match.key,
+            storeRevealed = revealed.key,
+            count = count
+        )
+        return UntilMatchSlots(match, revealed)
+    }
+
+    /** Extract each gathered entity's subtypes into a [SubtypeGroupsSlot] ([GatherSubtypesEffect]). */
+    fun gatherSubtypes(from: CollectionSlot, name: String? = null): SubtypeGroupsSlot {
+        val slot = SubtypeGroupsSlot(slotKey("subtypes", nextIndex(), name))
+        steps += GatherSubtypesEffect(from = from.key, storeAs = slot.key)
+        return slot
+    }
+
+    // =========================================================================
+    // Select
+    // =========================================================================
+
+    private fun select(
+        mode: SelectionMode,
+        from: CollectionSlot,
+        chooser: Chooser,
+        filter: GameObjectFilter,
+        prompt: String?,
+        selectedLabel: String?,
+        remainderLabel: String?,
+        useTargetingUI: Boolean,
+        showAllCards: Boolean,
+        restrictions: List<SelectionRestriction>,
+        alwaysPrompt: Boolean,
+        matchChosenCreatureType: Boolean,
+        name: String?,
+        remainderName: String?,
+        withRemainder: Boolean
+    ): SelectionSlots {
+        val index = nextIndex()
+        val selected = CollectionSlot(slotKey("selected", index, name))
+        val remainder = if (withRemainder) CollectionSlot(slotKey("remainder", index, remainderName)) else null
+        steps += SelectFromCollectionEffect(
+            from = from.key,
+            selection = mode,
+            chooser = chooser,
+            filter = filter,
+            storeSelected = selected.key,
+            storeRemainder = remainder?.key,
+            matchChosenCreatureType = matchChosenCreatureType,
+            prompt = prompt,
+            selectedLabel = selectedLabel,
+            remainderLabel = remainderLabel,
+            useTargetingUI = useTargetingUI,
+            showAllCards = showAllCards,
+            restrictions = restrictions,
+            alwaysPrompt = alwaysPrompt
+        )
+        return SelectionSlots(selected, remainder ?: selected)
+    }
+
+    /** Player chooses exactly [count] cards from [from] ([SelectFromCollectionEffect]). */
+    fun chooseExactly(
+        count: DynamicAmount,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = select(
+        SelectionMode.ChooseExactly(count), from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType,
+        name, remainderName = null, withRemainder = false
+    ).selected
+
+    /** Player chooses exactly [count] cards from [from]. */
+    fun chooseExactly(
+        count: Int,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = chooseExactly(
+        DynamicAmount.Fixed(count), from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType, name
+    )
+
+    /** Like [chooseExactly], but also keeps the non-selected cards as a remainder slot. */
+    fun chooseExactlySplit(
+        count: Int,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null,
+        remainderName: String? = null
+    ): SelectionSlots = select(
+        SelectionMode.ChooseExactly(DynamicAmount.Fixed(count)), from, chooser, filter, prompt,
+        selectedLabel, remainderLabel, useTargetingUI, showAllCards, restrictions, alwaysPrompt,
+        matchChosenCreatureType, name, remainderName, withRemainder = true
+    )
+
+    /** Player may choose up to [count] cards from [from]. */
+    fun chooseUpTo(
+        count: DynamicAmount,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = select(
+        SelectionMode.ChooseUpTo(count), from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType,
+        name, remainderName = null, withRemainder = false
+    ).selected
+
+    /** Player may choose up to [count] cards from [from]. */
+    fun chooseUpTo(
+        count: Int,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = chooseUpTo(
+        DynamicAmount.Fixed(count), from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType, name
+    )
+
+    /** Like [chooseUpTo], but also keeps the non-selected cards as a remainder slot. */
+    fun chooseUpToSplit(
+        count: Int,
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null,
+        remainderName: String? = null
+    ): SelectionSlots = select(
+        SelectionMode.ChooseUpTo(DynamicAmount.Fixed(count)), from, chooser, filter, prompt,
+        selectedLabel, remainderLabel, useTargetingUI, showAllCards, restrictions, alwaysPrompt,
+        matchChosenCreatureType, name, remainderName, withRemainder = true
+    )
+
+    /** Player may select any number of cards (0..all) from [from] ([SelectionMode.ChooseAnyNumber]). */
+    fun chooseAnyNumber(
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null
+    ): CollectionSlot = select(
+        SelectionMode.ChooseAnyNumber, from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType,
+        name, remainderName = null, withRemainder = false
+    ).selected
+
+    /** Like [chooseAnyNumber], but also keeps the non-selected cards as a remainder slot. */
+    fun chooseAnyNumberSplit(
+        from: CollectionSlot,
+        chooser: Chooser = Chooser.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        prompt: String? = null,
+        selectedLabel: String? = null,
+        remainderLabel: String? = null,
+        useTargetingUI: Boolean = false,
+        showAllCards: Boolean = false,
+        restrictions: List<SelectionRestriction> = emptyList(),
+        alwaysPrompt: Boolean = false,
+        matchChosenCreatureType: Boolean = false,
+        name: String? = null,
+        remainderName: String? = null
+    ): SelectionSlots = select(
+        SelectionMode.ChooseAnyNumber, from, chooser, filter, prompt, selectedLabel, remainderLabel,
+        useTargetingUI, showAllCards, restrictions, alwaysPrompt, matchChosenCreatureType,
+        name, remainderName, withRemainder = true
+    )
+
+    /** Engine picks [count] cards at random — no player choice ([SelectionMode.Random]). */
+    fun chooseRandom(
+        count: DynamicAmount,
+        from: CollectionSlot,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        name: String? = null
+    ): CollectionSlot = select(
+        SelectionMode.Random(count), from, Chooser.Controller, filter, prompt = null,
+        selectedLabel = null, remainderLabel = null, useTargetingUI = false, showAllCards = false,
+        restrictions = emptyList(), alwaysPrompt = false, matchChosenCreatureType = false,
+        name = name, remainderName = null, withRemainder = false
+    ).selected
+
+    /** Engine picks [count] cards at random — no player choice. */
+    fun chooseRandom(
+        count: Int,
+        from: CollectionSlot,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        name: String? = null
+    ): CollectionSlot = chooseRandom(DynamicAmount.Fixed(count), from, filter, name)
+
+    /** Select every card in [from] (no choice — [SelectionMode.All]), optionally narrowed by [filter]. */
+    fun selectAll(
+        from: CollectionSlot,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        name: String? = null
+    ): CollectionSlot = select(
+        SelectionMode.All, from, Chooser.Controller, filter, prompt = null,
+        selectedLabel = null, remainderLabel = null, useTargetingUI = false, showAllCards = false,
+        restrictions = emptyList(), alwaysPrompt = false, matchChosenCreatureType = false,
+        name = name, remainderName = null, withRemainder = false
+    ).selected
+
+    // =========================================================================
+    // Filter / partition (no player choice)
+    // =========================================================================
+
+    /** Keep only the cards in [from] matching [filter] ([FilterCollectionEffect]). */
+    fun filter(from: CollectionSlot, filter: CollectionFilter, name: String? = null): CollectionSlot {
+        val slot = CollectionSlot(slotKey("matching", nextIndex(), name))
+        steps += FilterCollectionEffect(from = from.key, filter = filter, storeMatching = slot.key)
+        return slot
+    }
+
+    /** Keep only the cards in [from] matching [filter] ([CollectionFilter.MatchesFilter] shorthand). */
+    fun filter(from: CollectionSlot, filter: GameObjectFilter, name: String? = null): CollectionSlot =
+        filter(from, CollectionFilter.MatchesFilter(filter), name)
+
+    /** Partition [from] into matching and non-matching slots ([FilterCollectionEffect]). */
+    fun filterSplit(
+        from: CollectionSlot,
+        filter: CollectionFilter,
+        name: String? = null,
+        restName: String? = null
+    ): FilterSlots {
+        val index = nextIndex()
+        val matching = CollectionSlot(slotKey("matching", index, name))
+        val rest = CollectionSlot(slotKey("rest", index, restName))
+        steps += FilterCollectionEffect(
+            from = from.key,
+            filter = filter,
+            storeMatching = matching.key,
+            storeNonMatching = rest.key
+        )
+        return FilterSlots(matching, rest)
+    }
+
+    /** Partition [from] by a [GameObjectFilter] into matching and non-matching slots. */
+    fun filterSplit(
+        from: CollectionSlot,
+        filter: GameObjectFilter,
+        name: String? = null,
+        restName: String? = null
+    ): FilterSlots = filterSplit(from, CollectionFilter.MatchesFilter(filter), name, restName)
+
+    // =========================================================================
+    // Capture / store
+    // =========================================================================
+
+    /** Snapshot the controller of each card in [from] as a parallel list ([CaptureControllersEffect]). */
+    fun captureControllers(from: CollectionSlot, name: String? = null): CollectionSlot {
+        val slot = CollectionSlot(slotKey("controllers", nextIndex(), name))
+        steps += CaptureControllersEffect(from = from.key, storeAs = slot.key)
+        return slot
+    }
+
+    /** Capture the name of the first card in [from] ([StoreCardNameEffect]). */
+    fun storeCardName(from: CollectionSlot, name: String? = null): ChosenSlot {
+        val slot = ChosenSlot(slotKey("cardName", nextIndex(), name))
+        steps += StoreCardNameEffect(from = from.key, storeAs = slot.key)
+        return slot
+    }
+
+    /** Evaluate [amount] once and store it for later [NumberSlot.amount] reads ([StoreNumberEffect]). */
+    fun storeNumber(amount: DynamicAmount, name: String? = null): NumberSlot {
+        val slot = NumberSlot(slotKey("number", nextIndex(), name))
+        steps += StoreNumberEffect(name = slot.key, amount = amount)
+        return slot
+    }
+
+    /** Player chooses an option (creature type / color / card name / …) ([ChooseOptionEffect]). */
+    fun chooseOption(
+        optionType: OptionType,
+        prompt: String? = null,
+        excludedOptions: List<String> = emptyList(),
+        name: String? = null
+    ): ChosenSlot {
+        val slot = ChosenSlot(slotKey("chosen", nextIndex(), name))
+        steps += ChooseOptionEffect(
+            optionType = optionType,
+            storeAs = slot.key,
+            prompt = prompt,
+            excludedOptions = excludedOptions
+        )
+        return slot
+    }
+
+    /** Note a creature type not yet noted on the source ([NoteCreatureTypeEffect]). */
+    fun noteCreatureType(prompt: String? = null, name: String? = null): ChosenSlot {
+        val slot = ChosenSlot(slotKey("noted", nextIndex(), name))
+        steps += NoteCreatureTypeEffect(storeAs = slot.key, prompt = prompt)
+        return slot
+    }
+
+    /**
+     * Select a target mid-resolution and store the chosen entity ids ([SelectTargetEffect]).
+     * Only for non-targeting choices or choices that depend on earlier pipeline results —
+     * printed "target" wording must use cast-time targeting instead.
+     */
+    fun selectTarget(requirement: TargetRequirement, name: String? = null): CollectionSlot {
+        val slot = CollectionSlot(slotKey("target", nextIndex(), name))
+        steps += SelectTargetEffect(requirement = requirement, storeAs = slot.key)
+        return slot
+    }
+
+    // =========================================================================
+    // Reveal / pile choice
+    // =========================================================================
+
+    /** Reveal the cards in [from] to all players ([RevealCollectionEffect]). */
+    fun reveal(
+        from: CollectionSlot,
+        revealToSelf: Boolean = true,
+        fromZone: Zone? = null,
+        toZone: Zone? = null
+    ) {
+        nextIndex()
+        steps += RevealCollectionEffect(from = from.key, revealToSelf = revealToSelf, fromZone = fromZone, toZone = toZone)
+    }
+
+    /** A player picks one of two piles; both are re-stored as chosen/other ([ChoosePileEffect]). */
+    fun choosePile(
+        pileA: CollectionSlot,
+        pileB: CollectionSlot,
+        pileALabel: String = "Pile 1",
+        pileBLabel: String = "Pile 2",
+        chooser: Chooser = Chooser.Controller,
+        prompt: String? = null,
+        chosenName: String? = null,
+        otherName: String? = null
+    ): PileSlots {
+        val index = nextIndex()
+        val chosen = CollectionSlot(slotKey("chosenPile", index, chosenName))
+        val other = CollectionSlot(slotKey("otherPile", index, otherName))
+        steps += ChoosePileEffect(
+            pileA = pileA.key,
+            pileB = pileB.key,
+            pileALabel = pileALabel,
+            pileBLabel = pileBLabel,
+            chooser = chooser,
+            storeChosenAs = chosen.key,
+            storeOtherAs = other.key,
+            prompt = prompt
+        )
+        return PileSlots(chosen, other)
+    }
+
+    // =========================================================================
+    // Move
+    // =========================================================================
+
+    /** Move the cards in [from] to [destination] ([MoveCollectionEffect]). */
+    fun move(
+        from: CollectionSlot,
+        destination: CardDestination,
+        order: CardOrder = CardOrder.Preserve,
+        revealed: Boolean = false,
+        revealToSelf: Boolean = true,
+        moveType: MoveType = MoveType.Default,
+        linkToSource: Boolean = false,
+        unlinkFromSource: Boolean = false,
+        faceDown: Boolean = false,
+        noRegenerate: Boolean = false,
+        underOwnersControl: Boolean = false,
+        addCounterType: CounterType? = null,
+        markEnteredViaSourceAbility: Boolean = false
+    ) {
+        nextIndex()
+        steps += MoveCollectionEffect(
+            from = from.key,
+            destination = destination,
+            order = order,
+            revealed = revealed,
+            revealToSelf = revealToSelf,
+            moveType = moveType,
+            linkToSource = linkToSource,
+            unlinkFromSource = unlinkFromSource,
+            faceDown = faceDown,
+            noRegenerate = noRegenerate,
+            underOwnersControl = underOwnersControl,
+            addCounterType = addCounterType,
+            markEnteredViaSourceAbility = markEnteredViaSourceAbility
+        )
+    }
+
+    /** Like [move], but also records which cards actually moved ([MoveCollectionEffect.storeMovedAs]). */
+    fun moveTracked(
+        from: CollectionSlot,
+        destination: CardDestination,
+        order: CardOrder = CardOrder.Preserve,
+        revealed: Boolean = false,
+        revealToSelf: Boolean = true,
+        moveType: MoveType = MoveType.Default,
+        linkToSource: Boolean = false,
+        unlinkFromSource: Boolean = false,
+        faceDown: Boolean = false,
+        noRegenerate: Boolean = false,
+        underOwnersControl: Boolean = false,
+        addCounterType: CounterType? = null,
+        markEnteredViaSourceAbility: Boolean = false,
+        name: String? = null
+    ): CollectionSlot {
+        val slot = CollectionSlot(slotKey("moved", nextIndex(), name))
+        steps += MoveCollectionEffect(
+            from = from.key,
+            destination = destination,
+            order = order,
+            revealed = revealed,
+            revealToSelf = revealToSelf,
+            moveType = moveType,
+            linkToSource = linkToSource,
+            unlinkFromSource = unlinkFromSource,
+            faceDown = faceDown,
+            noRegenerate = noRegenerate,
+            underOwnersControl = underOwnersControl,
+            addCounterType = addCounterType,
+            markEnteredViaSourceAbility = markEnteredViaSourceAbility,
+            storeMovedAs = slot.key
+        )
+        return slot
+    }
+
+    /** Destroy the permanents in [from] (move to owners' graveyards with [MoveType.Destroy]). */
+    fun destroy(from: CollectionSlot, noRegenerate: Boolean = false) =
+        move(from, CardDestination.ToZone(Zone.GRAVEYARD), moveType = MoveType.Destroy, noRegenerate = noRegenerate)
+
+    /** Sacrifice the permanents in [from] (owners' graveyards, [MoveType.Sacrifice]). */
+    fun sacrifice(from: CollectionSlot) =
+        move(from, CardDestination.ToZone(Zone.GRAVEYARD), moveType = MoveType.Sacrifice)
+
+    /** Exile the cards in [from]. */
+    fun exile(
+        from: CollectionSlot,
+        owner: Player = Player.You,
+        faceDown: Boolean = false,
+        linkToSource: Boolean = false
+    ) = move(
+        from, CardDestination.ToZone(Zone.EXILE, owner),
+        faceDown = faceDown, linkToSource = linkToSource
+    )
+
+    /** Put the cards in [from] into [player]'s hand. */
+    fun toHand(from: CollectionSlot, player: Player = Player.You, revealed: Boolean = false) =
+        move(from, CardDestination.ToZone(Zone.HAND, player), revealed = revealed)
+
+    /** Put the cards in [from] into [player]'s graveyard. */
+    fun toGraveyard(from: CollectionSlot, player: Player = Player.You) =
+        move(from, CardDestination.ToZone(Zone.GRAVEYARD, player))
+
+    /** Put the cards in [from] on top of [player]'s library. */
+    fun toLibraryTop(
+        from: CollectionSlot,
+        player: Player = Player.You,
+        order: CardOrder = CardOrder.ControllerChooses
+    ) = move(from, CardDestination.ToZone(Zone.LIBRARY, player, ZonePlacement.Top), order = order)
+
+    /** Put the cards in [from] on the bottom of [player]'s library. */
+    fun toLibraryBottom(
+        from: CollectionSlot,
+        player: Player = Player.You,
+        order: CardOrder = CardOrder.ControllerChooses
+    ) = move(from, CardDestination.ToZone(Zone.LIBRARY, player, ZonePlacement.Bottom), order = order)
+
+    // =========================================================================
+    // Branching / iteration
+    // =========================================================================
+
+    /**
+     * Run [block] only if [collection] holds at least [minSize] cards (optionally narrowed by
+     * [filter]) — serializes to [ConditionalOnCollectionEffect]. Chain `orElse { }` for the
+     * empty branch. Handles from the outer scope are visible inside the branch (the engine's
+     * `EffectContext` branches share the surrounding scope).
+     */
+    fun ifNotEmpty(
+        collection: CollectionSlot,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        minSize: Int = 1,
+        countDistinctCardTypes: Boolean = false,
+        block: PipelineBuilder.() -> Unit
+    ): ConditionalHandle {
+        nextIndex()
+        val stepPosition = steps.size
+        steps += ConditionalOnCollectionEffect(
+            collection = collection.key,
+            ifNotEmpty = nestedAsEffect(block),
+            minSize = minSize,
+            countDistinctCardTypes = countDistinctCardTypes,
+            filter = filter
+        )
+        return ConditionalHandle(stepPosition)
+    }
+
+    /** Continuation handle returned by [ifNotEmpty] so the else-branch can be chained. */
+    inner class ConditionalHandle internal constructor(private val stepPosition: Int) {
+        /** The branch to run when the collection check fails. */
+        infix fun orElse(block: PipelineBuilder.() -> Unit) {
+            val conditional = steps[stepPosition] as ConditionalOnCollectionEffect
+            require(conditional.ifEmpty == null) { "orElse { } may only be chained once" }
+            steps[stepPosition] = conditional.copy(ifEmpty = nestedAsEffect(block))
+        }
+    }
+
+    /**
+     * Iterate the unique controllers captured by [captureControllers] for cards that appear in
+     * [collection], running [block] once per controller ([ForEachCapturedControllerEffect]).
+     * The block receives the per-controller tally as a [NumberSlot].
+     */
+    fun forEachCaptured(
+        collection: CollectionSlot,
+        original: CollectionSlot,
+        controllers: CollectionSlot,
+        countName: String? = null,
+        block: PipelineBuilder.(count: NumberSlot) -> Unit
+    ) {
+        val count = NumberSlot(slotKey("count", nextIndex(), countName))
+        steps += ForEachCapturedControllerEffect(
+            collection = collection.key,
+            originalCollection = original.key,
+            controllerSnapshot = controllers.key,
+            countVariable = count.key,
+            effects = PipelineBuilder(shared).apply { block(count) }.steps.toList()
+        )
+    }
+
+    // =========================================================================
+    // Escape hatches
+    // =========================================================================
+
+    /** Append any non-pipeline [Effect] verbatim (a draw, a damage, a shuffle, …). */
+    fun run(effect: Effect) {
+        nextIndex()
+        steps += effect
+    }
+
+    /** Condition that [collection] currently holds a card matching [filter] ([CollectionContainsMatch]). */
+    fun whenMatches(collection: CollectionSlot, filter: GameObjectFilter = GameObjectFilter.Any): Condition =
+        CollectionContainsMatch(collection.key, filter)
+
+    companion object {
+        internal fun build(
+            stopOnError: Boolean,
+            descriptionOverride: String?,
+            descriptionAmounts: List<DynamicAmount>,
+            block: PipelineBuilder.() -> Unit
+        ): Effect {
+            val builder = PipelineBuilder(Shared()).apply(block)
+            require(builder.steps.isNotEmpty()) { "pipeline { } must add at least one step" }
+            return CompositeEffect(
+                effects = builder.steps.toList(),
+                stopOnError = stopOnError,
+                descriptionOverride = descriptionOverride,
+                descriptionAmounts = descriptionAmounts
+            )
+        }
+    }
+}

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilderTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilderTest.kt
@@ -1,0 +1,328 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.CollectionContainsMatch
+import com.wingedsheep.sdk.scripting.effects.CaptureControllersEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachCapturedControllerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.serialization.CardSerialization
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The `pipeline { }` builder must compile to the *exact* `CompositeEffect` tree the
+ * raw step constructors produce by hand — same types, same keys, same JSON — so the
+ * engine, the linter, and the snapshot goldens can't tell the difference between a
+ * hand-built pipeline and a builder-built one (`backlog/inline-pipeline-dsl.md` §2).
+ */
+class PipelineBuilderTest : DescribeSpec({
+
+    fun jsonOf(effect: Effect): String =
+        CardSerialization.compactJson.encodeToString(Effect.serializer(), effect)
+
+    describe("byte-identical serialization against hand-built trees") {
+
+        it("reproduces Lobotomy's hand-built pipeline exactly via name= overrides") {
+            // The hand-built tree from mtg-sets inv/cards/Lobotomy.kt, verbatim.
+            val handBuilt = CompositeEffect(
+                listOf(
+                    RevealHandEffect(EffectTarget.ContextTarget(0)),
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                        storeAs = "hand"
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "hand",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        chooser = Chooser.Controller,
+                        filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.Not(CardPredicate.IsBasicLand))),
+                        storeSelected = "chosen",
+                        prompt = "Choose a card other than a basic land card",
+                        alwaysPrompt = true,
+                        showAllCards = true
+                    ),
+                    Effects.StoreCardName(from = "chosen", storeAs = "chosenName"),
+                    GatherCardsEffect(
+                        source = CardSource.FromMultipleZones(
+                            zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                            player = Player.ContextPlayer(0),
+                            filter = GameObjectFilter.Any.namedFromVariable("chosenName")
+                        ),
+                        storeAs = "toExile"
+                    ),
+                    MoveCollectionEffect(
+                        from = "toExile",
+                        destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+                    ),
+                    ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0))
+                )
+            )
+
+            val built = Effects.Pipeline {
+                run(RevealHandEffect(EffectTarget.ContextTarget(0)))
+                val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "hand")
+                val chosen = chooseExactly(
+                    1, from = hand,
+                    filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.Not(CardPredicate.IsBasicLand))),
+                    prompt = "Choose a card other than a basic land card",
+                    alwaysPrompt = true,
+                    showAllCards = true,
+                    name = "chosen"
+                )
+                val chosenName = storeCardName(chosen, name = "chosenName")
+                val toExile = gather(
+                    CardSource.FromMultipleZones(
+                        zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                        player = Player.ContextPlayer(0),
+                        filter = GameObjectFilter.Any.namedFromVariable(chosenName)
+                    ),
+                    name = "toExile"
+                )
+                exile(toExile, owner = Player.ContextPlayer(0))
+                run(ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0)))
+            }
+
+            built shouldBe handBuilt
+            jsonOf(built) shouldBe jsonOf(handBuilt)
+        }
+
+        it("reproduces the Ancestral Memories shape (look at 7, keep 2, rest to graveyard)") {
+            val handBuilt = CompositeEffect(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7)),
+                        storeAs = "looked"
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "looked",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                        storeSelected = "kept",
+                        storeRemainder = "remainder"
+                    ),
+                    MoveCollectionEffect(from = "kept", destination = CardDestination.ToZone(Zone.HAND)),
+                    MoveCollectionEffect(from = "remainder", destination = CardDestination.ToZone(Zone.GRAVEYARD))
+                )
+            )
+
+            val built = Effects.Pipeline {
+                val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(7)), name = "looked")
+                val (kept, rest) = chooseExactlySplit(2, from = looked, name = "kept", remainderName = "remainder")
+                toHand(kept)
+                toGraveyard(rest)
+            }
+
+            built shouldBe handBuilt
+            jsonOf(built) shouldBe jsonOf(handBuilt)
+        }
+
+        it("reproduces the branch-on-gathered idiom (draw-reveal, creature to hand, else graveyard)") {
+            val handBuilt = CompositeEffect(
+                listOf(
+                    GatherCardsEffect(source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = "drawn"),
+                    RevealCollectionEffect(from = "drawn"),
+                    ConditionalOnCollectionEffect(
+                        collection = "drawn",
+                        filter = GameObjectFilter.Creature,
+                        ifNotEmpty = MoveCollectionEffect(from = "drawn", destination = CardDestination.ToZone(Zone.HAND)),
+                        ifEmpty = MoveCollectionEffect(from = "drawn", destination = CardDestination.ToZone(Zone.GRAVEYARD))
+                    )
+                )
+            )
+
+            val built = Effects.Pipeline {
+                val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), name = "drawn")
+                reveal(drawn)
+                ifNotEmpty(drawn, filter = GameObjectFilter.Creature) {
+                    toHand(drawn)
+                } orElse {
+                    toGraveyard(drawn)
+                }
+            }
+
+            built shouldBe handBuilt
+            jsonOf(built) shouldBe jsonOf(handBuilt)
+        }
+    }
+
+    describe("deterministic auto-generated keys") {
+
+        it("keys are verb-prefixed and positional per builder instance") {
+            val built = Effects.Pipeline {
+                val tied = gather(GameObjectFilter.Creature)
+                val pick = chooseExactly(1, from = tied, useTargetingUI = true)
+                destroy(pick, noRegenerate = true)
+            } as CompositeEffect
+
+            val gatherStep = built.effects[0].shouldBeInstanceOf<GatherCardsEffect>()
+            gatherStep.storeAs shouldBe "gathered0"
+            gatherStep.source shouldBe CardSource.BattlefieldMatching(filter = GameObjectFilter.Creature)
+
+            val selectStep = built.effects[1].shouldBeInstanceOf<SelectFromCollectionEffect>()
+            selectStep.from shouldBe "gathered0"
+            selectStep.storeSelected shouldBe "selected1"
+            selectStep.storeRemainder shouldBe null
+            selectStep.useTargetingUI shouldBe true
+
+            val moveStep = built.effects[2].shouldBeInstanceOf<MoveCollectionEffect>()
+            moveStep.from shouldBe "selected1"
+            moveStep.moveType shouldBe MoveType.Destroy
+            moveStep.noRegenerate shouldBe true
+            moveStep.destination shouldBe CardDestination.ToZone(Zone.GRAVEYARD)
+        }
+
+        it("renaming the Kotlin val does not change the serialized tree") {
+            fun build(useTargetingUI: Boolean) = Effects.Pipeline {
+                val someName = gather(GameObjectFilter.Creature)
+                val otherName = chooseExactly(1, from = someName, useTargetingUI = useTargetingUI)
+                destroy(otherName)
+            }
+            // Same steps, differently named vals → identical JSON.
+            jsonOf(build(true)) shouldBe jsonOf(Effects.Pipeline {
+                val a = gather(GameObjectFilter.Creature)
+                val b = chooseExactly(1, from = a, useTargetingUI = true)
+                destroy(b)
+            })
+        }
+
+        it("nested branch scopes share the key counter, so keys never collide") {
+            val built = Effects.Pipeline {
+                val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(3)))   // step 0
+                ifNotEmpty(drawn) {                                                   // step 1
+                    val inner = chooseExactly(1, from = drawn)                        // step 2
+                    toHand(inner)                                                     // step 3
+                }
+                val after = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)))   // step 4
+                toGraveyard(after)
+            } as CompositeEffect
+
+            val conditional = built.effects[1].shouldBeInstanceOf<ConditionalOnCollectionEffect>()
+            val innerSelect = (conditional.ifNotEmpty as CompositeEffect)
+                .effects[0].shouldBeInstanceOf<SelectFromCollectionEffect>()
+            innerSelect.storeSelected shouldBe "selected2"
+            (built.effects[2] as GatherCardsEffect).storeAs shouldBe "gathered4"
+        }
+    }
+
+    describe("authoring-error prevention") {
+
+        it("rejects duplicate explicit slot names") {
+            shouldThrow<IllegalArgumentException> {
+                Effects.Pipeline {
+                    gather(GameObjectFilter.Creature, name = "pile")
+                    gather(GameObjectFilter.Land, name = "pile")
+                }
+            }
+        }
+
+        it("rejects an empty pipeline") {
+            shouldThrow<IllegalArgumentException> { Effects.Pipeline { } }
+        }
+
+        it("rejects an empty branch block") {
+            shouldThrow<IllegalArgumentException> {
+                Effects.Pipeline {
+                    val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)))
+                    ifNotEmpty(drawn) { }
+                }
+            }
+        }
+
+        it("rejects chaining orElse twice") {
+            shouldThrow<IllegalArgumentException> {
+                Effects.Pipeline {
+                    val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)))
+                    val handle = ifNotEmpty(drawn) { toHand(drawn) }
+                    handle orElse { toGraveyard(drawn) }
+                    handle orElse { toGraveyard(drawn) }
+                }
+            }
+        }
+    }
+
+    describe("secondary outputs are only serialized when requested") {
+
+        it("chooseExactly leaves storeRemainder null; chooseExactlySplit sets it") {
+            val withoutRemainder = Effects.Pipeline {
+                val pile = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(3)))
+                toHand(chooseExactly(1, from = pile))
+            } as CompositeEffect
+            (withoutRemainder.effects[1] as SelectFromCollectionEffect).storeRemainder shouldBe null
+
+            val withRemainder = Effects.Pipeline {
+                val pile = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(3)))
+                val (kept, rest) = chooseExactlySplit(1, from = pile)
+                toHand(kept)
+                toGraveyard(rest)
+            } as CompositeEffect
+            val select = withRemainder.effects[1] as SelectFromCollectionEffect
+            select.storeSelected shouldBe "selected1"
+            select.storeRemainder shouldBe "remainder1"
+        }
+    }
+
+    describe("cross-namespace handles and conditions") {
+
+        it("NumberSlot.amount reads back as a VariableReference") {
+            val built = Effects.Pipeline {
+                val count = storeNumber(DynamicAmount.Fixed(3), name = "tally")
+                run(DealDamageEffect(count.amount, EffectTarget.ContextTarget(0)))
+            } as CompositeEffect
+            val damage = built.effects[1].shouldBeInstanceOf<DealDamageEffect>()
+            damage.amount shouldBe DynamicAmount.VariableReference("tally")
+        }
+
+        it("whenMatches builds a CollectionContainsMatch over the slot's key") {
+            var condition: CollectionContainsMatch? = null
+            Effects.Pipeline {
+                val drawn = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)))
+                condition = whenMatches(drawn, GameObjectFilter.Creature) as CollectionContainsMatch
+                toHand(drawn)
+            }
+            condition shouldBe CollectionContainsMatch("gathered0", GameObjectFilter.Creature)
+        }
+
+        it("forEachCaptured wires the three collections and exposes the per-controller tally") {
+            val built = Effects.Pipeline {
+                val targets = gather(CardSource.ChosenTargets, name = "targets")
+                val controllers = captureControllers(targets, name = "owners")
+                val dead = moveTracked(
+                    targets, CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Destroy, name = "destroyed"
+                )
+                forEachCaptured(dead, original = targets, controllers = controllers, countName = "perPlayer") { count ->
+                    run(DealDamageEffect(count.amount, EffectTarget.Controller))
+                }
+            } as CompositeEffect
+
+            (built.effects[1] as CaptureControllersEffect).storeAs shouldBe "owners"
+            val forEach = built.effects[3].shouldBeInstanceOf<ForEachCapturedControllerEffect>()
+            forEach.collection shouldBe "destroyed"
+            forEach.originalCollection shouldBe "targets"
+            forEach.controllerSnapshot shouldBe "owners"
+            forEach.countVariable shouldBe "perPlayer"
+            val inner = forEach.effects.single().shouldBeInstanceOf<DealDamageEffect>()
+            inner.amount shouldBe DynamicAmount.VariableReference("perPlayer")
+        }
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Lobotomy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Lobotomy.kt
@@ -3,22 +3,16 @@ package com.wingedsheep.mtg.sets.definitions.inv.cards
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.namedFromVariable
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.Chooser
-import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
-import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetPlayer
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Lobotomy
@@ -30,9 +24,12 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * name as the chosen card and exile them. Then that player shuffles.
  *
  * Invasion engine gap #10 — the "capture a card's name" half of the "name a card" family.
- * Instead of typing a name, the controller picks a card and [Effects.StoreCardName] records
- * its name into `chosenValues`; the search then matches every card of that name via
+ * Instead of typing a name, the controller picks a card and [PipelineBuilder.storeCardName]
+ * records its name; the search then matches every card of that name via
  * [GameObjectFilter.namedFromVariable] ([CardPredicate.NameEqualsChosen]).
+ *
+ * The explicit slot names preserve the original hand-threaded keys so the serialized
+ * tree (and the snapshot golden) is byte-identical to the pre-builder version.
  */
 val Lobotomy = card("Lobotomy") {
     manaCost = "{2}{U}{B}"
@@ -44,46 +41,36 @@ val Lobotomy = card("Lobotomy") {
 
     spell {
         val player = target("player", TargetPlayer())
-        effect = Effects.Composite(
-            listOf(
-                // 1. Target player reveals their hand.
-                RevealHandEffect(player),
-                // 2. Gather their hand so the controller can choose a card.
-                GatherCardsEffect(
-                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
-                    storeAs = "hand"
-                ),
-                // 3. You choose a card other than a basic land card.
-                SelectFromCollectionEffect(
-                    from = "hand",
-                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
-                    chooser = Chooser.Controller,
-                    filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.Not(CardPredicate.IsBasicLand))),
-                    storeSelected = "chosen",
-                    prompt = "Choose a card other than a basic land card",
-                    alwaysPrompt = true,
-                    showAllCards = true
-                ),
-                // 4. Record the chosen card's name.
-                Effects.StoreCardName(from = "chosen", storeAs = "chosenName"),
-                // 5. Find every card of that name across their graveyard, hand, and library.
-                GatherCardsEffect(
-                    source = CardSource.FromMultipleZones(
-                        zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
-                        player = Player.ContextPlayer(0),
-                        filter = GameObjectFilter.Any.namedFromVariable("chosenName")
-                    ),
-                    storeAs = "toExile"
-                ),
-                // 6. Exile them.
-                MoveCollectionEffect(
-                    from = "toExile",
-                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
-                ),
-                // 7. That player shuffles.
-                ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0))
+        effect = Effects.Pipeline {
+            // 1. Target player reveals their hand.
+            run(RevealHandEffect(player))
+            // 2. Gather their hand so the controller can choose a card.
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "hand")
+            // 3. You choose a card other than a basic land card.
+            val chosen = chooseExactly(
+                1, from = hand,
+                filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.Not(CardPredicate.IsBasicLand))),
+                prompt = "Choose a card other than a basic land card",
+                alwaysPrompt = true,
+                showAllCards = true,
+                name = "chosen"
             )
-        )
+            // 4. Record the chosen card's name.
+            val chosenName = storeCardName(chosen, name = "chosenName")
+            // 5. Find every card of that name across their graveyard, hand, and library.
+            val toExile = gather(
+                CardSource.FromMultipleZones(
+                    zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                    player = Player.ContextPlayer(0),
+                    filter = GameObjectFilter.Any.namedFromVariable(chosenName)
+                ),
+                name = "toExile"
+            )
+            // 6. Exile them.
+            exile(toExile, owner = Player.ContextPlayer(0))
+            // 7. That player shuffles.
+            run(ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0)))
+        }
     }
 
     metadata {


### PR DESCRIPTION
Implements **step 1 (builder core) + a pilot migration** of the inline pipeline DSL spec ([`backlog/inline-pipeline-dsl.md`](https://github.com/wingedsheep/argentum-engine/blob/main/backlog/inline-pipeline-dsl.md), merged in #633).

## Why

The "no single-use patterns" rule and the facade boundary collide on one-off pipeline cards: 231 card files today inline raw `GatherCardsEffect(...)` / `SelectFromCollectionEffect(...)` chains, hand-threading string slot keys — exactly the error class `CardLinter`'s dataflow check exists to catch. This restores the original §1.5 design intent (one-off cards compose Gather → Select → Move with no new SDK surface per card) *behind* the facade boundary instead of around it.

## What

- **`PipelineBuilder`** (`mtg-sdk/dsl/PipelineBuilder.kt`), entry point **`Effects.Pipeline { }`**: one verb per existing pipeline step type (the §2.3 spec table — gather, gatherUntilMatch, choose*/selectAll (+`…Split`), filter, move + sugar (destroy/sacrifice/exile/toHand/toGraveyard/toLibraryTop/Bottom), reveal, captureControllers, forEachCaptured, gatherSubtypes, storeCardName, storeNumber, chooseOption, noteCreatureType, choosePile, selectTarget, ifNotEmpty/orElse, whenMatches, run).
- **Typed slot handles** — `CollectionSlot` / `NumberSlot` / `ChosenSlot` / `SubtypeGroupsSlot`, one per `EffectContext` namespace (mirroring `CardLinter.Space`). A handle is only obtainable from the step that wrote it, so a read-without-write (the Atmospheric Greenhouse silent no-op class) cannot be expressed at the Kotlin layer. Cross-namespace overloads: `GameObjectFilter.namedFromVariable(ChosenSlot)`, `NumberSlot.amount`.
- **Deterministic, rename-stable keys** — `"<verb><stepIndex>"` (`gathered0`, `selected1`), optional `name =` override per producing step. Duplicate names / empty pipeline / empty branch fail at card load via `require`.
- **Zero engine change, zero JSON-contract change** — the builder emits the exact `CompositeEffect` tree the raw constructors produce. Raw string-keyed step types remain the JSON/custom-card surface; `CardLinter` stays the backstop there.
- **Pilot migration**: `inv/cards/Lobotomy.kt` (the spec's worked example) rewritten with the builder using explicit names → **byte-identical serialization, snapshot goldens untouched**, `CardLintTest` green.
- **Docs**: `card-sdk-language-reference.md` §5.5 (handle + verb tables, scoping rules, examples); §5 intro rescoped per the spec ("named entries are for named mechanics / second users; one-offs go inline"); spec status updated.

## Tests

- `PipelineBuilderTest` (13 tests): byte-identical serialization vs hand-built trees for the spec's worked examples (Lobotomy, Ancestral Memories shape, branch-on-gathered #618 idiom), deterministic/rename-stable keys, nested-scope key uniqueness, secondary-outputs-only-when-requested, `forEachCaptured` wiring, and the authoring-error `require`s.
- Full corpus gates: `CardDefinitionSnapshotTest` + `CardLintTest` pass with **no golden re-bless** (proves the migrated Lobotomy serializes identically). Full `just build` green.

## Out of scope (spec §5 steps 2–5, intentionally trailing)

New-card pilots, the mechanical migration of the remaining 230 inline cards (fan-out friendly, pure source diff), adding the raw step constructors to `FacadeBoundaryTest`'s forbidden list, and the mtgish generic pipeline renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)