### PR TITLE
OTJ token-creation cards (Form a Posse, Rise of the Varmints, Scalestorm Summoner) + mtgish emitter widening

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FormAPosse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FormAPosse.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Form a Posse
+ * {X}{R}{W}
+ * Sorcery
+ *
+ * Create X 1/1 red Mercenary creature tokens with "{T}: Target creature you control gets +1/+0
+ * until end of turn. Activate only as a sorcery."
+ */
+val FormAPosse = card("Form a Posse") {
+    manaCost = "{X}{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Sorcery"
+    oracleText = "Create X 1/1 red Mercenary creature tokens with \"{T}: Target creature you " +
+        "control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    spell {
+        effect = CreateTokenEffect(
+            count = DynamicAmount.XValue,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "J.Lonnee"
+        flavorText = "The terms were simple: half in advance, half when the entire town belonged to their employer."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg?1712356094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RiseOfTheVarmints.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RiseOfTheVarmints.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rise of the Varmints
+ * {3}{G}
+ * Sorcery
+ *
+ * Create X 2/1 green Varmint creature tokens, where X is the number of creature cards in your
+ * graveyard.
+ * Plot {2}{G}
+ */
+val RiseOfTheVarmints = card("Rise of the Varmints") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create X 2/1 green Varmint creature tokens, where X is the number of creature " +
+        "cards in your graveyard.\n" +
+        "Plot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.GRAVEYARD,
+                filter = GameObjectFilter.Creature
+            ),
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Varmint"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg?1712316688"
+        )
+    }
+
+    keywordAbility(KeywordAbility.plot("{2}{G}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Ralph Horsley"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg?1712355986"
+
+        ruling("2024-04-12", "The number of creature cards in your graveyard is counted as Rise of the Varmints resolves.")
+        ruling("2024-04-12", "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\"")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ScalestormSummoner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ScalestormSummoner.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Scalestorm Summoner
+ * {2}{R}
+ * Creature — Human Warlock
+ * 3/3
+ *
+ * Whenever this creature attacks, create a 3/1 red Dinosaur creature token if you control a
+ * creature with power 4 or greater.
+ */
+val ScalestormSummoner = card("Scalestorm Summoner") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warlock"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature attacks, create a 3/1 red Dinosaur creature token if you " +
+        "control a creature with power 4 or greater."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dinosaur"),
+            imageUri = "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg?1712316260"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "144"
+        artist = "Xabi Gaztelua"
+        flavorText = "The herd followed him through an Omenpath and found their curiosity rewarded with an untamed world rich with unsuspecting prey."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg?1712355842"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2099,6 +2099,70 @@
     ]
 }
 
+// Form a Posse
+{
+    "name": "Form a Posse",
+    "manaCost": "{X}{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create X 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": "XValue",
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Mercenary"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+            "activatedAbilities": [
+                {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        }
+                    ],
+                    "timing": "SorcerySpeed"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "J.Lonnee",
+        "flavorText": "The terms were simple: half in advance, half when the entire town belonged to their employer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg?1712356094"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
 // Forsaken Miner
 {
     "name": "Forsaken Miner",
@@ -4206,6 +4270,66 @@
     ]
 }
 
+// Rise of the Varmints
+{
+    "name": "Rise of the Varmints",
+    "manaCost": "{3}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create X 2/1 green Varmint creature tokens, where X is the number of creature cards in your graveyard.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "creature"
+            },
+            "power": 2,
+            "toughness": 1,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Varmint"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg?1712316688"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Ralph Horsley",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg?1712355986",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The number of creature cards in your graveyard is counted as Rise of the Varmints resolves."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\""
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rooftop Assassin
 {
     "name": "Rooftop Assassin",
@@ -4264,6 +4388,54 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Scalestorm Summoner
+{
+    "name": "Scalestorm Summoner",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Whenever this creature attacks, create a 3/1 red Dinosaur creature token if you control a creature with power 4 or greater.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dinosaur"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg?1712316260"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "UNCOMMON",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "The herd followed him through an Omenpath and found their curiosity rewarded with an untamed world rich with unsuspecting prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg?1712355842"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -473,10 +473,21 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     // card), so the MayAction wrapper is absorbed by the effect, not re-expressed as `optional = true`
     // (which would double-wrap vs the golden — Elvish Pioneer).
     val selfOptional = mayInner?.strField("_Action") in SELF_OPTIONAL_ACTIONS
-    val edsl = renderEffectList(effectActions, tvar) ?: return null
+
+    // An intervening-if written in the trigger's effect — "Whenever ~ attacks, create a token IF you
+    // control a creature with power 4 or greater" (Scalestorm Summoner) — is modeled in mtgish as a lone
+    // `If{cond}[then]` action, not a TriggerI. Per CR 603.4 this IS an intervening-if ability: the
+    // condition is checked when the trigger would fire and again on resolution. Lift it to a
+    // `triggerCondition = …` gate over the then-branch, but ONLY when the condition renders via the same
+    // strict [interveningIfDsl] used by TriggerI (no else-branch, single If). Any other shape falls
+    // through to the normal action path (where `on("If")` handles the static gates or declines).
+    val lifted = if (effTriggerCondition == null) liftInterveningIfAction(effectActions) else null
+    val condFromIf = lifted?.first
+    val edsl = renderEffectList(lifted?.second ?: effectActions, tvar) ?: return null
 
     val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
-    if (effTriggerCondition != null) stmts.add(Assign("triggerCondition", Lit(effTriggerCondition)))
+    val triggerCond = effTriggerCondition ?: condFromIf
+    if (triggerCond != null) stmts.add(Assign("triggerCondition", Lit(triggerCond)))
     if (oncePerTurn) stmts.add(Assign("oncePerTurn", Lit("true")))
     if (mayWrapped && !selfOptional) stmts.add(Assign("optional", Lit("true")))
     if (tvar != null) stmts.add(targetLocal(tnode!!))
@@ -530,6 +541,28 @@ internal fun EmitCtx.triggerIBlock(rule: JsonObject): List<Stmt>? {
         put("args", JsonArray(listOfNotNull(args.getOrNull(0)) + listOfNotNull(args.getOrNull(2))))
     }
     return triggerBlock(triggerA, triggerCondition = condDsl)
+}
+
+/**
+ * A trigger effect that is a single `If{cond}[then]` action -> the intervening-if condition DSL plus
+ * the then-branch actions, or null when it isn't a lone liftable `If`. Used by [triggerBlock] to model
+ * "Whenever ~ attacks, create a token if you control …" (Scalestorm Summoner) as a `triggerCondition`
+ * gate (CR 603.4). Declines (returns null, leaving the normal action path to handle/decline the `If`)
+ * when: there's more than one action, the action isn't an `If`, the condition doesn't render via the
+ * strict [interveningIfDsl], or the `If` carries an else-branch (which a single triggerCondition can't
+ * express). Never drops the condition or an else-branch.
+ */
+private fun EmitCtx.liftInterveningIfAction(actions: List<JsonObject>): Pair<String, List<JsonObject>>? {
+    val only = actions.singleOrNull() ?: return null
+    if (only.strField("_Action") != "If") return null
+    val args = only["args"].asArr ?: return null
+    val cond = args.getOrNull(0) as? JsonObject ?: return null
+    val thenActions = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (thenActions.isEmpty()) return null
+    // An else-branch (args[2]) can't be folded into a single intervening-if gate — decline.
+    if (args.getOrNull(2) != null) return null
+    val condDsl = interveningIfDsl(cond) ?: return null
+    return condDsl to thenActions
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -167,6 +167,19 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         "Trigger_AmountOfDamageDealt" ->
             return call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT"))
         "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
+        // "the number of [filter] cards in your graveyard" (Rise of the Varmints' Varmint count). The
+        // count's args are a `_CardsInGraveyard` filter — typically `And(IsCardtype Creature,
+        // InAPlayersGraveyard(You))`. Render as a resolution-time `DynamicAmount.Count` over the You
+        // graveyard with the recovered filter. Only the You-scoped graveyard renders; any other player
+        // scope (an opponent's graveyard, "each player's") declines -> SCAFFOLD rather than miscount.
+        "TheNumberOfGraveyardCards" -> {
+            if (!jsonContains(node["args"], "_Player", "You")) return null
+            val filter = gameObjectFilterDsl(node["args"]) ?: "GameObjectFilter.Any"
+            return call(
+                "DynamicAmount.Count",
+                arg("Player.You"), arg("Zone.GRAVEYARD"), arg(Lit(filter)),
+            )
+        }
         // "X is its toughness" / "its power" on THIS permanent (Armored Armadillo's "+X/+0 where X is its
         // toughness"). Only the ThisPermanent subject maps to the source-relative facade; any other
         // permanent subject declines (-> scaffold) rather than misattribute the stat.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -583,12 +583,17 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
     FilterPredicates.untapped(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.nontoken(filterNode)?.let { node = node.dot(it) }
-    if ("\"You\"" in blob) node = node.dot("youControl")
-    if ("\"Opponent\"" in blob) node = node.dot("opponentControls")
+    // The `.youControl()`/`.opponentControls()` suffix is a *controller* predicate — only a
+    // `ControlledByAPlayer` clause carries it. A bare `"You"` elsewhere in the blob (e.g. a graveyard
+    // count's `InAPlayersGraveyard(You)` ownership clause, whose player scope is carried separately by
+    // the enclosing DynamicAmount.Count) must NOT be misread as control of a battlefield permanent.
+    val hasControllerClause = "ControlledByAPlayer" in blob
+    if (hasControllerClause && "\"You\"" in blob) node = node.dot("youControl")
+    if (hasControllerClause && "\"Opponent\"" in blob) node = node.dot("opponentControls")
     // A ControlledByAPlayer clause naming a player we can't render (e.g. Ref_TargetPlayer — "creatures
     // target opponent controls") must decline rather than silently widen to every creature on the
     // battlefield (Neutralize the Guards).
-    if ("ControlledByAPlayer" in blob && "\"You\"" !in blob && "\"Opponent\"" !in blob) return null
+    if (hasControllerClause && "\"You\"" !in blob && "\"Opponent\"" !in blob) return null
     return node
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.Eval
 import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.arg
@@ -35,13 +36,19 @@ private val TOKEN_COLOR = mapOf(
 
 /** A `_CreatableToken` spec -> `Effects.CreateToken(...)`, or null (-> SCAFFOLD) for shapes we can't
  *  render exactly. `NumberTokens` wraps a base spec with a fixed count. */
-internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): Dsl? {
+internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1, dynamicCount: Dsl? = null): Dsl? {
     when (spec.strField("_CreatableToken")) {
         "NumberTokens" -> {
             val a = spec["args"].asArr ?: return null
-            val n = findInteger(a.getOrNull(0)) as? Int ?: return null
             val inner = a.getOrNull(1) as? JsonObject ?: return null
-            return createTokenDsl(inner, n)
+            // A fixed integer count renders inline as `count = N`. A dynamic count — "X" tokens
+            // (ValueX, Form a Posse) or "the number of creature cards in your graveyard" (Rise of
+            // the Varmints) — renders as a `DynamicAmount` via [dynamicAmountExpr]; decline
+            // (-> SCAFFOLD) on a count we can't render exactly rather than emit a wrong fixed number.
+            val n = findInteger(a.getOrNull(0)) as? Int
+            if (n != null) return createTokenDsl(inner, n)
+            val dynamic = dynamicAmountExpr(a.getOrNull(0)) ?: return null
+            return createTokenDsl(inner, dynamicCount = dynamic)
         }
         // Predefined artifact token with fixed characteristics -> its dedicated facade
         // (serialises as CreatePredefinedToken, not the generic CreateToken).
@@ -92,8 +99,21 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): Dsl? {
             if (tokenActivatedAbilities.isNotEmpty()) {
                 parts.add(arg("activatedAbilities", Call("listOf", tokenActivatedAbilities.map { arg(it) })))
             }
-            if (count != 1) parts.add(arg("count", "$count"))
-            return Call(ctor, parts)
+            // Count rendering depends on the constructor we picked:
+            //  - `Effects.CreateToken` facade: a fixed count is the trailing named `count: Int` overload;
+            //    a dynamic count is the `count: DynamicAmount` first-positional overload.
+            //  - raw `CreateTokenEffect` ctor (used when the token has activated abilities): the `count: Int`
+            //    secondary ctor does NOT expose `activatedAbilities`, so the count MUST be a `DynamicAmount`
+            //    on the primary ctor — a fixed count renders as `DynamicAmount.Fixed(N)`, not a bare Int
+            //    (otherwise `CreateTokenEffect(count = 2, activatedAbilities = …)` fails to compile —
+            //    Hellspur Posse Boss).
+            val usesRawCtor = tokenActivatedAbilities.isNotEmpty()
+            when {
+                dynamicCount != null -> return Call(ctor, listOf(arg("count", dynamicCount)) + parts)
+                count == 1 -> return Call(ctor, parts)
+                usesRawCtor -> return Call(ctor, listOf(arg("count", Lit("DynamicAmount.Fixed($count)"))) + parts)
+                else -> { parts.add(arg("count", "$count")); return Call(ctor, parts) }
+            }
         }
     }
     return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FormAPosseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FormAPosseScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Form a Posse (OTJ #204) — {X}{R}{W} Sorcery.
+ *
+ *   "Create X 1/1 red Mercenary creature tokens with "{T}: Target creature you control gets
+ *    +1/+0 until end of turn. Activate only as a sorcery.""
+ *
+ * Verifies the X-many token count (DynamicAmount.XValue) and that each token is a 1/1 red
+ * Mercenary carrying the granted tap ability.
+ */
+class FormAPosseScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("X=3 creates three 1/1 red Mercenary tokens, each with the granted tap ability") {
+        val driver = createDriver()
+        val player = driver.player1
+        val projector = StateProjector()
+
+        // {X}{R}{W} with X=3 → 5 mana.
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.giveColorlessMana(player, 3)
+
+        val posse = driver.putCardInHand(player, "Form a Posse")
+        val cast = driver.castXSpell(player, posse, xValue = 3)
+        cast.error shouldBe null
+        driver.bothPass()
+
+        val mercenaries = driver.getCreatures(player).filter {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Mercenary Token"
+        }
+        mercenaries.size shouldBe 3
+
+        val projected = projector.project(driver.state)
+        for (token in mercenaries) {
+            val card = driver.state.getEntity(token)!!.get<CardComponent>()!!
+            driver.state.getEntity(token)!!.has<TokenComponent>() shouldBe true
+            card.colors shouldBe setOf(Color.RED)
+            projected.getPower(token) shouldBe 1
+            projected.getToughness(token) shouldBe 1
+            // The token's {T} ability was granted to it.
+            driver.state.grantedActivatedAbilities.any { it.entityId == token } shouldBe true
+        }
+    }
+
+    test("X=0 creates no tokens") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+
+        val posse = driver.putCardInHand(player, "Form a Posse")
+        val before = driver.getCreatures(player).size
+        val cast = driver.castXSpell(player, posse, xValue = 0)
+        cast.error shouldBe null
+        driver.bothPass()
+
+        driver.getCreatures(player).size shouldBe before
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfTheVarmintsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfTheVarmintsScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rise of the Varmints (OTJ #179) — {3}{G} Sorcery, Plot {2}{G}.
+ *
+ *   "Create X 2/1 green Varmint creature tokens, where X is the number of creature cards in your
+ *    graveyard."
+ *
+ * Verifies the resolution-time count (DynamicAmount.Count over the graveyard, creature filter):
+ * only creature cards in the graveyard count, and each token is a 2/1 green Varmint.
+ */
+class RiseOfTheVarmintsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.varmints(playerId: com.wingedsheep.sdk.model.EntityId) =
+        getCreatures(playerId).filter {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Varmint Token"
+        }
+
+    test("creates one 2/1 green Varmint per creature card in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        val projector = StateProjector()
+
+        // Three creature cards + one non-creature card in the graveyard. Only creatures count.
+        driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.putCardInGraveyard(player, "Lightning Bolt")
+
+        // {3}{G} → 4 mana.
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 3)
+
+        val rise = driver.putCardInHand(player, "Rise of the Varmints")
+        val cast = driver.castSpell(player, rise)
+        cast.error shouldBe null
+        driver.bothPass()
+
+        val tokens = driver.varmints(player)
+        tokens.size shouldBe 3
+
+        val projected = projector.project(driver.state)
+        for (token in tokens) {
+            val card = driver.state.getEntity(token)!!.get<CardComponent>()!!
+            card.colors shouldBe setOf(Color.GREEN)
+            projected.getPower(token) shouldBe 2
+            projected.getToughness(token) shouldBe 1
+        }
+    }
+
+    test("empty graveyard creates no tokens") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 3)
+
+        val rise = driver.putCardInHand(player, "Rise of the Varmints")
+        val cast = driver.castSpell(player, rise)
+        cast.error shouldBe null
+        driver.bothPass()
+
+        driver.varmints(player).size shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScalestormSummonerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScalestormSummonerScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scalestorm Summoner (OTJ #144) — {2}{R} Human Warlock, 3/3.
+ *
+ *   "Whenever this creature attacks, create a 3/1 red Dinosaur creature token if you control a
+ *    creature with power 4 or greater."
+ *
+ * Verifies the intervening-"if" attack trigger: a Dinosaur token appears only when a power-4+
+ * creature is also under your control as the trigger resolves.
+ */
+class ScalestormSummonerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.dinosaurs(playerId: EntityId) =
+        getCreatures(playerId).count {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Dinosaur Token"
+        }
+
+    test("attacking with a power-4+ creature in play creates a 3/1 Dinosaur token") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val summoner = driver.putCreatureOnBattlefield(player, "Scalestorm Summoner")
+        // Hill Giant is a 3/3 — too small; use a 4/4+ creature for the condition.
+        driver.putCreatureOnBattlefield(player, "Lumengrid Gargoyle") // 4/4 artifact creature
+        driver.removeSummoningSickness(summoner)
+
+        driver.dinosaurs(player) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(summoner), driver.player2)
+        driver.bothPass() // resolve the attack trigger
+
+        driver.dinosaurs(player) shouldBe 1
+    }
+
+    test("attacking without a power-4+ creature creates no token") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val summoner = driver.putCreatureOnBattlefield(player, "Scalestorm Summoner")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2 — below threshold
+        driver.removeSummoningSickness(summoner)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(summoner), driver.player2)
+        driver.bothPass()
+
+        driver.dinosaurs(player) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Cards implemented (Outlaws of Thunder Junction, OTJ)

All three were SCAFFOLD-tier (engine covers them, emitter declined them). Each is now implemented with a passing rules-engine scenario test:

- **Form a Posse** — `{X}{R}{W}` Sorcery: create X 1/1 red Mercenary tokens with the granted `{T}: target creature you control gets +1/+0` sorcery-speed ability. Uses `DynamicAmount.XValue` count + `CreateTokenEffect.activatedAbilities` (same Mercenary token as Mourner's Surprise).
- **Rise of the Varmints** — `{3}{G}` Sorcery, **Plot** `{2}{G}`: create X 2/1 green Varmints where X is the number of creature cards in your graveyard. Uses `DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature)`.
- **Scalestorm Summoner** — `{2}{R}` 3/3 Human Warlock: attack trigger creating a 3/1 red Dinosaur, gated by an intervening "if you control a creature with power 4 or greater" (`Conditions.YouControl(Creature.powerAtLeast(4))`).

## mtgish emitter widening

Extended the auto-gen emitter so all three render at **AUTO** tier (verified via `coverage-fidelity --emit`), following the "render correctly or decline to SCAFFOLD — never a lossy approximation" rule:

- **TokenHandlers** — a `NumberTokens` count that isn't a fixed int renders as a `DynamicAmount` via `dynamicAmountExpr` (`ValueX`, graveyard count); declines on counts it can't render exactly. Fixed counts on the raw `CreateTokenEffect` ctor (the activated-ability path) now emit `DynamicAmount.Fixed(N)` rather than a bare `Int` — the Int overload lacks `activatedAbilities`, so the old code produced an uncompilable draft. This **also promotes Hellspur Posse Boss** from a broken draft to a whole-compiling AUTOGEN card.
- **EmitCtx.dynamicAmountExpr** — renders `TheNumberOfGraveyardCards` (You-graveyard scope only) as `DynamicAmount.Count(Player.You, Zone.GRAVEYARD, filter)`.
- **TargetRecovery.gameObjectFilterExpr** — the `.youControl()`/`.opponentControls()` suffix is now gated on an actual `ControlledByAPlayer` clause, so a graveyard count's `InAPlayersGraveyard(You)` ownership clause is no longer misread as control of a battlefield permanent.
- **CardStructure.triggerBlock** — a trigger effect that is a lone `If{cond}[then]` with a strict intervening-if condition (no else-branch) is lifted to a `triggerCondition` gate over the then-branch (CR 603.4) — Scalestorm Summoner.

## Verification

- 6/6 new scenario tests pass (`FormAPosse`, `RiseOfTheVarmints`, `ScalestormSummoner`).
- `EmitterGoldenTest` (POR, EOE) stays green — no calibrated-set drift, so no re-bless needed.
- `coverage-fidelity --emit` confirms all three at AUTO tier; `coverage-gaps --set OTJ` now lists Hellspur Posse Boss under AUTOGEN.
- OTJ card-snapshot golden re-blessed (additive: only the three new cards). CardLintTest passes.
- No SDK surface changed; the 14 pre-existing OTJ gameplay-tree mismatches in `coverage-verify OTJ` are unrelated (OTJ is not a calibrated 0-mismatch set; only POR is in the CI loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)