### PR TITLE
Fix mtgish Registry indexing extension receivers as declarations

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Registry.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Registry.kt
@@ -28,9 +28,15 @@ object Registry {
             .toSet()
 
     // --- import resolution: symbol -> package, from a live scan of the SDK source (anti-rot) -----
+    // For `fun`/`val`, the trailing guard rejects extension declarations: in
+    // `fun GameObjectFilter.namedFromVariable(...)` the captured identifier is the *receiver
+    // type*, not a declaration in this package — indexing it would shadow the type's real home
+    // (the receiver's name is followed by `.`, or by `<` for a generic receiver, while a true
+    // function/property name is followed by `(`, `=`, `:`, or whitespace).
     private val DECL = Regex(
         """^(?:public\s+|internal\s+)?(?:sealed\s+|abstract\s+|open\s+|data\s+|value\s+)?""" +
-            """(?:class|object|interface|enum class|fun|val)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
+            """(?:(?:class|object|interface|enum class)\s+([A-Za-z_][A-Za-z0-9_]*)""" +
+            """|(?:fun|val)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)(?![\w.<]))"""
     )
     private val PKG_PREF = listOf(
         "com.wingedsheep.sdk.dsl", "com.wingedsheep.sdk.scripting.effects",
@@ -47,7 +53,10 @@ object Registry {
                 val pm = Regex("""^package\s+([\w.]+)""").find(line)
                 if (pm != null) { pkg = pm.groupValues[1]; continue }
                 if (pkg != null && line.isNotEmpty() && !line[0].isWhitespace()) {
-                    DECL.find(line)?.let { idx.getOrPut(it.groupValues[1]) { mutableSetOf() }.add(pkg) }
+                    DECL.find(line)?.let { m ->
+                        val name = m.groupValues[1].ifEmpty { m.groupValues[2] }
+                        idx.getOrPut(name) { mutableSetOf() }.add(pkg!!)
+                    }
                 }
             }
         }


### PR DESCRIPTION
PipelineBuilder.kt (PR #636) added `fun GameObjectFilter.namedFromVariable(...)`; the Registry's DECL scan captured the *receiver type* as a top-level declaration in com.wingedsheep.sdk.dsl, which PKG_PREF prefers — so importsFor() resolved GameObjectFilter to the nonexistent com.wingedsheep.sdk.dsl.GameObjectFilter and EmitterGoldenTest drifted on every POR card using a filter (first: Armageddon).

Guard the fun/val branch of DECL so an identifier followed by `.` or `<` (an extension receiver) is not indexed; class/object/interface indexing is unchanged. Golden stays as committed — the generator was wrong, not the cards.