### PR TITLE
Group identical permanents on the battlefield, like lands

### DIFF
--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -27,15 +27,6 @@ const EMPTY_TAGGED: readonly TaggedAttachment[] = []
 // other UI (turn bar, opposing row). Collapse to a badge + browser overlay instead.
 const ATTACHMENT_COLLAPSE_THRESHOLD = 3
 
-function toSinglesStable(cards: readonly ClientCard[]): GroupedCard[] {
-  return cards.map((card) => ({
-    card,
-    count: 1,
-    cardIds: [card.id],
-    cards: [card],
-  }))
-}
-
 /**
  * Battlefield area with two rows per player, each using a 3-column grid:
  *
@@ -120,14 +111,18 @@ function BattlefieldContent({ isOpponent, spectatorMode = false }: { isOpponent:
   const planeswalkers = isOpponent ? opponentPlaneswalkers : playerPlaneswalkers
   const other = isOpponent ? opponentOther : playerOther
 
-  // Group identical lands, display creatures/planeswalkers/other individually.
+  // Group permanents that share exactly the same projected status (counters, P/T, tapped,
+  // combat assignment, attachments, chosen attributes, …) into a single overlapping stack —
+  // the same treatment lands have always had, now applied to every row. A horde of identical
+  // tokens collapses into one stack instead of sprawling across the row, and any one of them
+  // splits back out the moment it's buffed, tapped, attacks, etc. (see computeCardGroupKey).
   // Memoized so these arrays keep stable identity across unrelated store updates —
   // otherwise every battlefield re-render allocates fresh arrays that cascade
   // into child re-renders and invalidate downstream useMemos.
   const groupedLands = useMemo(() => groupCards(lands), [lands])
-  const groupedCreatures = useMemo(() => toSinglesStable(creatures), [creatures])
-  const groupedPlaneswalkers = useMemo(() => toSinglesStable(planeswalkers), [planeswalkers])
-  const groupedOther = useMemo(() => toSinglesStable(other), [other])
+  const groupedCreatures = useMemo(() => groupCards(creatures), [creatures])
+  const groupedPlaneswalkers = useMemo(() => groupCards(planeswalkers), [planeswalkers])
+  const groupedOther = useMemo(() => groupCards(other), [other])
 
   const hasCreatures = groupedCreatures.length > 0
   const hasPlaneswalkers = groupedPlaneswalkers.length > 0

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -510,6 +510,12 @@ export interface GroupedCard {
 /**
  * Computes a grouping key for a card based on properties that make cards "different".
  * Cards with different keys should NOT be grouped together.
+ *
+ * The goal is that two cards share a key only when they have *exactly the same projected
+ * status* — same printed identity AND same battlefield state (counters, P/T, damage,
+ * tapped, combat assignment, summoning sickness, chosen attributes, granted keywords,
+ * designations, …). That way a stack of N identical tokens collapses into one visual
+ * group, but the moment one of them is buffed, tapped, attacks, etc. it splits back out.
  */
 export function computeCardGroupKey(card: ClientCard): string {
   const parts: string[] = [card.name]
@@ -526,8 +532,13 @@ export function computeCardGroupKey(card: ClientCard): string {
     parts.push(`pt:${card.power}/${card.toughness}`)
   }
 
-  // Cards with attachments should never be grouped — use unique ID
+  // Cards with attachments (auras/equipment) should never be grouped — use unique ID
   if (card.attachments.length > 0) {
+    parts.push(`id:${card.id}`)
+  }
+
+  // Cards with linked-exiled cards (e.g. Suspension Field) carry hidden state — never group
+  if (card.linkedExile && card.linkedExile.length > 0) {
     parts.push(`id:${card.id}`)
   }
 
@@ -541,6 +552,25 @@ export function computeCardGroupKey(card: ClientCard): string {
     parts.push('tapped')
   }
 
+  // Combat participants are different from idle permanents, and from each other when they
+  // attack/block different things (drives distinct targeting arrows, so they can't share a slot).
+  if (card.isAttacking) {
+    parts.push(`attacking:${card.attackingTarget ?? ''}`)
+  }
+  if (card.isBlocking) {
+    parts.push(`blocking:${card.blockingTarget ?? ''}`)
+  }
+
+  // Summoning-sick creatures behave differently (can't attack/tap) — keep them visually distinct.
+  if (card.hasSummoningSickness) {
+    parts.push('sick')
+  }
+
+  // Phased-out permanents render translucent and are functionally absent — never mix with present ones.
+  if (card.isPhasedOut) {
+    parts.push('phased')
+  }
+
   // Transformed cards are different
   if (card.isTransformed) {
     parts.push('transformed')
@@ -549,6 +579,38 @@ export function computeCardGroupKey(card: ClientCard): string {
   // Face-down cards are different
   if (card.isFaceDown) {
     parts.push('facedown')
+  }
+
+  // "As enters, choose ..." selections (creature type / color / mode) are rendered as badges.
+  if (card.chosenCreatureType) parts.push(`ct:${card.chosenCreatureType}`)
+  if (card.chosenColor) parts.push(`cc:${card.chosenColor}`)
+  if (card.chosenMode) parts.push(`cm:${card.chosenMode}`)
+
+  // Class/Saga progress is a per-permanent badge, not shared identity.
+  if (card.classLevel != null) parts.push(`class:${card.classLevel}`)
+
+  // Special designations carry prominent badges.
+  if (card.isSuspected) parts.push('suspected')
+  if (card.isRingBearer) parts.push('ringbearer')
+  if (card.isCommander) parts.push('commander')
+
+  // Copy provenance is badged and shown in details, so a token copy doesn't merge with the original.
+  if (card.copyOf) parts.push(`copy:${card.copyOf}`)
+  if (card.nonLegendaryCopy) parts.push('nonleg')
+
+  // Granted/projected keywords, ability flags and protections differ when one copy is
+  // pumped or granted an ability (without an attachment) but its twin isn't.
+  if (card.keywords.length > 0) {
+    parts.push(`kw:${[...card.keywords].sort().join(',')}`)
+  }
+  if (card.abilityFlags && card.abilityFlags.length > 0) {
+    parts.push(`af:${[...card.abilityFlags].sort().join(',')}`)
+  }
+  if (card.protections && card.protections.length > 0) {
+    parts.push(`prot:${[...card.protections].sort().join(',')}`)
+  }
+  if (card.hexproofFromColors && card.hexproofFromColors.length > 0) {
+    parts.push(`hpx:${[...card.hexproofFromColors].sort().join(',')}`)
   }
 
   return parts.join('|')


### PR DESCRIPTION
## What

Until now only **lands** were collapsed into overlapping stacks on the battlefield; creatures, planeswalkers and other permanents were always rendered one-per-slot. So creating 20 tokens sprawled them across the whole row and shrank every card to fit.

This applies the existing land-grouping to **every** battlefield row, and broadens the grouping key so two permanents only share a stack when they have **exactly the same projected status**.

## How

- `Battlefield.tsx`: `groupedCreatures` / `groupedPlaneswalkers` / `groupedOther` now go through `groupCards(...)` instead of being mapped one-per-slot (the `toSinglesStable` helper is removed). `groupedLands` is unchanged.
- `selectors.ts` — `computeCardGroupKey`: in addition to the previous criteria (name, counters, P/T, attachments, damage, tapped, transformed, face-down) the key now also separates on:
  - linked-exiled cards (e.g. Suspension Field)
  - combat assignment — attacking / blocking **and** which thing it's assigned to (distinct targeting arrows)
  - summoning sickness
  - phased-out
  - chosen creature type / color / mode badges
  - Class level
  - suspected / Ring-bearer / commander designations
  - copy provenance (`copyOf`, non-legendary copy)
  - projected keywords / ability flags / protections / hexproof-from-colors

The moment one token is buffed, tapped, attacks, etc. it splits back out into its own stack.

## Behaviour notes

- Grouping is **purely visual**. `CardStack` already renders each card in a group individually with its own `data-card-id`, so targeting, ability activation, and combat declaration are unchanged — exactly how grouped lands already behave.
- Groups are capped at 4 per stack (`MAX_GROUP_SIZE`), same as lands — a horde of 10 splits into 4 + 4 + 2.

## Verification

- `npm run typecheck` ✅ and production `vite build` ✅
- Manual: scenario with 10 identical Grizzly Bears + 2 with a +1/+1 counter + a lone Hill Giant, opponent with 8 Goblin Bullies. The identical ones collapse into stacks of ≤4; the counter-bears form their own stack; the Hill Giant stays solo.

## Screenshots

Scenario: each side has many identical creatures (plus two `+1/+1`-countered Grizzly Bears and a lone Hill Giant on the bottom).

**Before** — every creature individually, row sprawls and cards shrink:

![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/group-identical-permanents-screenshots/before.png)

**After** — identical permanents collapse into stacks; the countered bears split into their own stack; the Hill Giant stays solo:

![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/group-identical-permanents-screenshots/after.png)

_(The `group-identical-permanents-screenshots` branch is a throwaway image host, not part of this PR.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)