### PR TITLE
Dev-only LLM tournament (sealed, single-elimination, cost tracking)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/llm/LlmClient.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/llm/LlmClient.kt
@@ -17,8 +17,23 @@ import java.time.Duration
 
 private val logger = LoggerFactory.getLogger(LlmClient::class.java)
 
+/**
+ * Token usage + dollar cost for one LLM call. [costUsd] is null when the endpoint doesn't report
+ * it (only OpenRouter does, and only when the request asks for `usage.include=true`).
+ */
+data class LlmUsage(
+    val model: String,
+    val generationId: String?,
+    val promptTokens: Int,
+    val completionTokens: Int,
+    val totalTokens: Int,
+    val costUsd: Double?
+)
+
 class LlmClient(
-    private val properties: AiConfig
+    private val properties: AiConfig,
+    /** Optional callback invoked with token usage + cost after each successful response. */
+    private val usageSink: ((LlmUsage) -> Unit)? = null
 ) {
     private val json = Json {
         ignoreUnknownKeys = true
@@ -60,6 +75,7 @@ class LlmClient(
                     logger.warn("LLM API error (attempt {}, status {}): {}", attempt, response.statusCode(), body)
                 } else if (body != null) {
                     val parsed = json.decodeFromString<ChatCompletionResponse>(body)
+                    reportUsage(parsed, effectiveModel)
                     val content = parsed.choices.firstOrNull()?.message?.content
                     if (content != null) {
                         logger.info("LLM response (attempt {}):\n{}", attempt, content)
@@ -90,6 +106,11 @@ class LlmClient(
         val jsonObj = buildJsonObject {
             put("model", model)
             put("temperature", 0.8)
+            // OpenRouter returns the actual dollar cost in `usage.cost` only when asked. Other
+            // OpenAI-compatible endpoints may reject the unknown field, so gate on the provider.
+            if (properties.baseUrl.contains("openrouter", ignoreCase = true)) {
+                putJsonObject("usage") { put("include", true) }
+            }
             reasoningEffort?.let { put("reasoning_effort", it) }
             cacheControl?.let {
                 putJsonObject("cache_control") {
@@ -119,6 +140,21 @@ class LlmClient(
         }
         return jsonObj.toString()
     }
+
+    private fun reportUsage(parsed: ChatCompletionResponse, model: String) {
+        val sink = usageSink ?: return
+        val usage = parsed.usage ?: return
+        sink(
+            LlmUsage(
+                model = parsed.model ?: model,
+                generationId = parsed.id,
+                promptTokens = usage.promptTokens,
+                completionTokens = usage.completionTokens,
+                totalTokens = usage.totalTokens,
+                costUsd = usage.cost
+            )
+        )
+    }
 }
 
 @Serializable
@@ -136,7 +172,22 @@ data class CacheControl(
 
 @Serializable
 data class ChatCompletionResponse(
-    val choices: List<Choice> = emptyList()
+    val id: String? = null,
+    val model: String? = null,
+    val choices: List<Choice> = emptyList(),
+    val usage: Usage? = null
+)
+
+@Serializable
+data class Usage(
+    @SerialName("prompt_tokens")
+    val promptTokens: Int = 0,
+    @SerialName("completion_tokens")
+    val completionTokens: Int = 0,
+    @SerialName("total_tokens")
+    val totalTokens: Int = 0,
+    /** OpenRouter-only: total cost of this generation in USD (present when usage.include=true). */
+    val cost: Double? = null
 )
 
 @Serializable

--- a/ai/src/test/kotlin/com/wingedsheep/ai/llm/LlmClientUsageTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/llm/LlmClientUsageTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.ai.llm
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.doubles.shouldBeExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+/**
+ * Verifies the OpenRouter usage/cost fields deserialize off a representative chat-completion body.
+ * (The live cost numbers must be verified against OpenRouter itself; this pins the parsing.)
+ */
+class LlmClientUsageTest : StringSpec({
+
+    val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    "parses usage.cost and token counts from an OpenRouter response" {
+        // Shape returned by OpenRouter when the request sets usage: { include: true }.
+        val body = """
+            {
+              "id": "gen-abc123",
+              "model": "anthropic/claude-sonnet-4",
+              "choices": [
+                { "message": { "role": "assistant", "content": "Forest" }, "finish_reason": "stop" }
+              ],
+              "usage": {
+                "prompt_tokens": 1200,
+                "completion_tokens": 50,
+                "total_tokens": 1250,
+                "cost": 0.004235,
+                "cost_details": { "upstream_inference_cost": 0.004 },
+                "prompt_tokens_details": { "cached_tokens": 800 }
+              }
+            }
+        """.trimIndent()
+
+        val parsed = json.decodeFromString<ChatCompletionResponse>(body)
+
+        parsed.id shouldBe "gen-abc123"
+        parsed.model shouldBe "anthropic/claude-sonnet-4"
+        parsed.choices.first().message?.content shouldBe "Forest"
+        parsed.usage?.promptTokens shouldBe 1200
+        parsed.usage?.completionTokens shouldBe 50
+        parsed.usage?.totalTokens shouldBe 1250
+        parsed.usage!!.cost!! shouldBeExactly 0.004235
+    }
+
+    "tolerates a response with usage tokens but no cost (non-OpenRouter / cost not requested)" {
+        val body = """
+            {
+              "choices": [ { "message": { "role": "assistant", "content": "ok" } } ],
+              "usage": { "prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12 }
+            }
+        """.trimIndent()
+
+        val parsed = json.decodeFromString<ChatCompletionResponse>(body)
+        parsed.usage?.totalTokens shouldBe 12
+        parsed.usage?.cost.shouldBeNull()
+    }
+
+    "tolerates a response with no usage block at all" {
+        val body = """{ "choices": [ { "message": { "role": "assistant", "content": "ok" } } ] }"""
+        val parsed = json.decodeFromString<ChatCompletionResponse>(body)
+        parsed.usage.shouldBeNull()
+        parsed.choices.first().message?.content shouldBe "ok"
+    }
+})

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -33,7 +33,8 @@ class AiGameManager(
     private val gameProperties: GameProperties,
     private val sessionRegistry: SessionRegistry,
     private val deckGenerator: SealedDeckGenerator,
-    private val cardRegistry: CardRegistry
+    private val cardRegistry: CardRegistry,
+    private val llmCostTracker: com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
 ) {
     private val activeSessions = ConcurrentHashMap<String, AiWebSocketSession>()
 
@@ -127,7 +128,12 @@ class AiGameManager(
                 playerId = aiPlayerId,
                 gameStateProvider = { gameSession?.getStateSnapshot() }
             )
-            val llmClient = LlmClient(aiConfig)
+            // Attribute in-game LLM token usage + cost to this game session, so the LLM-tournament
+            // can report cost per game. No-op when there's no game (e.g. placeholder identities).
+            val gameId = gameSession?.sessionId
+            val usageSink: ((com.wingedsheep.ai.llm.LlmUsage) -> Unit)? =
+                if (gameId != null) { usage -> llmCostTracker.record(gameId, usage) } else null
+            val llmClient = LlmClient(aiConfig, usageSink)
             LlmAiPlayerController(aiConfig, llmClient, aiPlayerId, fallback = engineFallback)
         }
     }
@@ -451,6 +457,18 @@ class AiGameManager(
 
         activeSessions[gameSession.sessionId] = newSession
         logger.info("Wired AI {} for game {} [mode={}]", aiPlayerId.value, gameSession.sessionId, aiProperties.mode)
+    }
+
+    /**
+     * Adjust the per-decision thinking delay of an AI player's live session. Used by the
+     * LLM-tournament pacing control to speed up / slow down an in-progress AI-vs-AI game.
+     * No-op if the player isn't an AI or has no live session.
+     */
+    fun setThinkingDelay(aiPlayerId: EntityId, thinkingDelayMs: Long) {
+        val ws = sessionRegistry.getAllIdentities()
+            .firstOrNull { it.playerId == aiPlayerId }
+            ?.webSocketSession as? AiWebSocketSession
+        ws?.thinkingDelayMs = thinkingDelayMs
     }
 
     /** Set of all AI player IDs (persists across matches within a tournament). */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -41,7 +41,12 @@ private val logger = LoggerFactory.getLogger(AiWebSocketSession::class.java)
 class AiWebSocketSession(
     private val aiPlayerId: EntityId,
     private val controller: AiPlayerController,
-    private val thinkingDelayMs: Long = 500,
+    /**
+     * Per-decision artificial delay so a human can follow along. Mutable + volatile so the
+     * LLM-tournament pacing control can speed up / slow down a live AI-vs-AI game; it's re-read
+     * on every decision, so a change takes effect on the AI's next move.
+     */
+    @Volatile var thinkingDelayMs: Long = 500,
     private val onActionReady: (EntityId, GameAction) -> Unit,
     private val onMulliganKeep: (EntityId) -> Unit,
     private val onMulliganTake: (EntityId) -> Unit,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/LlmTournamentController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/LlmTournamentController.kt
@@ -1,0 +1,250 @@
+package com.wingedsheep.gameserver.controller
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.gameserver.tournament.llm.DeckbuildMode
+import com.wingedsheep.gameserver.tournament.llm.LlmMatch
+import com.wingedsheep.gameserver.tournament.llm.LlmTournament
+import com.wingedsheep.gameserver.tournament.llm.LlmTournamentService
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+/**
+ * Dev-only endpoints driving an all-LLM single-elimination sealed tournament.
+ *
+ * Enable with: game.dev-endpoints.enabled=true (and game.ai.mode=llm + an OpenRouter key).
+ * The web client exposes this at /llm-tournament (dev builds only).
+ */
+@RestController
+@RequestMapping("/api/dev/llm-tournament")
+@ConditionalOnProperty(name = ["game.dev-endpoints.enabled"], havingValue = "true")
+class LlmTournamentController(
+    private val service: LlmTournamentService,
+    private val boosterGenerator: BoosterGenerator
+) {
+    private val logger = LoggerFactory.getLogger(LlmTournamentController::class.java)
+
+    // ---- Requests / responses -------------------------------------------------
+
+    data class CreateRequest(
+        val modelIds: List<String> = emptyList(),
+        val setCode: String = "",
+        /** "heuristic" or "llm" */
+        val deckbuildMode: String = "heuristic",
+        val bestOf: Int = 3
+    )
+
+    data class SpeedRequest(val thinkingDelayMs: Long = 500)
+
+    /** Token usage + dollar cost. costKnown=false means costUsd is a floor (provider didn't report cost). */
+    data class CostView(
+        val costUsd: Double,
+        val totalTokens: Long,
+        val calls: Int,
+        val costKnown: Boolean
+    )
+
+    data class ParticipantView(
+        val id: String,
+        val modelId: String,
+        val displayName: String,
+        val seed: Int,
+        val buildStatus: String,
+        val deckSize: Int,
+        val buildCost: CostView?,
+        /** The built deck as cardName -> count (empty until the deck is built). */
+        val deck: Map<String, Int>
+    )
+
+    data class FinishedGameView(
+        val gameSessionId: String,
+        val cost: CostView
+    )
+
+    data class MatchView(
+        val id: String,
+        val roundNumber: Int,
+        val slot: Int,
+        val player1Name: String?,
+        val player2Name: String?,
+        val player1ModelId: String?,
+        val player2ModelId: String?,
+        val player1GameWins: Int,
+        val player2GameWins: Int,
+        val winnerName: String?,
+        val bye: Boolean,
+        val complete: Boolean,
+        val status: String,
+        val currentGameSessionId: String?,
+        val finishedGames: List<FinishedGameView>,
+        val cost: CostView
+    )
+
+    data class RoundView(val roundNumber: Int, val matches: List<MatchView>)
+
+    data class TournamentView(
+        val id: String,
+        val setCode: String,
+        val deckbuildMode: String,
+        val bestOf: Int,
+        val status: String,
+        val thinkingDelayMs: Long,
+        val championName: String?,
+        val participants: List<ParticipantView>,
+        val rounds: List<RoundView>,
+        /** Total LLM cost of games played so far. */
+        val gameCost: CostView,
+        /** Total LLM cost of building all decks (zero for heuristic). */
+        val deckbuildCost: CostView,
+        /** False when no OpenRouter key is configured — decks + play silently fall back to engine AI. */
+        val llmAvailable: Boolean
+    )
+
+    /** Mirrors ServerMessage.AvailableSet so the dev page can reuse the shared SetPickerModal. */
+    data class SetInfo(
+        val code: String,
+        val name: String,
+        val partial: Boolean,
+        val block: String?,
+        val implementedCount: Int,
+        val releaseDate: String?
+    )
+
+    // ---- Endpoints ------------------------------------------------------------
+
+    @PostMapping
+    fun create(@RequestBody request: CreateRequest): ResponseEntity<Any> {
+        return try {
+            val mode = when (request.deckbuildMode.lowercase()) {
+                "llm" -> DeckbuildMode.LLM
+                else -> DeckbuildMode.HEURISTIC
+            }
+            val tournament = service.create(request.modelIds, request.setCode, mode, request.bestOf.coerceIn(1, 9))
+            ResponseEntity.ok(toView(tournament))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid request")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Cannot create tournament")))
+        } catch (e: Exception) {
+            logger.error("Failed to create LLM tournament", e)
+            ResponseEntity.internalServerError().body(mapOf("error" to (e.message ?: "Internal error")))
+        }
+    }
+
+    @GetMapping("/{id}")
+    fun get(@PathVariable id: String): ResponseEntity<Any> {
+        val tournament = service.get(id) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(toView(tournament))
+    }
+
+    @GetMapping
+    fun list(): ResponseEntity<List<TournamentView>> =
+        ResponseEntity.ok(service.all().map { toView(it) })
+
+    @PostMapping("/{id}/start")
+    fun start(@PathVariable id: String) = control(id) { service.start(it) }
+
+    @PostMapping("/{id}/pause")
+    fun pause(@PathVariable id: String) = control(id) { service.pause(it) }
+
+    @PostMapping("/{id}/resume")
+    fun resume(@PathVariable id: String) = control(id) { service.start(it) }
+
+    @PostMapping("/{id}/step")
+    fun step(@PathVariable id: String) = control(id) { service.step(it) }
+
+    @PostMapping("/{id}/speed")
+    fun speed(@PathVariable id: String, @RequestBody request: SpeedRequest) =
+        control(id) { service.setSpeed(it, request.thinkingDelayMs) }
+
+    @DeleteMapping("/{id}")
+    fun delete(@PathVariable id: String): ResponseEntity<Any> {
+        val tournament = service.get(id) ?: return ResponseEntity.notFound().build()
+        service.delete(tournament)
+        return ResponseEntity.ok(mapOf("deleted" to id))
+    }
+
+    @GetMapping("/sets")
+    fun listSets(): ResponseEntity<List<SetInfo>> =
+        ResponseEntity.ok(boosterGenerator.availableSets.values.map { config ->
+            SetInfo(
+                code = config.setCode,
+                name = config.setName,
+                partial = !config.fullyImplemented,
+                block = config.block,
+                implementedCount = config.distinctCardCount,
+                releaseDate = config.releaseDate
+            )
+        })
+
+    private fun control(id: String, action: (LlmTournament) -> Unit): ResponseEntity<Any> {
+        val tournament = service.get(id) ?: return ResponseEntity.notFound().build()
+        action(tournament)
+        return ResponseEntity.ok(toView(tournament))
+    }
+
+    // ---- View mapping ---------------------------------------------------------
+
+    private fun toView(t: LlmTournament): TournamentView {
+        return TournamentView(
+            id = t.id,
+            setCode = t.setCode,
+            deckbuildMode = t.deckbuildMode.name.lowercase(),
+            bestOf = t.bestOf,
+            status = t.status.name,
+            thinkingDelayMs = t.thinkingDelayMs,
+            championName = t.champion?.displayName,
+            participants = t.participants.map { p ->
+                ParticipantView(
+                    id = p.id.value,
+                    modelId = p.modelId,
+                    displayName = p.displayName,
+                    seed = p.seed,
+                    buildStatus = p.buildStatus.name,
+                    deckSize = p.deck.values.sum(),
+                    buildCost = p.buildCost?.let { costView(it) },
+                    deck = p.deck
+                )
+            },
+            rounds = t.rounds.map { round ->
+                RoundView(round.roundNumber, round.matches.map { matchView(t, it) })
+            },
+            gameCost = costView(t.totalGameCost()),
+            deckbuildCost = costView(t.totalDeckbuildCost()),
+            llmAvailable = service.llmAvailable()
+        )
+    }
+
+    private fun costView(c: com.wingedsheep.gameserver.tournament.llm.LlmCost) =
+        CostView(costUsd = c.costUsd, totalTokens = c.totalTokens, calls = c.calls, costKnown = c.costKnown)
+
+    private fun matchView(t: LlmTournament, m: LlmMatch): MatchView {
+        val status = when {
+            m.isBye -> "bye"
+            m.isComplete -> "done"
+            m.currentGameSessionId != null -> "live"
+            else -> "scheduled"
+        }
+        return MatchView(
+            id = m.id,
+            roundNumber = m.roundNumber,
+            slot = m.slot,
+            player1Name = t.participant(m.player1Id)?.displayName,
+            player2Name = t.participant(m.player2Id)?.displayName,
+            player1ModelId = t.participant(m.player1Id)?.modelId,
+            player2ModelId = t.participant(m.player2Id)?.modelId,
+            player1GameWins = m.player1GameWins,
+            player2GameWins = m.player2GameWins,
+            winnerName = t.participant(m.winnerId)?.displayName,
+            bye = m.isBye,
+            complete = m.isComplete,
+            status = status,
+            currentGameSessionId = m.currentGameSessionId,
+            finishedGames = m.finishedGames.map { FinishedGameView(it.gameSessionId, costView(it.cost)) },
+            cost = costView(m.finishedGames.fold(
+                com.wingedsheep.gameserver.tournament.llm.LlmCost.ZERO
+            ) { acc, g -> acc + g.cost })
+        )
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -68,6 +68,11 @@ class GamePlayHandler(
     // Callback for full match result handling (report result + notify + check round complete, all under lock)
     var handleMatchResultCallback: ((String, String, EntityId?, Int) -> Unit)? = null
 
+    // Callback fired when ANY game ends, used by the dev-only LLM tournament orchestrator to
+    // advance its bracket. Args: (gameSessionId, winnerId, winnerLifeRemaining). The orchestrator
+    // ignores game ids it doesn't own, so this is safe to fire unconditionally.
+    var llmTournamentGameOverCallback: ((String, EntityId?, Int) -> Unit)? = null
+
     fun handle(session: WebSocketSession, message: ClientMessage) {
         when (message) {
             is ClientMessage.CreateGame -> handleCreateGame(session, message)
@@ -296,6 +301,78 @@ class GamePlayHandler(
     private fun sendMulliganDecision(gameSession: GameSession, playerSession: PlayerSession) {
         val decision = gameSession.getMulliganDecision(playerSession.playerId)
         sender.send(playerSession.webSocketSession, decision)
+    }
+
+    /**
+     * Create and start a fresh AI-vs-AI [GameSession] with no human seats, for the dev-only
+     * LLM tournament orchestrator. Both players must already be registered AI identities (minted
+     * via [AiGameManager.createAiIdentity]); each gets its own pre-built deck and model. Mirrors
+     * the AI-wiring half of [TournamentMatchHandler.startSingleMatch] without any lobby plumbing.
+     *
+     * @return the new game session id (use it to spectate / locate the replay).
+     */
+    fun createAndStartAiVsAiGame(
+        player1Id: EntityId,
+        player1Deck: Map<String, Int>,
+        player2Id: EntityId,
+        player2Deck: Map<String, Int>,
+        setCode: String?,
+        thinkingDelayMs: Long
+    ): String {
+        val gameSession = GameSession(
+            cardRegistry = cardRegistry,
+            useHandSmoother = gameProperties.handSmoother.enabled,
+            debugMode = gameProperties.debugMode,
+            printingRegistry = printingRegistry,
+        )
+        gameSession.quickGameSetCode = setCode
+
+        wireAiSeat(gameSession, player1Id, player1Deck, thinkingDelayMs)
+        wireAiSeat(gameSession, player2Id, player2Deck, thinkingDelayMs)
+
+        gameRepository.save(gameSession)
+        startGame(gameSession)
+        logger.info("Started AI-vs-AI game {} ({} vs {})",
+            gameSession.sessionId, player1Id.value, player2Id.value)
+        return gameSession.sessionId
+    }
+
+    private fun wireAiSeat(
+        gameSession: GameSession,
+        aiPlayerId: EntityId,
+        deck: Map<String, Int>,
+        thinkingDelayMs: Long
+    ) {
+        val identity = sessionRegistry.getAllIdentities().firstOrNull { it.playerId == aiPlayerId }
+            ?: error("AI identity not found for ${aiPlayerId.value} — create it via AiGameManager.createAiIdentity first")
+
+        gameSession.addPlayer(identity.toPlayerSession(), deck)
+        gameSession.setPlayerPersistenceInfo(
+            aiPlayerId, identity.playerName, identity.token,
+            isAi = true, aiModelOverride = identity.aiModelOverride
+        )
+
+        aiGameManager.wireAiForGame(
+            gameSession = gameSession,
+            aiPlayerId = aiPlayerId,
+            deckList = deck,
+            onActionReady = { id, action -> handleAiAction(gameSession, id, action) },
+            onMulliganKeep = { id -> handleAiMulliganKeep(gameSession, id) },
+            onMulliganTake = { id -> handleAiMulliganTake(gameSession, id) },
+            onBottomCards = { id, cardIds -> handleAiBottomCards(gameSession, id, cardIds) }
+        )
+
+        // wireAiForGame swapped in a fresh AiWebSocketSession; point the game session's player
+        // slot at it so broadcasts reach the wired session, then apply the pacing speed.
+        identity.webSocketSession?.let { newWs ->
+            gameSession.replacePlayerSession(aiPlayerId, PlayerSession(
+                webSocketSession = newWs,
+                playerId = aiPlayerId,
+                playerName = identity.playerName,
+                currentGameSessionId = gameSession.sessionId
+            ))
+        }
+        aiGameManager.setThinkingDelay(aiPlayerId, thinkingDelayMs)
     }
 
     private fun handleKeepHand(session: WebSocketSession) {
@@ -552,6 +629,16 @@ class GamePlayHandler(
             )
             gameHistoryRepository.save(record)
             logger.info("Saved replay for game $gameSessionId ($frameCount frames)")
+        }
+
+        // Notify the dev LLM-tournament orchestrator (no-op for games it doesn't own).
+        // Fired before cleanup so it can launch the next bracket game off its own coroutine.
+        llmTournamentGameOverCallback?.let { callback ->
+            val winnerLife = if (winnerId != null) {
+                gameSession.getStateForTesting()?.getEntity(winnerId)
+                    ?.get<LifeTotalComponent>()?.life ?: 0
+            } else 0
+            callback(gameSessionId, winnerId, winnerLife)
         }
 
         gameRepository.remove(gameSessionId)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmCostTracker.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmCostTracker.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.gameserver.tournament.llm
+
+import com.wingedsheep.ai.llm.LlmUsage
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/** Aggregated token usage + dollar cost for one bucket (a game session, or a deckbuild). */
+data class LlmCost(
+    val calls: Int,
+    val promptTokens: Long,
+    val completionTokens: Long,
+    val totalTokens: Long,
+    val costUsd: Double,
+    /** False if any contributing call's endpoint didn't report a dollar cost (so [costUsd] is a floor). */
+    val costKnown: Boolean
+) {
+    operator fun plus(other: LlmCost) = LlmCost(
+        calls = calls + other.calls,
+        promptTokens = promptTokens + other.promptTokens,
+        completionTokens = completionTokens + other.completionTokens,
+        totalTokens = totalTokens + other.totalTokens,
+        costUsd = costUsd + other.costUsd,
+        costKnown = costKnown && other.costKnown
+    )
+
+    companion object {
+        val ZERO = LlmCost(0, 0, 0, 0, 0.0, true)
+    }
+}
+
+/**
+ * Accumulates LLM token usage + cost per arbitrary string bucket. The LLM-tournament uses the game
+ * session id as the bucket for in-game decisions, and a participant id for deck building, so cost
+ * can be attributed per game / per deck build. Thread-safe (records arrive on AI coroutine threads).
+ */
+@Component
+class LlmCostTracker {
+    private val buckets = ConcurrentHashMap<String, MutableAcc>()
+
+    private class MutableAcc {
+        var calls = 0
+        var promptTokens = 0L
+        var completionTokens = 0L
+        var totalTokens = 0L
+        var costUsd = 0.0
+        var costKnown = true
+
+        @Synchronized
+        fun add(usage: LlmUsage) {
+            calls++
+            promptTokens += usage.promptTokens
+            completionTokens += usage.completionTokens
+            totalTokens += usage.totalTokens
+            val c = usage.costUsd
+            if (c != null) costUsd += c else costKnown = false
+        }
+
+        @Synchronized
+        fun snapshot() = LlmCost(calls, promptTokens, completionTokens, totalTokens, costUsd, costKnown)
+    }
+
+    fun record(bucket: String, usage: LlmUsage) {
+        buckets.computeIfAbsent(bucket) { MutableAcc() }.add(usage)
+    }
+
+    fun snapshot(bucket: String): LlmCost = buckets[bucket]?.snapshot() ?: LlmCost.ZERO
+
+    fun clear(bucket: String) {
+        buckets.remove(bucket)
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmSealedDeckBuildService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmSealedDeckBuildService.kt
@@ -1,0 +1,210 @@
+package com.wingedsheep.gameserver.tournament.llm
+
+import com.wingedsheep.ai.engine.buildHeuristicSealedDeck
+import com.wingedsheep.ai.llm.AiConfig
+import com.wingedsheep.ai.llm.ChatMessage
+import com.wingedsheep.ai.llm.LlmClient
+import com.wingedsheep.ai.llm.LlmUsage
+import com.wingedsheep.gameserver.config.AiProperties
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.CardDefinition
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Builds a 40-card **sealed** deck from a pool. Shared by the human tournament lobby
+ * ([com.wingedsheep.gameserver.handler.LobbyHandler]) and the dev LLM tournament.
+ *
+ * - **heuristic**: [com.wingedsheep.ai.engine.buildHeuristicSealedDeck] — fast, free, deterministic.
+ * - **llm**: a single-shot sealed prompt to the given model; parsed + validated against the pool,
+ *   padded/trimmed to 40, basics as plain `Forest`/`Mountain`/… names. Falls back to heuristic if
+ *   the LLM is unavailable or returns an unusable list.
+ *
+ * NB: emits **plain card names** (incl. plain basic-land names) so the engine's `CardRegistry`
+ * resolves every entry. Do NOT use the constructed-deck `AiDeckBuilder` here — it targets 60 cards
+ * and its random fallback emits collector-numbered basic variants (e.g. `Mountain#272`) that the
+ * registry can't resolve.
+ */
+@Service
+class LlmSealedDeckBuildService(
+    private val gameProperties: GameProperties
+) {
+    private val logger = LoggerFactory.getLogger(LlmSealedDeckBuildService::class.java)
+
+    private val basics = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+
+    /**
+     * @param useLlm caller's intent to use model-driven building (ANDed with config + key availability)
+     * @param modelOverride the model to build with (null → server's configured deckbuilding model)
+     * @param usageSink optional token/cost callback for the LLM call
+     */
+    fun build(
+        pool: List<CardDefinition>,
+        useLlm: Boolean,
+        modelOverride: String? = null,
+        usageSink: ((LlmUsage) -> Unit)? = null
+    ): Map<String, Int> {
+        val ai = gameProperties.ai
+        // An explicit per-tournament "LLM" choice (useLlm) overrides the server's
+        // `heuristic-deckbuilding` convenience flag — that flag only governs casual vs-AI play.
+        val canLlm = useLlm && ai.enabled && ai.effectiveApiKey.isNotBlank()
+        if (!canLlm) {
+            logger.info(
+                "Sealed deckbuild → HEURISTIC. requestedLlm={}, aiEnabled={}, apiKeyPresent={}",
+                useLlm, ai.enabled, ai.effectiveApiKey.isNotBlank()
+            )
+        }
+        if (canLlm) {
+            try {
+                val deck = tryLlmSealedDeck(pool, ai, modelOverride, usageSink)
+                if (deck != null) return deck
+                logger.info("LLM sealed deckbuild returned nothing, falling back to heuristic")
+            } catch (e: Exception) {
+                logger.warn("LLM sealed deckbuild failed (model={}), falling back to heuristic: {}",
+                    modelOverride ?: ai.effectiveDeckbuildingModel, e.message)
+            }
+        }
+        val deck = buildHeuristicSealedDeck(pool)
+        logger.info("Heuristic sealed deck ({} cards)", deck.values.sum())
+        return deck
+    }
+
+    private fun tryLlmSealedDeck(
+        pool: List<CardDefinition>,
+        ai: AiProperties,
+        modelOverride: String?,
+        usageSink: ((LlmUsage) -> Unit)?
+    ): Map<String, Int>? {
+        val model = modelOverride ?: ai.effectiveDeckbuildingModel
+        val nonLands = pool.filter { !it.typeLine.isLand }
+        val poolLands = pool.filter { it.typeLine.isLand && !it.typeLine.isBasicLand }
+
+        val prompt = buildString {
+            appendLine("You are building a 40-card sealed deck from this card pool.")
+            appendLine()
+            appendLine("RULES:")
+            appendLine("- Exactly 40 cards total")
+            appendLine("- ~23 non-land cards (creatures + spells) and ~17 lands")
+            appendLine("- Pick 2 colors (sometimes splash a 3rd). Do NOT play all 5 colors.")
+            appendLine("- Only include cards you can actually cast with your lands")
+            appendLine("- You may add any number of basic lands: Plains, Island, Swamp, Mountain, Forest")
+            appendLine("- Prioritize creatures, removal, and a good mana curve")
+            appendLine("- Include non-basic lands from your pool if they fit your colors")
+            appendLine()
+            appendLine("YOUR CARD POOL:")
+
+            val byType = nonLands.groupBy { card ->
+                when {
+                    card.typeLine.isCreature -> "Creatures"
+                    card.typeLine.isInstant || card.typeLine.isSorcery -> "Spells"
+                    card.typeLine.isEnchantment -> "Enchantments"
+                    card.typeLine.isArtifact -> "Artifacts"
+                    else -> "Other"
+                }
+            }
+            for ((type, cards) in byType.entries.sortedBy { it.key }) {
+                appendLine()
+                appendLine("$type:")
+                val grouped = cards.groupBy { it.name }
+                for ((_, copies) in grouped.entries.sortedBy { it.value.first().cmc }) {
+                    val card = copies.first()
+                    val stats = if (card.creatureStats != null) " ${card.creatureStats}" else ""
+                    val oracle = if (card.oracleText.isNotBlank()) " — ${card.oracleText.replace("\n", " / ")}" else ""
+                    val count = if (copies.size > 1) "${copies.size}x " else ""
+                    appendLine("  $count${card.name} ${card.manaCost} — ${card.typeLine}$stats$oracle")
+                }
+            }
+            if (poolLands.isNotEmpty()) {
+                appendLine()
+                appendLine("Non-basic lands in pool:")
+                for ((_, copies) in poolLands.groupBy { it.name }) {
+                    val card = copies.first()
+                    val count = if (copies.size > 1) "${copies.size}x " else ""
+                    val oracle = if (card.oracleText.isNotBlank()) " — ${card.oracleText.replace("\n", " / ")}" else ""
+                    appendLine("  $count${card.name}$oracle")
+                }
+            }
+            appendLine()
+            appendLine("Reply ONLY with the deck list, one entry per line:")
+            appendLine("1x Card Name")
+            appendLine("9x Forest")
+        }
+
+        val client = LlmClient(ai.toAiConfig(), usageSink)
+        val messages = listOf(
+            ChatMessage("system",
+                "You are an expert Magic: The Gathering limited deckbuilder. " +
+                    "Analyze the sealed pool, pick the best 2 colors (with optional light splash), " +
+                    "and build a strong 40-card deck. Reply ONLY with the deck list."),
+            ChatMessage("user", prompt)
+        )
+
+        val response = client.chatCompletion(messages, modelOverride = model) ?: return null
+        return parseSealedDeckList(response, pool)
+    }
+
+    private fun parseSealedDeckList(response: String, pool: List<CardDefinition>): Map<String, Int>? {
+        val poolCounts = pool.groupBy { it.name }.mapValues { it.value.size }
+        val validNames = poolCounts.keys + basics
+
+        val deckMap = mutableMapOf<String, Int>()
+        val linePattern = Regex("""(\d+)\s*x?\s+(.+)""", RegexOption.IGNORE_CASE)
+
+        for (line in response.lines()) {
+            val match = linePattern.find(line.trim()) ?: continue
+            val count = match.groupValues[1].toIntOrNull() ?: continue
+            val name = match.groupValues[2].trim()
+            val exactMatch = validNames.find { it.equals(name, ignoreCase = true) } ?: continue
+            if (count < 1) continue
+            val maxAllowed = if (exactMatch in basics) count else poolCounts[exactMatch] ?: 0
+            val actual = count.coerceAtMost(maxAllowed)
+            if (actual > 0) deckMap[exactMatch] = (deckMap[exactMatch] ?: 0) + actual
+        }
+
+        val total = deckMap.values.sum()
+        if (total < 30) {
+            logger.warn("LLM sealed deckbuild: deck too small ({} cards), rejecting", total)
+            return null
+        }
+        if (total < 40) {
+            val primaryLand = guessPrimaryBasicLand(deckMap, pool)
+            deckMap[primaryLand] = (deckMap[primaryLand] ?: 0) + (40 - total)
+        }
+        while (deckMap.values.sum() > 40) {
+            val landToTrim = basics.filter { (deckMap[it] ?: 0) > 0 }.maxByOrNull { deckMap[it] ?: 0 } ?: break
+            deckMap[landToTrim] = (deckMap[landToTrim] ?: 0) - 1
+            if (deckMap[landToTrim] == 0) deckMap.remove(landToTrim)
+        }
+
+        logger.info("LLM sealed deck ({} cards): {}", deckMap.values.sum(),
+            deckMap.entries.sortedByDescending { it.value }.joinToString(", ") { "${it.value}x ${it.key}" })
+        return deckMap
+    }
+
+    private fun guessPrimaryBasicLand(deckMap: Map<String, Int>, pool: List<CardDefinition>): String {
+        val poolByName = pool.associateBy { it.name }
+        val colorCounts = mutableMapOf<Color, Int>()
+        for ((name, count) in deckMap) {
+            if (name in basics) continue
+            val card = poolByName[name] ?: continue
+            for (color in card.colors) colorCounts[color] = (colorCounts[color] ?: 0) + count
+        }
+        return when (colorCounts.maxByOrNull { it.value }?.key) {
+            Color.WHITE -> "Plains"
+            Color.BLUE -> "Island"
+            Color.BLACK -> "Swamp"
+            Color.RED -> "Mountain"
+            Color.GREEN -> "Forest"
+            else -> "Forest"
+        }
+    }
+
+    private fun AiProperties.toAiConfig() = AiConfig(
+        enabled = enabled, mode = mode, baseUrl = baseUrl,
+        apiKey = apiKey, openRouterApiKey = openRouterApiKey,
+        model = model, deckbuildingModel = deckbuildingModel,
+        reasoningEffort = reasoningEffort, maxRetries = maxRetries,
+        timeoutMs = timeoutMs, thinkingDelayMs = thinkingDelayMs
+    )
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmTournamentModel.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmTournamentModel.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.gameserver.tournament.llm
+
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Overall lifecycle of an LLM tournament. */
+enum class LlmTournamentStatus {
+    /** Generating sealed pools + building decks. */
+    BUILDING,
+
+    /** Pools/decks ready, bracket seeded, waiting for the user to press Start. */
+    READY,
+
+    /** Actively playing games (auto-launches the next game as each finishes). */
+    RUNNING,
+
+    /** Paused — the in-flight game finishes, but no new game auto-launches. */
+    PAUSED,
+
+    /** A single champion remains. */
+    COMPLETE
+}
+
+/** Per-participant deckbuild progress (surfaced in the UI during [LlmTournamentStatus.BUILDING]). */
+enum class ParticipantBuildStatus { PENDING, BUILDING_POOL, BUILDING_DECK, READY, FAILED }
+
+enum class DeckbuildMode { HEURISTIC, LLM }
+
+/**
+ * A tournament entrant: one OpenRouter model with its own sealed pool + built deck.
+ */
+class LlmParticipant(
+    val id: EntityId,
+    val modelId: String,
+    val displayName: String,
+    /** 1-based seed (input order); used to lay out the bracket. */
+    val seed: Int
+) {
+    @Volatile var pool: List<CardDefinition> = emptyList()
+    @Volatile var deck: Map<String, Int> = emptyMap()
+    @Volatile var buildStatus: ParticipantBuildStatus = ParticipantBuildStatus.PENDING
+
+    /** LLM cost of building this deck (null for heuristic / not yet built). */
+    @Volatile var buildCost: LlmCost? = null
+}
+
+/** One finished game of a match, with the LLM cost it incurred (both players combined). */
+class FinishedGame(
+    val gameSessionId: String,
+    val cost: LlmCost
+)
+
+/**
+ * A best-of-N match between two participants (or a bye when [player2Id] is null).
+ * Plays one game at a time; the first to ceil(bestOf/2) game wins takes the match.
+ */
+class LlmMatch(
+    val id: String,
+    val roundNumber: Int,
+    /** Position within the round (0-based), used to derive next-round pairings. */
+    val slot: Int,
+    var player1Id: EntityId?,
+    var player2Id: EntityId?
+) {
+    var player1GameWins: Int = 0
+    var player2GameWins: Int = 0
+    var winnerId: EntityId? = null
+    var isComplete: Boolean = false
+
+    /** The live game session id while a game is being played, else null. */
+    @Volatile var currentGameSessionId: String? = null
+
+    /** Finished games (replay targets + per-game cost), in play order. */
+    val finishedGames: MutableList<FinishedGame> = mutableListOf()
+
+    val isBye: Boolean get() = player1Id != null && player2Id == null
+
+    /** True when both seats are filled (a real, playable game) and the match isn't done. */
+    fun isPlayable(): Boolean = player1Id != null && player2Id != null && !isComplete
+}
+
+class LlmRound(
+    val roundNumber: Int,
+    val matches: List<LlmMatch>
+) {
+    val isComplete: Boolean get() = matches.all { it.isComplete }
+}
+
+/**
+ * A single-elimination, best-of-N LLM tournament. All mutation is guarded by [lock] inside
+ * [LlmTournamentService]; the [gameInFlight] gate guarantees at most one live game at a time.
+ */
+class LlmTournament(
+    val id: String,
+    val setCode: String,
+    val deckbuildMode: DeckbuildMode,
+    val bestOf: Int,
+    val participants: List<LlmParticipant>
+) {
+    val lock = Any()
+    val gameInFlight = AtomicBoolean(false)
+
+    @Volatile var status: LlmTournamentStatus = LlmTournamentStatus.BUILDING
+
+    /** Per-decision AI delay (ms); adjustable live via the pacing control. */
+    @Volatile var thinkingDelayMs: Long = 500
+
+    val rounds: MutableList<LlmRound> = mutableListOf()
+
+    /** gameSessionId -> match, for routing game-over callbacks back to the bracket. */
+    val gameToMatch: MutableMap<String, LlmMatch> = mutableMapOf()
+
+    val winsNeeded: Int get() = bestOf / 2 + 1
+
+    fun participant(id: EntityId?): LlmParticipant? = participants.firstOrNull { it.id == id }
+
+    val currentRound: LlmRound? get() = rounds.lastOrNull()
+
+    val champion: LlmParticipant?
+        get() = if (status == LlmTournamentStatus.COMPLETE) participant(currentRound?.matches?.singleOrNull()?.winnerId) else null
+
+    /** Total LLM cost so far across all played games (excludes deck building). */
+    fun totalGameCost(): LlmCost =
+        rounds.flatMap { it.matches }.flatMap { it.finishedGames }.fold(LlmCost.ZERO) { acc, g -> acc + g.cost }
+
+    /** Total LLM cost of building every participant's deck. */
+    fun totalDeckbuildCost(): LlmCost =
+        participants.mapNotNull { it.buildCost }.fold(LlmCost.ZERO) { acc, c -> acc + c }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmTournamentService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/llm/LlmTournamentService.kt
@@ -1,0 +1,342 @@
+package com.wingedsheep.gameserver.tournament.llm
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.gameserver.ai.AiGameManager
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.handler.GamePlayHandler
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Dev-only orchestrator for an all-LLM, single-elimination, best-of-N sealed tournament.
+ *
+ * Reuses the existing leaf primitives — [AiGameManager.createAiIdentity]/`wireAiForGame`,
+ * [GamePlayHandler.createAndStartAiVsAiGame], [BoosterGenerator], the replay stack — without
+ * touching the production round-robin tournament-lobby flow. It owns its own bracket model and
+ * a pacing gate ([LlmTournament.gameInFlight]) so at most one game runs at a time and the user
+ * controls when each game starts.
+ *
+ * Pacing is at game boundaries: you can't cleanly freeze a half-resolved engine game, so "pause"
+ * means "stop after the current game finishes."
+ */
+@Service
+class LlmTournamentService(
+    private val gamePlayHandler: GamePlayHandler,
+    private val aiGameManager: AiGameManager,
+    private val boosterGenerator: BoosterGenerator,
+    private val deckBuildService: LlmSealedDeckBuildService,
+    private val gameProperties: GameProperties,
+    private val costTracker: LlmCostTracker
+) {
+    private val logger = LoggerFactory.getLogger(LlmTournamentService::class.java)
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val tournaments = ConcurrentHashMap<String, LlmTournament>()
+
+    fun get(id: String): LlmTournament? = tournaments[id]
+    fun all(): List<LlmTournament> = tournaments.values.toList()
+
+    /**
+     * Whether the LLM is actually reachable. When false, both deck building and in-game play fall
+     * back to the built-in engine AI no matter what the user picks — the UI surfaces this.
+     */
+    fun llmAvailable(): Boolean =
+        gameProperties.ai.enabled && gameProperties.ai.effectiveApiKey.isNotBlank()
+
+    // =========================================================================
+    // Creation + build
+    // =========================================================================
+
+    fun create(modelIds: List<String>, setCode: String, deckbuildMode: DeckbuildMode, bestOf: Int = 3): LlmTournament {
+        require(modelIds.size >= 2) { "A tournament needs at least 2 models" }
+        require(aiGameManager.isEnabled) {
+            "AI is not enabled. Set game.ai.enabled=true and provide an OpenRouter API key (game.ai.mode=llm)."
+        }
+        require(boosterGenerator.availableSets.containsKey(setCode)) { "Unknown set code: $setCode" }
+
+        val participants = modelIds.mapIndexed { index, modelId ->
+            val identity = aiGameManager.createAiIdentity(modelOverride = modelId)
+            LlmParticipant(
+                id = identity.playerId,
+                modelId = modelId,
+                displayName = identity.playerName,
+                seed = index + 1
+            )
+        }
+
+        val tournament = LlmTournament(
+            id = "llmt-${UUID.randomUUID().toString().take(8)}",
+            setCode = setCode,
+            deckbuildMode = deckbuildMode,
+            bestOf = bestOf,
+            participants = participants
+        )
+        tournament.thinkingDelayMs = gameProperties.ai.thinkingDelayMs
+        tournaments[tournament.id] = tournament
+
+        seedFirstRound(tournament)
+        scope.launch { buildAll(tournament) }
+
+        logger.info("Created LLM tournament {} ({} models, set={}, mode={}, bestOf={})",
+            tournament.id, modelIds.size, setCode, deckbuildMode, bestOf)
+        return tournament
+    }
+
+    private suspend fun buildAll(tournament: LlmTournament) {
+        val useLlm = tournament.deckbuildMode == DeckbuildMode.LLM
+        try {
+            tournament.participants.map { participant ->
+                scope.async {
+                    try {
+                        participant.buildStatus = ParticipantBuildStatus.BUILDING_POOL
+                        participant.pool = boosterGenerator.generateSealedPool(tournament.setCode, boosterCount = 6)
+                        participant.buildStatus = ParticipantBuildStatus.BUILDING_DECK
+                        val bucket = "build:${participant.id.value}"
+                        val deck = deckBuildService.build(
+                            pool = participant.pool,
+                            useLlm = useLlm,
+                            modelOverride = participant.modelId,
+                            usageSink = { usage -> costTracker.record(bucket, usage) }
+                        )
+                        participant.deck = deck
+                        participant.buildCost = costTracker.snapshot(bucket).takeIf { it.calls > 0 }
+                        costTracker.clear(bucket)
+                        participant.buildStatus =
+                            if (deck.values.sum() >= 40) ParticipantBuildStatus.READY else ParticipantBuildStatus.FAILED
+                    } catch (e: Exception) {
+                        logger.error("Deck build failed for {} ({}): {}", participant.displayName, participant.modelId, e.message, e)
+                        participant.buildStatus = ParticipantBuildStatus.FAILED
+                    }
+                }
+            }.awaitAll()
+        } finally {
+            synchronized(tournament.lock) {
+                if (tournament.status == LlmTournamentStatus.BUILDING) {
+                    tournament.status = LlmTournamentStatus.READY
+                }
+            }
+            logger.info("LLM tournament {} decks built — ready", tournament.id)
+        }
+    }
+
+    // =========================================================================
+    // Bracket
+    // =========================================================================
+
+    private fun seedFirstRound(tournament: LlmTournament) {
+        synchronized(tournament.lock) {
+            val n = tournament.participants.size
+            val size = nextPowerOfTwo(n)
+            val seedOrder = bracketSeedOrder(size) // 1-based seed numbers in bracket slot order
+            val slots = seedOrder.map { seedNum -> tournament.participants.getOrNull(seedNum - 1) }
+
+            val matches = (0 until size step 2).mapIndexed { slotIndex, i ->
+                val p1 = slots[i]
+                val p2 = slots[i + 1]
+                LlmMatch(
+                    id = "m-${UUID.randomUUID().toString().take(6)}",
+                    roundNumber = 1,
+                    slot = slotIndex,
+                    player1Id = p1?.id,
+                    player2Id = p2?.id
+                ).also { resolveByeIfNeeded(it) }
+            }
+            tournament.rounds.add(LlmRound(1, matches))
+            advanceBracketIfRoundComplete(tournament)
+        }
+    }
+
+    /** A match with one empty seat is an auto-win for the present player. */
+    private fun resolveByeIfNeeded(match: LlmMatch) {
+        val p1 = match.player1Id
+        val p2 = match.player2Id
+        when {
+            p1 != null && p2 == null -> { match.winnerId = p1; match.isComplete = true }
+            p1 == null && p2 != null -> { match.player1Id = p2; match.player2Id = null; match.winnerId = p2; match.isComplete = true }
+            p1 == null && p2 == null -> { match.isComplete = true } // empty match (shouldn't happen for n>=2)
+        }
+    }
+
+    /** While the current round is fully decided, build the next round from its winners. */
+    private fun advanceBracketIfRoundComplete(tournament: LlmTournament) {
+        while (true) {
+            val current = tournament.currentRound ?: return
+            if (!current.isComplete) return
+            if (current.matches.size <= 1) {
+                tournament.status = LlmTournamentStatus.COMPLETE
+                logger.info("LLM tournament {} complete — champion {}",
+                    tournament.id, tournament.participant(current.matches.firstOrNull()?.winnerId)?.displayName)
+                return
+            }
+            val nextMatches = (current.matches.indices step 2).mapIndexed { slotIndex, i ->
+                LlmMatch(
+                    id = "m-${UUID.randomUUID().toString().take(6)}",
+                    roundNumber = current.roundNumber + 1,
+                    slot = slotIndex,
+                    player1Id = current.matches[i].winnerId,
+                    player2Id = current.matches[i + 1].winnerId
+                ).also { resolveByeIfNeeded(it) }
+            }
+            tournament.rounds.add(LlmRound(current.roundNumber + 1, nextMatches))
+        }
+    }
+
+    private fun findNextPlayableMatch(tournament: LlmTournament): LlmMatch? {
+        advanceBracketIfRoundComplete(tournament)
+        return tournament.currentRound?.matches?.firstOrNull { it.isPlayable() }
+    }
+
+    // =========================================================================
+    // Pacing controls
+    // =========================================================================
+
+    fun start(tournament: LlmTournament) {
+        synchronized(tournament.lock) {
+            if (tournament.status != LlmTournamentStatus.READY && tournament.status != LlmTournamentStatus.PAUSED) return
+            tournament.status = LlmTournamentStatus.RUNNING
+        }
+        scope.launch { tryLaunchNextGame(tournament, force = false) }
+    }
+
+    fun pause(tournament: LlmTournament) {
+        synchronized(tournament.lock) {
+            if (tournament.status == LlmTournamentStatus.RUNNING) tournament.status = LlmTournamentStatus.PAUSED
+        }
+    }
+
+    /** Play exactly one more game, even when paused (does not change RUNNING/PAUSED). */
+    fun step(tournament: LlmTournament) {
+        val canStep = tournament.status == LlmTournamentStatus.READY || tournament.status == LlmTournamentStatus.PAUSED
+        if (!canStep) return
+        scope.launch { tryLaunchNextGame(tournament, force = true) }
+    }
+
+    fun setSpeed(tournament: LlmTournament, thinkingDelayMs: Long) {
+        tournament.thinkingDelayMs = thinkingDelayMs.coerceIn(0, 60_000)
+        // Apply to the currently live match's AI players so the change takes effect immediately.
+        synchronized(tournament.lock) {
+            tournament.currentRound?.matches?.firstOrNull { it.currentGameSessionId != null }?.let { live ->
+                listOfNotNull(live.player1Id, live.player2Id).forEach {
+                    aiGameManager.setThinkingDelay(it, tournament.thinkingDelayMs)
+                }
+            }
+        }
+    }
+
+    fun delete(tournament: LlmTournament) {
+        tournaments.remove(tournament.id)
+    }
+
+    private fun tryLaunchNextGame(tournament: LlmTournament, force: Boolean): Boolean {
+        synchronized(tournament.lock) {
+            if (tournament.status == LlmTournamentStatus.COMPLETE || tournament.status == LlmTournamentStatus.BUILDING) return false
+            if (!force && tournament.status != LlmTournamentStatus.RUNNING) return false
+            if (!tournament.gameInFlight.compareAndSet(false, true)) return false // a game is already live
+
+            val match = findNextPlayableMatch(tournament)
+            if (match == null) {
+                tournament.gameInFlight.set(false)
+                return false
+            }
+            val p1 = tournament.participant(match.player1Id)
+            val p2 = tournament.participant(match.player2Id)
+            if (p1 == null || p2 == null) {
+                tournament.gameInFlight.set(false)
+                return false
+            }
+
+            val gameId = gamePlayHandler.createAndStartAiVsAiGame(
+                player1Id = p1.id,
+                player1Deck = p1.deck,
+                player2Id = p2.id,
+                player2Deck = p2.deck,
+                setCode = tournament.setCode,
+                thinkingDelayMs = tournament.thinkingDelayMs
+            )
+            match.currentGameSessionId = gameId
+            tournament.gameToMatch[gameId] = match
+            logger.info("LLM tournament {}: launched game {} for match {} (round {})",
+                tournament.id, gameId, match.id, match.roundNumber)
+            return true
+        }
+    }
+
+    // =========================================================================
+    // Game-over callback (wired in GameWebSocketHandler)
+    // =========================================================================
+
+    fun onGameComplete(gameSessionId: String, winnerId: EntityId?, winnerLifeRemaining: Int) {
+        val tournament = tournaments.values.firstOrNull { it.gameToMatch.containsKey(gameSessionId) } ?: return
+        synchronized(tournament.lock) {
+            val match = tournament.gameToMatch[gameSessionId] ?: return
+            tournament.gameInFlight.set(false)
+            match.currentGameSessionId = null
+            val gameCost = costTracker.snapshot(gameSessionId)
+            costTracker.clear(gameSessionId)
+            match.finishedGames.add(FinishedGame(gameSessionId, gameCost))
+
+            when (winnerId) {
+                match.player1Id -> match.player1GameWins++
+                match.player2Id -> match.player2GameWins++
+                else -> {} // draw / unknown — counts for neither
+            }
+
+            when {
+                match.player1GameWins >= tournament.winsNeeded -> { match.winnerId = match.player1Id; match.isComplete = true }
+                match.player2GameWins >= tournament.winsNeeded -> { match.winnerId = match.player2Id; match.isComplete = true }
+                match.finishedGames.size >= tournament.bestOf -> {
+                    // Out of games (e.g. draws); decide on the game tally, player1 wins ties.
+                    match.winnerId = if (match.player1GameWins >= match.player2GameWins) match.player1Id else match.player2Id
+                    match.isComplete = true
+                }
+            }
+
+            if (match.isComplete) {
+                logger.info("LLM tournament {}: match {} complete, winner {}",
+                    tournament.id, match.id, tournament.participant(match.winnerId)?.displayName)
+                advanceBracketIfRoundComplete(tournament)
+            }
+        }
+
+        if (tournament.status == LlmTournamentStatus.RUNNING) {
+            scope.launch { tryLaunchNextGame(tournament, force = false) }
+        }
+    }
+
+    // =========================================================================
+    // Bracket math
+    // =========================================================================
+
+    private fun nextPowerOfTwo(n: Int): Int {
+        var p = 1
+        while (p < n) p *= 2
+        return p
+    }
+
+    /**
+     * Standard single-elimination seeding order for [size] (a power of two): returns the 1-based
+     * seed number for each bracket slot, so top seeds meet byes/low seeds first. e.g. size 4 -> [1,4,2,3].
+     */
+    private fun bracketSeedOrder(size: Int): List<Int> {
+        var seeds = listOf(1)
+        while (seeds.size < size) {
+            val roundSize = seeds.size * 2
+            val next = ArrayList<Int>(roundSize)
+            for (s in seeds) {
+                next.add(s)
+                next.add(roundSize + 1 - s)
+            }
+            seeds = next
+        }
+        return seeds
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
@@ -21,7 +21,8 @@ class GameWebSocketHandler(
     private val gamePlayHandler: GamePlayHandler,
     private val lobbyHandler: LobbyHandler,
     private val quickGameLobbyHandler: QuickGameLobbyHandler,
-    private val sender: MessageSender
+    private val sender: MessageSender,
+    private val llmTournamentService: com.wingedsheep.gameserver.tournament.llm.LlmTournamentService
 ) : TextWebSocketHandler() {
 
     private val logger = LoggerFactory.getLogger(GameWebSocketHandler::class.java)
@@ -32,6 +33,9 @@ class GameWebSocketHandler(
         gamePlayHandler.broadcastActiveMatchesCallback = { lobbyId -> lobbyHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId) }
         gamePlayHandler.handleMatchResultCallback = { lobbyId, gameSessionId, winnerId, winnerLife ->
             lobbyHandler.handleMatchResult(lobbyId, gameSessionId, winnerId, winnerLife)
+        }
+        gamePlayHandler.llmTournamentGameOverCallback = { gameSessionId, winnerId, winnerLife ->
+            llmTournamentService.onGameComplete(gameSessionId, winnerId, winnerLife)
         }
         gamePlayHandler.joinSealedGameCallback = { session, msg -> lobbyHandler.handleJoinSealedGame(session, msg) }
         gamePlayHandler.joinLobbyCallback = { session, msg -> lobbyHandler.handleJoinLobby(session, msg) }

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -44,7 +44,16 @@ export default function App() {
   const matchIntro = useGameStore((state) => state.matchIntro)
   const startCombat = useGameStore((state) => state.startCombat)
   const connect = useGameStore((state) => state.connect)
+  const spectateGame = useGameStore((state) => state.spectateGame)
   const hasConnectedRef = useRef(false)
+
+  // Dev deep-link: /?spectate=<gameSessionId> connects and auto-spectates that game,
+  // used by the LLM-tournament page's "Watch" links to watch a live AI-vs-AI match.
+  const spectateParam = useMemo(
+    () => new URLSearchParams(window.location.search).get('spectate'),
+    []
+  )
+  const hasSpectatedRef = useRef(false)
 
   const viewingPlayer = useViewingPlayer()
   const battlefieldCards = useBattlefieldCards()
@@ -59,13 +68,23 @@ export default function App() {
 
   useEffect(() => {
     // Only auto-connect if we already have a stored player name (returning user)
-    // Otherwise, GameUI will show the name entry screen first
+    // Otherwise, GameUI will show the name entry screen first. A spectate deep-link
+    // connects under a throwaway name so a fresh dev browser can watch immediately.
     const storedName = localStorage.getItem('argentum-player-name')
-    if (storedName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+    const name = storedName ?? (spectateParam ? `Spectator-${Math.floor(Math.random() * 9000 + 1000)}` : null)
+    if (name && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
       hasConnectedRef.current = true
-      connect(storedName)
+      connect(name)
     }
-  }, [connectionStatus, connect])
+  }, [connectionStatus, connect, spectateParam])
+
+  // Once connected, honor a /?spectate=<gameId> deep-link (fire once).
+  useEffect(() => {
+    if (spectateParam && connectionStatus === 'connected' && !hasSpectatedRef.current && !spectatingState) {
+      hasSpectatedRef.current = true
+      spectateGame(spectateParam)
+    }
+  }, [spectateParam, connectionStatus, spectatingState, spectateGame])
 
   // Keep the URL bar in sync with tournament state so the link is shareable
   useEffect(() => {

--- a/web-client/src/components/llmTournament/LlmTournamentPage.tsx
+++ b/web-client/src/components/llmTournament/LlmTournamentPage.tsx
@@ -1,0 +1,919 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AvailableSet } from '@/types/messages'
+import { SetPickerModal } from '@/components/ui/SetPickerModal'
+
+// ============================================================================
+// Types mirroring LlmTournamentController DTOs
+// ============================================================================
+
+interface CostView {
+  costUsd: number
+  totalTokens: number
+  calls: number
+  costKnown: boolean
+}
+
+interface ParticipantView {
+  id: string
+  modelId: string
+  displayName: string
+  seed: number
+  buildStatus: string
+  deckSize: number
+  buildCost: CostView | null
+  deck: Record<string, number>
+}
+
+interface FinishedGameView {
+  gameSessionId: string
+  cost: CostView
+}
+
+interface MatchView {
+  id: string
+  roundNumber: number
+  slot: number
+  player1Name: string | null
+  player2Name: string | null
+  player1ModelId: string | null
+  player2ModelId: string | null
+  player1GameWins: number
+  player2GameWins: number
+  winnerName: string | null
+  bye: boolean
+  complete: boolean
+  status: 'scheduled' | 'live' | 'done' | 'bye'
+  currentGameSessionId: string | null
+  finishedGames: FinishedGameView[]
+  cost: CostView
+}
+
+interface RoundView {
+  roundNumber: number
+  matches: MatchView[]
+}
+
+interface TournamentView {
+  id: string
+  setCode: string
+  deckbuildMode: string
+  bestOf: number
+  status: string
+  thinkingDelayMs: number
+  championName: string | null
+  participants: ParticipantView[]
+  rounds: RoundView[]
+  gameCost: CostView
+  deckbuildCost: CostView
+  llmAvailable: boolean
+}
+
+const API = '/api/dev/llm-tournament'
+
+/** Format a dollar cost; costKnown=false → shown as a floor (e.g. "≥$0.0000"). */
+function fmtCost(c: CostView | null | undefined): string {
+  if (!c || c.calls === 0) return '—'
+  const dollars = c.costUsd
+  const prefix = c.costKnown ? '$' : '≥$'
+  const value = dollars >= 0.01 ? dollars.toFixed(4) : dollars.toFixed(6)
+  return `${prefix}${value}`
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return String(n)
+}
+
+const PRESET_MODELS = [
+  'deepseek/deepseek-v4-flash',
+  'tencent/hy3-preview',
+  'minimax/minimax-m3',
+  'xiaomi/mimo-v2.5',
+]
+
+// ============================================================================
+// Page
+// ============================================================================
+
+export function LlmTournamentPage() {
+  const [tournament, setTournament] = useState<TournamentView | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const tournamentIdRef = useRef<string | null>(null)
+
+  // Poll the active tournament
+  const refresh = useCallback(async () => {
+    const id = tournamentIdRef.current
+    if (!id) return
+    try {
+      const res = await fetch(`${API}/${id}`)
+      if (res.ok) setTournament(await res.json())
+    } catch {
+      /* transient — keep last view */
+    }
+  }, [])
+
+  useEffect(() => {
+    const interval = setInterval(refresh, 1500)
+    return () => clearInterval(interval)
+  }, [refresh])
+
+  const selectTournament = (view: TournamentView) => {
+    tournamentIdRef.current = view.id
+    setTournament(view)
+  }
+
+  const control = async (action: string, body?: unknown) => {
+    const id = tournamentIdRef.current
+    if (!id) return
+    try {
+      const init: RequestInit = body
+        ? { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+        : { method: 'POST' }
+      const res = await fetch(`${API}/${id}/${action}`, init)
+      if (res.ok) setTournament(await res.json())
+    } catch (e) {
+      setError(String(e))
+    }
+  }
+
+  return (
+    <div style={styles.page}>
+      <header style={styles.header}>
+        <h1 style={styles.h1}>🏆 LLM Tournament <span style={styles.devTag}>dev</span></h1>
+        <a href="/" style={styles.homeLink}>← Home</a>
+      </header>
+
+      {error && (
+        <div style={styles.errorBar} onClick={() => setError(null)}>
+          {error} <span style={{ float: 'right' }}>✕</span>
+        </div>
+      )}
+
+      {!tournament && (
+        <SetupForm onCreated={selectTournament} onError={setError} />
+      )}
+
+      {tournament && !tournament.llmAvailable && (
+        <div style={styles.warnBar}>
+          ⚠ No LLM API key configured on the server — deck building and in-game play fall back to the
+          built-in engine AI regardless of the LLM setting. Set <code>GAME_AI_API_KEY</code> (and an
+          OpenRouter <code>GAME_AI_BASE_URL</code>) in <code>.env</code> and start with{' '}
+          <code>just server</code> (a bare <code>./gradlew bootRun</code> doesn't load <code>.env</code>).
+        </div>
+      )}
+
+      {tournament && (
+        <>
+          <PacingBar
+            tournament={tournament}
+            onStart={() => control('start')}
+            onPause={() => control('pause')}
+            onResume={() => control('resume')}
+            onStep={() => control('step')}
+            onSpeed={(ms) => control('speed', { thinkingDelayMs: ms })}
+            onNew={() => {
+              tournamentIdRef.current = null
+              setTournament(null)
+            }}
+          />
+          {tournament.status === 'BUILDING' && <BuildProgress tournament={tournament} />}
+          <Bracket tournament={tournament} />
+          <ParticipantList tournament={tournament} />
+        </>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Setup form
+// ============================================================================
+
+function SetupForm({
+  onCreated,
+  onError,
+}: {
+  onCreated: (t: TournamentView) => void
+  onError: (e: string) => void
+}) {
+  const [sets, setSets] = useState<AvailableSet[]>([])
+  const [setCode, setSetCode] = useState('')
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [modelsText, setModelsText] = useState(PRESET_MODELS.slice(0, 4).join('\n'))
+  const [mode, setMode] = useState<'heuristic' | 'llm'>('heuristic')
+  const [bestOf, setBestOf] = useState(3)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    fetch(`${API}/sets`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((s: AvailableSet[]) => {
+        setSets(s)
+        // Default to the newest fully-implemented set, matching the lobby picker's bias.
+        const def = s.filter((x) => !x.partial).sort((a, b) => (b.releaseDate ?? '').localeCompare(a.releaseDate ?? ''))[0]
+        if (def && !setCode) setSetCode(def.code)
+      })
+      .catch(() => onError('Failed to load sets — is the server running with dev endpoints enabled?'))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const selectedSet = sets.find((s) => s.code === setCode)
+
+  const models = modelsText
+    .split(/[\n,]/)
+    .map((m) => m.trim())
+    .filter(Boolean)
+
+  const addPreset = (m: string) => {
+    if (!models.includes(m)) setModelsText((t) => (t.trim() ? `${t.trim()}\n${m}` : m))
+  }
+
+  const create = async () => {
+    if (models.length < 2) {
+      onError('Add at least 2 models')
+      return
+    }
+    if (!setCode) {
+      onError('Pick a set')
+      return
+    }
+    setBusy(true)
+    try {
+      const res = await fetch(API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modelIds: models, setCode, deckbuildMode: mode, bestOf }),
+      })
+      const data = await res.json()
+      if (res.ok) onCreated(data)
+      else onError(data.error || 'Failed to create tournament')
+    } catch (e) {
+      onError(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div style={styles.card}>
+      <h2 style={styles.h2}>New Tournament</h2>
+
+      <label style={styles.label}>Models (one per line — they are seeded top to bottom)</label>
+      <textarea
+        value={modelsText}
+        onChange={(e) => setModelsText(e.target.value)}
+        rows={6}
+        spellCheck={false}
+        style={styles.textarea}
+        placeholder="anthropic/claude-sonnet-4"
+      />
+      <div style={styles.presetRow}>
+        {PRESET_MODELS.map((m) => (
+          <button key={m} style={styles.presetBtn} onClick={() => addPreset(m)}>
+            + {m.split('/').pop()}
+          </button>
+        ))}
+      </div>
+      <div style={styles.hint}>{models.length} model{models.length === 1 ? '' : 's'}</div>
+
+      <div style={styles.formRow}>
+        <div style={{ flex: 1 }}>
+          <label style={styles.label}>Set</label>
+          <button type="button" style={styles.setButton} onClick={() => setPickerOpen(true)}>
+            {selectedSet ? `${selectedSet.name} (${selectedSet.code})` : 'Choose a set…'}
+          </button>
+        </div>
+        <div>
+          <label style={styles.label}>Deck building</label>
+          <div style={styles.radioRow}>
+            <label style={styles.radioLabel}>
+              <input type="radio" checked={mode === 'heuristic'} onChange={() => setMode('heuristic')} /> Heuristic
+            </label>
+            <label style={styles.radioLabel}>
+              <input type="radio" checked={mode === 'llm'} onChange={() => setMode('llm')} /> Each LLM builds
+            </label>
+          </div>
+        </div>
+        <div>
+          <label style={styles.label}>Best of</label>
+          <input
+            type="number"
+            min={1}
+            max={9}
+            step={2}
+            value={bestOf}
+            onChange={(e) => setBestOf(Number(e.target.value))}
+            style={{ ...styles.select, width: 70 }}
+          />
+        </div>
+      </div>
+
+      <button style={styles.primaryBtn} disabled={busy} onClick={create}>
+        {busy ? 'Creating…' : 'Create & build decks'}
+      </button>
+      <p style={styles.smallNote}>
+        Sealed: each model opens its own 6-pack pool. Single-elimination knockout. Requires the server
+        running with <code>game.dev-endpoints.enabled=true</code> and an OpenRouter API key.
+      </p>
+
+      {pickerOpen && (
+        <SetPickerModal
+          sets={sets}
+          selectedCodes={setCode ? [setCode] : []}
+          mode="single"
+          title="Choose a set"
+          onToggleSet={(code) => setSetCode(code)}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Pacing bar
+// ============================================================================
+
+function PacingBar({
+  tournament,
+  onStart,
+  onPause,
+  onResume,
+  onStep,
+  onSpeed,
+  onNew,
+}: {
+  tournament: TournamentView
+  onStart: () => void
+  onPause: () => void
+  onResume: () => void
+  onStep: () => void
+  onSpeed: (ms: number) => void
+  onNew: () => void
+}) {
+  const status = tournament.status
+  const building = status === 'BUILDING'
+  const running = status === 'RUNNING'
+  const complete = status === 'COMPLETE'
+
+  return (
+    <div style={styles.pacingBar}>
+      <div style={styles.statusGroup}>
+        <span style={{ ...styles.statusPill, ...statusPillColor(status) }}>{status}</span>
+        <span style={styles.metaText}>
+          {tournament.setCode} · {tournament.deckbuildMode} · Bo{tournament.bestOf}
+        </span>
+        {complete && tournament.championName && (
+          <span style={styles.champion}>👑 {tournament.championName}</span>
+        )}
+        <span style={styles.costSummary} title={
+          `Games: ${fmtCost(tournament.gameCost)} (${fmtTokens(tournament.gameCost.totalTokens)} tok, ${tournament.gameCost.calls} calls)\n` +
+          `Deckbuild: ${fmtCost(tournament.deckbuildCost)} (${fmtTokens(tournament.deckbuildCost.totalTokens)} tok)`
+        }>
+          💰 games {fmtCost(tournament.gameCost)}
+          {tournament.deckbuildCost.calls > 0 && <> · build {fmtCost(tournament.deckbuildCost)}</>}
+        </span>
+      </div>
+
+      <div style={styles.controlsGroup}>
+        {!running && !complete && (
+          <button style={styles.ctrlBtn} disabled={building} onClick={status === 'PAUSED' ? onResume : onStart}>
+            ▶ {status === 'PAUSED' ? 'Resume' : 'Start'}
+          </button>
+        )}
+        {running && (
+          <button style={styles.ctrlBtn} onClick={onPause}>
+            ⏸ Pause
+          </button>
+        )}
+        <button style={styles.ctrlBtn} disabled={building || running || complete} onClick={onStep}>
+          ⏭ Step game
+        </button>
+
+        <div style={styles.speedGroup}>
+          <span style={styles.metaText}>Speed</span>
+          <input
+            type="range"
+            min={0}
+            max={3000}
+            step={100}
+            value={tournament.thinkingDelayMs}
+            onChange={(e) => onSpeed(Number(e.target.value))}
+            style={{ width: 120 }}
+          />
+          <span style={styles.metaText}>{tournament.thinkingDelayMs}ms</span>
+        </div>
+
+        <button style={styles.secondaryBtn} onClick={onNew}>
+          + New
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Build progress
+// ============================================================================
+
+const BUILD_STAGE_LABEL: Record<string, string> = {
+  PENDING: 'queued',
+  BUILDING_POOL: 'opening packs…',
+  BUILDING_DECK: 'building deck…',
+  READY: 'ready',
+  FAILED: 'failed',
+}
+
+function BuildProgress({ tournament }: { tournament: TournamentView }) {
+  const total = tournament.participants.length
+  const ready = tournament.participants.filter((p) => p.buildStatus === 'READY').length
+  const failed = tournament.participants.filter((p) => p.buildStatus === 'FAILED').length
+  const pct = total > 0 ? Math.round(((ready + failed) / total) * 100) : 0
+  const inProgress = tournament.deckbuildMode === 'llm'
+  return (
+    <div style={styles.buildCard}>
+      <div style={styles.buildHeader}>
+        <span style={styles.buildTitle}>
+          {inProgress ? 'Models are building decks…' : 'Building pools & decks…'}
+        </span>
+        <span style={styles.metaText}>{ready}/{total} ready{failed > 0 ? ` · ${failed} failed` : ''}</span>
+      </div>
+      <div style={styles.progressTrack}>
+        <div style={{ ...styles.progressFill, width: `${pct}%` }} />
+      </div>
+      <div style={styles.buildList}>
+        {tournament.participants.map((p) => {
+          const active = p.buildStatus === 'BUILDING_POOL' || p.buildStatus === 'BUILDING_DECK'
+          return (
+            <div key={p.id} style={styles.buildRow}>
+              <span style={styles.buildRowName}>
+                {active && <span style={styles.spinner} />}
+                {p.displayName}
+              </span>
+              <span style={{ ...styles.miniPill, ...buildStatusColor(p.buildStatus) }}>
+                {BUILD_STAGE_LABEL[p.buildStatus] ?? p.buildStatus}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+      <style>{`@keyframes llmtspin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  )
+}
+
+// ============================================================================
+// Bracket
+// ============================================================================
+
+function Bracket({ tournament }: { tournament: TournamentView }) {
+  if (tournament.rounds.length === 0) return null
+  return (
+    <div style={styles.bracketScroll}>
+      <div style={styles.bracket}>
+        {tournament.rounds.map((round) => (
+          <div key={round.roundNumber} style={styles.roundCol}>
+            <div style={styles.roundTitle}>{roundLabel(round, tournament.rounds.length)}</div>
+            <div style={styles.matchStack}>
+              {round.matches.map((m) => (
+                <MatchCard key={m.id} match={m} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MatchCard({ match }: { match: MatchView }) {
+  return (
+    <div style={{ ...styles.matchCard, ...(match.status === 'live' ? styles.matchLive : {}) }}>
+      <SeatRow
+        name={match.player1Name}
+        model={match.player1ModelId}
+        wins={match.player1GameWins}
+        winner={!!match.winnerName && match.winnerName === match.player1Name}
+      />
+      <div style={styles.seatDivider} />
+      <SeatRow
+        name={match.player2Name}
+        model={match.player2ModelId}
+        wins={match.player2GameWins}
+        winner={!!match.winnerName && match.winnerName === match.player2Name}
+      />
+      <div style={styles.matchFooter}>
+        <span style={{ ...styles.miniPill, ...statusPillColor(matchStatusToStatus(match.status)) }}>
+          {match.status}
+        </span>
+        <span style={styles.matchLinks}>
+          {match.status === 'live' && match.currentGameSessionId && (
+            <a
+              href={`/?spectate=${match.currentGameSessionId}`}
+              target="_blank"
+              rel="noreferrer"
+              style={styles.watchLink}
+            >
+              👁 Watch
+            </a>
+          )}
+          {match.finishedGames.map((g, i) => (
+            <a
+              key={g.gameSessionId}
+              href={`/replay/${g.gameSessionId}`}
+              target="_blank"
+              rel="noreferrer"
+              style={styles.replayLink}
+              title={`Game ${i + 1}: ${fmtCost(g.cost)} · ${fmtTokens(g.cost.totalTokens)} tokens`}
+            >
+              ▷ G{i + 1}
+            </a>
+          ))}
+        </span>
+      </div>
+      {match.cost.calls > 0 && (
+        <div style={styles.matchCostRow}>
+          💰 {fmtCost(match.cost)} · {fmtTokens(match.cost.totalTokens)} tok
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SeatRow({
+  name,
+  model,
+  wins,
+  winner,
+}: {
+  name: string | null
+  model: string | null
+  wins: number
+  winner: boolean
+}) {
+  return (
+    <div style={{ ...styles.seatRow, ...(winner ? styles.seatWinner : {}) }}>
+      <div style={styles.seatInfo}>
+        <div style={styles.seatName}>{name ?? <span style={styles.bye}>— bye —</span>}</div>
+        {model && <div style={styles.seatModel}>{model}</div>}
+      </div>
+      <div style={styles.seatWins}>{name ? wins : ''}</div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Participants
+// ============================================================================
+
+function ParticipantList({ tournament }: { tournament: TournamentView }) {
+  const [deckOf, setDeckOf] = useState<ParticipantView | null>(null)
+  // Keep the open deck modal in sync as polling refreshes the tournament object.
+  const liveDeckOf = deckOf ? tournament.participants.find((p) => p.id === deckOf.id) ?? deckOf : null
+
+  return (
+    <div style={styles.card}>
+      <h2 style={styles.h2}>Participants</h2>
+      <table style={styles.table}>
+        <thead>
+          <tr>
+            <th style={styles.th}>Seed</th>
+            <th style={styles.th}>Name</th>
+            <th style={styles.th}>Model</th>
+            <th style={styles.th}>Deck</th>
+            <th style={styles.th}>Build</th>
+            <th style={styles.th}>Build cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tournament.participants.map((p) => (
+            <tr key={p.id}>
+              <td style={styles.td}>{p.seed}</td>
+              <td style={styles.td}>{p.displayName}</td>
+              <td style={{ ...styles.td, color: '#7dd3fc' }}>{p.modelId}</td>
+              <td style={styles.td}>
+                {p.deckSize > 0 ? (
+                  <button style={styles.linkButton} onClick={() => setDeckOf(p)}>
+                    {p.deckSize} cards ▸
+                  </button>
+                ) : '—'}
+              </td>
+              <td style={styles.td}>
+                <span style={{ ...styles.miniPill, ...buildStatusColor(p.buildStatus) }}>{p.buildStatus}</span>
+              </td>
+              <td style={styles.td}>
+                {p.buildCost ? `${fmtCost(p.buildCost)} (${fmtTokens(p.buildCost.totalTokens)} tok)` : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {liveDeckOf && <DeckModal participant={liveDeckOf} onClose={() => setDeckOf(null)} />}
+    </div>
+  )
+}
+
+const BASIC_LANDS = new Set(['Plains', 'Island', 'Swamp', 'Mountain', 'Forest'])
+
+function DeckModal({ participant, onClose }: { participant: ParticipantView; onClose: () => void }) {
+  const entries = Object.entries(participant.deck)
+  const sortFn = (a: [string, number], b: [string, number]) => b[1] - a[1] || a[0].localeCompare(b[0])
+  const spells = entries.filter(([name]) => !BASIC_LANDS.has(name)).sort(sortFn)
+  const lands = entries.filter(([name]) => BASIC_LANDS.has(name)).sort(sortFn)
+  const spellCount = spells.reduce((s, [, n]) => s + n, 0)
+  const landCount = lands.reduce((s, [, n]) => s + n, 0)
+
+  const renderGroup = (title: string, rows: [string, number][]) =>
+    rows.length > 0 && (
+      <div style={styles.deckGroup}>
+        <div style={styles.deckGroupTitle}>{title}</div>
+        {rows.map(([name, count]) => (
+          <div key={name} style={styles.deckLine}>
+            <span style={styles.deckCount}>{count}</span>
+            <span>{name}</span>
+          </div>
+        ))}
+      </div>
+    )
+
+  return (
+    <div style={styles.modalBackdrop} onClick={onClose}>
+      <div style={styles.modalPanel} onClick={(e) => e.stopPropagation()}>
+        <div style={styles.modalHeader}>
+          <div>
+            <div style={styles.modalTitle}>{participant.displayName}</div>
+            <div style={styles.seatModel}>{participant.modelId} · {participant.deckSize} cards</div>
+          </div>
+          <button style={styles.modalClose} onClick={onClose}>×</button>
+        </div>
+        <div style={styles.deckBody}>
+          {renderGroup(`Spells (${spellCount})`, spells)}
+          {renderGroup(`Lands (${landCount})`, lands)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Helpers + styles
+// ============================================================================
+
+function matchStatusToStatus(s: string): string {
+  switch (s) {
+    case 'live':
+      return 'RUNNING'
+    case 'done':
+      return 'COMPLETE'
+    case 'bye':
+      return 'READY'
+    default:
+      return 'PAUSED'
+  }
+}
+
+function roundLabel(round: RoundView, totalRounds: number): string {
+  const fromEnd = totalRounds - round.roundNumber
+  if (fromEnd === 0) return 'Final'
+  if (fromEnd === 1) return 'Semifinals'
+  if (fromEnd === 2) return 'Quarterfinals'
+  return `Round ${round.roundNumber}`
+}
+
+function statusPillColor(status: string): React.CSSProperties {
+  switch (status) {
+    case 'RUNNING':
+      return { background: '#166534', color: '#dcfce7' }
+    case 'PAUSED':
+      return { background: '#854d0e', color: '#fef9c3' }
+    case 'COMPLETE':
+      return { background: '#1e40af', color: '#dbeafe' }
+    case 'BUILDING':
+      return { background: '#4b5563', color: '#e5e7eb' }
+    case 'READY':
+      return { background: '#3730a3', color: '#e0e7ff' }
+    default:
+      return { background: '#374151', color: '#e5e7eb' }
+  }
+}
+
+function buildStatusColor(status: string): React.CSSProperties {
+  switch (status) {
+    case 'READY':
+      return { background: '#166534', color: '#dcfce7' }
+    case 'FAILED':
+      return { background: '#7f1d1d', color: '#fecaca' }
+    case 'PENDING':
+      return { background: '#374151', color: '#e5e7eb' }
+    default:
+      return { background: '#854d0e', color: '#fef9c3' }
+  }
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  page: {
+    minHeight: '100vh',
+    background: '#0a0a12',
+    color: '#e2e8f0',
+    padding: '20px 28px',
+    fontFamily: 'system-ui, sans-serif',
+  },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 },
+  h1: { fontSize: 26, margin: 0, display: 'flex', alignItems: 'center', gap: 10 },
+  devTag: {
+    fontSize: 11,
+    background: '#7f1d1d',
+    color: '#fecaca',
+    padding: '2px 8px',
+    borderRadius: 999,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  homeLink: { color: '#7dd3fc', textDecoration: 'none' },
+  h2: { fontSize: 16, margin: '0 0 12px', color: '#cbd5e1' },
+  errorBar: { background: '#7f1d1d', color: '#fecaca', padding: '10px 14px', borderRadius: 8, marginBottom: 14, cursor: 'pointer' },
+  warnBar: { background: '#422006', color: '#fed7aa', border: '1px solid #854d0e', padding: '10px 14px', borderRadius: 8, marginBottom: 14, fontSize: 13, lineHeight: 1.5 },
+  card: { background: '#11131d', border: '1px solid #1f2433', borderRadius: 12, padding: 18, marginBottom: 16, maxWidth: 760 },
+  label: { display: 'block', fontSize: 12, color: '#94a3b8', marginBottom: 6 },
+  textarea: {
+    width: '100%',
+    background: '#0a0a12',
+    color: '#e2e8f0',
+    border: '1px solid #2a3142',
+    borderRadius: 8,
+    padding: 10,
+    fontFamily: 'monospace',
+    fontSize: 13,
+    boxSizing: 'border-box',
+    resize: 'vertical',
+  },
+  presetRow: { display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 },
+  presetBtn: {
+    background: '#1e293b',
+    color: '#cbd5e1',
+    border: '1px solid #334155',
+    borderRadius: 6,
+    padding: '4px 8px',
+    fontSize: 11,
+    cursor: 'pointer',
+  },
+  hint: { fontSize: 12, color: '#64748b', marginTop: 6 },
+  formRow: { display: 'flex', gap: 18, alignItems: 'flex-start', margin: '16px 0' },
+  select: {
+    background: '#0a0a12',
+    color: '#e2e8f0',
+    border: '1px solid #2a3142',
+    borderRadius: 8,
+    padding: '8px 10px',
+    fontSize: 13,
+  },
+  setButton: {
+    background: '#0a0a12',
+    color: '#e2e8f0',
+    border: '1px solid #2a3142',
+    borderRadius: 8,
+    padding: '8px 12px',
+    fontSize: 13,
+    cursor: 'pointer',
+    textAlign: 'left',
+    minWidth: 220,
+  },
+  costSummary: { fontSize: 12, color: '#fbbf24', fontWeight: 600, cursor: 'help' },
+  matchCostRow: {
+    padding: '4px 12px',
+    fontSize: 11,
+    color: '#fbbf24',
+    background: '#0c0e16',
+    borderTop: '1px solid #161a26',
+  },
+  radioRow: { display: 'flex', gap: 14, paddingTop: 6 },
+  radioLabel: { fontSize: 13, display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' },
+  primaryBtn: {
+    background: '#2563eb',
+    color: 'white',
+    border: 'none',
+    borderRadius: 8,
+    padding: '10px 18px',
+    fontSize: 14,
+    cursor: 'pointer',
+    fontWeight: 600,
+  },
+  smallNote: { fontSize: 11, color: '#64748b', marginTop: 12, lineHeight: 1.5 },
+  pacingBar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: 12,
+    background: '#11131d',
+    border: '1px solid #1f2433',
+    borderRadius: 12,
+    padding: '12px 16px',
+    marginBottom: 16,
+  },
+  statusGroup: { display: 'flex', alignItems: 'center', gap: 12 },
+  statusPill: { fontSize: 12, fontWeight: 700, padding: '4px 12px', borderRadius: 999, letterSpacing: 0.5 },
+  metaText: { fontSize: 12, color: '#94a3b8' },
+  champion: { fontSize: 14, fontWeight: 700, color: '#fde047' },
+  controlsGroup: { display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' },
+  ctrlBtn: {
+    background: '#1e293b',
+    color: '#e2e8f0',
+    border: '1px solid #334155',
+    borderRadius: 8,
+    padding: '8px 14px',
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  secondaryBtn: {
+    background: 'transparent',
+    color: '#7dd3fc',
+    border: '1px solid #334155',
+    borderRadius: 8,
+    padding: '8px 14px',
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  speedGroup: { display: 'flex', alignItems: 'center', gap: 8 },
+  buildCard: {
+    background: '#11131d',
+    border: '1px solid #1f2433',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  buildHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+  buildTitle: { fontSize: 14, fontWeight: 600, color: '#cbd5e1' },
+  progressTrack: { height: 6, background: '#1f2433', borderRadius: 999, overflow: 'hidden', marginBottom: 12 },
+  progressFill: { height: '100%', background: '#2563eb', transition: 'width 0.4s ease' },
+  buildList: { display: 'flex', flexDirection: 'column', gap: 6 },
+  buildRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 13 },
+  buildRowName: { display: 'flex', alignItems: 'center', gap: 8 },
+  spinner: {
+    width: 12,
+    height: 12,
+    border: '2px solid #334155',
+    borderTopColor: '#7dd3fc',
+    borderRadius: '50%',
+    display: 'inline-block',
+    animation: 'llmtspin 0.8s linear infinite',
+  },
+  linkButton: {
+    background: 'none',
+    border: 'none',
+    color: '#7dd3fc',
+    cursor: 'pointer',
+    fontSize: 13,
+    padding: 0,
+    textDecoration: 'underline',
+  },
+  modalBackdrop: {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+  },
+  modalPanel: {
+    background: '#11131d', border: '1px solid #2a3142', borderRadius: 12,
+    width: 'min(520px, 92vw)', maxHeight: '82vh', display: 'flex', flexDirection: 'column',
+  },
+  modalHeader: {
+    display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+    padding: '14px 18px', borderBottom: '1px solid #1f2433',
+  },
+  modalTitle: { fontSize: 16, fontWeight: 700 },
+  modalClose: { background: 'none', border: 'none', color: '#94a3b8', fontSize: 24, cursor: 'pointer', lineHeight: 1 },
+  deckBody: { padding: 18, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 18 },
+  deckGroup: {},
+  deckGroupTitle: { fontSize: 13, fontWeight: 700, color: '#94a3b8', marginBottom: 8 },
+  deckLine: { display: 'flex', gap: 10, fontSize: 13, padding: '2px 0' },
+  deckCount: { color: '#64748b', minWidth: 20, textAlign: 'right' },
+  bracketScroll: { overflowX: 'auto', paddingBottom: 12, marginBottom: 16 },
+  bracket: { display: 'flex', gap: 28, alignItems: 'stretch', minHeight: 100 },
+  roundCol: { display: 'flex', flexDirection: 'column', minWidth: 220 },
+  roundTitle: { fontSize: 13, fontWeight: 700, color: '#94a3b8', marginBottom: 12, textAlign: 'center' },
+  matchStack: { display: 'flex', flexDirection: 'column', justifyContent: 'space-around', flex: 1, gap: 14 },
+  matchCard: { background: '#11131d', border: '1px solid #1f2433', borderRadius: 10, overflow: 'hidden' },
+  matchLive: { border: '1px solid #16a34a', boxShadow: '0 0 0 1px #16a34a55' },
+  seatRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' },
+  seatWinner: { background: '#0f291a' },
+  seatInfo: { minWidth: 0 },
+  seatName: { fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 150 },
+  seatModel: { fontSize: 10, color: '#64748b', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 150 },
+  seatWins: { fontSize: 16, fontWeight: 700, color: '#e2e8f0', marginLeft: 8 },
+  seatDivider: { height: 1, background: '#1f2433' },
+  bye: { color: '#475569', fontStyle: 'italic', fontWeight: 400 },
+  matchFooter: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '6px 12px',
+    background: '#0c0e16',
+    borderTop: '1px solid #1f2433',
+  },
+  miniPill: { fontSize: 10, fontWeight: 700, padding: '2px 8px', borderRadius: 999, textTransform: 'uppercase' },
+  matchLinks: { display: 'flex', gap: 8, alignItems: 'center' },
+  watchLink: { color: '#4ade80', fontSize: 12, textDecoration: 'none', fontWeight: 600 },
+  replayLink: { color: '#7dd3fc', fontSize: 12, textDecoration: 'none' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
+  th: { textAlign: 'left', padding: '6px 10px', color: '#64748b', borderBottom: '1px solid #1f2433', fontWeight: 600 },
+  td: { padding: '6px 10px', borderBottom: '1px solid #161a26' },
+}

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -412,6 +412,14 @@ function ConnectionOverlay({
                 >
                   Scenario Builder
                 </button>
+                {import.meta.env.DEV && (
+                  <button
+                    onClick={() => navigate('/llm-tournament')}
+                    className={styles.secondaryButton}
+                  >
+                    LLM Tournament
+                  </button>
+                )}
                 <button
                   onClick={() => setShowReplays(true)}
                   className={styles.secondaryButton}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -11,6 +11,7 @@ import { AdminPage } from './components/admin/AdminPage'
 import { ReplayPage } from './components/replay/ReplayPage'
 import { DeckbuilderPage } from './components/deckbuilder/DeckbuilderPage'
 import { ScenarioBuilderPage } from './components/scenario/ScenarioBuilderPage'
+import { LlmTournamentPage } from './components/llmTournament/LlmTournamentPage'
 import { initAnalytics } from './utils/analytics'
 
 initAnalytics()
@@ -30,6 +31,7 @@ createRoot(rootElement).render(
         <Route path="/deckbuilder" element={<DeckbuilderPage />} />
         <Route path="/deckbuilder/:deckId" element={<DeckbuilderPage />} />
         <Route path="/scenario" element={<ScenarioBuilderPage />} />
+        <Route path="/llm-tournament" element={<LlmTournamentPage />} />
         <Route path="*" element={<App />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## What

A **dev-only** feature to run a tournament between OpenRouter LLMs: pick N models, pick a set, each model opens its own **sealed** 6-pack pool and builds a deck, then plays a **single-elimination, best-of-3** AI-vs-AI knockout bracket. You can watch matches live, review replays, control the pace, and see token/dollar cost per game.

Gated by `game.dev-endpoints.enabled=true` (same as the scenario builder); the UI button only shows in dev builds.

## How it works

Reuses the existing OpenRouter LLM player, sealed-pool generation, deckbuild advisors, replay stack, and spectate path — it's orchestration + a dev UI, not new engine code. Built as a **standalone `LlmTournamentService`** rather than extending the round-robin `TournamentManager` (which is circle-method + lobby/Redis-entangled), keeping the production tournament flow untouched.

### Backend (`game-server`)
- **`LlmTournamentService`** — own single-elim bracket model + bo3 tally; a `gameInFlight` gate runs one game at a time so pacing (start/pause/resume/step) and spectate are unambiguous. Pause stops at game boundaries (an engine game can't be frozen mid-resolution).
- **`GamePlayHandler.createAndStartAiVsAiGame`** — starts an AI-vs-AI game with no human seat (mirrors `TournamentMatchHandler.startSingleMatch`'s AI wiring). A settable `llmTournamentGameOverCallback` (wired in `GameWebSocketHandler`) advances the bracket on game over.
- **`LlmSealedDeckBuildService`** — 40-card sealed build, heuristic or per-model LLM, emitting plain card/basic-land names the engine registry resolves. An explicit "Each LLM builds" choice overrides the `local` profile's `heuristic-deckbuilding=true` convenience default.
- **Cost tracking** — `LlmClient` requests OpenRouter `usage.include` and parses `usage.cost`/tokens via a usage sink; `LlmCostTracker` attributes cost per game / per deckbuild; surfaced per game / match / tournament / participant.
- **`LlmTournamentController`** — dev-gated REST: create / get / start / pause / resume / step / speed / delete / sets.

### Frontend (`web-client`)
- **`/llm-tournament`** page (dev-only menu button): model setup, the **shared `SetPickerModal`** (same as the normal lobby), bracket tree with game tallies, pacing controls + speed slider, per-deck viewer, live build progress, cost display, and a no-API-key warning banner.
- **Watch** links live-spectate via a new `/?spectate=<gameId>` deep-link in `App.tsx`; **Replay** links to the existing `/replay/<gameId>`.

## Testing
- `LlmClientUsageTest` pins the OpenRouter usage/cost parsing.
- Verified end-to-end locally: create → pool-gen → 40-card deckbuild → bracket seeding → pacing → one-live-game serialization → AI-vs-AI play → registry-resolvable decks (no `Mountain#272` crash). Real LLM play/cost needs `GAME_AI_API_KEY` + `GAME_AI_BASE_URL=…openrouter…` (start via `just server`, which loads `.env`).

## Notes
- `LlmSealedDeckBuildService` overlaps with `LobbyHandler`'s private sealed builder; left un-unified deliberately (LobbyHandler keys off a different model field and powers the production flow) — worth a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)