### PR TITLE
LLM tournament: URL-persisted state + robust live spectating

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -67,14 +67,19 @@ export default function App() {
   )
 
   useEffect(() => {
-    // Only auto-connect if we already have a stored player name (returning user)
-    // Otherwise, GameUI will show the name entry screen first. A spectate deep-link
-    // connects under a throwaway name so a fresh dev browser can watch immediately.
-    const storedName = localStorage.getItem('argentum-player-name')
-    const name = storedName ?? (spectateParam ? `Spectator-${Math.floor(Math.random() * 9000 + 1000)}` : null)
-    if (name && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+    if (connectionStatus !== 'disconnected' || hasConnectedRef.current) return
+    if (spectateParam) {
+      // Spectate deep-link: connect as an isolated, ephemeral spectator (no shared token/name) so
+      // it doesn't collide with the user's identity and each watch gets a fresh session.
       hasConnectedRef.current = true
-      connect(name)
+      connect(`Spectator-${Math.floor(Math.random() * 9000 + 1000)}`, { spectator: true })
+      return
+    }
+    // Otherwise only auto-connect for a returning user with a stored name; new users see name entry.
+    const storedName = localStorage.getItem('argentum-player-name')
+    if (storedName) {
+      hasConnectedRef.current = true
+      connect(storedName)
     }
   }, [connectionStatus, connect, spectateParam])
 

--- a/web-client/src/components/llmTournament/LlmTournamentPage.tsx
+++ b/web-client/src/components/llmTournament/LlmTournamentPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import type { AvailableSet } from '@/types/messages'
 import { SetPickerModal } from '@/components/ui/SetPickerModal'
 
@@ -84,6 +85,16 @@ function fmtTokens(n: number): string {
   return String(n)
 }
 
+/** The game session id of whatever match is live right now (one at a time), else null. */
+function currentLiveGameId(t: TournamentView): string | null {
+  for (const round of t.rounds) {
+    for (const m of round.matches) {
+      if (m.status === 'live' && m.currentGameSessionId) return m.currentGameSessionId
+    }
+  }
+  return null
+}
+
 const PRESET_MODELS = [
   'deepseek/deepseek-v4-flash',
   'tencent/hy3-preview',
@@ -96,21 +107,41 @@ const PRESET_MODELS = [
 // ============================================================================
 
 export function LlmTournamentPage() {
+  const { id: routeId } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
   const [tournament, setTournament] = useState<TournamentView | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const tournamentIdRef = useRef<string | null>(null)
+  const tournamentIdRef = useRef<string | null>(routeId ?? null)
 
-  // Poll the active tournament
+  // Poll the active tournament. The id lives in the URL (/llm-tournament/:id) so a page refresh
+  // re-loads the same tournament; a 404 (e.g. server restarted — tournaments are in-memory) drops
+  // back to the setup form.
   const refresh = useCallback(async () => {
     const id = tournamentIdRef.current
     if (!id) return
     try {
       const res = await fetch(`${API}/${id}`)
-      if (res.ok) setTournament(await res.json())
+      if (res.ok) {
+        setTournament(await res.json())
+      } else if (res.status === 404) {
+        tournamentIdRef.current = null
+        setTournament(null)
+        navigate('/llm-tournament', { replace: true })
+      }
     } catch {
       /* transient — keep last view */
     }
-  }, [])
+  }, [navigate])
+
+  // Sync the active id from the URL (initial load, refresh, back/forward) and fetch immediately.
+  useEffect(() => {
+    tournamentIdRef.current = routeId ?? null
+    if (routeId) {
+      void refresh()
+    } else {
+      setTournament(null)
+    }
+  }, [routeId, refresh])
 
   useEffect(() => {
     const interval = setInterval(refresh, 1500)
@@ -120,6 +151,7 @@ export function LlmTournamentPage() {
   const selectTournament = (view: TournamentView) => {
     tournamentIdRef.current = view.id
     setTournament(view)
+    navigate(`/llm-tournament/${view.id}`)
   }
 
   const control = async (action: string, body?: unknown) => {
@@ -174,6 +206,7 @@ export function LlmTournamentPage() {
             onNew={() => {
               tournamentIdRef.current = null
               setTournament(null)
+              navigate('/llm-tournament')
             }}
           />
           {tournament.status === 'BUILDING' && <BuildProgress tournament={tournament} />}
@@ -355,6 +388,7 @@ function PacingBar({
   const building = status === 'BUILDING'
   const running = status === 'RUNNING'
   const complete = status === 'COMPLETE'
+  const liveGameId = currentLiveGameId(tournament)
 
   return (
     <div style={styles.pacingBar}>
@@ -376,6 +410,17 @@ function PacingBar({
       </div>
 
       <div style={styles.controlsGroup}>
+        {liveGameId && (
+          <a
+            href={`/?spectate=${liveGameId}`}
+            target="_blank"
+            rel="noreferrer"
+            style={styles.watchLiveBtn}
+            title="Open the in-progress game in a new tab — updates to whichever game is live"
+          >
+            👁 Watch live game
+          </a>
+        )}
         {!running && !complete && (
           <button style={styles.ctrlBtn} disabled={building} onClick={status === 'PAUSED' ? onResume : onStart}>
             ▶ {status === 'PAUSED' ? 'Resume' : 'Start'}
@@ -824,6 +869,16 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '8px 14px',
     fontSize: 13,
     cursor: 'pointer',
+  },
+  watchLiveBtn: {
+    background: '#166534',
+    color: '#dcfce7',
+    border: '1px solid #16a34a',
+    borderRadius: 8,
+    padding: '8px 14px',
+    fontSize: 13,
+    fontWeight: 600,
+    textDecoration: 'none',
   },
   secondaryBtn: {
     background: 'transparent',

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -32,6 +32,7 @@ createRoot(rootElement).render(
         <Route path="/deckbuilder/:deckId" element={<DeckbuilderPage />} />
         <Route path="/scenario" element={<ScenarioBuilderPage />} />
         <Route path="/llm-tournament" element={<LlmTournamentPage />} />
+        <Route path="/llm-tournament/:id" element={<LlmTournamentPage />} />
         <Route path="*" element={<App />} />
       </Routes>
     </BrowserRouter>

--- a/web-client/src/store/slices/connectionSlice.ts
+++ b/web-client/src/store/slices/connectionSlice.ts
@@ -27,7 +27,13 @@ export interface ConnectionSliceState {
 }
 
 export interface ConnectionSliceActions {
-  connect: (playerName: string) => void
+  /**
+   * Connect to the server. `spectator: true` opens an isolated, ephemeral session — it does NOT
+   * reuse or overwrite the stored token/name — so a spectate deep-link in a second tab can't
+   * collide with (or clobber) the user's real identity, and each spectate gets a fresh session
+   * instead of the server restoring a previous (now-finished) spectating game.
+   */
+  connect: (playerName: string, options?: { spectator?: boolean }) => void
   disconnect: () => void
   setPendingTournamentId: (lobbyId: string | null) => void
   setPendingSpectateGameId: (gameSessionId: string | null) => void
@@ -47,7 +53,8 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
   onlinePlayers: null,
 
   // Actions
-  connect: (playerName) => {
+  connect: (playerName, options) => {
+    const spectator = options?.spectator === true
     const { connectionStatus } = get()
     if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
       return
@@ -58,8 +65,11 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
       existingWs.disconnect()
     }
 
-    // Store player name for reconnection
-    localStorage.setItem('argentum-player-name', playerName)
+    // Store player name for reconnection — but never for an ephemeral spectator session, which
+    // must not clobber the user's real identity.
+    if (!spectator) {
+      localStorage.setItem('argentum-player-name', playerName)
+    }
 
     // Build message handlers from the full store
     const handlers = createMessageHandlers(set, get)
@@ -78,9 +88,11 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
           if (urlToken) {
             localStorage.setItem('argentum-token', urlToken)
           }
-          const token = urlToken ?? localStorage.getItem('argentum-token') ?? undefined
-          const storedName = localStorage.getItem('argentum-player-name') ?? playerName
-          getWebSocket()?.send(createConnectMessage(storedName, token))
+          // Spectator sessions connect tokenless (fresh identity every time) so a new spectate tab
+          // never reconnects as an existing identity and gets its old spectating game restored.
+          const token = spectator ? undefined : (urlToken ?? localStorage.getItem('argentum-token') ?? undefined)
+          const connectName = spectator ? playerName : (localStorage.getItem('argentum-player-name') ?? playerName)
+          getWebSocket()?.send(createConnectMessage(connectName, token))
         }
       },
       onError: () => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -732,7 +732,7 @@ export type GameStore = {
   aiEnabled: boolean
   availableSets: readonly AvailableSet[]
   onlinePlayers: number | null
-  connect: (playerName: string) => void
+  connect: (playerName: string, options?: { spectator?: boolean }) => void
   disconnect: () => void
   setPendingTournamentId: (lobbyId: string | null) => void
   setPendingSpectateGameId: (gameSessionId: string | null) => void


### PR DESCRIPTION
Stacked on #650 (base: `llm-tournament`). Two fixes to the dev LLM tournament UI.

## 1. Refresh keeps the tournament
The active tournament id now lives in the URL (`/llm-tournament/:id`), so a page refresh re-loads the same tournament (immediate fetch + polling) instead of dropping to the setup form. A 404 (tournaments are in-memory, so they vanish on a server restart) cleanly falls back to the setup form.

## 2. You can watch live games throughout the tournament
Previously, after game 1 ended you could only open game 1's replay. Root cause: every browser tab connects with the **same token from `localStorage`**, so opening a second "Watch" tab reconnected as your existing identity and the server **restored its previous (now-finished) spectating game** instead of the new live one.

- The spectate deep-link now connects as an **isolated, ephemeral spectator** (`connect(name, { spectator: true })`) — no shared token (fresh identity each time) and it no longer overwrites your real stored player name.
- Added a top-level **"👁 Watch live game"** control in the pacing bar that always points at whichever game is currently live, so you can follow the whole tournament from one button instead of hunting for the right match's link.

## Files
- `web-client/src/components/llmTournament/LlmTournamentPage.tsx`, `main.tsx` — URL persistence + watch-live control
- `web-client/src/App.tsx` — spectate deep-link uses an ephemeral spectator session
- `web-client/src/store/slices/connectionSlice.ts`, `types.ts` — `connect(name, { spectator })` opt-in

Frontend typechecks. The multi-tab/reconnect behavior is worth a quick manual check (watch game 1, let it finish, hit "Watch live game", confirm game 2 streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)