### PR TITLE
mtgish: render SetPT layer effect ("becomes a P/T")

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -153,13 +153,14 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
 }
 
-/** CreatePermanentLayerEffectUntil / its each-permanent form -> ModifyStats / GrantKeyword,
- *  optionally over a group (ForEachInGroup). The `args` are always `[target/filter, [layerEffects],
- *  expiration]`; EVERY entry in the layer-effects list must render, or the whole card scaffolds — a
- *  layer effect we silently drop (e.g. an AddAbility granting a triggered ability alongside a P/T
- *  buff) would emit a confidently-wrong card. The `_Expiration` is honoured exactly: end-of-turn uses
- *  the default-duration facade; "for as long as it remains tapped" carries an explicit
- *  Duration.WhileSourceTapped(); any other expiration scaffolds rather than emit a wrong duration. */
+/** CreatePermanentLayerEffectUntil / its each-permanent form -> ModifyStats / SetBasePowerToughness /
+ *  GrantKeyword, optionally over a group (ForEachInGroup). The `args` are always `[target/filter,
+ *  [layerEffects], expiration]`; EVERY entry in the layer-effects list must render, or the whole card
+ *  scaffolds — a layer effect we silently drop (e.g. an AddAbility granting a triggered ability
+ *  alongside a P/T buff, or an AddCardtype riding a SetPT "becomes a 0/0 artifact") would emit a
+ *  confidently-wrong card. The `_Expiration` is honoured exactly: end-of-turn uses the default-duration
+ *  facade; "for as long as it remains tapped" carries an explicit Duration.WhileSourceTapped(); any
+ *  other expiration scaffolds rather than emit a wrong duration. */
 internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: String?): Dsl? {
     val mass = action == "CreateEachPermanentLayerEffectUntil"
     val target = if (mass) "EffectTarget.Self" else refTarget(node["args"], tvar)
@@ -181,6 +182,18 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
                     if (duration.isEmpty()) call("Effects.ModifyStats", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}"), arg(Lit(target)))
                     else call("ModifyStatsEffect", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}"), arg(Lit(target)), arg(Lit(duration))),
                 )
+            }
+            "SetPT" -> {
+                // "becomes a P/T" — set base power and toughness (CR 613.4b, layer 7b). The IR nests the
+                // values one level deeper than AdjustPT: args is `{_PT: PT, args: [p, t]}`. Unlike ModifyStats,
+                // SetBasePowerToughnessEffect defaults to Duration.Permanent, so the end-of-turn case MUST emit
+                // an explicit Duration.EndOfTurn rather than relying on the default (which would set it forever).
+                val pt = (leObj["args"] as? JsonObject)?.get("args").asArr
+                if (pt == null || pt.size != 2) return null
+                val p = pt[0].asInt() ?: return null
+                val t = pt[1].asInt() ?: return null
+                val dur = if (duration.isEmpty()) "Duration.EndOfTurn" else duration
+                inner.add(call("SetBasePowerToughnessEffect", arg(Lit(target)), arg("$p"), arg("$t"), arg(Lit(dur))))
             }
             "AdjustPTX" -> {
                 // "+X/+X" / "-X/-X" where X is a dynamic game number (Wirewood Pride: +Elf-count, Feeding
@@ -214,7 +227,7 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
                 if (duration.isNotEmpty()) gkArgs.add(arg(Lit(duration)))
                 inner.add(Call("Effects.GrantKeyword", gkArgs))
             }
-            else -> return null  // any other layer effect (e.g. set base P/T, lose abilities) -> SCAFFOLD
+            else -> return null  // any other layer effect (e.g. add card type, lose abilities) -> SCAFFOLD
         }
     }
     if (inner.isEmpty()) return null

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -40,4 +40,48 @@ class EffectHandlerTest : StringSpec({
     "an unrecognised action declines (-> SCAFFOLD)" {
         effect("""{"_Action":"SomeActionWeDoNotModel"}""").shouldBeNull()
     }
+
+    // --- SetPT layer effect ("target creature becomes a P/T until end of turn") -------------------
+    fun layer(json: String, tvar: String?): String? = ctx.renderAction(obj(json), tvar)?.let(::render)
+
+    "SetPT sets base P/T, and the end-of-turn case emits an EXPLICIT Duration.EndOfTurn" {
+        // SetBasePowerToughnessEffect defaults to Duration.Permanent, so the EOT layer effect must spell
+        // the duration out — relying on the default would set the creature's P/T forever.
+        layer(
+            """{"_Action":"CreatePermanentLayerEffectUntil","args":[{"_Permanent":"Ref_TargetPermanent"},""" +
+                """[{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[5,1]}}],{"_Expiration":"UntilEndOfTurn"}]}""",
+            "t",
+        ) shouldBe "SetBasePowerToughnessEffect(t, 5, 1, Duration.EndOfTurn)"
+    }
+
+    "SetPT carries a non-default expiration verbatim (for as long as it remains tapped)" {
+        layer(
+            """{"_Action":"CreatePermanentLayerEffectUntil","args":[{"_Permanent":"Ref_TargetPermanent"},""" +
+                """[{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[0,2]}}],""" +
+                """{"_Expiration":"ForAsLongAsPermanentRemainsTapped"}]}""",
+            "t",
+        ) shouldBe "SetBasePowerToughnessEffect(t, 0, 2, Duration.WhileSourceTapped())"
+    }
+
+    "the each-permanent SetPT form wraps the set over a group" {
+        layer(
+            """{"_Action":"CreateEachPermanentLayerEffectUntil","args":[""" +
+                """{"_Permanents":"And","args":[{"_Permanents":"IsCardtype","args":"Creature"},""" +
+                """{"_Permanents":"ControlledByAPlayer","args":{"_Players":"SinglePlayer","args":{"_Player":"You"}}}]},""" +
+                """[{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[1,1]}}],{"_Expiration":"UntilEndOfTurn"}]}""",
+            null,
+        ) shouldBe "Effects.ForEachInGroup(GroupFilter(GameObjectFilter.Creature.youControl()), " +
+            "SetBasePowerToughnessEffect(EffectTarget.Self, 1, 1, Duration.EndOfTurn))"
+    }
+
+    "a SetPT riding an unsupported AddCardtype still scaffolds (no silently-dropped 'becomes an artifact')" {
+        // "It becomes a 0/0 artifact creature": AddCardtype isn't rendered here, so the whole card must
+        // scaffold rather than emit just the P/T set and drop the type change.
+        layer(
+            """{"_Action":"CreatePermanentLayerEffectUntil","args":[{"_Permanent":"Ref_TargetPermanent"},""" +
+                """[{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[0,0]}},""" +
+                """{"_LayerEffect":"AddCardtype","args":"Artifact"}],{"_Expiration":"UntilEndOfTurn"}]}""",
+            "t",
+        ).shouldBeNull()
+    }
 })

--- a/mtgish-tooling/src/test/resources/fixtures/eoe.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/eoe.emitted.golden.txt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.station
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.TimingRule
@@ -56,6 +57,7 @@ import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.station
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GrantCardType
 import com.wingedsheep.sdk.scripting.GrantKeyword
@@ -104,6 +106,7 @@ val GalvanizingSawship = card("Galvanizing Sawship") {
 package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.station
 import com.wingedsheep.sdk.model.Rarity
 
 

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -67,14 +67,19 @@ export default function App() {
   )
 
   useEffect(() => {
-    // Only auto-connect if we already have a stored player name (returning user)
-    // Otherwise, GameUI will show the name entry screen first. A spectate deep-link
-    // connects under a throwaway name so a fresh dev browser can watch immediately.
-    const storedName = localStorage.getItem('argentum-player-name')
-    const name = storedName ?? (spectateParam ? `Spectator-${Math.floor(Math.random() * 9000 + 1000)}` : null)
-    if (name && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+    if (connectionStatus !== 'disconnected' || hasConnectedRef.current) return
+    if (spectateParam) {
+      // Spectate deep-link: connect as an isolated, ephemeral spectator (no shared token/name) so
+      // it doesn't collide with the user's identity and each watch gets a fresh session.
       hasConnectedRef.current = true
-      connect(name)
+      connect(`Spectator-${Math.floor(Math.random() * 9000 + 1000)}`, { spectator: true })
+      return
+    }
+    // Otherwise only auto-connect for a returning user with a stored name; new users see name entry.
+    const storedName = localStorage.getItem('argentum-player-name')
+    if (storedName) {
+      hasConnectedRef.current = true
+      connect(storedName)
     }
   }, [connectionStatus, connect, spectateParam])
 

--- a/web-client/src/components/llmTournament/LlmTournamentPage.tsx
+++ b/web-client/src/components/llmTournament/LlmTournamentPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import type { AvailableSet } from '@/types/messages'
 import { SetPickerModal } from '@/components/ui/SetPickerModal'
 
@@ -84,6 +85,16 @@ function fmtTokens(n: number): string {
   return String(n)
 }
 
+/** The game session id of whatever match is live right now (one at a time), else null. */
+function currentLiveGameId(t: TournamentView): string | null {
+  for (const round of t.rounds) {
+    for (const m of round.matches) {
+      if (m.status === 'live' && m.currentGameSessionId) return m.currentGameSessionId
+    }
+  }
+  return null
+}
+
 const PRESET_MODELS = [
   'deepseek/deepseek-v4-flash',
   'tencent/hy3-preview',
@@ -96,21 +107,41 @@ const PRESET_MODELS = [
 // ============================================================================
 
 export function LlmTournamentPage() {
+  const { id: routeId } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
   const [tournament, setTournament] = useState<TournamentView | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const tournamentIdRef = useRef<string | null>(null)
+  const tournamentIdRef = useRef<string | null>(routeId ?? null)
 
-  // Poll the active tournament
+  // Poll the active tournament. The id lives in the URL (/llm-tournament/:id) so a page refresh
+  // re-loads the same tournament; a 404 (e.g. server restarted — tournaments are in-memory) drops
+  // back to the setup form.
   const refresh = useCallback(async () => {
     const id = tournamentIdRef.current
     if (!id) return
     try {
       const res = await fetch(`${API}/${id}`)
-      if (res.ok) setTournament(await res.json())
+      if (res.ok) {
+        setTournament(await res.json())
+      } else if (res.status === 404) {
+        tournamentIdRef.current = null
+        setTournament(null)
+        navigate('/llm-tournament', { replace: true })
+      }
     } catch {
       /* transient — keep last view */
     }
-  }, [])
+  }, [navigate])
+
+  // Sync the active id from the URL (initial load, refresh, back/forward) and fetch immediately.
+  useEffect(() => {
+    tournamentIdRef.current = routeId ?? null
+    if (routeId) {
+      void refresh()
+    } else {
+      setTournament(null)
+    }
+  }, [routeId, refresh])
 
   useEffect(() => {
     const interval = setInterval(refresh, 1500)
@@ -120,6 +151,7 @@ export function LlmTournamentPage() {
   const selectTournament = (view: TournamentView) => {
     tournamentIdRef.current = view.id
     setTournament(view)
+    navigate(`/llm-tournament/${view.id}`)
   }
 
   const control = async (action: string, body?: unknown) => {
@@ -174,6 +206,7 @@ export function LlmTournamentPage() {
             onNew={() => {
               tournamentIdRef.current = null
               setTournament(null)
+              navigate('/llm-tournament')
             }}
           />
           {tournament.status === 'BUILDING' && <BuildProgress tournament={tournament} />}
@@ -355,6 +388,7 @@ function PacingBar({
   const building = status === 'BUILDING'
   const running = status === 'RUNNING'
   const complete = status === 'COMPLETE'
+  const liveGameId = currentLiveGameId(tournament)
 
   return (
     <div style={styles.pacingBar}>
@@ -376,6 +410,17 @@ function PacingBar({
       </div>
 
       <div style={styles.controlsGroup}>
+        {liveGameId && (
+          <a
+            href={`/?spectate=${liveGameId}`}
+            target="_blank"
+            rel="noreferrer"
+            style={styles.watchLiveBtn}
+            title="Open the in-progress game in a new tab — updates to whichever game is live"
+          >
+            👁 Watch live game
+          </a>
+        )}
         {!running && !complete && (
           <button style={styles.ctrlBtn} disabled={building} onClick={status === 'PAUSED' ? onResume : onStart}>
             ▶ {status === 'PAUSED' ? 'Resume' : 'Start'}
@@ -824,6 +869,16 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '8px 14px',
     fontSize: 13,
     cursor: 'pointer',
+  },
+  watchLiveBtn: {
+    background: '#166534',
+    color: '#dcfce7',
+    border: '1px solid #16a34a',
+    borderRadius: 8,
+    padding: '8px 14px',
+    fontSize: 13,
+    fontWeight: 600,
+    textDecoration: 'none',
   },
   secondaryBtn: {
     background: 'transparent',

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -32,6 +32,7 @@ createRoot(rootElement).render(
         <Route path="/deckbuilder/:deckId" element={<DeckbuilderPage />} />
         <Route path="/scenario" element={<ScenarioBuilderPage />} />
         <Route path="/llm-tournament" element={<LlmTournamentPage />} />
+        <Route path="/llm-tournament/:id" element={<LlmTournamentPage />} />
         <Route path="*" element={<App />} />
       </Routes>
     </BrowserRouter>

--- a/web-client/src/store/slices/connectionSlice.ts
+++ b/web-client/src/store/slices/connectionSlice.ts
@@ -27,7 +27,13 @@ export interface ConnectionSliceState {
 }
 
 export interface ConnectionSliceActions {
-  connect: (playerName: string) => void
+  /**
+   * Connect to the server. `spectator: true` opens an isolated, ephemeral session — it does NOT
+   * reuse or overwrite the stored token/name — so a spectate deep-link in a second tab can't
+   * collide with (or clobber) the user's real identity, and each spectate gets a fresh session
+   * instead of the server restoring a previous (now-finished) spectating game.
+   */
+  connect: (playerName: string, options?: { spectator?: boolean }) => void
   disconnect: () => void
   setPendingTournamentId: (lobbyId: string | null) => void
   setPendingSpectateGameId: (gameSessionId: string | null) => void
@@ -47,7 +53,8 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
   onlinePlayers: null,
 
   // Actions
-  connect: (playerName) => {
+  connect: (playerName, options) => {
+    const spectator = options?.spectator === true
     const { connectionStatus } = get()
     if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
       return
@@ -58,8 +65,11 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
       existingWs.disconnect()
     }
 
-    // Store player name for reconnection
-    localStorage.setItem('argentum-player-name', playerName)
+    // Store player name for reconnection — but never for an ephemeral spectator session, which
+    // must not clobber the user's real identity.
+    if (!spectator) {
+      localStorage.setItem('argentum-player-name', playerName)
+    }
 
     // Build message handlers from the full store
     const handlers = createMessageHandlers(set, get)
@@ -78,9 +88,11 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
           if (urlToken) {
             localStorage.setItem('argentum-token', urlToken)
           }
-          const token = urlToken ?? localStorage.getItem('argentum-token') ?? undefined
-          const storedName = localStorage.getItem('argentum-player-name') ?? playerName
-          getWebSocket()?.send(createConnectMessage(storedName, token))
+          // Spectator sessions connect tokenless (fresh identity every time) so a new spectate tab
+          // never reconnects as an existing identity and gets its old spectating game restored.
+          const token = spectator ? undefined : (urlToken ?? localStorage.getItem('argentum-token') ?? undefined)
+          const connectName = spectator ? playerName : (localStorage.getItem('argentum-player-name') ?? playerName)
+          getWebSocket()?.send(createConnectMessage(connectName, token))
         }
       },
       onError: () => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -732,7 +732,7 @@ export type GameStore = {
   aiEnabled: boolean
   availableSets: readonly AvailableSet[]
   onlinePlayers: number | null
-  connect: (playerName: string) => void
+  connect: (playerName: string, options?: { spectator?: boolean }) => void
   disconnect: () => void
   setPendingTournamentId: (lobbyId: string | null) => void
   setPendingSpectateGameId: (gameSessionId: string | null) => void


### PR DESCRIPTION
## What

Teaches the mtgish emitter's `renderLayerEffect` to render the `SetPT` `_LayerEffect` — "target creature **becomes** a P/T until end of turn" — onto `SetBasePowerToughnessEffect`. SetPT is the 3rd-most-common layer-effect variant in the corpus (385 instances of `_LayerEffect: SetPT`), behind only `AddAbility` and `AdjustPT`. Previously it hit the `else -> return null` arm and scaffolded.

Covers both envelopes:
- `CreatePermanentLayerEffectUntil` (single target) → `SetBasePowerToughnessEffect(t, p, q, Duration.…)`
- `CreateEachPermanentLayerEffectUntil` (group) → wrapped in `Effects.ForEachInGroup(filter, …)`

## Two subtleties

1. **Nested args.** Unlike `AdjustPT` (whose `args` is a bare `[p, t]`), SetPT nests one level deeper: `{_PT: PT, args: [p, t]}`.
2. **Duration default.** `SetBasePowerToughnessEffect` defaults to `Duration.Permanent` (whereas `ModifyStats` defaults to `EndOfTurn`). So the until-end-of-turn case emits an **explicit** `Duration.EndOfTurn` — relying on the default would set the creature's P/T *forever*. `ForAsLongAsPermanentRemainsTapped` is carried verbatim as `Duration.WhileSourceTapped()`.

A SetPT riding an as-yet-unrendered layer effect (e.g. `AddCardtype` in "becomes a 0/0 artifact creature") still scaffolds the **whole** card rather than emit a partial render that silently drops the type change — matching the "every layer effect must render or scaffold" contract.

No SDK surface change (`SetBasePowerToughnessEffect` already exists); imports auto-derive from the emitted text via the live-SDK scan.

## Tests

- Adds 4 focused `EffectHandlerTest` cases: explicit `Duration.EndOfTurn`, verbatim `WhileSourceTapped`, the group form, and the AddCardtype-rider scaffold guard.
- Full `:mtgish-tooling:test` is green.

## Note on the EOE golden change

The diff includes 3 `+import com.wingedsheep.sdk.dsl.station` lines in `eoe.emitted.golden.txt`. **These are unrelated to SetPT** — they're a pre-existing golden drift: commit `c9e9f79d8` ("Move set-specific mechanics off the core CardBuilder") relocated `station` to a top-level `com.wingedsheep.sdk.dsl` symbol, which this module's live-SDK import scan now resolves, but the EOE golden (last blessed at `bc749fbcd`) was never re-blessed. The `EmitterGoldenTest` EOE case was already red on `main` for this reason. Re-blessed here (per author's request) to bring CI green; no card body changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)