### PR TITLE
Add OTJ cards (batch B): Tomb Trawler, Marauding Sphinx, Nezumi Linkbreaker

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MaraudingSphinx.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MaraudingSphinx.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Marauding Sphinx
+ * {3}{U}{U}
+ * Creature — Sphinx Rogue
+ * 3/5
+ *
+ * Flying, vigilance, ward {2}
+ * Whenever you commit a crime, surveil 2. This ability triggers only once each turn.
+ */
+val MaraudingSphinx = card("Marauding Sphinx") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx Rogue"
+    power = 3
+    toughness = 5
+    oracleText = "Flying, vigilance, ward {2}\n" +
+        "Whenever you commit a crime, surveil 2. This ability triggers only once each turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = Patterns.Library.surveil(2)
+        description = "Whenever you commit a crime, surveil 2. This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Mila Pesic"
+        flavorText = "She poses a riddle to each mark, allowing them a chance to keep their goods. " +
+            "Thus far, none have succeeded."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg?1712355453"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NezumiLinkbreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NezumiLinkbreaker.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nezumi Linkbreaker
+ * {B}
+ * Creature — Rat Warlock
+ * 1/1
+ *
+ * When this creature dies, create a 1/1 red Mercenary creature token with "{T}: Target creature
+ * you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ */
+val NezumiLinkbreaker = card("Nezumi Linkbreaker") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat Warlock"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed,
+                ),
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+        )
+        description = "When this creature dies, create a 1/1 red Mercenary creature token with " +
+            "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Miro Petrov"
+        flavorText = "\"If they want to get to Prosperity so badly, they can walk there.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg?1712355626"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TombTrawler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TombTrawler.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Tomb Trawler
+ * {2}
+ * Artifact Creature — Golem
+ * 0/4
+ *
+ * {2}: Put target card from your graveyard on the bottom of your library.
+ */
+val TombTrawler = card("Tomb Trawler") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 0
+    toughness = 4
+    oracleText = "{2}: Put target card from your graveyard on the bottom of your library."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Any.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Move(
+            target = t,
+            destination = Zone.LIBRARY,
+            placement = ZonePlacement.Bottom,
+        )
+        description = "{2}: Put target card from your graveyard on the bottom of your library."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "250"
+        artist = "Anton Solovianchyk"
+        flavorText = "\"Dying is common on Thunder Junction. Resting in peace is a much rarer commodity.\"\n" +
+            "—Baron Bertram Graywater"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg?1712356295"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3711,6 +3711,102 @@
     ]
 }
 
+// Marauding Sphinx
+{
+    "name": "Marauding Sphinx",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Sphinx Rogue",
+    "oracleText": "Flying, vigilance, ward {2}\nWhenever you commit a crime, surveil 2. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, surveil 2. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "flavorText": "She poses a riddle to each mark, allowing them a chance to keep their goods. Thus far, none have succeeded.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg?1712355453"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mine Raider
 {
     "name": "Mine Raider",
@@ -3862,6 +3958,82 @@
         "artist": "Zuzanna Wużyk",
         "flavorText": "\"Y'all should've known better than to buy me a coffin!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg?1712355617"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nezumi Linkbreaker
+{
+    "name": "Nezumi Linkbreaker",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Rat Warlock",
+    "oracleText": "When this creature dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Miro Petrov",
+        "flavorText": "\"If they want to get to Prosperity so badly, they can walk there.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg?1712355626"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -6110,6 +6282,60 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Tomb Trawler
+{
+    "name": "Tomb Trawler",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "{2}: Put target card from your graveyard on the bottom of your library.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Library",
+                    "placement": "Bottom"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{2}: Put target card from your graveyard on the bottom of your library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "UNCOMMON",
+        "artist": "Anton Solovianchyk",
+        "flavorText": "\"Dying is common on Thunder Junction. Resting in peace is a much rarer commodity.\"\n—Baron Bertram Graywater",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg?1712356295"
+    },
+    "colorIdentityOverride": []
 }
 
 // Trained Arynx

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -15,6 +15,8 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // OTJ Plot (CR 718) — "When this card becomes plotted, …" (Triggers.BecomesPlotted, Aloe Alchemist).
     supported("WhenACardBecomesPlotted", "trigger: this card becomes plotted (Triggers.BecomesPlotted)")
     supported("WhenAPermanentBecomesTheTargetOfASpellOrAbility", "trigger: becomes target (Triggers.BecomesTargetByOpponent / BecomesTarget / CreatureYouControlBecomesTargetByOpponent)")
+    // OTJ crime (CR 700.10) — "Whenever you commit a crime, …" (Triggers.YouCommitCrime, Marauding Sphinx).
+    supported("WhenAPlayerCommitsACrime", "trigger: you commit a crime (Triggers.YouCommitCrime)")
 
     // Intervening-if conditions (CR 603.4) gating a TriggerI, plus the Mount "while saddled" gate. The
     // emitter renders the recognised shapes to `triggerCondition = Conditions.*`; an unrenderable

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -20,6 +20,7 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("PutGraveyardCardOntoBattlefield", "MoveCollection graveyard->battlefield (reanimate)", composes = listOf("MoveToZone"))
     composed("ShuffleGraveyardCardIntoLibrary", "MoveCollection + ShuffleLibrary", composes = listOf("MoveToZone", "ShuffleLibrary"))
     composed("ReturnDeadGraveyardCardToTopOfLibrary", "MoveCollection -> library top", composes = listOf("MoveToZone"))
+    composed("PutGraveyardCardOnBottomOfLibrary", "MoveCollection -> library bottom (Tomb Trawler)", composes = listOf("MoveToZone"))
     composed("ReturnGraveyardCardToHand", UNIVERSAL, composes = listOf("MoveToZone"))
     composed("PutEachGraveyardCardIntoHand", UNIVERSAL, composes = listOf("MoveCollection"))
     composed("ExileGraveyardCard", UNIVERSAL, composes = listOf("MoveToZone"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -849,6 +849,14 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         val category = spellCastCategory(argv?.getOrNull(1) as? JsonObject) ?: return null
         return castTriggerDsl(scope, category)
     }
+
+    // "Whenever you commit a crime" — WhenAPlayerCommitsACrime scoped to SinglePlayer(You). Only the
+    // You scope maps to Triggers.YouCommitCrime; any other player scope (AnyPlayer / Opponent) has no
+    // matching Triggers.* constant yet, so it declines -> SCAFFOLD. Pairs with the TriggerOnceEachTurn
+    // envelope for "this ability triggers only once each turn" (Marauding Sphinx).
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerCommitsACrime") && jsonContains(trig, "_Player", "You"))
+        return "Triggers.YouCommitCrime"
+
     return null
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -196,6 +196,14 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     on("SearchLibrary") { _, args, _ -> renderSearch(args) }
     on("LookAtTheTopNumberCardsOfLibrary", "LookAtTheTopNumberCardsOfPlayersLibrary") { node, args, tvar -> renderLook(node, args, tvar) }
 
+    on("PutGraveyardCardOnBottomOfLibrary") { _, args, tvar ->
+        // "Put target card from your graveyard on the bottom of your library" (Tomb Trawler). The
+        // target graveyard card is already recovered into the bound `tvar`; a plain Move to the bottom
+        // of the library expresses it. Self ("this card from your graveyard") falls back to Self.
+        val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
+        call("Effects.Move", arg(Lit(tgt)), arg("Zone.LIBRARY"), arg("ZonePlacement.Bottom"))
+    }
+
     on("PutGraveyardCardOntoBattlefield", "PutGraveyardCardIntoHand",
         "ReturnDeadGraveyardCardToTopOfLibrary", "PutPermanentOnTopOfOwnersLibrary") { node, args, tvar ->
         val a = node.strField("_Action")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaraudingSphinxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaraudingSphinxScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.MaraudingSphinx
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Marauding Sphinx — {3}{U}{U} 3/5 Creature — Sphinx Rogue
+ *
+ * "Flying, vigilance, ward {2}
+ *  Whenever you commit a crime, surveil 2. This ability triggers only once each turn."
+ */
+class MaraudingSphinxScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MaraudingSphinx)
+        return driver
+    }
+
+    test("has flying and vigilance") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val sphinx = driver.putCreatureOnBattlefield(me, "Marauding Sphinx")
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(sphinx, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(sphinx, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("committing a crime surveils 2, but only once each turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Marauding Sphinx")
+
+        // Seed a known library top so surveil presents two cards.
+        val top2 = driver.putCardOnTopOfLibrary(me, "Island")
+        val top1 = driver.putCardOnTopOfLibrary(me, "Mountain")
+
+        // Commit a crime: cast Lightning Bolt targeting the opponent.
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> commit-crime event -> surveil trigger on stack
+        driver.bothPass() // resolve surveil trigger -> pauses for the surveil decision
+
+        // Surveil 2 pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options.size shouldBe 2
+
+        // Mill the top card; keep the second on top.
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(top1)))
+        driver.isPaused shouldBe true
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        driver.submitOrderedResponse(me, reorder.cards)
+        driver.isPaused shouldBe false
+        driver.getGraveyard(me).contains(top1) shouldBe true
+
+        // Commit a SECOND crime the same turn — the ability triggers only once each turn,
+        // so no second surveil decision should appear.
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.isPaused shouldBe false
+        // top2 is still the library top: no second surveil moved it.
+        driver.state.getLibrary(me).first() shouldBe top2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NezumiLinkbreakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NezumiLinkbreakerScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.NezumiLinkbreaker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Nezumi Linkbreaker — {B} 1/1 Creature — Rat Warlock
+ *
+ * "When this creature dies, create a 1/1 red Mercenary creature token with
+ *  "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.""
+ */
+class NezumiLinkbreakerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(NezumiLinkbreaker)
+        return driver
+    }
+
+    test("creates a 1/1 red Mercenary token when it dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nezumi = driver.putCreatureOnBattlefield(player, "Nezumi Linkbreaker")
+        driver.findPermanent(player, "Nezumi Linkbreaker") shouldNotBe null
+
+        // Kill it with Doom Blade (black creatures can't be targeted by Doom Blade, so use a
+        // non-black destroy). Nezumi is black, so use Lightning Bolt for lethal damage instead.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(nezumi))
+        driver.bothPass() // resolve Bolt -> Nezumi dies -> dies trigger on stack
+        driver.bothPass() // resolve the dies trigger -> Mercenary token created
+
+        driver.findPermanent(player, "Nezumi Linkbreaker") shouldBe null
+        driver.getGraveyardCardNames(player).contains("Nezumi Linkbreaker") shouldBe true
+        driver.findPermanent(player, "Mercenary Token") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TombTrawlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TombTrawlerScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TombTrawler
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tomb Trawler — {2} 0/4 Artifact Creature — Golem
+ *
+ * "{2}: Put target card from your graveyard on the bottom of your library."
+ */
+class TombTrawlerScenarioTest : FunSpec({
+
+    val trawlerAbilityId = TombTrawler.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TombTrawler)
+        return driver
+    }
+
+    test("puts a target card from your graveyard on the bottom of your library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Tomb Trawler")
+        val trawler = driver.findPermanent(player, "Tomb Trawler")!!
+
+        // A Grizzly Bears card sits in the graveyard.
+        val bears = driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.getGraveyardCardNames(player).contains("Grizzly Bears") shouldBe true
+
+        driver.giveColorlessMana(player, 2)
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = trawler,
+                abilityId = trawlerAbilityId,
+                targets = listOf(ChosenTarget.Card(bears, player, Zone.GRAVEYARD)),
+            ),
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass() // resolve the ability
+
+        // The card left the graveyard and is now the bottom card of the library.
+        driver.getGraveyardCardNames(player).contains("Grizzly Bears") shouldBe false
+        val library = driver.state.getLibrary(player)
+        val bottomId = library.last()
+        driver.state.getEntity(bottomId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+        driver.state.getEntity(bottomId) shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Cards implemented

All three are Outlaws of Thunder Junction originals (no earlier printing → OTJ canonical), built from existing SDK primitives with passing scenario tests:

- **Tomb Trawler** `{2}` 0/4 Artifact Creature — Golem — `{2}: Put target card from your graveyard on the bottom of your library.` Activated ability → `Effects.Move(t, Zone.LIBRARY, ZonePlacement.Bottom)` targeting a card in your graveyard.
- **Marauding Sphinx** `{3}{U}{U}` 3/5 Sphinx Rogue — Flying, vigilance, ward {2}; `Whenever you commit a crime, surveil 2. This ability triggers only once each turn.` → `Triggers.YouCommitCrime` + `oncePerTurn = true` + `Patterns.Library.surveil(2)`.
- **Nezumi Linkbreaker** `{B}` 1/1 Rat Warlock — dies trigger creating the standard 1/1 red Mercenary token with its sorcery-speed `{T}: target creature you control gets +1/+0` activated ability.

## Skipped

- **Slickshot Lockpicker** — its ETB grants a *target* instant/sorcery in the graveyard temporary **flashback at its own mana cost** (Snapcaster-style), then exile. The engine has no dynamic grant-flashback / temporary cast-from-graveyard permission (only exile-zone `GrantMayPlayFromExile` keyed by a named collection exists). Modeling it faithfully needs a new effect + engine plumbing → `add-feature` territory. Left correctly at the mtgish `SCAFFOLD` tier rather than shipping a lossy approximation.

## mtgish-tooling changes

Both new mechanics now render whole (AUTO tier) so they auto-draft across every set:

- **emitter** `ZoneHandlers.kt`: `PutGraveyardCardOnBottomOfLibrary` → `Effects.Move(..., Zone.LIBRARY, ZonePlacement.Bottom)`.
- **emitter** `CardStructure.triggerSpecFor`: `WhenAPlayerCommitsACrime` (You scope) → `Triggers.YouCommitCrime`; non-You scopes still decline → SCAFFOLD.
- **bridge** `ZoneMovement.kt` + `TriggersCostsAndContinuous.kt`: matching `composed`/`supported` capability entries so the probe scores these coverable.

## Verification

- 3 scenario tests pass (`TombTrawlerScenarioTest`, `MaraudingSphinxScenarioTest`, `NezumiLinkbreakerScenarioTest`).
- `CardLintTest` + `CardDefinitionSnapshotTest` pass (OTJ golden re-blessed).
- `EmitterGoldenTest` passes; `coverage-verify POR` → **GATE PASS 158/158** (no regression).
- The `coverage-verify OTJ` gate fails only on **pre-existing** `descriptionOverride` drift across ~14 existing cards (Mine Raider, Oasis Gardener, Spinewoods Paladin, …). OTJ is not a calibrated 0-mismatch set; these additions introduce no new mismatch class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)