### PR TITLE
Add OTJ cards: Rodeo Pyromancers, Sterling Supplier, Quick Draw (+mtgish auto-gen)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/QuickDraw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/QuickDraw.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Quick Draw
+ * {R}
+ * Instant
+ *
+ * Target creature you control gets +1/+1 and gains first strike until end of turn.
+ * Creatures target opponent controls lose first strike and double strike until end of turn.
+ */
+val QuickDraw = card("Quick Draw") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +1/+1 and gains first strike until end of turn. " +
+        "Creatures target opponent controls lose first strike and double strike until end of turn."
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 1, toughness = 1, target = creature),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, target = creature),
+            Patterns.Group.removeKeywordFromAll(
+                keyword = Keyword.FIRST_STRIKE,
+                filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(opponent))
+            ),
+            Patterns.Group.removeKeywordFromAll(
+                keyword = Keyword.DOUBLE_STRIKE,
+                filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(opponent))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Lie Setiawan"
+        flavorText = "The opening of the Omenpaths awoke the wild magic of Thunder Junction. " +
+            "Settlers dubbed it \"thunder\" and put it to use in everything from farming tools to deadly weapons."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg?1712355816"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RodeoPyromancers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RodeoPyromancers.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rodeo Pyromancers
+ * {3}{R}
+ * Creature — Human Mercenary
+ * 3/4
+ * Whenever you cast your first spell each turn, add {R}{R}.
+ */
+val RodeoPyromancers = card("Rodeo Pyromancers") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "Whenever you cast your first spell each turn, add {R}{R}."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(1, Player.You)
+        effect = Effects.AddMana(Color.RED, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Kim Sokol"
+        flavorText = "\"My citizens throw good money at them, and for what? Cheap tricks and " +
+            "collateral damage. Damnable Slickshot charlatans.\"\n—Baron Bertram Graywater"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg?1712355836"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SterlingSupplier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SterlingSupplier.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sterling Supplier
+ * {4}{W}
+ * Creature — Bird Soldier
+ * 3/4
+ * Flying
+ * When this creature enters, put a +1/+1 counter on another target creature you control.
+ */
+val SterlingSupplier = card("Sterling Supplier") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, put a +1/+1 counter on another target creature you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Camille Alquier"
+        flavorText = "The Sterling Company can always rely on him to bring the thunder."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg?1712355360"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4099,6 +4099,116 @@
     ]
 }
 
+// Quick Draw
+{
+    "name": "Quick Draw",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gets +1/+1 and gains first strike until end of turn. Creatures target opponent controls lose first strike and double strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControlledByReferencedPlayer",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target opponent"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "RemoveKeyword",
+                        "keyword": "FIRST_STRIKE",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControlledByReferencedPlayer",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target opponent"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "RemoveKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            },
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Lie Setiawan",
+        "flavorText": "The opening of the Omenpaths awoke the wild magic of Thunder Junction. Settlers dubbed it \"thunder\" and put it to use in everything from farming tools to deadly weapons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg?1712355816"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Quilled Charger
 {
     "name": "Quilled Charger",
@@ -4553,6 +4663,48 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rodeo Pyromancers
+{
+    "name": "Rodeo Pyromancers",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "Whenever you cast your first spell each turn, add {R}{R}.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 1,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Kim Sokol",
+        "flavorText": "\"My citizens throw good money at them, and for what? Cheap tricks and collateral damage. Damnable Slickshot charlatans.\"\n—Baron Bertram Graywater",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg?1712355836"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5746,6 +5898,58 @@
         "artist": "David Astruga",
         "flavorText": "\"If you don't want to tell me where the stash is, you'd best start getting comfy in there. You just let me know when you've changed your mind.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/0/1/019d539f-04c2-43f1-8677-6d6fbb0e94f7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sterling Supplier
+{
+    "name": "Sterling Supplier",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying\nWhen this creature enters, put a +1/+1 counter on another target creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Camille Alquier",
+        "flavorText": "The Sterling Company can always rely on him to bring the thunder.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg?1712355360"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -10,6 +10,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenACreatureBlocks", "trigger: blocks (Ydwen Efreet)")
     supported("WhenACreatureDealsCombatDamageToAPlayer", "trigger: combat damage to player")
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
+    supported("WhenAPlayerCastsTheirNthSpellInATurn", "trigger: you cast your Nth spell each turn (Triggers.NthSpellCast(N, Player.You) — Rodeo Pyromancers)")
     supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
     // OTJ Plot (CR 718) — "When this card becomes plotted, …" (Triggers.BecomesPlotted, Aloe Alchemist).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -838,6 +838,27 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
             "TriggerBinding.ANY)"
     }
 
+    // "Whenever you cast your Nth spell each turn" — WhenAPlayerCastsTheirNthSpellInATurn. The args are
+    // [caster scope, an `== N` comparison, a spell filter]. Only the exact You + EqualTo + AnySpell shape
+    // maps to Triggers.NthSpellCast(N, Player.You) (Rodeo Pyromancers' "first spell each turn"); any other
+    // caster scope, comparison, or a typed/constrained spell filter declines -> SCAFFOLD rather than
+    // silently widening it.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerCastsTheirNthSpellInATurn")) {
+        val argv = trig["args"].asArr
+        val scope = castScope(argv?.getOrNull(0) as? JsonObject)
+        val comparison = argv?.getOrNull(1) as? JsonObject
+        val spells = argv?.getOrNull(2) as? JsonObject
+        val n = (comparison?.field("args") as? JsonElement).let { findInteger(it) } as? Int
+        if (scope == CastScope.YOU &&
+            comparison?.strField("_Comparison") == "EqualTo" &&
+            spells?.strField("_Spells") == "AnySpell" &&
+            n != null
+        ) {
+            return "Triggers.NthSpellCast($n, Player.You)"
+        }
+        return null
+    }
+
     // "Whenever {you / a player / an opponent} casts a [type] spell" — WhenAPlayerCastsASpell. The
     // first arg is the caster scope (You / AnyPlayer / Opponent — anything else, e.g. HostPlayer,
     // declines); the second is the spell filter, classified to an EXACT category. A filter carrying

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -178,6 +178,26 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
     val nonCardtypes = filterNode.argWordsTagged("IsNonCardtype")
     if (nonCardtypes.any { it != "Artifact" }) return null
+    // "ANOTHER target creature you control" — `And(Other(<self>), IsCardtype Creature, ControlledByAPlayer
+    // You)`. This exact self-exclusion + you-control shape has a named TargetFilter constant
+    // (OtherCreatureYouControl) that composes excludeSelf, so render it directly (Cunning Coyote, Sterling
+    // Supplier's ETB +1/+1). Guard strictly: only when the sole predicates are Other + Creature + You, with
+    // no extra subtype / colour / power / keyword / state clause that the constant wouldn't carry.
+    run {
+        val otherYouControlExtras = listOf(
+            "IsCreatureType", "IsNonCreatureType", "IsArtifactType", "IsLandType", "IsEnchantmentType",
+            "IsNonCardtype", "IsColor", "IsNonColor", "PowerIs", "ToughnessIs", "ManaValueIs", "HasAbility",
+            "DoesntHaveAbility", "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "IsFaceDown",
+            "IsNonToken", "HasACounterOfType", "WasDealtDamageThisTurn",
+        )
+        if (jsonContains(filterNode, "_Permanents", "Other") &&
+            "Creature" in filterNode.argWordsTagged("IsCardtype") &&
+            "\"You\"" in blob && "ControlledByAPlayer" in blob &&
+            otherYouControlExtras.none { it in blob }
+        ) {
+            return Lit("TargetFilter.OtherCreatureYouControl")
+        }
+    }
     // "ANOTHER target creature you control" — an `Other(ThisPermanent)` self-exclusion. The TargetFilter
     // surface built here doesn't compose excludeSelf, so silently dropping it would let the source target
     // itself (an illegal target). Decline (-> SCAFFOLD) rather than emit a target missing the "another"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickDrawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickDrawScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Quick Draw (OTJ #138) — {R} Instant.
+ *
+ *   "Target creature you control gets +1/+1 and gains first strike until end of turn.
+ *    Creatures target opponent controls lose first strike and double strike until end of turn."
+ *
+ * Verifies that the controlled creature is pumped and gains first strike, while every creature
+ * the targeted opponent controls loses first strike (White Knight) and double strike (Fencing
+ * Ace) until end of turn.
+ */
+class QuickDrawScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Quick Draw") {
+
+            test("pumps your creature and strips opponent's first/double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Quick Draw")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2, no first strike
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "White Knight") // 2/2 first strike
+                    .withCardOnBattlefield(2, "Fencing Ace") // 1/1 double strike
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val whiteKnight = game.findPermanent("White Knight")!!
+                val fencingAce = game.findPermanent("Fencing Ace")!!
+
+                var projected = stateProjector.project(game.state)
+                projected.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+                projected.hasKeyword(whiteKnight, Keyword.FIRST_STRIKE) shouldBe true
+                projected.hasKeyword(fencingAce, Keyword.DOUBLE_STRIKE) shouldBe true
+
+                // Find Quick Draw in hand and cast it: target 0 = our creature, target 1 = opponent.
+                val handCard = game.state.getHand(game.player1Id).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Quick Draw"
+                }
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = handCard,
+                        targets = listOf(
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Player(game.player2Id),
+                        )
+                    )
+                )
+                withClue("Casting Quick Draw should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                projected = stateProjector.project(game.state)
+                withClue("Your creature gains +1/+1 and first strike") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                    projected.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                }
+                withClue("Opponent's White Knight loses first strike") {
+                    projected.hasKeyword(whiteKnight, Keyword.FIRST_STRIKE) shouldBe false
+                }
+                withClue("Opponent's Fencing Ace loses double strike") {
+                    projected.hasKeyword(fencingAce, Keyword.DOUBLE_STRIKE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RodeoPyromancersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RodeoPyromancersScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rodeo Pyromancers (OTJ #143) — {3}{R} Human Mercenary, 3/4.
+ *
+ *   "Whenever you cast your first spell each turn, add {R}{R}."
+ *
+ * Verifies the first spell the controller casts each turn triggers the ability and adds {R}{R}
+ * to their mana pool, and that a second spell that same turn does not trigger it again.
+ */
+class RodeoPyromancersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rodeo Pyromancers") {
+
+            test("first spell each turn adds {R}{R}; second spell does not trigger again") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rodeo Pyromancers")
+                    .withCardInHand(1, "Grizzly Bears") // first spell, {1}{G}
+                    .withCardInHand(1, "Goblin Guide") // second spell, {R}
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun pool(): ManaPoolComponent =
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+                // Cast first spell — {1}{G} paid from the two Forests.
+                val first = game.castSpell(1, "Grizzly Bears")
+                withClue("Casting the first spell should succeed: ${first.error}") {
+                    first.error shouldBe null
+                }
+                // Resolve the Rodeo trigger (and the creature spell).
+                game.resolveStack()
+
+                withClue("First spell triggers Rodeo Pyromancers, adding {R}{R}") {
+                    pool().red shouldBe 2
+                }
+
+                // Cast a second spell this turn — Goblin Guide's {R} is paid from the pooled red.
+                // No lands remain, so the cast is only possible because the {R}{R} is in the pool.
+                val second = game.castSpell(1, "Goblin Guide")
+                withClue("Casting the second spell should succeed (paid from pooled red): ${second.error}") {
+                    second.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Second spell does NOT trigger Rodeo again: only one {R} remains (2 added, 1 spent)") {
+                    // If a second trigger had fired it would have added another {R}{R}, leaving 3.
+                    pool().red shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SterlingSupplierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SterlingSupplierScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sterling Supplier (OTJ #33) — {4}{W} Bird Soldier, 3/4, Flying.
+ *
+ *   "When this creature enters, put a +1/+1 counter on another target creature you control."
+ *
+ * Verifies the ETB trigger targets *another* creature the controller owns and adds a +1/+1
+ * counter (a permanent stat boost via the counter, distinct from the Supplier itself).
+ */
+class SterlingSupplierScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Sterling Supplier") {
+
+            test("ETB puts a +1/+1 counter on another creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sterling Supplier")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                var projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 2
+                projected.getToughness(bears) shouldBe 2
+
+                val cast = game.castSpell(1, "Sterling Supplier")
+                withClue("Casting Sterling Supplier should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // resolve the creature spell; ETB trigger goes on the stack
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the ETB trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(bears))))
+                game.resolveStack()
+
+                projected = stateProjector.project(game.state)
+                withClue("Grizzly Bears gains a +1/+1 counter from Sterling Supplier's ETB") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+
+                val supplier = game.findPermanent("Sterling Supplier")!!
+                projected.hasKeyword(supplier, Keyword.FLYING) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards implemented (Outlaws of Thunder Junction)

All three use existing SDK primitives — no engine changes needed.

- **Rodeo Pyromancers** `{3}{R}` 3/4 Human Mercenary — "Whenever you cast your first spell each turn, add {R}{R}." → `Triggers.NthSpellCast(1, Player.You)` + `Effects.AddMana(Color.RED, 2)`.
- **Sterling Supplier** `{4}{W}` 3/4 Bird Soldier, Flying — ETB puts a +1/+1 counter on another target creature you control (`TargetFilter.OtherCreatureYouControl`).
- **Quick Draw** `{R}` Instant — target creature you control gets +1/+1 and gains first strike; all creatures a target opponent controls lose first strike and double strike (until end of turn). Uses `Patterns.Group.removeKeywordFromAll` scoped to `targetPlayerControls(opponent)`.

Each card has a passing rules-engine scenario test (`RodeoPyromancersScenarioTest`, `SterlingSupplierScenarioTest`, `QuickDrawScenarioTest`). OTJ card snapshot golden re-blessed (only the three new cards added).

## Skipped

- **Prairie Dog** — its activated ability grants a temporary (until-end-of-turn) "+1/+1 counters are doubled (plus one)" replacement effect. The engine has no mechanism to grant a duration-scoped replacement effect (`ReplacementEffectUtils` only scans battlefield permanents; emblems carry only P/T + keyword grants). That is `add-feature` scope, so it was left unimplemented rather than shipped as a lossy partial. The end-step half ("haven't cast a spell from hand") is buildable today (same condition as Inventive Wingsmith), but the doubling replacement is the blocker.

## mtgish-tooling changes (fix the emitter, never hand-patch generated cards)

- **Bridge** (`TriggersCostsAndContinuous.kt`): `WhenAPlayerCastsTheirNthSpellInATurn` marked `supported`.
- **Emitter** (`CardStructure.triggerSpecFor`): render the exact You + EqualTo + AnySpell Nth-spell trigger to `Triggers.NthSpellCast(N, Player.You)`; any other scope/comparison/filter declines → SCAFFOLD.
- **Emitter** (`TargetRecovery.creatureFilterExpr`): render the exact `And(Other, Creature, ControlledByAPlayer You)` filter to `TargetFilter.OtherCreatureYouControl`, with a strict guard that declines if any extra subtype/colour/power/keyword/state clause is present.
- **Result**: Rodeo Pyromancers and Sterling Supplier now emit at fidelity tier **AUTO** (were SCAFFOLD). Quick Draw stays **SCAFFOLD** (multi-target + group-scoped keyword-removal layer effect — declined per the conservative fidelity policy rather than emit a lossy approximation).

## Verification

- `EmitterGoldenTest` — **PASS** (no drift on calibrated sets; the emitter changes are strict additions).
- `coverage-verify POR` — **GATE PASS, 158/158** (0-mismatch maintained).
- `coverage-verify OTJ` — the 14 gameplay-tree mismatches are all **pre-existing and unrelated** (descriptionOverride / target-filter nuances on Armored Armadillo, Magebane Lizard, Shoot the Sheriff, …). Sterling Supplier and Rodeo Pyromancers emit cleanly and gameplay-tree match the golden; Quick Draw is correctly listed as implemented-but-declined.
- Scenario tests + `CardLintTest` + `CardDefinitionSnapshotTest` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)