### PR TITLE
Quick Game: build random/AI decks with the Draftsim autobuilder

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -1,10 +1,20 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.ai.assist.DeckBuildRequest
+import com.wingedsheep.ai.assist.DraftsimDeckBuildAdvisor
 import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.sdk.model.CardDefinition
+import org.slf4j.LoggerFactory
 
 /**
  * Generates a 40-card sealed deck by opening 8 boosters from a set and
  * selecting a playable build from the resulting pool.
+ *
+ * The build itself comes from the Draftsim autobuilder ([DraftsimDeckBuildAdvisor]) — the same
+ * archetype-aware, ratings-driven engine the deckbuild "Auto-build" button uses — so quick/AI games
+ * get the same quality of automatic build as a human clicking Auto-build, backed by Draftsim's
+ * per-set ratings/removal/archetype tables. The [buildHeuristicSealedDeck] color-and-curve heuristic
+ * remains as a safety net for the rare pool Draftsim can't build from.
  *
  * Basic land names in the output are distributed across art variants
  * from the selected set.
@@ -44,10 +54,36 @@ class SealedDeckGenerator(
         requireNotNull(boosterGenerator.availableSets[setCode]) { "Unknown set code: $setCode" }
 
         val pool = boosterGenerator.generateSealedPool(setCode, boosterCount = 8)
-        val deck = buildHeuristicSealedDeck(pool)
+        val deck = buildSealedDeck(pool, setCode)
 
         // Distribute basic lands across art variants for visual variety
         val variants = boosterGenerator.getAllBasicLandVariants(setCode)
         return BoosterGenerator.distributeBasicLandVariants(deck, variants)
+    }
+
+    /**
+     * Builds a sealed deck from [pool] with the Draftsim autobuilder, scoped to [setCode] so it loads
+     * that set's ratings/removal/archetype tables. Sets without a Draftsim ratings file still build
+     * (the scorer falls back to a rarity ladder). Falls back to [buildHeuristicSealedDeck] only if
+     * Draftsim throws or yields an empty list — the heuristic always produces a legal 40-card deck.
+     */
+    private fun buildSealedDeck(pool: List<CardDefinition>, setCode: String): Map<String, Int> {
+        val result = runCatching {
+            DraftsimDeckBuildAdvisor.buildDeck(DeckBuildRequest(pool = pool, setCodes = listOf(setCode)))
+        }.getOrElse { error ->
+            logger.warn("Draftsim build failed for set '{}'; falling back to heuristic", setCode, error)
+            null
+        }
+        val build = result?.builds?.getOrNull(result.recommended)
+        if (build != null && build.deckList.isNotEmpty()) return build.deckList
+
+        if (result != null) {
+            logger.warn("Draftsim produced no build for set '{}'; falling back to heuristic", setCode)
+        }
+        return buildHeuristicSealedDeck(pool)
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(SealedDeckGenerator::class.java)
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
@@ -77,7 +77,12 @@ class SealedDeckGeneratorTest : FunSpec({
         )
 
         shouldNotThrowAny {
-            repeat(200) { gen.generate(gen.randomSetCode()) }
+            repeat(200) {
+                // The Draftsim autobuilder path (or its heuristic fallback) must always yield a
+                // complete 40-card sealed deck. A synthetic set has no Draftsim ratings file, so this
+                // also exercises the rarity-ladder fallback inside the builder.
+                gen.generate(gen.randomSetCode()).values.sum() shouldBe 40
+            }
         }
     }
 

--- a/gym/build.gradle.kts
+++ b/gym/build.gradle.kts
@@ -10,6 +10,11 @@ dependencies {
     implementation(project(":ai"))
 
     implementation(libs.bundles.kotlinxEcosystem)
+    // :ai's deck generation (SealedDeckGenerator → Draftsim autobuilder) logs via slf4j. We don't
+    // compile against it — the dependency is transitive — but the API must be on the runtime
+    // classpath, which propagates to non-Spring consumers like :gym-trainer. Spring consumers
+    // (:gym-server) already supply a binding.
+    runtimeOnly(libs.slf4jApi)
 
     testImplementation(project(":mtg-sets"))
     testImplementation(libs.kotestRunner)


### PR DESCRIPTION
## What

Quick Game's **automatic** deckbuilding now uses Draftsim data, as it should have.

### The gap

Quick Game and AI-opponent decks are generated by `SealedDeckGenerator`, which ran the opened pool straight through `buildHeuristicSealedDeck` — the two-color + mana-curve heuristic, with real 17Lands ratings available only for BLB and pure heuristics for everything else.

Meanwhile the richer **Draftsim autobuilder** (`DraftsimDeckBuildAdvisor` → `DraftsimDeckBuilder`) — archetype-aware, ratings/removal-driven, with vendored per-set tables for ~46 sets — was wired into the interactive **"Auto-build"** button but *never* into automatic generation. So a human clicking Auto-build got Draftsim quality; a Quick Game / AI opponent did not.

### The change

Route `SealedDeckGenerator.generate(setCode)` through `DraftsimDeckBuildAdvisor.buildDeck(...)`, scoped to the opened set so it loads that set's ratings/removal/archetype tables and returns the recommended 23-nonland + 17-land build. Basics still come out by name and are distributed across art variants exactly as before.

- Sets **without** a Draftsim ratings file still build — the Draftsim scorer falls back to its rarity ladder.
- The existing `buildHeuristicSealedDeck` stays as a **safety net**: used only if Draftsim throws or returns no build (logged).

This covers every automatic path that goes through `SealedDeckGenerator`: the Quick Game random pool, AI opponents (`AiGameManager`), and AI-vs-AI games (`GamePlayHandler`).

Out of scope: the tournament-lobby AI deckbuild (`LobbyHandler.buildAiSealedDeck`, which has its own LLM path) and the interactive Auto-build UI (already offers Draftsim).

## Tests

- `SealedDeckGeneratorTest` — existing no-throw guard strengthened to assert the new path (Draftsim or its fallback) always yields a complete **40-card** deck, including the rarity-ladder fallback on synthetic sets with no Draftsim file.
- Full `ai` advisor + draftsim suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)