### PR TITLE
OTJ cards: Patient Naturalist, Outcaster Greenblade, Spinewoods Armadillo, Prickly Pair

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutcasterGreenblade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutcasterGreenblade.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Outcaster Greenblade
+ * {2}{G}
+ * Creature — Human Mercenary
+ * 1/2
+ *
+ * When this creature enters, search your library for a basic land card or a Desert card,
+ * reveal it, put it into your hand, then shuffle.
+ * This creature gets +1/+1 for each Desert you control.
+ *
+ * The static self-buff is a [GrantDynamicStatsEffect] whose bonus counts Deserts you control;
+ * the count is read through projected state so it updates live as Deserts enter/leave.
+ */
+val OutcasterGreenblade = card("Outcaster Greenblade") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Mercenary"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, search your library for a basic land card or a " +
+        "Desert card, reveal it, put it into your hand, then shuffle.\nThis creature gets +1/+1 " +
+        "for each Desert you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand or GameObjectFilter.Land.withSubtype(Subtype.DESERT),
+            destination = SearchDestination.HAND,
+            reveal = true,
+            shuffleAfter = true
+        )
+    }
+
+    staticAbility {
+        val deserts = DynamicAmount.Count(
+            player = Player.You,
+            zone = Zone.BATTLEFIELD,
+            filter = GameObjectFilter.Land.withSubtype(Subtype.DESERT)
+        )
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = deserts,
+            toughnessBonus = deserts
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "172"
+        artist = "Josu Hernaiz"
+        flavorText = "In the shade of his sword, the desert blooms."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg?1712355958"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PatientNaturalist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PatientNaturalist.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Patient Naturalist
+ * {2}{G}
+ * Creature — Human Scout
+ * 2/3
+ *
+ * When this creature enters, mill three cards. Put a land card from among the milled cards
+ * into your hand. If you can't, create a Treasure token.
+ *
+ * Modeled as an inline Gather → Move (mill) → partition pipeline: the top three cards go to
+ * the graveyard, the milled collection is partitioned on `Land`, and the land partition is
+ * what's offered to hand. If no land was among the milled cards (`ifNotEmpty` on the land
+ * partition is empty), a Treasure is created instead — matching "if you can't, create a
+ * Treasure token." The gathered collection tracks entity refs, so selecting from it after
+ * the mill move still points at exactly those three cards now in the graveyard.
+ */
+val PatientNaturalist = card("Patient Naturalist") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, mill three cards. Put a land card from among the " +
+        "milled cards into your hand. If you can't, create a Treasure token. (To mill three " +
+        "cards, put the top three cards of your library into your graveyard.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Pipeline {
+            val milled = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(3), Player.You))
+            toGraveyard(milled)
+            ifNotEmpty(milled, filter = GameObjectFilter.Land) {
+                val lands = filter(milled, GameObjectFilter.Land)
+                val chosen = chooseExactly(1, from = lands)
+                toHand(chosen)
+            } orElse {
+                run(Effects.CreateTreasure(1))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Inka Schulz"
+        flavorText = "The Atiin delight in delving into the unique wonders of each world they visit."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg?1712355965"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PricklyPair.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PricklyPair.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Prickly Pair
+ * {2}{R}
+ * Creature — Plant Mercenary
+ * 2/2
+ *
+ * When this creature enters, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *
+ * The created token is the standard OTJ Mercenary token (same one made by Mourner's Surprise):
+ * a sorcery-speed [TimingRule.SorcerySpeed] tap ability that pumps a creature you control +1/+0.
+ */
+val PricklyPair = card("Prickly Pair") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Plant Mercenary"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Brian Valeza"
+        flavorText = "They grew together, awoke together, and took up arms together. If they were going to fall, they'd do that together too."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg?1712355809"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SpinewoodsArmadillo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SpinewoodsArmadillo.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Spinewoods Armadillo
+ * {4}{G}{G}
+ * Creature — Armadillo
+ * 7/7
+ *
+ * Reach
+ * Ward {3}
+ * {1}{G}, Discard this card: Search your library for a basic land card or a Desert card,
+ * reveal it, put it into your hand, then shuffle. You gain 3 life.
+ *
+ * The last ability functions from hand: its cost discards this card ([Costs.DiscardSelf]) and
+ * it's activated from the hand zone ([activateFromZone] = [Zone.HAND]), so it reads as a
+ * land-fetch you can use when this fatty is stranded in hand.
+ */
+val SpinewoodsArmadillo = card("Spinewoods Armadillo") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Armadillo"
+    power = 7
+    toughness = 7
+    oracleText = "Reach\nWard {3} (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player pays {3}.)\n{1}{G}, Discard " +
+        "this card: Search your library for a basic land card or a Desert card, reveal it, put it " +
+        "into your hand, then shuffle. You gain 3 life."
+
+    keywords(Keyword.REACH)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{3}")))
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand or GameObjectFilter.Land.withSubtype(Subtype.DESERT),
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            ),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "Iris Compiet"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg?1712356001"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3915,6 +3915,115 @@
     "colorIdentityOverride": []
 }
 
+// Outcaster Greenblade
+{
+    "name": "Outcaster Greenblade",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "When this creature enters, search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle.\nThis creature gets +1/+1 for each Desert you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                "IsBasicLand",
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsLand",
+                                                        {
+                                                            "type": "HasSubtype",
+                                                            "subtype": "Desert"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Desert"
+                },
+                "toughnessBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Desert"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "In the shade of his sword, the desert blooms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg?1712355958"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Outcaster Trailblazer
 {
     "name": "Outcaster Trailblazer",
@@ -4016,6 +4125,105 @@
     ]
 }
 
+// Patient Naturalist
+{
+    "name": "Patient Naturalist",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "When this creature enters, mill three cards. Put a land card from among the milled cards into your hand. If you can't, create a Treasure token. (To mill three cards, put the top three cards of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "gathered0",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "FilterCollection",
+                                        "from": "gathered0",
+                                        "filter": {
+                                            "type": "MatchesFilter",
+                                            "filter": "land"
+                                        },
+                                        "storeMatching": "matching3"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "matching3",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected4"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "selected4",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        }
+                                    }
+                                ]
+                            },
+                            "ifEmpty": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            },
+                            "filter": "land"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Inka Schulz",
+        "flavorText": "The Atiin delight in delving into the unique wonders of each world they visit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg?1712355965"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pillage the Bog
 {
     "name": "Pillage the Bog",
@@ -4096,6 +4304,80 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Prickly Pair
+{
+    "name": "Prickly Pair",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Plant Mercenary",
+    "oracleText": "When this creature enters, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Brian Valeza",
+        "flavorText": "They grew together, awoke together, and took up arms together. If they were going to fall, they'd do that together too.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg?1712355809"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5284,6 +5566,128 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Spinewoods Armadillo
+{
+    "name": "Spinewoods Armadillo",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Armadillo",
+    "oracleText": "Reach\nWard {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\n{1}{G}, Discard this card: Search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "REACH",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{3}"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "Or",
+                                                    "predicates": [
+                                                        "IsBasicLand",
+                                                        {
+                                                            "type": "And",
+                                                            "predicates": [
+                                                                "IsLand",
+                                                                {
+                                                                    "type": "HasSubtype",
+                                                                    "subtype": "Desert"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary"
+                            ]
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "activateFromZone": "Hand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "Iris Compiet",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg?1712356001"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -15,6 +15,10 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("TriggerOnceEachTurn", "envelope: triggered ability that triggers only once each turn")
     envelope("Activated", "envelope: activated ability")
     envelope("ActivatedWithModifiers", "envelope: activated ability")
+    // Zone-scoped activated abilities: the inner Activated rule carries the real capability; the
+    // wrapper only sets the ability's `activateFromZone` (Zone.HAND / Zone.GRAVEYARD).
+    envelope("FromHand", "envelope: activated ability used from hand (activateFromZone = Zone.HAND)")
+    envelope("FromGraveyard", "envelope: activated ability used from graveyard (activateFromZone = Zone.GRAVEYARD)")
     envelope("And", "envelope: cost/action conjunction")
     envelope("If", "conditional envelope")
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1043,6 +1043,20 @@ internal fun EmitCtx.fromGraveyardBlock(rule: JsonObject): List<Stmt>? {
     }
 }
 
+/**
+ * `FromHand[Activated]` -> an `activatedAbility { … }` whose `activateFromZone = Zone.HAND` ("{cost},
+ * Discard this card: …", Spinewoods Armadillo's land-fetch). The same shape as [fromGraveyardBlock] but
+ * scoped to the hand zone; the self-discard cost renders via [abilityCostDsl]'s `DiscardCard`/
+ * `Costs.DiscardSelf` case. Only a plain Activated inner renders; anything else scaffolds.
+ */
+internal fun EmitCtx.fromHandBlock(rule: JsonObject): List<Stmt>? {
+    val inner = rule["args"] as? JsonObject
+    return when (inner?.strField("_Rule")) {
+        "Activated", "ActivatedWithModifiers" -> activatedBlock(inner, activateFromZone = "Zone.HAND")
+        else -> { reasons.add("FromHand"); return null }
+    }
+}
+
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
 internal fun EmitCtx.activatedBlock(rule: JsonObject, activateFromZone: String? = null): List<Stmt>? {
     val args = rule["args"].asArr
@@ -1169,6 +1183,11 @@ internal fun EmitCtx.abilityCostDsl(node: JsonElement?): String? {
         // (ManaCostX -> "{X}") as the mana cost (Silklash Spider).
         "PayManaX" -> renderMana((obj["args"].asArr)?.getOrNull(0)).ifEmpty { null }?.let { "Costs.Mana(\"$it\")" }
         "DiscardACard" -> "Costs.DiscardCard"  // "Discard a card" (Patchwork Gnomes)
+        // "Discard this card" — the self-discard cost of a from-hand activated ability (Spinewoods
+        // Armadillo's land-fetch). Only the ThisCardInHand subject maps to Costs.DiscardSelf; any other
+        // discarded card declines so we never render a self-discard as a generic one.
+        "DiscardCard" ->
+            if (jsonContains(obj.field("args"), "_CardInHand", "ThisCardInHand")) "Costs.DiscardSelf" else null
         "DiscardHand" -> "Costs.DiscardHand"  // "Discard your hand" (Slate of Ancestry)
         // "Discard a card at random" — a fixed, no-choice cost (the engine picks): Costs.DiscardAtRandom(1).
         // It carries no value selection / X / inherited choice, so it is safe to render exactly (Canyon Drake).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -151,6 +151,7 @@ object Emitter {
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
+                rname == "FromHand" -> block = ctx.fromHandBlock(rule)
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.firstArgWordTagged
 import com.wingedsheep.tooling.coverage.firstWordAtKey
 import com.wingedsheep.tooling.coverage.hasTag
@@ -155,6 +156,63 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
 private fun EmitCtx.scaffoldLord(): List<Stmt>? { reasons.add("EachPermanentLayerEffect"); return null }
 
 /**
+ * A self-buff `PermanentLayerEffect(ThisPermanent, [AdjustPTForEach])` -> one
+ * `staticAbility { ability = GrantDynamicStatsEffect(filter = GroupFilter.source(), powerBonus = …,
+ * toughnessBonus = …) }`. `AdjustPTForEach`'s args are `[powerMult, toughnessMult, countNode]`:
+ * "this creature gets +powerMult/+toughnessMult for each [countNode]". The per-permanent count is
+ * rendered as a resolution-time `DynamicAmount.Count` over the You battlefield with the recovered
+ * filter (matching the `Count(Player.You, Zone.BATTLEFIELD, …)` convention used by hand-authored
+ * "for each [type] you control" cards, e.g. Desert's Due). A multiplier other than 1 wraps the count
+ * in `DynamicAmount.Multiply`.
+ *
+ * Only the You-controlled-battlefield count shape renders; any other count scope, a non-AdjustPTForEach
+ * layer effect, or a filter the count path can't express exactly returns null so the card scaffolds
+ * rather than emit a wrong buff. ("Crusading Knight" — Swamps your *opponents* control — therefore still
+ * scaffolds here; the You case is the common Outlaws Desert pattern.)
+ */
+private fun EmitCtx.selfDynamicStatsBlock(rule: JsonObject): List<Stmt>? {
+    val args = rule["args"] as? JsonArray ?: return null
+    val layerEffects = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (layerEffects.isEmpty()) return null
+    val stmts = mutableListOf<Stmt>()
+    for (le in layerEffects) {
+        if (le.strField("_StaticLayerEffect") != "AdjustPTForEach") return null
+        val pt = le["args"] as? JsonArray ?: return null
+        if (pt.size != 3) return null
+        val powerMult = pt[0].asInt() ?: return null
+        val toughnessMult = pt[1].asInt() ?: return null
+        // The count must be a You-controlled battlefield tally; decline anything else (opponent /
+        // each-player scope, or a filter the count path widens) so we never misrender the buff.
+        val countNode = pt[2] as? JsonObject ?: return null
+        if (countNode.strField("_GameNumber") != "TheNumberOfPermanentsOnTheBattlefield") return null
+        if (!jsonContains(countNode, "_Player", "You")) return null
+        // Reject the predicates the land/type count filter path can't render faithfully (it silently
+        // widens to GameObjectFilter.Any) — mirror dynamicAmountExpr's guards.
+        val blob = compact(countNode)
+        if ("IsArtifactType" in blob || "SharesACreatureTypeWithPermanent" in blob) return null
+        if (countNode.firstArgWordTagged("IsEnchantmentType") != null &&
+            countNode.firstArgWordTagged("IsCreatureType") == null) return null
+        val subtype = countNode.firstArgWordTagged("IsCreatureType")
+        val filter = if (subtype != null) Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$subtype\""))
+                     else landSearchFilterExpr(countNode)
+        val count: Dsl = call("DynamicAmount.Count", arg("Player.You"), arg("Zone.BATTLEFIELD"), arg(filter))
+        fun bonus(mult: Int): Dsl =
+            if (mult == 1) count else call("DynamicAmount.Multiply", arg(count), arg("$mult"))
+        stmts.add(
+            staticAbilityStmt(
+                call(
+                    "GrantDynamicStatsEffect",
+                    arg("filter", call("GroupFilter.source")),
+                    arg("powerBonus", bonus(powerMult)),
+                    arg("toughnessBonus", bonus(toughnessMult)),
+                )
+            )
+        )
+    }
+    return stmts
+}
+
+/**
  * An `Activated` / `ActivatedWithModifiers` rule granted to a group ("All Slivers have '{cost}: …'") ->
  * an `ActivatedAbility(id = AbilityId.generate(), cost = …, [timing = …], effect = …, [targetRequirement
  * = …])` constructor expression for wrapping in `GrantActivatedAbility`. Reuses the same cost / target /
@@ -250,6 +308,13 @@ private fun auraYouControlTarget(filter: JsonObject): String? {
  */
 internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"] as? JsonArray
+    // "This creature gets +X/+Y for each [permanents you control]" (Outcaster Greenblade, Crusading
+    // Knight): a self-targeting layer effect whose subject is ThisPermanent, not an aura's host. Route
+    // to the dynamic self-buff renderer; only the AdjustPTForEach shape renders there, everything else
+    // falls through to the scaffold below.
+    if (jsonContains(args?.getOrNull(0), "_Permanent", "ThisPermanent")) {
+        selfDynamicStatsBlock(rule)?.let { return it }
+    }
     if (args == null || !jsonContains(args.getOrNull(0), "_Permanent", "HostPermanent")) {
         reasons.add("PermanentLayerEffect"); return null
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutcasterGreenbladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutcasterGreenbladeScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Outcaster Greenblade (OTJ #172) — {2}{G} 1/2 Creature — Human Mercenary.
+ *
+ * "When this creature enters, search your library for a basic land card or a Desert card,
+ *  reveal it, put it into your hand, then shuffle.
+ *  This creature gets +1/+1 for each Desert you control."
+ *
+ * Verifies the basic-or-Desert library search ETB and the live Desert-counting self-buff.
+ */
+class OutcasterGreenbladeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("ETB searches for a basic land or Desert and puts it into hand") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val forest = driver.putCardOnTopOfLibrary(player, "Forest")
+        val desert = driver.putCardOnTopOfLibrary(player, "Eroded Canyon") // Land — Desert
+
+        val greenblade = driver.putCardInHand(player, "Outcaster Greenblade")
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.castSpell(player, greenblade).isSuccess shouldBe true
+        // Resolve the creature spell, then its ETB trigger (which pauses for the search).
+        var guard = 0
+        while (driver.stackSize > 0 && !driver.isPaused && guard++ < 10) driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Both the basic land and the Desert are eligible.
+        decision.options.toSet() shouldBe setOf(forest, desert)
+        driver.submitCardSelection(player, listOf(desert))
+        driver.isPaused shouldBe false
+
+        driver.getHand(player).contains(desert) shouldBe true
+    }
+
+    test("gets +1/+1 for each Desert you control") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val greenblade = driver.putCreatureOnBattlefield(player, "Outcaster Greenblade")
+
+        // Base 1/2 with no Deserts.
+        projector.getProjectedPower(driver.state, greenblade) shouldBe 1
+        projector.getProjectedToughness(driver.state, greenblade) shouldBe 2
+
+        driver.putPermanentOnBattlefield(player, "Eroded Canyon")
+        projector.getProjectedPower(driver.state, greenblade) shouldBe 2
+        projector.getProjectedToughness(driver.state, greenblade) shouldBe 3
+
+        driver.putPermanentOnBattlefield(player, "Festering Gulch")
+        projector.getProjectedPower(driver.state, greenblade) shouldBe 3
+        projector.getProjectedToughness(driver.state, greenblade) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatientNaturalistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatientNaturalistScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Patient Naturalist (OTJ #174) — {2}{G} 2/3 Creature.
+ *
+ * "When this creature enters, mill three cards. Put a land card from among the milled cards
+ *  into your hand. If you can't, create a Treasure token."
+ *
+ * Verifies: top three cards are milled to the graveyard; a land among them is chosen and put
+ * into hand; when no land was milled, a Treasure token is created instead.
+ */
+class PatientNaturalistScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.Treasure)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("mills three, puts a land into hand from among them") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Top three (topmost is the last put): two nonland, one Forest.
+        val bears1 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val forest = driver.putCardOnTopOfLibrary(player, "Forest")
+        val bears2 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val naturalist = driver.putCardInHand(player, "Patient Naturalist")
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.castSpell(player, naturalist).isSuccess shouldBe true
+        var guard = 0
+        while (driver.stackSize > 0 && !driver.isPaused && guard++ < 10) driver.bothPass()
+
+        // Exactly one land was milled → it's auto-chosen (single option) and put into hand.
+        if (driver.isPaused) {
+            val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            decision.options shouldBe listOf(forest)
+            driver.submitCardSelection(player, listOf(forest))
+        }
+
+        val hand = driver.getHand(player)
+        hand.contains(forest) shouldBe true
+        val graveyard = driver.getGraveyard(player)
+        graveyard.contains(bears1) shouldBe true
+        graveyard.contains(bears2) shouldBe true
+        // The land went to hand, not the graveyard.
+        graveyard.contains(forest) shouldBe false
+    }
+
+    test("creates a Treasure token when no land was milled") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Top three are all nonland creatures — no land to put into hand.
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val naturalist = driver.putCardInHand(player, "Patient Naturalist")
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.castSpell(player, naturalist).isSuccess shouldBe true
+        var guard = 0
+        while (driver.stackSize > 0 && !driver.isPaused && guard++ < 10) driver.bothPass()
+
+        driver.isPaused shouldBe false
+
+        val battlefield = driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))
+        val treasures = battlefield.count { id ->
+            driver.getCardName(id)?.equals("Treasure", ignoreCase = true) == true
+        }
+        treasures shouldBe 1
+
+        // All three milled cards are in the graveyard.
+        driver.getGraveyard(player).size shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PricklyPairScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PricklyPairScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Prickly Pair (OTJ #137) — {2}{R} 2/2 Creature — Plant Mercenary.
+ *
+ * "When this creature enters, create a 1/1 red Mercenary creature token with
+ *  '{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.'"
+ *
+ * Verifies the ETB makes a single 1/1 red Mercenary token carrying the granted activated ability.
+ */
+class PricklyPairScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    test("ETB creates a 1/1 red Mercenary token with an activated ability") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tokensBefore = driver.state.getBattlefield().filter {
+            val e = driver.state.getEntity(it)
+            e?.has<TokenComponent>() == true &&
+                e.get<ControllerComponent>()?.playerId == player
+        }.toSet()
+
+        val pair = driver.putCardInHand(player, "Prickly Pair")
+        driver.giveMana(player, Color.RED, 3)
+        driver.castSpell(player, pair).isSuccess shouldBe true
+        // Resolve the creature spell, then its ETB trigger.
+        var guard = 0
+        while (driver.stackSize > 0 && !driver.isPaused && guard++ < 10) driver.bothPass()
+
+        val newTokens = driver.state.getBattlefield().filter {
+            val e = driver.state.getEntity(it)
+            e?.has<TokenComponent>() == true &&
+                e.get<ControllerComponent>()?.playerId == player
+        }.toSet() - tokensBefore
+
+        newTokens.size shouldBe 1
+        val token = newTokens.first()
+        projector.getProjectedPower(driver.state, token) shouldBe 1
+        projector.getProjectedToughness(driver.state, token) shouldBe 1
+
+        val card = driver.state.getEntity(token)!!.get<CardComponent>()!!
+        card.colors shouldBe setOf(Color.RED)
+        card.typeLine.subtypes.map { it.value }.contains("Mercenary") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinewoodsArmadilloScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinewoodsArmadilloScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SpinewoodsArmadillo
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Spinewoods Armadillo (OTJ #182) — {4}{G}{G} 7/7 Creature — Armadillo.
+ *
+ * "Reach
+ *  Ward {3}
+ *  {1}{G}, Discard this card: Search your library for a basic land card or a Desert card,
+ *  reveal it, put it into your hand, then shuffle. You gain 3 life."
+ *
+ * Exercises the from-hand activated ability: paying {1}{G} and discarding this card fetches a
+ * basic/Desert land into hand and gains 3 life. (Reach/Ward are the named keywords.)
+ */
+class SpinewoodsArmadilloScenarioTest : FunSpec({
+
+    val abilityId = SpinewoodsArmadillo.activatedAbilities.first().id
+
+    test("from-hand ability fetches a land into hand and gains 3 life, discarding this card") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putCardOnTopOfLibrary(player, "Forest")
+        val armadillo = driver.putCardInHand(player, "Spinewoods Armadillo")
+        driver.giveMana(player, Color.GREEN, 2)
+
+        val lifeBefore = driver.state.getEntity(player)!!.get<LifeTotalComponent>()!!.life
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = armadillo, abilityId = abilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Search decision for the basic land.
+        if (driver.isPaused) {
+            val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            decision.options.contains(forest) shouldBe true
+            driver.submitCardSelection(player, listOf(forest))
+        }
+        driver.isPaused shouldBe false
+
+        // Armadillo was discarded (no longer in hand), land is now in hand, +3 life.
+        driver.getHand(player).contains(armadillo) shouldBe false
+        driver.getGraveyard(player).contains(armadillo) shouldBe true
+        driver.getHand(player).contains(forest) shouldBe true
+        driver.state.getEntity(player)!!.get<LifeTotalComponent>()!!.life shouldBe lifeBefore + 3
+    }
+})


### PR DESCRIPTION
Implements four Outlaws of Thunder Junction cards (all canonical OTJ printings) and teaches the mtgish emitter to auto-generate two of them.

## Cards
- **Patient Naturalist** ({2}{G} 2/3) — ETB mill three; put a land card from among the milled cards into hand, else create a Treasure token. Modeled as an inline `Effects.Pipeline { }` (Gather top 3 → mill to graveyard → partition on `Land`) with the Treasure fallback gated on whether a land was milled.
- **Outcaster Greenblade** ({2}{G} 1/2) — ETB search for a basic land or Desert card to hand; static "+1/+1 for each Desert you control" via `GrantDynamicStatsEffect(GroupFilter.source(), DynamicAmount.Count(You, BATTLEFIELD, Land Desert))`.
- **Spinewoods Armadillo** ({4}{G}{G} 7/7) — Reach, Ward {3}, and a from-hand activated ability `{1}{G}, Discard this card:` that tutors a basic/Desert land into hand and gains 3 life (`activateFromZone = Zone.HAND`, `Costs.DiscardSelf`).
- **Prickly Pair** ({2}{R} 2/2) — ETB creates the standard OTJ 1/1 red Mercenary token with its sorcery-speed `{T}: +1/+0` pump.

Scenario tests in `rules-engine` cover each card: the search filters, the Treasure fallback, the live Desert lord, the from-hand discard-self tutor, and the Mercenary token.

## mtgish-tooling changes
Two of the cards were SCAFFOLD-tier; taught the emitter to render them whole (Patient Naturalist's `MustCost(PutACardOfTypeMilledThisWayIntoHand)` + `Unless(CostWasPaid)` shape is genuinely card-specific extra-cost territory, so it's left as SCAFFOLD per the fidelity policy):
- **StaticAbilities.kt** — `PermanentLayerEffect(ThisPermanent, AdjustPTForEach)` self-buff → `GrantDynamicStatsEffect` with a `DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, filter)` count (the generic "+X/+Y for each [you control]" lord shape; opponent/each-player scopes and unrenderable filters still decline).
- **CardStructure.kt** — `FromHand[Activated]` envelope → `activatedAbility` with `activateFromZone = Zone.HAND`; `DiscardCard(ThisCardInHand)` cost → `Costs.DiscardSelf`.
- **bridge/Envelopes.kt** — `FromHand` / `FromGraveyard` envelopes so the probe scores zone-scoped activated abilities as coverable.

## Verification
- `coverage-verify POR`: **GATE PASS, 0 mismatch** (158/158) — no regression.
- `coverage-verify OTJ`: Outcaster Greenblade and Spinewoods Armadillo are now auto-emitted and gameplay-tree match; Patient Naturalist correctly remains SCAFFOLD. No new mismatches introduced — OTJ's remaining mismatches are pre-existing, unrelated cards (descriptionOverride / filter shapes).
- `EmitterGoldenTest` (POR/EOE), `CardDefinitionSnapshotTest`, `CardLintTest`, and the four scenario tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)