### PR TITLE
Multiplayer Phase 0: kill the single-opponent context

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiOpponent.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiOpponent.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The single opponent of [playerId], for the built-in AI's 1v1 model.
+ *
+ * The AI is deliberately two-player only: board evaluation is a me-minus-opponent
+ * differential, search models exactly one responding opponent, and the advisors
+ * reason about "the" opponent. Multiplayer pods launch without AI seats; making the
+ * AI pod-competent is its own project (see `backlog/multiplayer.md`, "AI pod
+ * players"). Engine code must never use this — it resolves opponents via targets,
+ * iteration, or the per-creature defending player.
+ */
+internal fun GameState.soleOpponent(playerId: EntityId): EntityId? =
+    getOpponents(playerId).firstOrNull()

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -57,7 +57,7 @@ class CombatAdvisor(
             return DeclareAttackers(playerId, emptyMap())
         }
 
-        val opponentId = state.getOpponent(playerId) ?: defendingPlayers.first()
+        val opponentId = state.soleOpponent(playerId) ?: defendingPlayers.first()
         val opponentLife = state.getEntity(opponentId)?.get<LifeTotalComponent>()?.life ?: 20
         val opponentCreatures = CombatMath.getOpponentUntappedCreatures(state, projected, opponentId)
         val mandatory = legalAction.mandatoryAttackers ?: emptyList()
@@ -776,7 +776,7 @@ class CombatAdvisor(
         val baseScore = evaluator.evaluate(current, postProjected, playerId)
 
         // Estimate our next-turn attack potential: what damage can we push through?
-        val opponentId = state.getOpponent(playerId) ?: return baseScore
+        val opponentId = state.soleOpponent(playerId) ?: return baseScore
         val myAttackers = CombatMath.getCreaturesThatCanAttack(current, postProjected, playerId)
         val opponentBlockers = CombatMath.getOpponentUntappedCreatures(current, postProjected, opponentId)
         val ourDamageThrough = if (myAttackers.isNotEmpty()) {
@@ -820,7 +820,7 @@ class CombatAdvisor(
 
         // Next-turn check: after taking this damage, would opponent's next attack kill us?
         val lifeAfter = myLife - incomingDamage
-        val opponentId = state.getOpponent(playerId) ?: return false
+        val opponentId = state.soleOpponent(playerId) ?: return false
 
         // Our blockers next turn: untapped creatures that aren't currently assigned to block
         // (conservatively — some may die in this combat, but this is a fast heuristic)

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -159,7 +159,7 @@ class DecisionResponder(
         }
 
         // Players — prefer opponent
-        val isOpponent = targetId == state.getOpponent(playerId)
+        val isOpponent = targetId == state.soleOpponent(playerId)
         if (isOpponent) return 3.0
 
         return 0.0
@@ -301,7 +301,7 @@ class DecisionResponder(
         playerId: EntityId
     ): DecisionResponse {
         val projected = state.projectedState
-        val opponentId = state.getOpponent(playerId)
+        val opponentId = state.soleOpponent(playerId)
 
         val distribution = mutableMapOf<EntityId, Int>()
         var remaining = decision.totalAmount

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Searcher.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Searcher.kt
@@ -62,7 +62,7 @@ class Searcher(
         }
 
         // Depth 2+: model opponent's response
-        val opponentId = state.getOpponent(playerId) ?: return evaluator.evaluate(resultState, resultState.projectedState, playerId)
+        val opponentId = state.soleOpponent(playerId) ?: return evaluator.evaluate(resultState, resultState.projectedState, playerId)
 
         // Check if opponent can actually respond
         if (!canRespond(resultState, opponentId)) {
@@ -185,7 +185,7 @@ class Searcher(
             val score = if (remainingDepth <= 1 || nodesSearched >= config.maxNodes) {
                 evaluator.evaluate(result.state, result.state.projectedState, aiPlayerId)
             } else {
-                val opponentId = state.getOpponent(aiPlayerId)
+                val opponentId = state.soleOpponent(aiPlayerId)
                 if (opponentId != null && canRespond(result.state, opponentId)) {
                     opponentPly(result.state, aiPlayerId, opponentId, remainingDepth - 1, currentAlpha, beta)
                 } else {
@@ -266,7 +266,7 @@ class Searcher(
     ): Int {
         if (scoredCandidates.size <= 1) return 1
 
-        val opponentId = state.getOpponent(playerId)
+        val opponentId = state.soleOpponent(playerId)
 
         // Can opponent even respond? If not, deeper search is pointless.
         if (opponentId == null || !canRespond(state, opponentId)) return 1

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.ai.engine.evaluation.BoardPresence
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.ai.engine.soleOpponent
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.sdk.core.Keyword
@@ -85,7 +86,7 @@ private fun handSize(state: GameState, playerId: EntityId): Int =
  * is devastating; giving one to an opponent with 5+ cards barely matters.
  */
 private fun giftPenalty(state: GameState, playerId: EntityId): Double {
-    val opponentId = state.getOpponent(playerId) ?: return 1.5
+    val opponentId = state.soleOpponent(playerId) ?: return 1.5
     val oppHand = handSize(state, opponentId)
     return when {
         oppHand == 0 -> 4.0   // hellbent opponent — huge cost to give them a card
@@ -376,7 +377,7 @@ object BoardWipeAdvisor : CardAdvisor {
     override fun evaluateCast(context: CastContext): Double? {
         val state = context.state
         val playerId = context.playerId
-        val opponentId = state.getOpponent(playerId) ?: return null
+        val opponentId = state.soleOpponent(playerId) ?: return null
         val projected = context.projected
 
         val myBoardValue = creatureBoardValue(state, projected, playerId)
@@ -424,7 +425,7 @@ object GiftRemovalAdvisor : CardAdvisor {
         // For Parting Gust: permanent exile (gift) is almost always better
         // than temporary exile (base), unless opponent is hellbent
         if (context.sourceCardName == "Parting Gust") {
-            val opponentId = state.getOpponent(playerId) ?: return null
+            val opponentId = state.soleOpponent(playerId) ?: return null
             val oppHand = handSize(state, opponentId)
             if (oppHand == 0) {
                 // Don't give a hellbent opponent a card for marginal upside
@@ -437,7 +438,7 @@ object GiftRemovalAdvisor : CardAdvisor {
         // Consider both life and opponent hand
         if (context.sourceCardName == "Nocturnal Hunger") {
             val myLife = lifeTotal(state, playerId)
-            val opponentId = state.getOpponent(playerId) ?: return null
+            val opponentId = state.soleOpponent(playerId) ?: return null
             val oppHand = handSize(state, opponentId)
 
             val preferGift = when {

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/OnslaughtAdvisorModule.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/OnslaughtAdvisorModule.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.ai.engine.advisor.modules
 import com.wingedsheep.ai.engine.advisor.*
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.ai.engine.soleOpponent
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -48,7 +49,7 @@ object GoblinSharpshooterAdvisor : CardAdvisor {
         // This fires for the activated ability ({T}: deal 1 damage)
         val state = context.state
         val playerId = context.playerId
-        val opponentId = state.getOpponent(playerId) ?: return null
+        val opponentId = state.soleOpponent(playerId) ?: return null
 
         val projected = context.projected
         val oppCreatures = projected.getBattlefieldControlledBy(opponentId)
@@ -81,7 +82,7 @@ object GoblinSharpshooterAdvisor : CardAdvisor {
 
         val state = context.state
         val playerId = context.playerId
-        val opponentId = state.getOpponent(playerId) ?: return null
+        val opponentId = state.soleOpponent(playerId) ?: return null
         val projected = context.projected
 
         // Priority 1: opponent creatures at exactly 1 remaining toughness (kills → untap → chain)

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.ai.engine.evaluation
 import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.ai.engine.soleOpponent
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -27,7 +28,7 @@ import com.wingedsheep.sdk.model.EntityId
  */
 object LifeDifferential : BoardFeature {
     override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
-        val opponentId = state.getOpponent(playerId) ?: return 0.0
+        val opponentId = state.soleOpponent(playerId) ?: return 0.0
         val myLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
         val theirLife = state.getEntity(opponentId)?.get<LifeTotalComponent>()?.life ?: 0
         return lifeValue(myLife) - lifeValue(theirLife)
@@ -53,7 +54,7 @@ object LifeDifferential : BoardFeature {
  */
 object BoardPresence : BoardFeature {
     override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
-        val opponentId = state.getOpponent(playerId) ?: return 0.0
+        val opponentId = state.soleOpponent(playerId) ?: return 0.0
         return boardValue(state, projected, playerId) - boardValue(state, projected, opponentId)
     }
 
@@ -216,7 +217,7 @@ object BoardPresence : BoardFeature {
  */
 object CardAdvantage : BoardFeature {
     override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
-        val opponentId = state.getOpponent(playerId) ?: return 0.0
+        val opponentId = state.soleOpponent(playerId) ?: return 0.0
         val myCards = state.getZone(playerId, Zone.HAND).size
         val theirCards = state.getZone(opponentId, Zone.HAND).size
         return cardValue(myCards) - cardValue(theirCards)
@@ -245,7 +246,7 @@ object CardAdvantage : BoardFeature {
  */
 object ThreatAssessment : BoardFeature {
     override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
-        val opponentId = state.getOpponent(playerId) ?: return 0.0
+        val opponentId = state.soleOpponent(playerId) ?: return 0.0
 
         val myLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 20
         val theirLife = state.getEntity(opponentId)?.get<LifeTotalComponent>()?.life ?: 20
@@ -346,7 +347,7 @@ object ThreatAssessment : BoardFeature {
  */
 object Tempo : BoardFeature {
     override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
-        val opponentId = state.getOpponent(playerId) ?: return 0.0
+        val opponentId = state.soleOpponent(playerId) ?: return 0.0
 
         val myLands = countLands(state, projected, playerId)
         val theirLands = countLands(state, projected, opponentId)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AdvisorBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AdvisorBenchmark.kt
@@ -287,7 +287,7 @@ private fun playAdvisorGame(
                                 val sim = GameSimulator(registry)
                                 val la = sim.getLegalActions(state, prioId).find { it.actionType == "DeclareAttackers" }
                                 val mandatory = la?.mandatoryAttackers ?: emptyList()
-                                val opponentId = state.turnOrder.firstOrNull { it != prioId }
+                                val opponentId = state.getOpponents(prioId).firstOrNull()
                                 DeclareAttackers(prioId, if (mandatory.isNotEmpty() && opponentId != null) mandatory.associateWith { opponentId } else emptyMap())
                             }
                             else -> PassPriority(prioId)

--- a/backlog/multiplayer.md
+++ b/backlog/multiplayer.md
@@ -164,7 +164,17 @@ layer, the client's "the opponent" rendering, and the AI.
 
 ---
 
-## Phase 0 — Kill the single-opponent context (engine groundwork, no behavior change)
+## Phase 0 — Kill the single-opponent context (engine groundwork, no behavior change) ✅
+
+**Status: landed.** `Player.Opponent` and `EffectContext.opponentId` are gone; `GameState.getOpponent`
+is replaced by `getOpponents(playerId)` (turn-order, excluding lost players) + `activePlayers`. New
+vocabulary: `Player.DefendingPlayer` (CR 802.2a, resolved from the source's attack assignment) and
+`Player.AnOpponent` (genuinely non-targeted "an opponent" chooser shapes only — Callous Oppressor,
+Risky Move; resolves to first opponent in turn order until the choose-an-opponent flow exists).
+Central single-player resolution lives in `TargetResolutionUtils.resolvePlayerRef`. The built-in AI
+keeps an explicitly 1v1 `soleOpponent` helper in the `ai` module. Verified by
+`MultiplayerSmokeTest` (4-player init, priority round-trip, turn cycle, EachOpponent fan-out,
+DefendingPlayer resolution).
 
 The riskiest work, done first, while everything is still verifiable against the existing 2-player test corpus.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -645,7 +645,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   - `target = CounterTarget.Spell` / `Ability` / `SpellOrAbility` — `SpellOrAbility` dispatches at resolution by inspecting whether the stack entity has a `SpellOnStackComponent`. Used by Teferi's Response.
   - `condition = CounterCondition.UnlessPaysMana(cost, onPaid?)` / `UnlessPaysDynamic(amount, onPaid?)` — "unless its controller pays …" with an optional `onPaid: Effect` rider that fires **only** when the spell's controller pays (Divert Disaster's "If they do, you create a Lander token"). The rider executes with the counter's controller as `controllerId`, so "you" in the rider resolves to the caster of the counter. The rider does not fire when the spell is countered. Facade: `Effects.CounterUnlessPays(cost, onPaid)` / `Effects.CounterUnlessDynamicPays(amount, exileOnCounter, onPaid)`.
 - `CounterAllOnStackEffect(filter?, destination?)` — counter everything matching.
-- `OpenLifeBid(onWin, participant = Player.Opponent)` — open life-bidding auction between you and `participant` (resolved against the effect context). You open at a bid of 1; the two bidders alternate topping the high bid (yes/no to top, then a number for the amount, capped at the bidder's life) until one passes. The high bidder loses that much life; `onWin` runs **only if you win**, with the original targets in context. If `participant` resolves to you (or to nobody), you're the sole bidder and win at the opening bid. For Mages' Contest, bid against the targeted spell's controller and counter it: `Effects.OpenLifeBid(Effects.CounterSpell(), Player.ControllerOf("target spell"))` — pair with a `TargetSpell` requirement.
+- `OpenLifeBid(onWin, participant = Player.AnOpponent)` — open life-bidding auction between you and `participant` (resolved against the effect context). You open at a bid of 1; the two bidders alternate topping the high bid (yes/no to top, then a number for the amount, capped at the bidder's life) until one passes. The high bidder loses that much life; `onWin` runs **only if you win**, with the original targets in context. If `participant` resolves to you (or to nobody), you're the sole bidder and win at the opening bid. For Mages' Contest, bid against the targeted spell's controller and counter it: `Effects.OpenLifeBid(Effects.CounterSpell(), Player.ControllerOf("target spell"))` — pair with a `TargetSpell` requirement.
 - `DestroySourceOfTargetedAbilityEffect` — when the targeted stack object is a permanent's activated/triggered ability, destroy that source permanent. Compose *before* the counter step so the ability component is still readable (Teferi's Response).
 - `CopyTargetSpellEffect(target)` — copy a spell on the stack.
 - `CopyTargetTriggeredAbilityEffect(target)` — copy a triggered ability on the stack.
@@ -1046,7 +1046,35 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `EffectTarget.Controller` — controller of the source ability.
 - `EffectTarget.Self` — the source permanent.
 - `EffectTarget.TriggeringEntity` — the entity that caused the trigger to fire.
-- `EffectTarget.PlayerRef(...)` — a player slot: `You`, `Each`, `Opponent`, etc.
+- `EffectTarget.PlayerRef(...)` — a player slot; see the `Player` reference list below.
+
+**`Player` references** (multiplayer-safe vocabulary — there is deliberately no bare
+`Player.Opponent`; every reference says *which* player it means):
+
+- `Player.You` — the controller of the ability/effect.
+- `Player.Each` — all players (active players only; lost players are skipped).
+- `Player.EachOpponent` — all of your opponents. Also the *matching* form for "an opponent"
+  in event filters (`SpellCastEvent(player = …)`), exists-conditions, and battlefield
+  aggregations ("creatures your opponents control").
+- `Player.ActivePlayerFirst` — all players in APNAP order.
+- `Player.TargetPlayer` / `Player.TargetOpponent` — the bound player target (resolved from the
+  chosen targets, never from turn order).
+- `Player.DefendingPlayer` — CR 802.2a: the player the ability's source is attacking, read from
+  the source's attack assignment (a creature attacking a planeswalker defends against its
+  controller); falls back to the trigger's damaged player as last-known information for "deals
+  combat damage to a player" triggers. Use for attack/combat-damage triggers ("defending player
+  mills four cards", "that player sacrifices a creature").
+- `Player.TriggeringPlayer` — the player bound by the trigger (the caster for `SpellCastEvent`,
+  the active player for per-player step triggers — "at the beginning of each opponent's upkeep,
+  *that player* …").
+- `Player.AnOpponent` — a genuinely non-targeted "an opponent" (a chooser: "an opponent chooses a
+  creature type"). Currently resolves to the first opponent in turn order; the proper multiplayer
+  choice flow is tracked in `backlog/multiplayer.md`. Do **not** use it where the text means
+  `TargetOpponent`, `EachOpponent`, `DefendingPlayer`, or `TriggeringPlayer`.
+- `Player.ChosenOpponent` — the opponent locked into the source's `ChoiceSlot.OPPONENT` slot.
+- `Player.ControllerOf(desc)` / `Player.OwnerOf(desc)` — controller/owner of the first chosen target.
+- `Player.ContextPlayer(i)` / `Player.Candidate` / `Player.Any` — positional target, CR 115
+  candidate during target-restriction evaluation, and "a player" matching.
 - `EffectTarget.ContextProperty(key)` — value plumbed into `EffectContext` (damage amount, life gained, blight
   amount, …).
 - `EnchantedCreature` / `EquippedCreature` — resolve via `AttachedToComponent`; requires the state-aware
@@ -1571,7 +1599,7 @@ in the repo today):
 
 - `YouDraw` — when you draw a card. Fires once per individual card drawn (CR 121.2), so a
   single "draw N" effect triggers it N times.
-- `OpponentDraws` — when an opponent draws a card (once per card; the `Player.Opponent` analogue
+- `OpponentDraws` — when an opponent draws a card (once per card; the `Player.EachOpponent` analogue
   of `YouDraw`).
 - `OpponentDrawsExceptFirstEachDrawStep` — whenever an opponent draws a card **except** the first
   card they draw in each of their own draw steps (CR 504.1's turn-based draw is exempt; every
@@ -1633,7 +1661,7 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   Celebrant). Backed by `EventPattern.AbilityActivatedEvent(player)`.
 
 **Other casters.** The same shape, scoped to a different caster via the runtime
-`Player.Each` / `Player.Opponent` matching on `SpellCastEvent`. Bind the payoff to the
+`Player.Each` / `Player.EachOpponent` matching on `SpellCastEvent`. Bind the payoff to the
 caster with `EffectTarget.PlayerRef(Player.TriggeringPlayer)`.
 
 - `AnyPlayerCastsSpell` — any player (including you) casts a spell.
@@ -3241,7 +3269,7 @@ replacementEffect {
   modification occurs before considering any of the individual card draws.") — so a paused-and-
   resumed per-card loop doesn't double-modify. Note that "you" in restriction text reads as the
   drawing player, not the source's controller; for `DrawEvent(player = Player.You)` they coincide,
-  but `DrawEvent(player = Player.Opponent)` cards needing "you" = source controller would have to
+  but `DrawEvent(player = Player.EachOpponent)` cards needing "you" = source controller would have to
   use a source-relative condition instead. Use for "if you would draw one or more cards, you draw
   that many cards plus N instead" (Quantum Riddler:
   `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -79,7 +79,7 @@ object Conditions {
      */
     val OpponentControlsMoreLands: ConditionInterface =
         Compare(
-            DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Land),
+            DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Land),
             ComparisonOperator.GT,
             DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land)
         )
@@ -89,7 +89,7 @@ object Conditions {
      */
     val OpponentControlsMoreCreatures: ConditionInterface =
         Compare(
-            DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
+            DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature),
             ComparisonOperator.GT,
             DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
         )
@@ -102,7 +102,7 @@ object Conditions {
         Compare(
             DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature),
             ComparisonOperator.GT,
-            DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature)
+            DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature)
         )
 
     /**
@@ -110,13 +110,13 @@ object Conditions {
      * Used for CantAttackUnless (e.g. Deep-Sea Serpent, Slipstream Eel).
      */
     fun OpponentControlsLandType(landType: String): ConditionInterface =
-        Exists(Player.Opponent, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype(landType))
+        Exists(Player.EachOpponent, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype(landType))
 
     /**
      * If an opponent controls a creature.
      */
     val OpponentControlsCreature: ConditionInterface =
-        Exists(Player.Opponent, Zone.BATTLEFIELD, GameObjectFilter.Creature)
+        Exists(Player.EachOpponent, Zone.BATTLEFIELD, GameObjectFilter.Creature)
 
     /**
      * If you control a creature.
@@ -385,13 +385,13 @@ object Conditions {
      * If you have more life than an opponent.
      */
     val MoreLifeThanOpponent: ConditionInterface =
-        Compare(DynamicAmount.LifeTotal(Player.You), ComparisonOperator.GT, DynamicAmount.LifeTotal(Player.Opponent))
+        Compare(DynamicAmount.LifeTotal(Player.You), ComparisonOperator.GT, DynamicAmount.LifeTotal(Player.EachOpponent))
 
     /**
      * If you have less life than an opponent.
      */
     val LessLifeThanOpponent: ConditionInterface =
-        Compare(DynamicAmount.LifeTotal(Player.You), ComparisonOperator.LT, DynamicAmount.LifeTotal(Player.Opponent))
+        Compare(DynamicAmount.LifeTotal(Player.You), ComparisonOperator.LT, DynamicAmount.LifeTotal(Player.EachOpponent))
 
     // =========================================================================
     // Hand Conditions (via Compare / Exists)
@@ -419,7 +419,7 @@ object Conditions {
      * If an opponent has N or fewer cards in hand.
      */
     fun OpponentCardsInHandAtMost(count: Int): ConditionInterface =
-        Compare(DynamicAmount.Count(Player.Opponent, Zone.HAND), ComparisonOperator.LTE, DynamicAmount.Fixed(count))
+        Compare(DynamicAmount.Count(Player.EachOpponent, Zone.HAND), ComparisonOperator.LTE, DynamicAmount.Fixed(count))
 
     // =========================================================================
     // Graveyard Conditions (via Compare / Exists)
@@ -836,7 +836,7 @@ object Conditions {
      * Used for cards like Hired Claw: "Activate only if an opponent lost life this turn"
      */
     val OpponentLostLifeThisTurn: ConditionInterface =
-        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.Opponent)
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.EachOpponent)
 
     // =========================================================================
     // Candidate-player target restrictions (CR 115)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -193,7 +193,7 @@ object DynamicAmounts {
     // =========================================================================
 
     fun creaturesAttackingYou(multiplier: Int = 1): DynamicAmount {
-        val base = battlefield(Player.Opponent, GameObjectFilter.Creature.attacking()).count()
+        val base = battlefield(Player.EachOpponent, GameObjectFilter.Creature.attacking()).count()
         return if (multiplier == 1) base else DynamicAmount.Multiply(base, multiplier)
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1918,7 +1918,7 @@ object Effects {
      * the targeted spell's controller and counter it — pair with a `TargetSpell` requirement:
      * `Effects.OpenLifeBid(Effects.CounterSpell(), Player.ControllerOf("target spell"))`.
      */
-    fun OpenLifeBid(onWin: Effect, participant: Player = Player.Opponent): Effect =
+    fun OpenLifeBid(onWin: Effect, participant: Player = Player.AnOpponent): Effect =
         OpenLifeBidEffect(onWin = onWin, participant = participant)
 
     /**
@@ -2213,7 +2213,7 @@ object Effects {
      * Target player can't cast spells this turn.
      * Used for cards like Xantid Swarm.
      */
-    fun CantCastSpells(target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent), duration: Duration = Duration.EndOfTurn): Effect =
+    fun CantCastSpells(target: EffectTarget, duration: Duration = Duration.EndOfTurn): Effect =
         CantCastSpellsEffect(target, duration)
 
     /**
@@ -2228,7 +2228,7 @@ object Effects {
      * Target player can't activate planeswalkers' loyalty abilities for the duration.
      * Compose with [CantCastSpells] for cards that forbid both (e.g. Revel in Silence).
      */
-    fun CantActivateLoyaltyAbilities(target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent), duration: Duration = Duration.EndOfTurn): Effect =
+    fun CantActivateLoyaltyAbilities(target: EffectTarget, duration: Duration = Duration.EndOfTurn): Effect =
         CantActivateLoyaltyAbilitiesEffect(target, duration)
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -44,7 +44,10 @@ object HandPatterns {
             }
             return CompositeEffect(listOf(
                 GatherCardsEffect(
-                    source = CardSource.FromZone(Zone.HAND, Player.Opponent),
+                    // TODO(multiplayer Phase 1, backlog/multiplayer.md): "each opponent discards,
+                    //  you draw per discard" needs cross-iteration count accumulation; until then
+                    //  this hits one opponent (identical in two-player games).
+                    source = CardSource.FromZone(Zone.HAND, Player.AnOpponent),
                     storeAs = "hand"
                 ),
                 SelectFromCollectionEffect(
@@ -56,7 +59,7 @@ object HandPatterns {
                 ),
                 MoveCollectionEffect(
                     from = "discarded",
-                    destination = CardDestination.ToZone(Zone.GRAVEYARD, player = Player.Opponent),
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, player = Player.AnOpponent),
                     moveType = MoveType.Discard
                 ),
                 DrawCardsEffect(count = drawCount)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
@@ -25,7 +25,8 @@ internal fun effectTargetToChooser(target: EffectTarget): Chooser = when (target
     is EffectTarget.BoundVariable -> Chooser.TargetPlayer
     is EffectTarget.PlayerRef -> when (target.player) {
         is Player.You -> Chooser.Controller
-        is Player.Opponent, is Player.TargetOpponent, is Player.EachOpponent -> Chooser.Opponent
+        is Player.TargetOpponent -> Chooser.TargetPlayer
+        is Player.AnOpponent, is Player.EachOpponent -> Chooser.Opponent
         is Player.TriggeringPlayer -> Chooser.TriggeringPlayer
         // "Its owner" (e.g. Recoil: "Return target permanent to its owner's hand. Then that
         // player discards a card.") resolves to whoever owns the targeted permanent, which may be

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -661,7 +661,7 @@ object Triggers {
      * Whenever an opponent draws a card. Fires once per card an opponent draws (CR 121.2).
      */
     val OpponentDraws: TriggerSpec = TriggerSpec(
-        event = DrawEvent(Player.Opponent),
+        event = DrawEvent(Player.EachOpponent),
         binding = TriggerBinding.ANY
     )
 
@@ -671,7 +671,7 @@ object Triggers {
      * Orcish Bowmasters / A-Orcish Bowmasters.
      */
     val OpponentDrawsExceptFirstEachDrawStep: TriggerSpec = TriggerSpec(
-        event = DrawEvent(Player.Opponent, exceptFirstInDrawStep = true),
+        event = DrawEvent(Player.EachOpponent, exceptFirstInDrawStep = true),
         binding = TriggerBinding.ANY
     )
 
@@ -827,7 +827,7 @@ object Triggers {
     // -------------------------------------------------------------------------
     // Spell cast by another player (any player / an opponent).
     //
-    // `Player.Each` / `Player.Opponent` are matched at runtime by
+    // `Player.Each` / `Player.EachOpponent` are matched at runtime by
     // `TriggerMatcher.matchesPlayer`. Bind the payoff to the caster with
     // `Player.TriggeringPlayer`.
     // -------------------------------------------------------------------------
@@ -844,7 +844,7 @@ object Triggers {
      * Whenever an opponent casts a spell.
      */
     val OpponentCastsSpell: TriggerSpec = TriggerSpec(
-        event = SpellCastEvent(player = Player.Opponent),
+        event = SpellCastEvent(player = Player.EachOpponent),
         binding = TriggerBinding.ANY
     )
 
@@ -880,7 +880,7 @@ object Triggers {
         spellFilter: GameObjectFilter = GameObjectFilter.Any,
         requires: Set<SpellCastPredicate> = emptySet(),
     ): TriggerSpec = TriggerSpec(
-        event = SpellCastEvent(spellFilter = spellFilter, player = Player.Opponent, requires = requires),
+        event = SpellCastEvent(spellFilter = spellFilter, player = Player.EachOpponent, requires = requires),
         binding = TriggerBinding.ANY
     )
 
@@ -892,7 +892,7 @@ object Triggers {
      * Whenever an opponent discards a card.
      */
     val AnyOpponentDiscards: TriggerSpec = TriggerSpec(
-        event = DiscardEvent(player = Player.Opponent),
+        event = DiscardEvent(player = Player.EachOpponent),
         binding = TriggerBinding.ANY
     )
 
@@ -913,7 +913,7 @@ object Triggers {
      * - "Whenever a player discards a card":
      *   `discards(player = Player.Each)`
      * - "Whenever an opponent discards a creature card":
-     *   `discards(player = Player.Opponent, cardFilter = GameObjectFilter.Creature)`
+     *   `discards(player = Player.EachOpponent, cardFilter = GameObjectFilter.Creature)`
      *
      * Note: fires once per card discarded — e.g. an opponent discarding 3 cards
      * in one resolution fires this 3 times. Mirrors how [YouDraw] handles
@@ -946,7 +946,7 @@ object Triggers {
      * activated abilities) do. Used for Flamescroll Celebrant.
      */
     val OpponentActivatesAbility: TriggerSpec = TriggerSpec(
-        event = AbilityActivatedEvent(player = Player.Opponent),
+        event = AbilityActivatedEvent(player = Player.EachOpponent),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -210,7 +210,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      *
      * Examples:
      * - "you would draw a card" → DrawEvent(player = Player.You)
-     * - "an opponent would draw" → DrawEvent(player = Player.Opponent)
+     * - "an opponent would draw" → DrawEvent(player = Player.EachOpponent)
      *
      * When [exceptFirstInDrawStep] is set, the first card the drawing player draws in
      * each of their own draw steps (CR 504.1's turn-based draw, normally) does **not**
@@ -1168,7 +1168,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * `AbilityActivatedEvent` for non-mana activated abilities — including planeswalker loyalty
      * abilities (CR 606), which are activated abilities. This template therefore matches exactly
      * "activates an ability that isn't a mana ability"; [player] scopes whose activations count
-     * ([Player.Opponent] for "an opponent activates …", [Player.You] for your own, etc.).
+     * ([Player.EachOpponent] for "an opponent activates …", [Player.You] for your own, etc.).
      *
      * Used by Flamescroll Celebrant: "Whenever an opponent activates an ability that isn't a mana
      * ability, this creature deals 1 damage to that player."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -482,7 +482,7 @@ data class CapDamage(
  * mirrors [ModifyLifeLoss]'s shape — use it for cards whose extra-draw clause is gated by
  * arbitrary additional conditions. Note that "you" in restriction text reads as the drawing
  * player, not the source's controller — for `DrawEvent(player = Player.You)` they're the
- * same, but a future `DrawEvent(player = Player.Opponent)` card whose restriction means
+ * same, but a future `DrawEvent(player = Player.EachOpponent)` card whose restriction means
  * "you" = source controller would need a source-relative condition instead.
  *
  * Examples:
@@ -678,9 +678,9 @@ data class ModifyLifeGain(
  * Examples:
  * - Bloodletter of Aclazotz (loses twice as much during your turn):
  *     `ModifyLifeLoss(multiplier = 2, restrictions = listOf(IsYourTurn),
- *                    appliesTo = LifeLossEvent(player = Player.Opponent))`
+ *                    appliesTo = LifeLossEvent(player = Player.EachOpponent))`
  * - "Each opponent loses an additional 1 life":
- *     `ModifyLifeLoss(modifier = 1, appliesTo = LifeLossEvent(player = Player.Opponent))`
+ *     `ModifyLifeLoss(modifier = 1, appliesTo = LifeLossEvent(player = Player.EachOpponent))`
  * - "If you would lose life, you lose 1 less life instead" (with floor at 0):
  *     `ModifyLifeLoss(modifier = -1, appliesTo = LifeLossEvent(player = Player.You))`
  *
@@ -787,7 +787,7 @@ data class LifeLossFloor(
         append(" that would reduce ")
         when ((appliesTo as? EventPattern.LifeLossEvent)?.player) {
             Player.You -> append("your")
-            Player.Opponent, Player.EachOpponent -> append("an opponent's")
+            Player.EachOpponent -> append("an opponent's")
             else -> append("a player's")
         }
         append(" life total to less than $floor reduces it to $floor instead")
@@ -961,7 +961,7 @@ data class ModeOption(
  *
  * Examples:
  * - Riptide Replicator: `EntersWithChoice(ChoiceType.COLOR)`
- * - Callous Oppressor: `EntersWithChoice(ChoiceType.CREATURE_TYPE, chooser = Player.Opponent)`
+ * - Callous Oppressor: `EntersWithChoice(ChoiceType.CREATURE_TYPE, chooser = Player.AnOpponent)`
  * - Dauntless Bodyguard: `EntersWithChoice(ChoiceType.CREATURE_ON_BATTLEFIELD)`
  */
 @SerialName("EntersWithChoice")
@@ -987,12 +987,12 @@ data class EntersWithChoice(
     )
 ) : ReplacementEffect {
     override val description: String = when (choiceType) {
-        ChoiceType.COLOR -> if (chooser == Player.Opponent) {
+        ChoiceType.COLOR -> if (chooser == Player.AnOpponent) {
             "As this permanent enters, an opponent chooses a color"
         } else {
             "As this permanent enters, choose a color"
         }
-        ChoiceType.CREATURE_TYPE -> if (chooser == Player.Opponent) {
+        ChoiceType.CREATURE_TYPE -> if (chooser == Player.AnOpponent) {
             "As this permanent enters, an opponent chooses a creature type"
         } else {
             "As this permanent enters, choose a creature type"
@@ -1000,18 +1000,18 @@ data class EntersWithChoice(
         ChoiceType.CREATURE_ON_BATTLEFIELD -> "As this creature enters, choose another creature you control"
         ChoiceType.MODE -> {
             val labels = modeOptions.joinToString(" or ") { it.label }
-            if (chooser == Player.Opponent) {
+            if (chooser == Player.AnOpponent) {
                 "As this permanent enters, an opponent chooses $labels"
             } else {
                 "As this permanent enters, choose $labels"
             }
         }
-        ChoiceType.BASIC_LAND_TYPE -> if (chooser == Player.Opponent) {
+        ChoiceType.BASIC_LAND_TYPE -> if (chooser == Player.AnOpponent) {
             "As this permanent enters, an opponent chooses a basic land type"
         } else {
             "As this permanent enters, choose a basic land type"
         }
-        ChoiceType.OPPONENT -> if (chooser == Player.Opponent) {
+        ChoiceType.OPPONENT -> if (chooser == Player.AnOpponent) {
             "As this permanent enters, an opponent chooses an opponent"
         } else {
             "As this permanent enters, choose an opponent"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -391,7 +391,7 @@ data class PlayersCantCastSpells(
     override val description: String = buildString {
         when (affected) {
             is Player.You -> append("You can't cast ")
-            is Player.Opponent, is Player.EachOpponent -> append("Your opponents can't cast ")
+            is Player.EachOpponent -> append("Your opponents can't cast ")
             else -> append("${affected.description.replaceFirstChar { it.uppercase() }} can't cast ")
         }
         append(if (spellFilter == GameObjectFilter.Any) "spells" else "${spellFilter.description} spells")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -63,7 +63,7 @@ enum class ComparisonOperator {
  * Compare(LifeTotal(Player.You), ComparisonOperator.LTE, Fixed(5))
  *
  * // More life than opponent
- * Compare(LifeTotal(Player.You), ComparisonOperator.GT, LifeTotal(Player.Opponent))
+ * Compare(LifeTotal(Player.You), ComparisonOperator.GT, LifeTotal(Player.EachOpponent))
  * ```
  */
 @SerialName("Compare")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AuctionEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AuctionEffects.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OpenLifeBidEffect(
     val onWin: Effect,
-    val participant: Player = Player.Opponent
+    val participant: Player = Player.AnOpponent
 ) : Effect {
     override val description: String =
         "You and ${participant.description} bid life. You start the bidding with a bid of 1. " +

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -208,7 +208,7 @@ data class HijackNextTurnEffect(
 @SerialName("CantCastSpells")
 @Serializable
 data class CantCastSpellsEffect(
-    val target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent),
+    val target: EffectTarget,
     val duration: Duration = Duration.EndOfTurn
 ) : Effect {
     override val description: String = "${target.description.replaceFirstChar { it.uppercase() }} can't cast spells ${duration.description}"
@@ -226,7 +226,7 @@ data class CantCastSpellsEffect(
 @SerialName("CantActivateLoyaltyAbilities")
 @Serializable
 data class CantActivateLoyaltyAbilitiesEffect(
-    val target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent),
+    val target: EffectTarget,
     val duration: Duration = Duration.EndOfTurn
 ) : Effect {
     override val description: String = "${target.description.replaceFirstChar { it.uppercase() }} can't activate planeswalkers' loyalty abilities ${duration.description}"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -26,11 +26,38 @@ sealed interface Player {
         override val description: String = "you"
     }
 
-    /** Any single opponent (not targeted) */
-    @SerialName("Opponent")
+    /**
+     * A genuinely non-targeted "an opponent" — used only where the printed text has a
+     * single opponent act without targeting them (a chooser: "an opponent chooses a
+     * creature type", "choose ... an opponent"). The engine currently resolves this to
+     * the controller's first opponent in turn order; the proper multiplayer flow (the
+     * controller picks which opponent) is tracked in `backlog/multiplayer.md`.
+     *
+     * Do NOT use this for:
+     * - "target opponent" → [TargetOpponent]
+     * - "each opponent" / "your opponents" / "an opponent controls" (exists/aggregation) → [EachOpponent]
+     * - "defending player" / combat-damage-to-a-player triggers → [DefendingPlayer]
+     * - "that player" in a per-opponent trigger ("at the beginning of each opponent's
+     *   upkeep, that player ...") → [TriggeringPlayer]
+     */
+    @SerialName("AnOpponent")
     @Serializable
-    data object Opponent : Player {
+    data object AnOpponent : Player {
         override val description: String = "an opponent"
+    }
+
+    /**
+     * The defending player, per CR 802.2a: the specific player the ability's source is
+     * attacking, determined per attacking creature — never "the opponent" via turn order.
+     * Resolves through the source's attack assignment (a creature attacking a planeswalker
+     * defends against that planeswalker's controller); for "deals combat damage to a
+     * player" triggers whose source has left combat before resolution, the damaged player
+     * is read from the trigger context as last-known information.
+     */
+    @SerialName("DefendingPlayer")
+    @Serializable
+    data object DefendingPlayer : Player {
+        override val description: String = "defending player"
     }
 
     /** All opponents */
@@ -151,7 +178,8 @@ sealed interface Player {
     val possessive: String
         get() = when (this) {
             You -> "your"
-            Opponent -> "opponent's"
+            AnOpponent -> "an opponent's"
+            DefendingPlayer -> "defending player's"
             TargetOpponent -> "target opponent's"
             TargetPlayer -> "target player's"
             Each -> "each player's"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -195,7 +195,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
      * Examples:
      * ```kotlin
      * LifeTotal(Player.You)       // your life total
-     * LifeTotal(Player.Opponent)  // opponent's life total
+     * LifeTotal(Player.TargetOpponent)  // target opponent's life total
      * ```
      */
     @SerialName("LifeTotal")
@@ -414,7 +414,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
 
     /**
      * Multiply a dynamic amount by a fixed multiplier.
-     * Example: Multiply(AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature.attacking()), 3)
+     * Example: Multiply(AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature.attacking()), 3)
      */
     @SerialName("Multiply")
     @Serializable
@@ -554,7 +554,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 Zone.BATTLEFIELD -> {
                     when (player) {
                         Player.You -> append("you control")
-                        Player.Opponent, Player.TargetOpponent -> append("${player.description} controls")
+                        Player.TargetOpponent -> append("${player.description} controls")
                         Player.Each -> append("on the battlefield")
                         else -> append("${player.description} controls")
                     }
@@ -658,7 +658,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
             append(" ")
             when (player) {
                 Player.You -> append("you control")
-                Player.Opponent, Player.TargetOpponent -> append("${player.description} controls")
+                Player.TargetOpponent -> append("${player.description} controls")
                 Player.Each -> append("on the battlefield")
                 else -> append("${player.description} controls")
             }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/DomainDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/DomainDslTest.kt
@@ -31,9 +31,9 @@ class DomainDslTest : DescribeSpec({
         }
 
         it("supports counting domain for an opponent") {
-            val amount = DynamicAmounts.domain(Player.Opponent)
+            val amount = DynamicAmounts.domain(Player.AnOpponent)
             amount.shouldBeInstanceOf<DynamicAmount.AggregateBattlefield>()
-            amount.player shouldBe Player.Opponent
+            amount.player shouldBe Player.AnOpponent
             amount.description shouldBe
                 "the number of basic land types among lands an opponent controls"
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/KhabalGhoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/KhabalGhoul.kt
@@ -32,7 +32,7 @@ val KhabalGhoul = card("Khabál Ghoul") {
             Counters.PLUS_ONE_PLUS_ONE,
             DynamicAmount.Add(
                 DynamicAmounts.creaturesDiedThisTurn(Player.You),
-                DynamicAmounts.creaturesDiedThisTurn(Player.Opponent),
+                DynamicAmounts.creaturesDiedThisTurn(Player.EachOpponent),
             ),
             EffectTarget.Self,
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BezaTheBoundingSpring.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BezaTheBoundingSpring.kt
@@ -52,7 +52,7 @@ val BezaTheBoundingSpring = card("Beza, the Bounding Spring") {
             )
         ) then ConditionalEffect(
             condition = Compare(
-                DynamicAmount.Count(Player.Opponent, Zone.HAND),
+                DynamicAmount.Count(Player.EachOpponent, Zone.HAND),
                 ComparisonOperator.GT,
                 DynamicAmount.Count(Player.You, Zone.HAND)
             ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/IntoTheFloodMaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/IntoTheFloodMaw.kt
@@ -48,7 +48,7 @@ val IntoTheFloodMaw = card("Into the Flood Maw") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongstalkBrawl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongstalkBrawl.kt
@@ -52,7 +52,7 @@ val LongstalkBrawl = card("Longstalk Brawl") {
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
                     tapped = true,
-                    controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 )
                     .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MindSpiral.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MindSpiral.kt
@@ -54,7 +54,7 @@ val MindSpiral = card("Mind Spiral") {
                             toughness = 1,
                             colors = setOf(Color.BLUE),
                             creatureTypes = setOf("Fish"),
-                            controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                            controller = EffectTarget.PlayerRef(Player.AnOpponent),
                             tapped = true,
                             imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                         ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PartingGust.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PartingGust.kt
@@ -64,7 +64,7 @@ val PartingGust = card("Parting Gust") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.Exile(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SazacapsBrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SazacapsBrew.kt
@@ -59,7 +59,7 @@ val SazacapsBrew = card("Sazacap's Brew") {
                             colors = setOf(Color.BLUE),
                             creatureTypes = setOf("Fish"),
                             tapped = true,
-                            controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                            controller = EffectTarget.PlayerRef(Player.AnOpponent),
                             imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                         ),
                         DrawCardsEffect(2, EffectTarget.ContextTarget(0)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
@@ -55,7 +55,7 @@ val StarforgedSword = card("Starforged Sword") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.EachOpponent),
+                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.AttachEquipment(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/HaphazardBombardment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/HaphazardBombardment.kt
@@ -64,7 +64,7 @@ val HaphazardBombardment = card("Haphazard Bombardment") {
         trigger = Triggers.YourEndStep
         triggerCondition = Compare(
             left = DynamicAmount.AggregateBattlefield(
-                player = Player.Opponent,
+                player = Player.EachOpponent,
                 filter = GameObjectFilter.Any.withCounter(Counters.AIM),
                 aggregation = Aggregation.COUNT
             ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AlpharaelStonechosen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AlpharaelStonechosen.kt
@@ -35,8 +35,8 @@ val AlpharaelStonechosen = card("Alpharael, Stonechosen") {
         triggerCondition = Conditions.Void
         effect = Effects.LoseHalfLife(
             roundUp = true,
-            target = EffectTarget.PlayerRef(Player.Opponent),
-            lifePlayer = Player.Opponent
+            target = EffectTarget.PlayerRef(Player.DefendingPlayer),
+            lifePlayer = Player.DefendingPlayer
         )
         description = "Void — Whenever Alpharael attacks, if a nonland permanent left the battlefield this turn or a spell was warped this turn, defending player loses half their life, rounded up."
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LashwhipPredator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LashwhipPredator.kt
@@ -37,7 +37,7 @@ val LashwhipPredator = card("Lashwhip Predator") {
             modification = CostModification.ReduceGeneric(2),
             gating = CostGating.OnlyIf(
                 Compare(
-                    DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
+                    DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature),
                     ComparisonOperator.GTE,
                     DynamicAmount.Fixed(3),
                 ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SotheraTheSupervoid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SotheraTheSupervoid.kt
@@ -74,7 +74,7 @@ val SotheraTheSupervoid = card("Sothera, the Supervoid") {
         triggerCondition = AnyCondition(
             listOf(
                 Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature, negate = true),
-                Exists(Player.Opponent, Zone.BATTLEFIELD, GameObjectFilter.Creature, negate = true)
+                Exists(Player.EachOpponent, Zone.BATTLEFIELD, GameObjectFilter.Creature, negate = true)
             )
         )
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SpecimenFreighter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SpecimenFreighter.kt
@@ -75,7 +75,7 @@ val SpecimenFreighter = card("Specimen Freighter") {
     // Whenever this Spacecraft attacks, defending player mills four cards
     triggeredAbility {
         trigger = Triggers.Attacks
-        effect = Patterns.Library.mill(4, EffectTarget.PlayerRef(Player.Opponent))
+        effect = Patterns.Library.mill(4, EffectTarget.PlayerRef(Player.DefendingPlayer))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrusadingKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrusadingKnight.kt
@@ -34,12 +34,12 @@ val CrusadingKnight = card("Crusading Knight") {
         ability = GrantDynamicStatsEffect(
             filter = GroupFilter.source(),
             powerBonus = DynamicAmount.Count(
-                player = Player.Opponent,
+                player = Player.EachOpponent,
                 zone = Zone.BATTLEFIELD,
                 filter = GameObjectFilter.Land.withSubtype("Swamp")
             ),
             toughnessBonus = DynamicAmount.Count(
-                player = Player.Opponent,
+                player = Player.EachOpponent,
                 zone = Zone.BATTLEFIELD,
                 filter = GameObjectFilter.Land.withSubtype("Swamp")
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FightOrFlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FightOrFlight.kt
@@ -44,7 +44,7 @@ val FightOrFlight = card("Fight or Flight") {
                 // 1. Gather the creatures the active opponent controls.
                 GatherCardsEffect(
                     source = CardSource.ControlledPermanents(
-                        player = Player.Opponent,
+                        player = Player.TriggeringPlayer,
                         filter = GameObjectFilter.Creature
                     ),
                     storeAs = "creatures"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuRunner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuRunner.kt
@@ -33,7 +33,7 @@ val KavuRunner = card("Kavu Runner") {
             ability = GrantKeyword(Keyword.HASTE, Filters.Self),
             condition = Conditions.Not(
                 Exists(
-                    Player.Opponent,
+                    Player.EachOpponent,
                     Zone.BATTLEFIELD,
                     GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLUE)
                 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MaraudingKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MaraudingKnight.kt
@@ -34,12 +34,12 @@ val MaraudingKnight = card("Marauding Knight") {
         ability = GrantDynamicStatsEffect(
             filter = GroupFilter.source(),
             powerBonus = DynamicAmount.Count(
-                player = Player.Opponent,
+                player = Player.EachOpponent,
                 zone = Zone.BATTLEFIELD,
                 filter = GameObjectFilter.Land.withSubtype("Plains")
             ),
             toughnessBonus = DynamicAmount.Count(
-                player = Player.Opponent,
+                player = Player.EachOpponent,
                 zone = Zone.BATTLEFIELD,
                 filter = GameObjectFilter.Land.withSubtype("Plains")
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkittishKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkittishKavu.kt
@@ -32,7 +32,7 @@ val SkittishKavu = card("Skittish Kavu") {
             ability = ModifyStats(1, 1, Filters.Self),
             condition = Conditions.Not(
                 Exists(
-                    Player.Opponent,
+                    Player.EachOpponent,
                     Zone.BATTLEFIELD,
                     GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLUE)
                 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsaboTavoc.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsaboTavoc.kt
@@ -36,7 +36,7 @@ val TsaboTavoc = card("Tsabo Tavoc") {
 
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
-        effect = ForceSacrificeEffect(GameObjectFilter.Creature, 1, EffectTarget.PlayerRef(Player.Opponent))
+        effect = ForceSacrificeEffect(GameObjectFilter.Creature, 1, EffectTarget.PlayerRef(Player.DefendingPlayer))
     }
 
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/SorinSolemnVisitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/SorinSolemnVisitor.kt
@@ -72,7 +72,7 @@ val SorinSolemnVisitor = card("Sorin, Solemn Visitor") {
                 effect = ForceSacrificeEffect(
                     filter = GameObjectFilter.Creature,
                     count = 1,
-                    target = EffectTarget.PlayerRef(Player.Opponent)
+                    target = EffectTarget.PlayerRef(Player.TriggeringPlayer)
                 )
             ),
             descriptionOverride = "At the beginning of each opponent's upkeep, that player sacrifices a creature."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodletterOfAclazotz.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodletterOfAclazotz.kt
@@ -36,7 +36,7 @@ val BloodletterOfAclazotz = card("Bloodletter of Aclazotz") {
         ModifyLifeLoss(
             multiplier = 2,
             restrictions = listOf(IsYourTurn),
-            appliesTo = EventPattern.LifeLossEvent(player = Player.Opponent),
+            appliesTo = EventPattern.LifeLossEvent(player = Player.EachOpponent),
         )
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/LavabornMuse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/LavabornMuse.kt
@@ -1,13 +1,16 @@
 package com.wingedsheep.mtg.sets.definitions.lgn.cards
 
-import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Lavaborn Muse
@@ -29,10 +32,11 @@ val LavabornMuse = card("Lavaborn Muse") {
 
     triggeredAbility {
         trigger = Triggers.EachOpponentUpkeep
-        triggerCondition = Conditions.OpponentCardsInHandAtMost(2)
+        // "That player" is the player whose upkeep it is — bound by the step trigger.
+        triggerCondition = upkeepPlayerHandAtMost(2)
         effect = ConditionalEffect(
-            condition = Conditions.OpponentCardsInHandAtMost(2),
-            effect = Effects.DealDamage(3, EffectTarget.PlayerRef(Player.Opponent))
+            condition = upkeepPlayerHandAtMost(2),
+            effect = Effects.DealDamage(3, EffectTarget.PlayerRef(Player.TriggeringPlayer))
         )
     }
 
@@ -45,3 +49,10 @@ val LavabornMuse = card("Lavaborn Muse") {
         ruling("2004-10-04", "The number of cards in hand is checked both at the beginning of upkeep and when the triggered ability resolves.")
     }
 }
+
+/** "If that player has [count] or fewer cards in hand" — the player whose upkeep triggered. */
+private fun upkeepPlayerHandAtMost(count: Int) = Compare(
+    DynamicAmount.Count(Player.TriggeringPlayer, Zone.HAND),
+    ComparisonOperator.LTE,
+    DynamicAmount.Fixed(count)
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CabalExecutioner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CabalExecutioner.kt
@@ -26,7 +26,7 @@ val CabalExecutioner = card("Cabal Executioner") {
 
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
-        effect = ForceSacrificeEffect(GameObjectFilter.Creature, 1, EffectTarget.PlayerRef(Player.Opponent))
+        effect = ForceSacrificeEffect(GameObjectFilter.Creature, 1, EffectTarget.PlayerRef(Player.DefendingPlayer))
     }
 
     morph = "{3}{B}{B}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CallousOppressor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/CallousOppressor.kt
@@ -31,7 +31,7 @@ val CallousOppressor = card("Callous Oppressor") {
     oracleText = "You may choose not to untap Callous Oppressor during your untap step.\nAs Callous Oppressor enters the battlefield, an opponent chooses a creature type.\n{T}: Gain control of target creature that isn't of the chosen type for as long as Callous Oppressor remains tapped."
 
     flags(AbilityFlag.MAY_NOT_UNTAP)
-    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE, chooser = com.wingedsheep.sdk.scripting.references.Player.Opponent))
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE, chooser = com.wingedsheep.sdk.scripting.references.Player.AnOpponent))
 
     activatedAbility {
         cost = Costs.Tap

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/EbonbladeReaper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/EbonbladeReaper.kt
@@ -33,8 +33,8 @@ val EbonbladeReaper = card("Ebonblade Reaper") {
         trigger = Triggers.DealsCombatDamageToPlayer
         effect = Effects.LoseHalfLife(
             roundUp = true,
-            target = EffectTarget.PlayerRef(Player.Opponent),
-            lifePlayer = Player.Opponent
+            target = EffectTarget.PlayerRef(Player.DefendingPlayer),
+            lifePlayer = Player.DefendingPlayer
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RiskyMove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/RiskyMove.kt
@@ -39,10 +39,13 @@ val RiskyMove = card("Risky Move") {
     triggeredAbility {
         trigger = Triggers.GainControlOfSelf
         val t = target("target", Targets.CreatureYouControl)
+        // "Choose ... an opponent" is a non-targeted choice; until the multiplayer
+        // choose-an-opponent flow exists (backlog/multiplayer.md), AnOpponent resolves
+        // to the first opponent in turn order — exact in two-player games.
         effect = FlipCoinEffect(
             lostEffect = GiveControlToTargetPlayerEffect(
                 permanent = t,
-                newController = EffectTarget.PlayerRef(Player.Opponent)
+                newController = EffectTarget.PlayerRef(Player.AnOpponent)
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/PygmyKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/PygmyKavu.kt
@@ -31,7 +31,7 @@ val PygmyKavu = card("Pygmy Kavu") {
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
         effect = DrawCardsEffect(
-            DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature.withColor(Color.BLACK))
+            DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature.withColor(Color.BLACK))
         )
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlessedReversal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlessedReversal.kt
@@ -26,7 +26,7 @@ val BlessedReversal = card("Blessed Reversal") {
     spell {
         effect = GainLifeEffect(
             DynamicAmount.Multiply(
-                DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature.attacking()),
+                DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature.attacking()),
                 3
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/DecreeOfSilence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/DecreeOfSilence.kt
@@ -40,7 +40,7 @@ val DecreeOfSilence = card("Decree of Silence") {
     // Ability 1: Whenever an opponent casts a spell, counter that spell + depletion counter + sacrifice check
     triggeredAbility {
         trigger = TriggerSpec(
-            event = EventPattern.SpellCastEvent(player = Player.Opponent),
+            event = EventPattern.SpellCastEvent(player = Player.EachOpponent),
             binding = TriggerBinding.ANY
         )
         effect = Effects.CounterTriggeringSpell()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/Metamorphose.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/Metamorphose.kt
@@ -38,9 +38,13 @@ val Metamorphose = card("Metamorphose") {
                 // Put targeted permanent on top of its owner's library
                 Effects.PutOnTopOfLibrary(permanent),
                 // That opponent may put a permanent card from their hand onto the battlefield
+                // "That opponent" — the player whose permanent was targeted. By the time the
+                // hand is gathered the permanent is on its owner's library, so ControllerOf
+                // resolves through the card's owner (controller == owner for all but stolen
+                // permanents).
                 GatherCardsEffect(
                     source = CardSource.FromZone(
-                        Zone.HAND, Player.Opponent,
+                        Zone.HAND, Player.ControllerOf("permanent an opponent controls"),
                         GameObjectFilter(
                             cardPredicates = listOf(
                                 CardPredicate.Or(
@@ -59,13 +63,13 @@ val Metamorphose = card("Metamorphose") {
                 SelectFromCollectionEffect(
                     from = "put_candidates",
                     selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
-                    chooser = Chooser.Opponent,
+                    chooser = Chooser.ControllerOfSelection,
                     storeSelected = "putting",
                     prompt = "You may put an artifact, creature, enchantment, or land card from your hand onto the battlefield"
                 ),
                 MoveCollectionEffect(
                     from = "putting",
-                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, player = Player.Opponent)
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, player = Player.ControllerOf("permanent an opponent controls"))
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/XantidSwarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/XantidSwarm.kt
@@ -28,7 +28,7 @@ val XantidSwarm = card("Xantid Swarm") {
 
     triggeredAbility {
         trigger = Triggers.Attacks
-        effect = Effects.CantCastSpells(EffectTarget.PlayerRef(Player.Opponent))
+        effect = Effects.CantCastSpells(EffectTarget.PlayerRef(Player.DefendingPlayer))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FlamescrollCelebrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FlamescrollCelebrant.kt
@@ -54,8 +54,8 @@ val FlamescrollCelebrant = card("Flamescroll Celebrant") {
         spell {
             selfExile()
             effect = Effects.Composite(
-                Effects.CantCastSpells(EffectTarget.PlayerRef(Player.Opponent)),
-                Effects.CantActivateLoyaltyAbilities(EffectTarget.PlayerRef(Player.Opponent)),
+                Effects.CantCastSpells(EffectTarget.PlayerRef(Player.EachOpponent)),
+                Effects.CantActivateLoyaltyAbilities(EffectTarget.PlayerRef(Player.EachOpponent)),
             )
         }
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -59,17 +60,15 @@ val BetorKinToAll = card("Betor, Kin to All") {
                 )
             )
             // "Then if ... 40 or greater, each opponent loses half their life, rounded up."
-            // The loss amount is computed once from Player.Opponent's life, then applied to every
-            // EachOpponent target — exact in 1v1. In multiplayer each opponent would lose half of a
-            // single opponent's life rather than their own (a LoseLifeExecutor architecture limit,
-            // not this card's); revisit if/when multiplayer is supported.
+            // Iterated per opponent so each loses half of *their own* life total — the
+            // loop rebinds the controller, so the LoseHalfLife defaults (target =
+            // Controller, lifePlayer = You) read the iterated opponent.
             .then(
                 ConditionalEffect(
                     condition = totalToughnessAtLeast(40),
-                    effect = Effects.LoseHalfLife(
-                        roundUp = true,
-                        target = EffectTarget.PlayerRef(Player.EachOpponent),
-                        lifePlayer = Player.Opponent
+                    effect = ForEachPlayerEffect(
+                        players = Player.EachOpponent,
+                        effects = listOf(Effects.LoseHalfLife(roundUp = true))
                     )
                 )
             )

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -810,7 +810,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -1790,7 +1790,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -2155,7 +2155,7 @@
                         },
                         "right": {
                             "type": "TurnTracking",
-                            "player": "Opponent",
+                            "player": "EachOpponent",
                             "tracker": "CREATURES_DIED"
                         }
                     },
@@ -2529,7 +2529,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -1121,7 +1121,7 @@
                                     "type": "Compare",
                                     "left": {
                                         "type": "AggregateBattlefield",
-                                        "player": "Opponent",
+                                        "player": "EachOpponent",
                                         "filter": "land"
                                     },
                                     "operator": "GT",
@@ -1150,7 +1150,7 @@
                                     "operator": "LT",
                                     "right": {
                                         "type": "LifeTotal",
-                                        "player": "Opponent"
+                                        "player": "EachOpponent"
                                     }
                                 }
                             },
@@ -1170,7 +1170,7 @@
                                     "type": "Compare",
                                     "left": {
                                         "type": "AggregateBattlefield",
-                                        "player": "Opponent",
+                                        "player": "EachOpponent",
                                         "filter": "creature"
                                     },
                                     "operator": "GT",
@@ -1206,7 +1206,7 @@
                                     "type": "Compare",
                                     "left": {
                                         "type": "Count",
-                                        "player": "Opponent",
+                                        "player": "EachOpponent",
                                         "zone": "Hand"
                                     },
                                     "operator": "GT",
@@ -3195,7 +3195,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "TurnTracking",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "tracker": "LIFE_LOST"
                     },
                     "operator": "GTE",
@@ -6714,7 +6714,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "TurnTracking",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "tracker": "LIFE_LOST"
                     },
                     "operator": "GTE",
@@ -6810,7 +6810,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "TurnTracking",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "tracker": "LIFE_LOST"
                     },
                     "operator": "GTE",
@@ -7245,7 +7245,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "TurnTracking",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "tracker": "LIFE_LOST"
                     },
                     "operator": "GTE",
@@ -8755,7 +8755,7 @@
                                     "type": "Compare",
                                     "left": {
                                         "type": "TurnTracking",
-                                        "player": "Opponent",
+                                        "player": "EachOpponent",
                                         "tracker": "LIFE_LOST"
                                     },
                                     "operator": "GTE",
@@ -20258,7 +20258,7 @@
                             "type": "Compare",
                             "left": {
                                 "type": "TurnTracking",
-                                "player": "Opponent",
+                                "player": "EachOpponent",
                                 "tracker": "LIFE_LOST"
                             },
                             "operator": "GTE",

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -9532,7 +9532,7 @@
                                 "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 },
                                 "tapped": true
                             },
@@ -11190,7 +11190,7 @@
                                 "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 },
                                 "tapped": true
                             },
@@ -12107,7 +12107,7 @@
                                 "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 },
                                 "tapped": true
                             },
@@ -13452,7 +13452,7 @@
                                 "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 },
                                 "tapped": true
                             },
@@ -16055,7 +16055,7 @@
                                 "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 },
                                 "tapped": true
                             },
@@ -18199,7 +18199,7 @@
                                         "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
                                         "controller": {
                                             "type": "PlayerRef",
-                                            "player": "EachOpponent"
+                                            "player": "AnOpponent"
                                         },
                                         "tapped": true
                                     },

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -5523,7 +5523,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": {
                             "statePredicates": [
                                 {

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -464,7 +464,7 @@
                         "type": "Divide",
                         "numerator": {
                             "type": "LifeTotal",
-                            "player": "Opponent"
+                            "player": "DefendingPlayer"
                         },
                         "denominator": {
                             "type": "Fixed",
@@ -473,7 +473,7 @@
                     },
                     "target": {
                         "type": "PlayerRef",
-                        "player": "Opponent"
+                        "player": "DefendingPlayer"
                     }
                 },
                 "triggerCondition": "Void",
@@ -4528,7 +4528,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "DiscardEvent",
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 },
                 "binding": "ANY",
                 "effect": {
@@ -8762,7 +8762,7 @@
                         "type": "Compare",
                         "left": {
                             "type": "AggregateBattlefield",
-                            "player": "Opponent",
+                            "player": "EachOpponent",
                             "filter": "creature"
                         },
                         "operator": "GTE",
@@ -14571,7 +14571,7 @@
                         },
                         {
                             "type": "Exists",
-                            "player": "Opponent",
+                            "player": "EachOpponent",
                             "zone": "Battlefield",
                             "filter": "creature",
                             "negate": true
@@ -14711,7 +14711,7 @@
                                     "type": "Fixed",
                                     "amount": 4
                                 },
-                                "player": "Opponent"
+                                "player": "DefendingPlayer"
                             },
                             "storeAs": "milled"
                         },
@@ -14721,7 +14721,7 @@
                             "destination": {
                                 "type": "ToZone",
                                 "zone": "Graveyard",
-                                "player": "Opponent"
+                                "player": "DefendingPlayer"
                             }
                         }
                     ]
@@ -15729,7 +15729,7 @@
                             "type": "Compare",
                             "left": {
                                 "type": "AggregateBattlefield",
-                                "player": "Opponent",
+                                "player": "EachOpponent",
                                 "filter": "land"
                             },
                             "operator": "GT",

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -3380,13 +3380,13 @@
                 },
                 "powerBonus": {
                     "type": "Count",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Swamp"
                 },
                 "toughnessBonus": {
                     "type": "Count",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Swamp"
                 }
@@ -5141,7 +5141,7 @@
                             "type": "GatherCards",
                             "source": {
                                 "type": "ControlledPermanents",
-                                "player": "Opponent",
+                                "player": "TriggeringPlayer",
                                 "filter": "creature"
                             },
                             "storeAs": "creatures"
@@ -6755,7 +6755,7 @@
                     "type": "Not",
                     "condition": {
                         "type": "Exists",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "zone": "Battlefield",
                         "filter": "creature white|blue"
                     }
@@ -7651,13 +7651,13 @@
                 },
                 "powerBonus": {
                     "type": "Count",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Plains"
                 },
                 "toughnessBonus": {
                     "type": "Count",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Plains"
                 }
@@ -11011,7 +11011,7 @@
                             "IsMulticolored"
                         ]
                     },
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 },
                 "binding": "ANY",
                 "effect": {
@@ -12663,7 +12663,7 @@
                     "type": "Not",
                     "condition": {
                         "type": "Exists",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "zone": "Battlefield",
                         "filter": "creature white|blue"
                     }
@@ -16012,7 +16012,7 @@
                     "filter": "creature",
                     "target": {
                         "type": "PlayerRef",
-                        "player": "Opponent"
+                        "player": "DefendingPlayer"
                     }
                 }
             }
@@ -17354,7 +17354,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -11251,7 +11251,7 @@
                             "filter": "creature",
                             "target": {
                                 "type": "PlayerRef",
-                                "player": "Opponent"
+                                "player": "TriggeringPlayer"
                             }
                         }
                     },

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -92,7 +92,7 @@
                 ],
                 "appliesTo": {
                     "type": "LifeLossEvent",
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -3404,7 +3404,7 @@
                     "operator": "GT",
                     "right": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": "creature"
                     }
                 }
@@ -3421,7 +3421,7 @@
                     "operator": "GT",
                     "right": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": "creature"
                     }
                 }
@@ -4325,7 +4325,7 @@
                             "type": "Compare",
                             "left": {
                                 "type": "Count",
-                                "player": "Opponent",
+                                "player": "TriggeringPlayer",
                                 "zone": "Hand"
                             },
                             "operator": "LTE",
@@ -4343,7 +4343,7 @@
                         },
                         "target": {
                             "type": "PlayerRef",
-                            "player": "Opponent"
+                            "player": "TriggeringPlayer"
                         }
                     }
                 },
@@ -4351,7 +4351,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "Count",
-                        "player": "Opponent",
+                        "player": "TriggeringPlayer",
                         "zone": "Hand"
                     },
                     "operator": "LTE",
@@ -7009,7 +7009,7 @@
                     "type": "Not",
                     "condition": {
                         "type": "Exists",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "zone": "Battlefield",
                         "filter": "creature"
                     }

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -17,7 +17,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "DrawEvent",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "exceptFirstInDrawStep": true
                 },
                 "binding": "ANY",
@@ -10079,7 +10079,7 @@
                 "id": "ability_2",
                 "trigger": {
                     "type": "DrawEvent",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "exceptFirstInDrawStep": true
                 },
                 "binding": "ANY",

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -2248,7 +2248,7 @@
                     "filter": "creature",
                     "target": {
                         "type": "PlayerRef",
-                        "player": "Opponent"
+                        "player": "DefendingPlayer"
                     }
                 }
             }
@@ -2386,7 +2386,7 @@
             {
                 "type": "EntersWithChoice",
                 "choiceType": "CREATURE_TYPE",
-                "chooser": "Opponent"
+                "chooser": "AnOpponent"
             }
         ]
     },
@@ -5243,7 +5243,7 @@
                         "type": "Divide",
                         "numerator": {
                             "type": "LifeTotal",
-                            "player": "Opponent"
+                            "player": "DefendingPlayer"
                         },
                         "denominator": {
                             "type": "Fixed",
@@ -5252,7 +5252,7 @@
                     },
                     "target": {
                         "type": "PlayerRef",
-                        "player": "Opponent"
+                        "player": "DefendingPlayer"
                     }
                 }
             }
@@ -12582,7 +12582,7 @@
                         },
                         "newController": {
                             "type": "PlayerRef",
-                            "player": "Opponent"
+                            "player": "AnOpponent"
                         }
                     }
                 },
@@ -14277,7 +14277,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -15591,7 +15591,7 @@
                     "source": {
                         "type": "FromZone",
                         "zone": "Hand",
-                        "player": "Opponent"
+                        "player": "AnOpponent"
                     },
                     "storeAs": "hand"
                 },
@@ -15615,7 +15615,7 @@
                     "destination": {
                         "type": "ToZone",
                         "zone": "Graveyard",
-                        "player": "Opponent"
+                        "player": "AnOpponent"
                     },
                     "moveType": "Discard"
                 },
@@ -17304,7 +17304,7 @@
                             "type": "Compare",
                             "left": {
                                 "type": "AggregateBattlefield",
-                                "player": "Opponent",
+                                "player": "EachOpponent",
                                 "filter": "land"
                             },
                             "operator": "GT",

--- a/mtg-sets/src/test/resources/snapshots/cards/PLS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PLS.json
@@ -1115,7 +1115,7 @@
                     "type": "DrawCards",
                     "count": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": "creature black"
                     }
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -482,7 +482,7 @@
                 "type": "Multiply",
                 "amount": {
                     "type": "AggregateBattlefield",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "filter": "creature attacking"
                 },
                 "multiplier": 3
@@ -1396,7 +1396,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -2389,7 +2389,7 @@
                     "type": "Compare",
                     "left": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": "land"
                     },
                     "operator": "GT",

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -2245,7 +2245,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "SpellCastEvent",
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 },
                 "binding": "ANY",
                 "effect": {
@@ -4765,7 +4765,10 @@
                     "source": {
                         "type": "FromZone",
                         "zone": "Hand",
-                        "player": "Opponent",
+                        "player": {
+                            "type": "ControllerOf",
+                            "targetDescription": "permanent an opponent controls"
+                        },
                         "filter": "artifact|creature|enchantment|land"
                     },
                     "storeAs": "put_candidates"
@@ -4780,7 +4783,7 @@
                             "amount": 1
                         }
                     },
-                    "chooser": "Opponent",
+                    "chooser": "ControllerOfSelection",
                     "storeSelected": "putting",
                     "prompt": "You may put an artifact, creature, enchantment, or land card from your hand onto the battlefield"
                 },
@@ -4790,7 +4793,10 @@
                     "destination": {
                         "type": "ToZone",
                         "zone": "Battlefield",
-                        "player": "Opponent"
+                        "player": {
+                            "type": "ControllerOf",
+                            "targetDescription": "permanent an opponent controls"
+                        }
                     }
                 }
             ]
@@ -7835,7 +7841,13 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "CantCastSpells"
+                "effect": {
+                    "type": "CantCastSpells",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "DefendingPlayer"
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -14,7 +14,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "AbilityActivatedEvent",
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 },
                 "binding": "ANY",
                 "effect": {
@@ -90,8 +90,20 @@
                 "spellEffect": {
                     "type": "Composite",
                     "effects": [
-                        "CantCastSpells",
-                        "CantActivateLoyaltyAbilities"
+                        {
+                            "type": "CantCastSpells",
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "CantActivateLoyaltyAbilities",
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
                     ]
                 },
                 "selfExileOnResolve": true

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -1671,21 +1671,25 @@
                                 }
                             },
                             "then": {
-                                "type": "LoseLife",
-                                "amount": {
-                                    "type": "Divide",
-                                    "numerator": {
-                                        "type": "LifeTotal",
-                                        "player": "Opponent"
-                                    },
-                                    "denominator": {
-                                        "type": "Fixed",
-                                        "amount": 2
-                                    }
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Players",
+                                    "players": "EachOpponent"
                                 },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                "body": {
+                                    "type": "LoseLife",
+                                    "amount": {
+                                        "type": "Divide",
+                                        "numerator": {
+                                            "type": "LifeTotal",
+                                            "player": "You"
+                                        },
+                                        "denominator": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "target": "Controller"
                                 }
                             }
                         }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1687,7 +1687,7 @@
                     "type": "GainLife",
                     "amount": {
                         "type": "AggregateBattlefield",
-                        "player": "Opponent",
+                        "player": "EachOpponent",
                         "filter": "creature attacking"
                     }
                 }
@@ -2096,7 +2096,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "Opponent",
+                    "player": "EachOpponent",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/UDS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/UDS.json
@@ -15,7 +15,7 @@
                             "IsCreature"
                         ]
                     },
-                    "player": "Opponent"
+                    "player": "EachOpponent"
                 },
                 "binding": "ANY",
                 "effect": {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -204,7 +204,7 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         "PowerOfPermanent" ->
             return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourcePower") else null
         "LifeTotalOfPlayer" -> {
-            val player = if (jsonContains(node, "_Player", "Opponent")) "Player.Opponent" else "Player.You"
+            val player = if (jsonContains(node, "_Player", "Opponent")) "Player.EachOpponent" else "Player.You"
             return call("DynamicAmount.LifeTotal", arg(player))
         }
         // "the number of [type] spells <player> has cast this turn" (Magebane Lizard). args = a spell
@@ -288,14 +288,14 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         val battlefieldCount = gn == "TheNumberOfPermanentsOnTheBattlefield"
         if (!battlefieldCount && (" hand" in oracle || " in it" in oracle)) return null
         val player = when {
-            "attacking you" in oracle -> "Player.Opponent"
+            "attacking you" in oracle -> "Player.EachOpponent"
             "on the battlefield" in oracle -> "Player.Each"
             "target opponent controls" in oracle || jsonContains(node, "_Player", "Ref_TargetOpponent") -> "Player.TargetOpponent"
             "target player controls" in oracle || jsonContains(node, "_Player", "Ref_TargetPlayer") -> "Player.TargetPlayer"
             // A plain "an opponent controls" controller clause is `ControlledByAPlayer{_Players: Opponent}`
             // — the key is plural `_Players`, so the singular `_Player` probe above misses it and the count
             // would wrongly default to Player.You (Pygmy Kavu's "each black creature your opponents control").
-            jsonContains(node, "_Player", "Opponent") || jsonContains(node, "_Players", "Opponent") -> "Player.Opponent"
+            jsonContains(node, "_Player", "Opponent") || jsonContains(node, "_Players", "Opponent") -> "Player.EachOpponent"
             // An explicit "you control" controller predicate (Fire Dragon's "Mountains you control").
             "ControlledByAPlayer" in compact(node) -> "Player.You"
             // A global battlefield tally with NO controller predicate ("the number of attacking
@@ -333,7 +333,7 @@ private fun spellsCastThisTurnFilter(spells: JsonObject?): String? = when (spell
 private fun spellsCastThisTurnPlayer(player: JsonObject?): String? = when (player?.strField("_Player")) {
     "Trigger_ThatPlayer" -> "Player.TriggeringPlayer"
     "You" -> "Player.You"
-    "Opponent" -> "Player.Opponent"
+    "Opponent" -> "Player.EachOpponent"
     else -> null
 }
 
@@ -367,7 +367,9 @@ private fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     // "{T}: Add {C}. This land deals N damage to you" carries a `_DamageRecipient: Player{You}` recipient
     // that is the controller, not a chosen target (Adarkar Wastes, Caldera Lake, Ancient Tomb).
     if (ref == "You") return "EffectTarget.PlayerRef(Player.You)"
-    if (ref == "Opponent") return "EffectTarget.PlayerRef(Player.Opponent)"
+    // A bare non-targeted "Opponent" recipient has no single multiplayer meaning
+    // (defending player / each opponent / a chosen one) — decline -> SCAFFOLD.
+    if (ref == "Opponent") return null
     return tvar
 }
 

--- a/mtgish-tooling/src/test/resources/fixtures/por.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/por.emitted.golden.txt
@@ -617,7 +617,7 @@ val BlessedReversal = card("Blessed Reversal") {
     spell {
         effect = GainLifeEffect(
             DynamicAmount.Multiply(
-                DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature.attacking()),
+                DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature.attacking()),
                 3
             )
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -214,7 +214,6 @@ data class RingTemptContinuation(
  * [amount] +1/+1 counters and becomes [subtype] if it isn't already.
  *
  * @property controllerId The player amassing (also the chooser).
- * @property opponentId That player's opponent (for the resolution context).
  * @property subtype The Army subtype being amassed (e.g., "Orc").
  * @property amount Number of +1/+1 counters to place.
  * @property sourceId The amassing source (for context/display).
@@ -224,7 +223,6 @@ data class RingTemptContinuation(
 data class AmassContinuation(
     override val decisionId: String,
     val controllerId: EntityId,
-    val opponentId: EntityId?,
     val subtype: String,
     val amount: Int,
     val sourceId: EntityId?,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -350,7 +350,6 @@ data class ForEachContinuation(
  * @property sourceId The spell/ability that caused this effect
  * @property sourceName Name of the source for display
  * @property controllerId The controller of the effect
- * @property opponentId The opponent (for effect context)
  * @property xValue The X value (if applicable)
  * @property targets The chosen targets (for effect context)
  * @property phase Current phase of the repeat loop

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -52,7 +52,6 @@ data class CounterUnlessPaysContinuation(
  * @property manaCost The mana cost to pay
  * @property effect The effect to execute if the player pays
  * @property controllerId The controller for effect context
- * @property opponentId The opponent for effect context
  * @property xValue The X value if applicable
  * @property targets The chosen targets for effect context
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -29,7 +29,6 @@ import kotlinx.serialization.Serializable
  * @property sourceName Name of the source for event messages
  * @property modes The full list of modes (indexed by original position)
  * @property xValue The X value if applicable
- * @property opponentId The opponent player ID
  * @property chooseCount Total modes to pick (1 for classic modal, 2+ for Commands)
  * @property selectedModeIndices Original mode indices already picked, in order
  * @property availableIndices Original mode indices still offered; null = all
@@ -47,7 +46,6 @@ data class ModalContinuation(
     val sourceName: String?,
     val modes: List<@Serializable Mode>,
     val xValue: Int? = null,
-    val opponentId: EntityId? = null,
     val triggeringEntityId: EntityId? = null,
     val chooseCount: Int = 1,
     /**
@@ -95,7 +93,6 @@ data class ModalPreChosenContinuation(
     val controllerId: EntityId,
     val sourceId: EntityId?,
     val sourceName: String?,
-    val opponentId: EntityId? = null,
     val xValue: Int? = null,
     val triggeringEntityId: EntityId? = null,
     val remainingEntries: List<ModalPreChosenEntry>
@@ -112,7 +109,6 @@ data class ModalPreChosenContinuation(
  * @property sourceName Name of the source for event messages
  * @property effect The chosen mode's effect to execute
  * @property xValue The X value if applicable
- * @property opponentId The opponent player ID
  */
 @Serializable
 data class ModalTargetContinuation(
@@ -122,7 +118,6 @@ data class ModalTargetContinuation(
     val sourceName: String?,
     val effect: Effect,
     val xValue: Int? = null,
-    val opponentId: EntityId? = null,
     val targetRequirements: List<TargetRequirement> = emptyList(),
     /** Original modes list for cancelling back to mode selection */
     val modes: List<@Serializable Mode>? = null,
@@ -350,7 +345,6 @@ data class DevourEntersContinuation(
  * @property modes The budget modes (cost + effect)
  * @property remainingBudget How many pawprints are left to spend
  * @property selectedModeIndices Mode indices selected so far, in order of selection
- * @property opponentId The opponent player ID
  */
 @Serializable
 data class BudgetModalContinuation(
@@ -361,7 +355,6 @@ data class BudgetModalContinuation(
     val modes: List<@Serializable BudgetMode>,
     val remainingBudget: Int,
     val selectedModeIndices: List<Int> = emptyList(),
-    val opponentId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -396,7 +389,6 @@ data class CreateTokenCopyOfChosenContinuation(
  * @property choices The feasible choices presented to the player (indices match the decision options)
  * @property targets Original targets from the effect context (preserved for ContextTarget resolution)
  * @property namedTargets Named targets from the pipeline state
- * @property opponentId The opponent player ID
  * @property triggeringEntityId The entity that triggered the ability
  */
 @Serializable
@@ -409,6 +401,5 @@ data class ChooseActionContinuation(
     val choices: List<@Serializable EffectChoice>,
     val targets: List<ChosenTarget> = emptyList(),
     val namedTargets: Map<String, ChosenTarget> = emptyMap(),
-    val opponentId: EntityId? = null,
     val triggeringEntityId: EntityId? = null
 ) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
@@ -60,11 +60,9 @@ class StateTriggerPoller(
             val abilities = cardDef.script.stateTriggeredAbilities
             if (abilities.isEmpty()) continue
 
-            val opponentId = workingState.turnOrder.firstOrNull { it != controllerId }
             val effectContext = EffectContext(
                 sourceId = permanentId,
                 controllerId = controllerId,
-                opponentId = opponentId
             )
 
             var latches = container.get<StateTriggerLatchesComponent>() ?: StateTriggerLatchesComponent()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -322,7 +322,6 @@ class TriggerAbilityResolver(
                         val context = EffectContext(
                             sourceId = permanentId,
                             controllerId = controllerId,
-                            opponentId = null
                         )
                         if (ConditionEvaluator().evaluate(state, ability.condition, context)) {
                             result.add(grant.ability)
@@ -451,7 +450,6 @@ class TriggerAbilityResolver(
                         val context = EffectContext(
                             sourceId = permanentId,
                             controllerId = controllerId,
-                            opponentId = null
                         )
                         if (ConditionEvaluator().evaluate(state, ability.condition, context)) conditionalWard else continue
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2204,10 +2204,9 @@ class TriggerDetector(
                     is AdditionalAttackTriggers -> ability
                     is ConditionalStaticAbility ->
                         (ability.ability as? AdditionalAttackTriggers)?.takeIf {
-                            val opponentId = state.turnOrder.firstOrNull { it != controllerId }
                             conditionEvaluator.evaluate(
                                 state, ability.condition,
-                                EffectContext(sourceId = permanentId, controllerId = controllerId, opponentId = opponentId)
+                                EffectContext(sourceId = permanentId, controllerId = controllerId)
                             )
                         }
                     else -> null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -881,7 +881,7 @@ class TriggerMatcher(
         return when (player) {
             Player.You -> eventPlayerId == controllerId
             Player.Each -> true
-            Player.Opponent -> eventPlayerId != controllerId
+            Player.EachOpponent -> eventPlayerId != controllerId
             else -> true
         }
     }
@@ -1051,7 +1051,7 @@ class TriggerMatcher(
         return when (player) {
             Player.You -> controllerId == activePlayerId
             Player.Each -> true
-            Player.Opponent, Player.EachOpponent -> controllerId != activePlayerId
+            Player.EachOpponent -> controllerId != activePlayerId
             else -> true
         }
     }
@@ -1145,7 +1145,6 @@ class TriggerMatcher(
             val context = EffectContext(
                 sourceId = trigger.sourceId,
                 controllerId = trigger.controllerId,
-                opponentId = state.turnOrder.firstOrNull { it != trigger.controllerId },
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                 triggerDamageAmount = trigger.triggerContext.damageAmount,
                 triggerCounterCount = trigger.triggerContext.counterCount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -412,7 +412,6 @@ class TriggerProcessor(
             val context = EffectContext(
                 sourceId = trigger.sourceId,
                 controllerId = trigger.controllerId,
-                opponentId = state.getOpponent(trigger.controllerId),
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                 triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
                 triggerDamageAmount = trigger.triggerContext.damageAmount,
@@ -617,7 +616,6 @@ class TriggerProcessor(
         val context = EffectContext(
             sourceId = trigger.sourceId,
             controllerId = trigger.controllerId,
-            opponentId = state.getOpponent(trigger.controllerId)
         )
         return DynamicAmountEvaluator().evaluate(state, resolvedAmount, context)
     }
@@ -668,7 +666,6 @@ class TriggerProcessor(
                     val context = EffectContext(
                         sourceId = trigger.sourceId,
                         controllerId = trigger.controllerId,
-                        opponentId = state.getOpponent(trigger.controllerId),
                         triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                         triggeringPlayerId = trigger.triggerContext.triggeringPlayerId
                     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -368,7 +368,6 @@ class ConditionEvaluator(
         return EffectContext(
             sourceId = ctx.sourceId,
             controllerId = controllerId,
-            opponentId = state.getOpponent(controllerId)
         )
     }
 
@@ -467,10 +466,9 @@ class ConditionEvaluator(
 
         val playerIds: List<EntityId> = when (condition.player) {
             is Player.You -> controllerId?.let { listOf(it) } ?: emptyList()
-            is Player.Opponent -> controllerId?.let { c -> state.turnOrder.filter { it != c } } ?: emptyList()
-            is Player.EachOpponent -> controllerId?.let { c -> state.turnOrder.filter { it != c } } ?: emptyList()
-            is Player.Each -> state.turnOrder
-            is Player.Any -> state.turnOrder
+            is Player.EachOpponent -> controllerId?.let { state.getOpponents(it) } ?: emptyList()
+            is Player.Each -> state.activePlayers
+            is Player.Any -> state.activePlayers
             is Player.Candidate -> listOfNotNull((ctx as? Resolution)?.effectContext?.candidatePlayerId)
             is Player.ChosenOpponent -> listOfNotNull(
                 ctx.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
@@ -584,7 +582,7 @@ class ConditionEvaluator(
      *
      * - [Player.You]: controller-of-source (resolution: effectContext.controllerId;
      *   projection: source's projected controller).
-     * - [Player.Opponent]: any opponent of the controller. Returns the first opponent
+     * - [Player.AnOpponent]: a non-targeted opponent of the controller. Returns the first opponent
      *   in turn order — sufficient for per-player tracker reads where each player has
      *   its own bucket.
      * - [Player.TriggeringPlayer]: only resolvable in resolution mode.
@@ -595,9 +593,9 @@ class ConditionEvaluator(
         return when (player) {
             is Player.You -> ctx.controllerId
                 ?: ctx.sourceId?.let { state.getEntity(it)?.get<ControllerComponent>()?.playerId }
-            is Player.Opponent -> {
+            is Player.AnOpponent -> {
                 val c = ctx.controllerId ?: return null
-                state.turnOrder.firstOrNull { it != c }
+                state.getOpponents(c).firstOrNull()
             }
             is Player.TriggeringPlayer -> (ctx as? Resolution)?.effectContext?.triggeringPlayerId
             is Player.Candidate -> (ctx as? Resolution)?.effectContext?.candidatePlayerId
@@ -834,10 +832,10 @@ class ConditionEvaluator(
     }
 
     private fun evaluateOpponentSpellOnStack(state: GameState, context: EffectContext): Boolean {
-        val opponentId = context.opponentId ?: return false
+        val opponents = state.getOpponents(context.controllerId)
         return state.stack.any { entityId ->
             val container = state.getEntity(entityId) ?: return@any false
-            container.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>()?.casterId == opponentId
+            container.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>()?.casterId in opponents
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -684,12 +684,12 @@ class DynamicAmountEvaluator(
     ): List<EntityId> {
         return when (player) {
             is Player.You -> listOf(context.controllerId)
-            is Player.Opponent -> state.turnOrder.filter { it != context.controllerId }
-            is Player.EachOpponent -> state.turnOrder.filter { it != context.controllerId }
-            is Player.TargetOpponent -> listOfNotNull(context.opponentId)
-            is Player.TargetPlayer -> listOfNotNull(context.opponentId)
-            is Player.Each -> state.turnOrder
-            is Player.Any -> state.turnOrder
+            is Player.EachOpponent -> state.getOpponents(context.controllerId)
+            is Player.TargetOpponent, is Player.TargetPlayer -> listOfNotNull(
+                TargetResolutionUtils.resolvePlayerRef(player, context, state)
+            )
+            is Player.Each -> state.activePlayers
+            is Player.Any -> state.activePlayers
             is Player.ContextPlayer -> {
                 val target = context.positionalTarget(player.index) ?: return emptyList()
                 when (target) {
@@ -713,12 +713,15 @@ class DynamicAmountEvaluator(
                 listOfNotNull(context.triggeringPlayerId ?: context.triggeringEntityId)
             }
             is Player.ActivePlayerFirst -> {
-                val activePlayer = state.activePlayerId ?: return state.turnOrder
-                listOf(activePlayer) + state.turnOrder.filter { it != activePlayer }
+                val activePlayer = state.activePlayerId ?: return state.activePlayers
+                listOf(activePlayer) + state.activePlayers.filter { it != activePlayer }
             }
             is Player.Candidate -> listOfNotNull(context.candidatePlayerId)
             is Player.ChosenOpponent -> listOfNotNull(
                 context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+            )
+            is Player.AnOpponent, is Player.DefendingPlayer -> listOfNotNull(
+                TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
         }
     }
@@ -935,7 +938,7 @@ class DynamicAmountEvaluator(
      */
     private fun basePowerOfPrintedCard(state: GameState, entityId: EntityId): Int {
         val card = state.getEntity(entityId)?.get<CardComponent>() ?: return 0
-        val ctx = EffectContext(sourceId = entityId, controllerId = card.ownerId ?: return 0, opponentId = null)
+        val ctx = EffectContext(sourceId = entityId, controllerId = card.ownerId ?: return 0)
         return when (val p = card.baseStats?.power) {
             is CharacteristicValue.Fixed -> p.value
             is CharacteristicValue.Dynamic -> evaluate(state, p.source, ctx)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -24,7 +24,6 @@ data class EffectContext(
     // --- Core ---
     val sourceId: EntityId?,
     val controllerId: EntityId,
-    val opponentId: EntityId?,
     /**
      * The player currently under consideration as a target, bound while evaluating a
      * `TargetPlayer.restriction` / `TargetOpponent.restriction` (CR 115). Resolves

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1049,16 +1049,15 @@ data class PredicateContext(
          * Create from EffectContext for compatibility.
          */
         fun fromEffectContext(context: EffectContext): PredicateContext {
-            // Derive the concretely chosen player target from the effect's targets.
-            // Falls back to opponentId when no player target is present — preserves the
-            // historic behavior for cards that reference "target opponent" implicitly.
+            // "Target opponent" / "target player" predicates read the concretely chosen
+            // player target — never a turn-order-derived opponent.
             val chosenPlayerTarget = context.targets.firstNotNullOfOrNull { target ->
                 (target as? ChosenTarget.Player)?.playerId
             }
             return PredicateContext(
                 controllerId = context.controllerId,
-                targetOpponentId = context.opponentId,
-                targetPlayerId = chosenPlayerTarget ?: context.opponentId,
+                targetOpponentId = chosenPlayerTarget,
+                targetPlayerId = chosenPlayerTarget,
                 sourceId = context.sourceId,
                 triggeringEntityId = context.triggeringEntityId,
                 affectedEntityId = context.affectedEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -845,11 +845,9 @@ class ActivateAbilityHandler(
                     else -> finalEffect
                 }
             }
-            val opponentId = state.turnOrder.firstOrNull { it != action.playerId }
             val context = EffectContext(
                 sourceId = action.sourceId,
                 controllerId = action.playerId,
-                opponentId = opponentId,
                 targets = action.targets,
                 // Thread the chosen X so X-based mana abilities produce the right amount
                 // ("{X}, {T}, Sacrifice this: Add X mana..." — Wizard's Rockets). Without
@@ -1370,7 +1368,6 @@ class ActivateAbilityHandler(
         val reductionContext = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = null,
             targets = targets
         )
         val amount = DynamicAmountEvaluator().evaluate(state, reduction, reductionContext)
@@ -1571,11 +1568,9 @@ class ActivateAbilityHandler(
                 else null
             }
             is ActivationRestriction.OnlyIfCondition -> {
-                val opponentId = state.turnOrder.firstOrNull { it != playerId }
                 val context = EffectContext(
                     sourceId = sourceId,
                     controllerId = playerId,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = 0
                 )
@@ -1759,12 +1754,10 @@ class ActivateAbilityHandler(
                 // The controller of the enchanted land gets the mana
                 val landController = currentState.getEntity(sourceId)
                     ?.get<ControllerComponent>()?.playerId ?: controllerId
-                val opponentId = currentState.turnOrder.firstOrNull { it != landController }
 
                 val context = EffectContext(
                     sourceId = entityId,
                     controllerId = landController,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = null
                 )
@@ -1863,11 +1856,9 @@ class ActivateAbilityHandler(
                         currentState, currentState.projectedState, sourceId, onSourceTap.sourceFilter, filterContext
                     )) continue
 
-                val opponentId = currentState.turnOrder.firstOrNull { it != tappingPlayerId }
                 val effectContext = EffectContext(
                     sourceId = entityId,
                     controllerId = tappingPlayerId,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = null
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/TypecycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/TypecycleCardHandler.kt
@@ -251,7 +251,6 @@ class TypecycleCardHandler(
         val effectContext = EffectContext(
             sourceId = action.cardId,
             controllerId = action.playerId,
-            opponentId = currentState.getOpponent(action.playerId)
         )
 
         val searchResult = effectExecutorRegistry.execute(currentState, searchEffect, effectContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -188,11 +188,9 @@ class PlayLandHandler(
                 val onEnterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>(zoneChangeEvent)
                 newState = newState.tick()
 
-                val opponentId = newState.turnOrder.firstOrNull { it != action.playerId }
                 val effectContext = EffectContext(
                     sourceId = action.cardId,
                     controllerId = action.playerId,
-                    opponentId = opponentId,
                 )
                 val effectResult = effectExecutor(newState, onEnter.effect, effectContext)
                 if (effectResult.isPaused) {
@@ -282,7 +280,6 @@ class PlayLandHandler(
                         val context = EffectContext(
                             sourceId = action.cardId,
                             controllerId = action.playerId,
-                            opponentId = newState.turnOrder.firstOrNull { it != action.playerId }
                         )
                         !ConditionEvaluator().evaluate(newState, entersTapped.unlessCondition!!, context)
                     } else {
@@ -323,8 +320,8 @@ class PlayLandHandler(
                 newState = newState.tick()
 
                 val chooserId = when (firstChoice.chooser) {
-                    com.wingedsheep.sdk.scripting.references.Player.Opponent ->
-                        newState.turnOrder.firstOrNull { it != action.playerId } ?: action.playerId
+                    com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
+                        newState.getOpponents(action.playerId).firstOrNull() ?: action.playerId
                     else -> action.playerId
                 }
 
@@ -608,11 +605,9 @@ class PlayLandHandler(
         sourceId: EntityId,
         controllerId: EntityId
     ): Boolean {
-        val opponentId = state.turnOrder.firstOrNull { it != controllerId }
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = opponentId
         )
         return conditionEvaluator.evaluate(state, condition, context)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -374,11 +374,9 @@ class TurnFaceUpHandler(
 
         // Execute face-up replacement effect (e.g., "put five +1/+1 counters on it")
         if (morphData.faceUpEffect != null) {
-            val opponentId = currentState.turnOrder.firstOrNull { it != action.playerId }
             val effectContext = com.wingedsheep.engine.handlers.EffectContext(
                 sourceId = action.sourceId,
                 controllerId = action.playerId,
-                opponentId = opponentId
             )
             val effectResult = effectExecutorRegistry.execute(currentState, morphData.faceUpEffect, effectContext)
             if (effectResult.error == null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/special/ConcedeHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/special/ConcedeHandler.kt
@@ -12,8 +12,9 @@ import kotlin.reflect.KClass
 /**
  * Handler for the Concede action.
  *
- * Concession is always valid and immediately ends the game with
- * the opponent as the winner.
+ * Concession is always valid. The winner is the sole remaining opponent — in a
+ * multiplayer pod the game must instead continue without the conceding player
+ * (CR 800.4a leave-the-game processing, backlog/multiplayer.md Phase 1.2).
  */
 class ConcedeHandler : ActionHandler<Concede> {
     override val actionType: KClass<Concede> = Concede::class
@@ -24,12 +25,12 @@ class ConcedeHandler : ActionHandler<Concede> {
     }
 
     override fun execute(state: GameState, action: Concede): ExecutionResult {
-        val opponent = state.getOpponent(action.playerId)
+        val winner = state.getOpponents(action.playerId).singleOrNull()
         return ExecutionResult.success(
-            state.copy(gameOver = true, winnerId = opponent),
+            state.copy(gameOver = true, winnerId = winner),
             listOf(
                 PlayerLostEvent(action.playerId, GameEndReason.CONCESSION),
-                GameEndedEvent(opponent, GameEndReason.CONCESSION)
+                GameEndedEvent(winner, GameEndReason.CONCESSION)
             )
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -821,11 +821,9 @@ class CastSpellHandler(
         restrictions: List<CastRestriction>,
         playerId: EntityId
     ): String? {
-        val opponentId = state.turnOrder.firstOrNull { it != playerId }
         val context = EffectContext(
             sourceId = null,
             controllerId = playerId,
-            opponentId = opponentId,
             targets = emptyList(),
             xValue = 0
         )
@@ -2259,7 +2257,6 @@ class CastSpellHandler(
             val captureContext = EffectContext(
                 sourceId = action.cardId,
                 controllerId = action.playerId,
-                opponentId = currentState.turnOrder.firstOrNull { it != action.playerId },
                 targets = emptyList(),
                 xValue = 0
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -321,11 +321,9 @@ class CastZoneResolver(
         val spellDef = spellCard?.let { cardRegistry.getCard(it.cardDefinitionId) }
         val conditionalFlash = spellDef?.script?.conditionalFlash
         if (conditionalFlash != null) {
-            val opponentId = state.turnOrder.firstOrNull { it != spellOwner }
             val effectContext = EffectContext(
                 sourceId = spellCardId,
                 controllerId = spellOwner,
-                opponentId = opponentId
             )
             if (conditionEvaluator.evaluate(state, conditionalFlash, effectContext)) {
                 return true
@@ -508,11 +506,9 @@ class CastZoneResolver(
         controllerId: EntityId,
         amount: com.wingedsheep.sdk.scripting.values.DynamicAmount
     ): Int {
-        val opponentId = state.turnOrder.firstOrNull { it != controllerId }
         val context = EffectContext(
             sourceId = granterId,
             controllerId = controllerId,
-            opponentId = opponentId
         )
         return DynamicAmountEvaluator().evaluate(state, amount, context)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
@@ -41,7 +41,6 @@ class AmassContinuationResumer(
             state = state,
             armyId = chosen,
             controllerId = continuation.controllerId,
-            opponentId = continuation.opponentId,
             subtype = continuation.subtype,
             amount = continuation.amount,
             sourceId = continuation.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CardSpecificContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CardSpecificContinuationResumer.kt
@@ -229,7 +229,6 @@ class CardSpecificContinuationResumer(
         val context = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = continuation.sourceId,
             controllerId = playerId,
-            opponentId = state.turnOrder.firstOrNull { it != playerId },
             xValue = bidAmount
         )
         return services.effectExecutorRegistry.execute(state, effect, context).toExecutionResult()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatContinuationResumer.kt
@@ -297,7 +297,6 @@ class CombatContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = null
         )
         newState = newState.addFloatingEffect(
             layer = Layer.ABILITY,
@@ -329,7 +328,6 @@ class CombatContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = null
         )
         val modification = if (continuation.amount == null) {
             // Prevent all damage from the chosen source for the rest of the turn (Samite Ministration)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -69,7 +69,6 @@ class CoreAutoResumerModule(
             val effectContext = EffectContext(
                 sourceId = continuation.cardId,
                 controllerId = continuation.playerId,
-                opponentId = state.getOpponent(continuation.playerId)
             )
             val searchResult = services.effectExecutorRegistry.execute(state, searchEffect, effectContext).toExecutionResult()
             mergeAndContinue(searchResult, events, checkForMore)
@@ -124,7 +123,6 @@ class CoreAutoResumerModule(
                 controllerId = continuation.controllerId,
                 sourceId = continuation.sourceId,
                 sourceName = continuation.sourceName,
-                opponentId = continuation.opponentId,
                 xValue = continuation.xValue,
                 triggeringEntityId = continuation.triggeringEntityId
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -159,7 +159,6 @@ class CostPaymentContinuationResumer(
         EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.payerId,
-            opponentId = state.turnOrder.firstOrNull { it != continuation.payerId },
             targets = continuation.targets,
             pipeline = PipelineState(
                 namedTargets = continuation.namedTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CreatureTypeChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CreatureTypeChoiceContinuationResumer.kt
@@ -138,7 +138,6 @@ class CreatureTypeChoiceContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = null
         )
         val newState = state.addFloatingEffect(
             layer = Layer.TYPE,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DrawReplacementContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DrawReplacementContinuationResumer.kt
@@ -212,7 +212,6 @@ class DrawReplacementContinuationResumer(
             val effectContext = EffectContext(
                 controllerId = playerId,
                 sourceId = continuation.sourceId,
-                opponentId = opponents.firstOrNull(),
                 targets = emptyList()
             )
             val effectResult = services.effectExecutorRegistry.execute(
@@ -352,7 +351,6 @@ class DrawReplacementContinuationResumer(
         val effectContext = EffectContext(
             controllerId = playerId,
             sourceId = continuation.sourceId,
-            opponentId = opponents.firstOrNull(),
             targets = chosenTargets,
             pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(continuation.targetRequirements, chosenTargets))
         )
@@ -423,7 +421,6 @@ class DrawReplacementContinuationResumer(
             val effectContext = com.wingedsheep.engine.handlers.EffectContext(
                 controllerId = playerId,
                 sourceId = continuation.sourceId,
-                opponentId = opponents.firstOrNull(),
                 targets = emptyList()
             )
             val effectResult = services.effectExecutorRegistry.execute(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -116,7 +116,6 @@ class EffectAndTriggerContinuationResumer(
                     com.wingedsheep.engine.handlers.EffectContext(
                         sourceId = continuation.sourceId,
                         controllerId = continuation.controllerId,
-                        opponentId = state.getOpponent(continuation.controllerId)
                     )
                 )
             } ?: effect.totalDamage

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -279,11 +279,9 @@ class ManaPaymentContinuationResumer(
             com.wingedsheep.sdk.dsl.Patterns.Hand.discardCards(continuation.count)
         }
 
-        val opponentId = state.turnOrder.firstOrNull { it != continuation.payingPlayerId }
         val discardContext = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = continuation.controllerId,
             controllerId = continuation.payingPlayerId,
-            opponentId = opponentId
         )
 
         val discardResult = services.effectExecutorRegistry
@@ -509,8 +507,8 @@ class ManaPaymentContinuationResumer(
      * paid the counter-unless cost, then continue the pipeline.
      *
      * The rider executes with [riderController] as `controllerId` (the controller of the
-     * counter effect, i.e. "you" in "you create a Lander token"), with the spell's
-     * opponent as `opponentId`. If the rider pauses for a sub-decision we surface that
+     * counter effect, i.e. "you" in "you create a Lander token"). If the rider pauses
+     * for a sub-decision we surface that
      * pause directly; on error we also propagate it. Otherwise events from the prior
      * payment phase are concatenated with the rider's events.
      */
@@ -524,11 +522,9 @@ class ManaPaymentContinuationResumer(
     ): ExecutionResult {
         if (onPaid == null) return checkForMore(state, priorEvents)
 
-        val opponentId = state.turnOrder.firstOrNull { it != riderController }
         val riderContext = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = sourceId,
             controllerId = riderController,
-            opponentId = opponentId
         )
         val riderResult = services.effectExecutorRegistry
             .execute(state, onPaid, riderContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -101,7 +101,6 @@ class MiscContinuationResumer(
         val drawContext = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.playerId,
-            opponentId = null
         )
         val result = services.effectExecutorRegistry.execute(currentState, drawEffect, drawContext).toExecutionResult()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -131,7 +131,6 @@ class ModalAndCloneContinuationResumer(
             sourceId = continuation.sourceId,
             sourceName = continuation.sourceName,
             xValue = continuation.xValue,
-            opponentId = continuation.opponentId,
             triggeringEntityId = continuation.triggeringEntityId,
             allowCancelBackToModesList = if (allowCancelBackToModes) continuation.modes else null,
             outerTargets = continuation.outerTargets,
@@ -159,7 +158,6 @@ class ModalAndCloneContinuationResumer(
         sourceId: EntityId?,
         sourceName: String?,
         xValue: Int?,
-        opponentId: EntityId?,
         triggeringEntityId: EntityId?,
         allowCancelBackToModesList: List<Mode>?,
         outerTargets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
@@ -183,7 +181,6 @@ class ModalAndCloneContinuationResumer(
                 val context = EffectContext(
                     sourceId = sourceId,
                     controllerId = controllerId,
-                    opponentId = opponentId,
                     xValue = xValue,
                     targets = outerTargets,
                     pipeline = PipelineState(namedTargets = outerNamedTargets),
@@ -239,7 +236,6 @@ class ModalAndCloneContinuationResumer(
                     val context = EffectContext(
                         sourceId = sourceId,
                         controllerId = controllerId,
-                        opponentId = opponentId,
                         xValue = xValue,
                         targets = chosenTargets,
                         pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(head.targetRequirements, chosenTargets)),
@@ -279,7 +275,6 @@ class ModalAndCloneContinuationResumer(
                 sourceName = sourceName,
                 effect = head.effect,
                 xValue = xValue,
-                opponentId = opponentId,
                 targetRequirements = head.targetRequirements,
                 modes = if (tail.isEmpty()) allowCancelBackToModesList else null,
                 triggeringEntityId = triggeringEntityId,
@@ -340,7 +335,6 @@ class ModalAndCloneContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = continuation.opponentId,
             xValue = continuation.xValue,
             targets = chosenTargets,
             pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(continuation.targetRequirements, chosenTargets)),
@@ -359,7 +353,6 @@ class ModalAndCloneContinuationResumer(
                 sourceId = continuation.sourceId,
                 sourceName = continuation.sourceName,
                 xValue = continuation.xValue,
-                opponentId = continuation.opponentId,
                 triggeringEntityId = continuation.triggeringEntityId,
                 allowCancelBackToModesList = null,
                 outerTargets = continuation.outerTargets,
@@ -700,8 +693,8 @@ class ModalAndCloneContinuationResumer(
 
         if (nextChoice != null) {
             val chooserId = when (nextChoice.chooser) {
-                com.wingedsheep.sdk.scripting.references.Player.Opponent ->
-                    newState.turnOrder.firstOrNull { it != continuation.controllerId } ?: continuation.controllerId
+                com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
+                    newState.getOpponents(continuation.controllerId).firstOrNull() ?: continuation.controllerId
                 else -> continuation.controllerId
             }
 
@@ -1212,7 +1205,6 @@ class ModalAndCloneContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = continuation.opponentId
         )
 
         val result = services.effectExecutorRegistry.execute(state, CompositeEffect(effects), context).toExecutionResult()
@@ -1279,7 +1271,6 @@ class ModalAndCloneContinuationResumer(
             sourceName = continuation.sourceName,
             modes = modes,
             xValue = continuation.xValue,
-            opponentId = continuation.opponentId,
             triggeringEntityId = continuation.triggeringEntityId,
             outerTargets = continuation.outerTargets,
             outerNamedTargets = continuation.outerNamedTargets
@@ -1327,7 +1318,6 @@ class ModalAndCloneContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = continuation.opponentId,
             targets = continuation.targets,
             triggeringEntityId = continuation.triggeringEntityId,
             pipeline = PipelineState(namedTargets = continuation.namedTargets)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -198,7 +198,6 @@ class SacrificeAndPayContinuationResumer(
             val context = EffectContext(
                 sourceId = continuation.sourceId,
                 controllerId = continuation.playerId,
-                opponentId = null,
                 targets = continuation.targets,
                 pipeline = PipelineState(namedTargets = continuation.namedTargets),
                 triggeringEntityId = continuation.triggeringEntityId,
@@ -217,7 +216,6 @@ class SacrificeAndPayContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.playerId,
-            opponentId = null,
             targets = continuation.targets,
             pipeline = PipelineState(namedTargets = continuation.namedTargets),
             triggeringEntityId = continuation.triggeringEntityId,
@@ -566,7 +564,6 @@ class SacrificeAndPayContinuationResumer(
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = playerId,
-            opponentId = null,
             targets = continuation.targets,
             pipeline = PipelineState(namedTargets = continuation.namedTargets),
             triggeringEntityId = continuation.triggeringEntityId,
@@ -669,7 +666,6 @@ class SacrificeAndPayContinuationResumer(
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
-            opponentId = null,
             pipeline = PipelineState(storedCollections = continuation.storedCollections),
             triggeringEntityId = continuation.triggeringEntityId,
             triggeringPlayerId = continuation.triggeringPlayerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -560,10 +560,8 @@ object DamageUtils {
                 when (lifeGainEvent.player) {
                     Player.Each, Player.Any -> return true
                     Player.You -> if (playerId == sourceControllerId) return true
-                    // Player.EachOpponent reads identically to Player.Opponent here — both mean
-                    // "scope this prevention to opponents of the replacement's host controller".
-                    // Used by Gríma Wormtongue (LTR): "Your opponents can't gain life."
-                    Player.Opponent, Player.EachOpponent ->
+                    // "Your opponents can't gain life." — Gríma Wormtongue (LTR).
+                    Player.EachOpponent ->
                         if (playerId != sourceControllerId) return true
                     else -> {}
                 }
@@ -981,7 +979,6 @@ object DamageUtils {
                     val context = EffectContext(
                         sourceId = entityId,
                         controllerId = sourceControllerId,
-                        opponentId = state.turnOrder.firstOrNull { it != sourceControllerId },
                     )
                     if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
                 }
@@ -1356,18 +1353,16 @@ object DamageUtils {
                 val playerMatches = when (pattern.player) {
                     Player.Each, Player.Any -> true
                     Player.You -> losingPlayerId == sourceControllerId
-                    Player.Opponent, Player.EachOpponent -> losingPlayerId != sourceControllerId
+                    Player.EachOpponent -> losingPlayerId != sourceControllerId
                     else -> false
                 }
                 if (!playerMatches) continue
 
                 val restrictions = restrictionsOf(effect)
                 if (restrictions.isNotEmpty()) {
-                    val opponentId = state.turnOrder.firstOrNull { it != sourceControllerId }
                     val context = EffectContext(
                         sourceId = entityId,
                         controllerId = sourceControllerId,
-                        opponentId = opponentId,
                     )
                     if (restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
@@ -67,7 +67,6 @@ object EntersWithCountersHelper {
                         val condContext = EffectContext(
                             sourceId = enteringEntityId,
                             controllerId = enteringControllerId,
-                            opponentId = newState.turnOrder.firstOrNull { it != enteringControllerId }
                         )
                         if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
                     }
@@ -89,7 +88,6 @@ object EntersWithCountersHelper {
                     val context = EffectContext(
                         sourceId = enteringEntityId,
                         controllerId = enteringControllerId,
-                        opponentId = newState.turnOrder.firstOrNull { it != enteringControllerId },
                         xValue = xValue
                     )
                     val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
@@ -151,7 +149,6 @@ object EntersWithCountersHelper {
                             val condContext = EffectContext(
                                 sourceId = sourceId,
                                 controllerId = sourceControllerId,
-                                opponentId = newState.turnOrder.firstOrNull { it != sourceControllerId }
                             )
                             if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
                         }
@@ -174,7 +171,6 @@ object EntersWithCountersHelper {
                         val context = EffectContext(
                             sourceId = sourceId,
                             controllerId = sourceControllerId,
-                            opponentId = newState.turnOrder.firstOrNull { it != sourceControllerId }
                         )
                         val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
                         if (count > 0) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
@@ -57,8 +57,7 @@ object LifeGainModifiers {
                 val recipientMatches = when (lifeGainEvent.player) {
                     Player.Each -> true
                     Player.You -> recipientId == sourceControllerId
-                    Player.Opponent -> recipientId != sourceControllerId
-                    Player.TargetOpponent -> recipientId != sourceControllerId
+                    Player.EachOpponent, Player.TargetOpponent -> recipientId != sourceControllerId
                     else -> recipientId == sourceControllerId
                 }
                 if (!recipientMatches) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -1,11 +1,13 @@
 package com.wingedsheep.engine.handlers.effects
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureRef
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.model.EntityId
@@ -79,6 +81,59 @@ object TargetResolutionUtils {
     }
 
     /**
+     * The first chosen target that is a player. "Target player" / "target opponent"
+     * references resolve through the bound targets — never through turn order.
+     */
+    private fun firstPlayerTarget(context: EffectContext): EntityId? =
+        context.targets.firstOrNull { it is ChosenTarget.Player }?.toEntityId()
+            ?: context.targets.firstOrNull()?.toEntityId()
+
+    /**
+     * The defending player for the ability's source, per CR 802.2a: read from the
+     * source's attack assignment (a creature attacking a planeswalker defends against
+     * that planeswalker's controller). When the source has already left combat (e.g.
+     * it died dealing combat damage), the trigger event's player is last-known
+     * information for "deals combat damage to a player" triggers.
+     */
+    fun resolveDefendingPlayer(context: EffectContext, state: GameState): EntityId? {
+        val defenderId = context.sourceId
+            ?.let { state.getEntity(it)?.get<AttackingComponent>()?.defenderId }
+        if (defenderId != null) {
+            return if (defenderId in state.turnOrder) defenderId
+            else state.getEntity(defenderId)?.get<ControllerComponent>()?.playerId
+        }
+        return (context.triggeringPlayerId ?: context.triggeringEntityId)
+            ?.takeIf { it in state.turnOrder }
+    }
+
+    /**
+     * Central single-player resolution for a [Player] reference. Every executor that
+     * maps a `Player` to one concrete player id goes through here — per-executor copies
+     * of this switch are what made `EffectContext.opponentId` so hard to kill.
+     *
+     * Multi-player references ([Player.Each], [Player.EachOpponent],
+     * [Player.ActivePlayerFirst]) return `null`: they have no single-player meaning and
+     * must be resolved through [resolvePlayerTargets] / an iteration.
+     */
+    fun resolvePlayerRef(player: Player, context: EffectContext, state: GameState): EntityId? {
+        return when (player) {
+            Player.You -> context.controllerId
+            Player.TargetPlayer, Player.TargetOpponent, Player.Any -> firstPlayerTarget(context)
+            is Player.ContextPlayer -> context.positionalTarget(player.index)?.toEntityId()
+            Player.TriggeringPlayer -> context.triggeringPlayerId ?: context.triggeringEntityId
+            Player.Candidate -> context.candidatePlayerId
+            Player.AnOpponent -> state.getOpponents(context.controllerId).firstOrNull()
+            Player.DefendingPlayer -> resolveDefendingPlayer(context, state)
+            Player.ChosenOpponent -> context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+            is Player.OwnerOf -> context.targets.firstOrNull()?.toEntityId()
+                ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
+            is Player.ControllerOf -> context.targets.firstOrNull()?.toEntityId()
+                ?.let { controllerOf(state, it) }
+            Player.Each, Player.EachOpponent, Player.ActivePlayerFirst -> null
+        }
+    }
+
+    /**
      * Resolve a player target from the effect target definition and context.
      */
     fun resolvePlayerTarget(effectTarget: EffectTarget, context: EffectContext): EntityId? {
@@ -90,8 +145,7 @@ object TargetResolutionUtils {
                 context.pipeline.storedCollections[effectTarget.collectionName]?.getOrNull(effectTarget.index)
             is EffectTarget.PlayerRef -> when (effectTarget.player) {
                 Player.You -> context.controllerId
-                Player.Opponent, Player.TargetOpponent, Player.EachOpponent -> context.opponentId
-                Player.TargetPlayer, Player.Any -> context.targets.firstOrNull()?.toEntityId()
+                Player.TargetPlayer, Player.TargetOpponent, Player.Any -> firstPlayerTarget(context)
                 Player.TriggeringPlayer -> context.triggeringPlayerId ?: context.triggeringEntityId
                 else -> null
             }
@@ -117,6 +171,12 @@ object TargetResolutionUtils {
      * Resolve a player target with access to game state (for relational references like OwnerOf/ControllerOf).
      */
     fun resolvePlayerTarget(effectTarget: EffectTarget, context: EffectContext, state: GameState): EntityId? {
+        // Player references get the full state-aware resolution (combat derivation,
+        // chosen-opponent slots, relational owner/controller lookups).
+        if (effectTarget is EffectTarget.PlayerRef) {
+            return resolvePlayerRef(effectTarget.player, context, state)
+        }
+
         // Try stateless resolution first
         resolvePlayerTarget(effectTarget, context)?.let { return it }
 
@@ -132,21 +192,7 @@ object TargetResolutionUtils {
             return controllerOf(state, targetEntityId)
         }
 
-        // Handle state-dependent relational references
-        return when (effectTarget) {
-            is EffectTarget.PlayerRef -> when (val player = effectTarget.player) {
-                is Player.OwnerOf -> {
-                    val targetEntity = context.targets.firstOrNull()?.toEntityId() ?: return null
-                    state.getEntity(targetEntity)?.get<CardComponent>()?.ownerId
-                }
-                is Player.ControllerOf -> {
-                    val targetEntity = context.targets.firstOrNull()?.toEntityId() ?: return null
-                    controllerOf(state, targetEntity)
-                }
-                else -> null
-            }
-            else -> null
-        }
+        return null
     }
 
     /**
@@ -168,20 +214,10 @@ object TargetResolutionUtils {
                 controllerId?.let { listOf(it) } ?: emptyList()
             }
             is EffectTarget.PlayerRef -> when (effectTarget.player) {
-                Player.Each -> state.turnOrder
-                Player.EachOpponent -> state.turnOrder.filter { it != context.controllerId }
-                Player.You -> listOf(context.controllerId)
-                Player.Opponent, Player.TargetOpponent -> state.turnOrder.filter { it != context.controllerId }
-                Player.TargetPlayer, Player.Any -> {
-                    context.targets.firstOrNull()?.toEntityId()?.let { listOf(it) } ?: emptyList()
-                }
-                Player.TriggeringPlayer -> {
-                    (context.triggeringPlayerId ?: context.triggeringEntityId)?.let { listOf(it) } ?: emptyList()
-                }
-                is Player.OwnerOf, is Player.ControllerOf -> {
-                    resolvePlayerTarget(effectTarget, context, state)?.let { listOf(it) } ?: emptyList()
-                }
-                else -> emptyList()
+                Player.Each -> state.activePlayers
+                Player.EachOpponent -> state.getOpponents(context.controllerId)
+                else -> resolvePlayerRef(effectTarget.player, context, state)
+                    ?.let { listOf(it) } ?: emptyList()
             }
             // Use the state-aware resolver so state-dependent targets (e.g. TargetController,
             // which reads the target spell/permanent's controller) resolve here too. It tries

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -567,9 +567,10 @@ object ZoneMovementUtils {
             if (ReplacementEffectUtils.isExtraTurnPrevented(state)) return state
 
             val cid = controllerId ?: return state
-            val opponentId = state.getOpponent(cid) ?: return state
-            return state.updateEntity(opponentId) { container ->
-                container.with(SkipNextTurnComponent)
+            return state.getOpponents(cid).fold(state) { acc, opponentId ->
+                acc.updateEntity(opponentId) { container ->
+                    container.with(SkipNextTurnComponent)
+                }
             }
         }
         if (effect is com.wingedsheep.sdk.scripting.effects.AddCountersEffect && entityId != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
@@ -48,7 +48,9 @@ class BeholdEffectExecutor(
         val predicateContext = PredicateContext(
             controllerId = beholder,
             sourceId = context.sourceId,
-            targetOpponentId = context.opponentId,
+            targetOpponentId = context.targets.firstNotNullOfOrNull {
+                (it as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Player)?.playerId
+            },
         )
 
         val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BudgetModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BudgetModalEffectExecutor.kt
@@ -58,7 +58,6 @@ class BudgetModalEffectExecutor(
             modes = effect.modes,
             remainingBudget = effect.budget,
             selectedModeIndices = emptyList(),
-            opponentId = context.opponentId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseActionEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseActionEffectExecutor.kt
@@ -83,7 +83,6 @@ class ChooseActionEffectExecutor(
             choices = feasibleChoices,
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
-            opponentId = context.opponentId,
             triggeringEntityId = context.triggeringEntityId
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -38,7 +38,7 @@ import kotlin.reflect.KClass
  * Per-space context binding (see [IterationSpace] for the contract):
  * - Targets: the current target becomes the context's only target (`ContextTarget(0)`),
  *   storedCollections wiped.
- * - Players: `controllerId` rebound to the current player, `opponentId` recomputed
+ * - Players: `controllerId` rebound to the current player
  *   relative to them, storedCollections wiped.
  * - Collection / Group: `pipeline.iterationTarget` set so `EffectTarget.Self` resolves
  *   to the current entity; outer collections preserved.
@@ -177,13 +177,12 @@ class ForEachExecutor(
             pipeline = outerContext.pipeline.copy(storedCollections = emptyMap())
         )
 
-        // Recompute opponentId relative to the iterated player so Chooser.Opponent /
-        // Player.Opponent inside the loop resolve to *this* player's opponent (e.g.
+        // Rebind the controller to the iterated player so You / Chooser.Controller /
+        // Chooser.Opponent inside the loop resolve relative to *this* player (e.g.
         // Bend or Break: an opponent of each separating player chooses that player's
-        // pile), not the original caster's opponent.
+        // pile), not the original caster.
         is ForEachItem.OfPlayer -> outerContext.copy(
             controllerId = item.playerId,
-            opponentId = state.turnOrder.firstOrNull { it != item.playerId } ?: outerContext.opponentId,
             pipeline = outerContext.pipeline.copy(storedCollections = emptyMap())
         )
 
@@ -196,16 +195,17 @@ class ForEachExecutor(
 
     private fun resolvePlayers(player: Player, state: GameState, context: EffectContext): List<EntityId> {
         return when (player) {
-            Player.Each -> state.turnOrder
+            Player.Each -> state.activePlayers
             Player.ActivePlayerFirst -> {
-                val activePlayer = state.activePlayerId ?: return state.turnOrder
-                listOf(activePlayer) + state.turnOrder.filter { it != activePlayer }
+                val activePlayer = state.activePlayerId ?: return state.activePlayers
+                listOf(activePlayer) + state.activePlayers.filter { it != activePlayer }
             }
             Player.You -> listOf(context.controllerId)
-            Player.Opponent, Player.TargetOpponent, Player.EachOpponent -> {
-                state.turnOrder.filter { it != context.controllerId }
-            }
-            else -> state.turnOrder
+            Player.EachOpponent -> state.getOpponents(context.controllerId)
+            Player.TargetOpponent, Player.TargetPlayer -> listOfNotNull(
+                TargetResolutionUtils.resolvePlayerRef(player, context, state)
+            )
+            else -> state.activePlayers
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -440,7 +440,7 @@ class GatedEffectExecutor(
 
         SuccessCriterion.Auto.terminalCollectionMove(action)?.let { move ->
             val destination = move.destination as? CardDestination.ToZone ?: return GatedActionSnapshot()
-            val ownerId = resolvePlayer(destination.player, context) ?: return GatedActionSnapshot()
+            val ownerId = resolvePlayer(destination.player, context, state) ?: return GatedActionSnapshot()
             return zoneSnapshot(state, ownerId, destination.zone)
         }
 
@@ -464,15 +464,8 @@ class GatedEffectExecutor(
             destinationZonePreSize = state.zones[ZoneKey(ownerId, zone)]?.size ?: 0
         )
 
-    private fun resolvePlayer(player: Player, context: EffectContext): EntityId? = when (player) {
-        is Player.You -> context.controllerId
-        is Player.Opponent -> context.opponentId
-        is Player.TargetOpponent -> context.opponentId
-        is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-        is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
-        is Player.TriggeringPlayer -> context.triggeringEntityId
-        else -> context.controllerId
-    }
+    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): EntityId? =
+        TargetResolutionUtils.resolvePlayerRef(player, context, state) ?: context.controllerId
 
     companion object {
         /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayRevealCardFromHandEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayRevealCardFromHandEffectExecutor.kt
@@ -52,7 +52,9 @@ class MayRevealCardFromHandEffectExecutor(
         val predicateContext = PredicateContext(
             controllerId = revealer,
             sourceId = context.sourceId,
-            targetOpponentId = context.opponentId,
+            targetOpponentId = context.targets.firstNotNullOfOrNull {
+                (it as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Player)?.playerId
+            },
         )
         val eligible = handCards.filter { cardId ->
             predicateEvaluator.matches(state, state.projectedState, cardId, effect.filter, predicateContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
@@ -121,7 +121,6 @@ class ModalEffectExecutor(
             sourceName = sourceName,
             modes = effect.modes,
             xValue = context.xValue,
-            opponentId = context.opponentId,
             triggeringEntityId = context.triggeringEntityId,
             chooseCount = effectiveChooseCount,
             minChooseCount = effectiveMinChooseCount,
@@ -169,7 +168,6 @@ class ModalEffectExecutor(
             controllerId = context.controllerId,
             sourceId = context.sourceId,
             sourceName = sourceName,
-            opponentId = context.opponentId,
             xValue = context.xValue,
             triggeringEntityId = context.triggeringEntityId
         )
@@ -220,7 +218,6 @@ internal data class ModalPreChosenBaseContext(
     val controllerId: com.wingedsheep.sdk.model.EntityId,
     val sourceId: com.wingedsheep.sdk.model.EntityId?,
     val sourceName: String?,
-    val opponentId: com.wingedsheep.sdk.model.EntityId?,
     val xValue: Int?,
     val triggeringEntityId: com.wingedsheep.sdk.model.EntityId?
 )
@@ -277,7 +274,6 @@ internal fun processPreChosenModeQueue(
     val effectContext = EffectContext(
         sourceId = ctx.sourceId,
         controllerId = ctx.controllerId,
-        opponentId = ctx.opponentId,
         xValue = ctx.xValue,
         targets = head.targets,
         pipeline = PipelineState(
@@ -295,7 +291,6 @@ internal fun processPreChosenModeQueue(
                 controllerId = ctx.controllerId,
                 sourceId = ctx.sourceId,
                 sourceName = ctx.sourceName,
-                opponentId = ctx.opponentId,
                 xValue = ctx.xValue,
                 triggeringEntityId = ctx.triggeringEntityId,
                 remainingEntries = tail

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
@@ -166,7 +166,7 @@ class DrawReplacementDispatcher(
                 when (drawEvent.player) {
                     Player.Each -> return true
                     Player.You -> if (playerId == sourceControllerId) return true
-                    Player.Opponent, Player.EachOpponent -> if (sourceControllerId != null && playerId != sourceControllerId) return true
+                    Player.EachOpponent -> if (sourceControllerId != null && playerId != sourceControllerId) return true
                     else -> {}
                 }
             }
@@ -388,7 +388,7 @@ class DrawReplacementDispatcher(
                 val matchesPlayer = when (drawEvent.player) {
                     Player.Each -> true
                     Player.You -> sourceControllerId != null && playerId == sourceControllerId
-                    Player.Opponent, Player.EachOpponent ->
+                    Player.EachOpponent ->
                         sourceControllerId != null && playerId != sourceControllerId
                     else -> false
                 }
@@ -397,7 +397,6 @@ class DrawReplacementDispatcher(
                 val effectContext = com.wingedsheep.engine.handlers.EffectContext(
                     sourceId = entityId,
                     controllerId = playerId,
-                    opponentId = state.getOpponent(playerId),
                 )
                 val restrictionsHold = effect.restrictions.all { restriction ->
                     conditionEvaluator.evaluate(state, restriction, effectContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementShieldConsumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementShieldConsumer.kt
@@ -78,7 +78,6 @@ class DrawReplacementShieldConsumer(
         val context = EffectContext(
             controllerId = playerId,
             sourceId = mod.sourceId,
-            opponentId = newState.turnOrder.firstOrNull { it != playerId },
             targets = mod.targets,
             xValue = mod.xValue,
             pipeline = PipelineState(namedTargets = mod.namedTargets)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
@@ -34,7 +34,7 @@ class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
 
         val deciderId = when (effect.chooser) {
             Chooser.Controller -> context.controllerId
-            Chooser.Opponent -> context.opponentId
+            Chooser.Opponent -> state.getOpponents(context.controllerId).firstOrNull()
                 ?: return EffectResult.error(state, "No opponent for ChoosePile chooser")
             Chooser.TargetPlayer -> context.targets.firstOrNull()?.let {
                 TargetResolutionUtils.run { it.toEntityId() }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileLibraryUntilManaValueExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileLibraryUntilManaValueExecutor.kt
@@ -99,10 +99,12 @@ class ExileLibraryUntilManaValueExecutor : EffectExecutor<ExileLibraryUntilManaV
 
     private fun resolvePlayers(player: Player, state: GameState, context: EffectContext): List<EntityId> {
         return when (player) {
-            Player.Each, Player.ActivePlayerFirst -> state.turnOrder
+            Player.Each, Player.ActivePlayerFirst -> state.activePlayers
             Player.You -> listOf(context.controllerId)
-            Player.Opponent, Player.EachOpponent, Player.TargetOpponent ->
-                state.turnOrder.filter { it != context.controllerId }
+            Player.EachOpponent -> state.getOpponents(context.controllerId)
+            Player.TargetOpponent -> listOfNotNull(
+                TargetResolutionUtils.resolvePlayerRef(player, context, state)
+            )
             Player.TargetPlayer -> context.targets.firstOrNull()?.let {
                 listOf(TargetResolutionUtils.run { it.toEntityId() })
             } ?: emptyList()
@@ -110,7 +112,7 @@ class ExileLibraryUntilManaValueExecutor : EffectExecutor<ExileLibraryUntilManaV
                 listOf(TargetResolutionUtils.run { it.toEntityId() })
             } ?: emptyList()
             Player.TriggeringPlayer -> listOfNotNull(context.triggeringEntityId)
-            else -> state.turnOrder.filter { it != context.controllerId }
+            else -> state.getOpponents(context.controllerId)
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -268,26 +268,8 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
         else -> false
     }
 
-    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): com.wingedsheep.sdk.model.EntityId? {
-        return when (player) {
-            is Player.You -> context.controllerId
-            is Player.Opponent -> context.opponentId
-            is Player.TargetOpponent -> context.opponentId
-            is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.TriggeringPlayer -> context.triggeringEntityId
-            is Player.OwnerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            is Player.ControllerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId
-                    ?: state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            else -> context.controllerId
-        }
-    }
+    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): com.wingedsheep.sdk.model.EntityId? =
+        TargetResolutionUtils.resolvePlayerRef(player, context, state) ?: context.controllerId
 
     /**
      * Resolve a [Player] reference to the list of player ids whose zone should be gathered

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherUntilMatchExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherUntilMatchExecutor.kt
@@ -89,26 +89,6 @@ class GatherUntilMatchExecutor : EffectExecutor<GatherUntilMatchEffect> {
         )
     }
 
-    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): EntityId? {
-        return when (player) {
-            is Player.You -> context.controllerId
-            is Player.Opponent -> context.opponentId
-            is Player.TargetOpponent -> context.opponentId
-            is Player.TargetPlayer -> context.opponentId
-            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let {
-                TargetResolutionUtils.run { it.toEntityId() }
-            }
-            is Player.TriggeringPlayer -> context.triggeringEntityId
-            is Player.OwnerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            is Player.ControllerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<ControllerComponent>()?.playerId
-                    ?: state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            else -> context.controllerId
-        }
-    }
+    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): EntityId? =
+        TargetResolutionUtils.resolvePlayerRef(player, context, state) ?: context.controllerId
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -752,24 +752,6 @@ class MoveCollectionExecutor(
         return null
     }
 
-    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): EntityId? {
-        return when (player) {
-            is Player.You -> context.controllerId
-            is Player.Opponent -> context.opponentId
-            is Player.TargetOpponent -> context.opponentId
-            is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.TriggeringPlayer -> context.triggeringEntityId
-            is Player.OwnerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            is Player.ControllerOf -> context.targets.firstOrNull()?.let {
-                val eid = TargetResolutionUtils.run { it.toEntityId() }
-                state.getEntity(eid)?.get<ControllerComponent>()?.playerId
-                    ?: state.getEntity(eid)?.get<CardComponent>()?.ownerId
-            }
-            else -> context.controllerId
-        }
-    }
+    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState): EntityId? =
+        TargetResolutionUtils.resolvePlayerRef(player, context, state) ?: context.controllerId
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -91,7 +91,7 @@ class SelectFromCollectionExecutor(
         // Resolve who makes the decision
         val decidingPlayerId = when (effect.chooser) {
             Chooser.Controller -> null // null = default to controller in createDecision
-            Chooser.Opponent -> context.opponentId
+            Chooser.Opponent -> state.getOpponents(context.controllerId).firstOrNull()
                 ?: return EffectResult.error(state, "No opponent for Opponent chooser")
             Chooser.TargetPlayer -> context.targets.firstOrNull()?.let {
                 TargetResolutionUtils.run { it.toEntityId() }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/TappedForManaBonusResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/TappedForManaBonusResolver.kt
@@ -140,7 +140,6 @@ class TappedForManaBonusResolver(
         EffectContext(
             sourceId = auraId,
             controllerId = controllerId,
-            opponentId = state.turnOrder.firstOrNull { it != controllerId },
             targets = emptyList(),
             xValue = null,
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
@@ -44,7 +44,6 @@ class AmassExecutor(
         context: EffectContext
     ): EffectResult {
         val controllerId = context.controllerId
-        val opponentId = context.opponentId
         val subtype = effect.subtype
         val amount = amountEvaluator.evaluate(state, effect.amount, context)
 
@@ -69,7 +68,7 @@ class AmassExecutor(
                 ?: return EffectResult.success(createResult.state, createResult.events)
 
             val applied = AmassResolution.applyToArmy(
-                createResult.state, tokenId, controllerId, opponentId, subtype, amount, context.sourceId, executeEffect
+                createResult.state, tokenId, controllerId, subtype, amount, context.sourceId, executeEffect
             )
             // Preserve the AmassedArmy pipeline entry produced by AmassResolution so a
             // composite "Amass X. Then [effect using amassed Army's power]" still threads
@@ -86,7 +85,7 @@ class AmassExecutor(
         // Exactly one Army → no choice to make.
         if (armies.size == 1) {
             return AmassResolution.applyToArmy(
-                state, armies.single(), controllerId, opponentId, subtype, amount, context.sourceId, executeEffect
+                state, armies.single(), controllerId, subtype, amount, context.sourceId, executeEffect
             )
         }
 
@@ -112,7 +111,6 @@ class AmassExecutor(
         val continuation = AmassContinuation(
             decisionId = decisionId,
             controllerId = controllerId,
-            opponentId = opponentId,
             subtype = subtype,
             amount = amount,
             sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassResolution.kt
@@ -29,13 +29,12 @@ object AmassResolution {
         state: GameState,
         armyId: EntityId,
         controllerId: EntityId,
-        opponentId: EntityId?,
         subtype: String,
         amount: Int,
         sourceId: EntityId?,
         executeEffect: (GameState, Effect, EffectContext) -> EffectResult
     ): EffectResult {
-        val context = EffectContext(sourceId = sourceId, controllerId = controllerId, opponentId = opponentId)
+        val context = EffectContext(sourceId = sourceId, controllerId = controllerId)
         var newState = state
         val events = mutableListOf<GameEvent>()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -279,7 +279,6 @@ class AnyPlayerMayPayExecutor(
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = null,
             pipeline = PipelineState(storedCollections = storedCollections),
             triggeringEntityId = triggeringEntityId,
             triggeringPlayerId = triggeringPlayerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantActivateLoyaltyAbilitiesExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantActivateLoyaltyAbilitiesExecutor.kt
@@ -24,11 +24,10 @@ class CantActivateLoyaltyAbilitiesExecutor : EffectExecutor<CantActivateLoyaltyA
         effect: CantActivateLoyaltyAbilitiesEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolvePlayerTarget(effect.target)
-            ?: return EffectResult.error(state, "No valid target for can't-activate-loyalty effect")
-
-        if (!state.turnOrder.contains(targetId)) {
-            return EffectResult.error(state, "Target is not a player")
+        val targetIds = context.resolvePlayerTargets(effect.target, state)
+            .filter { state.turnOrder.contains(it) }
+        if (targetIds.isEmpty()) {
+            return EffectResult.error(state, "No valid target for can't-activate-loyalty effect")
         }
 
         val removeOn = when (effect.duration) {
@@ -36,8 +35,10 @@ class CantActivateLoyaltyAbilitiesExecutor : EffectExecutor<CantActivateLoyaltyA
             else -> PlayerEffectRemoval.EndOfTurn
         }
 
-        val newState = state.updateEntity(targetId) { container ->
-            container.with(CantActivateLoyaltyAbilitiesComponent(removeOn = removeOn))
+        val newState = targetIds.fold(state) { acc, targetId ->
+            acc.updateEntity(targetId) { container ->
+                container.with(CantActivateLoyaltyAbilitiesComponent(removeOn = removeOn))
+            }
         }
 
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantCastSpellsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantCastSpellsExecutor.kt
@@ -23,11 +23,10 @@ class CantCastSpellsExecutor : EffectExecutor<CantCastSpellsEffect> {
         effect: CantCastSpellsEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolvePlayerTarget(effect.target)
-            ?: return EffectResult.error(state, "No valid target for can't cast spells effect")
-
-        if (!state.turnOrder.contains(targetId)) {
-            return EffectResult.error(state, "Target is not a player")
+        val targetIds = context.resolvePlayerTargets(effect.target, state)
+            .filter { state.turnOrder.contains(it) }
+        if (targetIds.isEmpty()) {
+            return EffectResult.error(state, "No valid target for can't cast spells effect")
         }
 
         val removeOn = when (effect.duration) {
@@ -35,8 +34,10 @@ class CantCastSpellsExecutor : EffectExecutor<CantCastSpellsEffect> {
             else -> PlayerEffectRemoval.EndOfTurn
         }
 
-        val newState = state.updateEntity(targetId) { container ->
-            container.with(CantCastSpellsComponent(removeOn = removeOn))
+        val newState = targetIds.fold(state) { acc, targetId ->
+            acc.updateEntity(targetId) { container ->
+                container.with(CantCastSpellsComponent(removeOn = removeOn))
+            }
         }
 
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/OpenLifeBidExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/OpenLifeBidExecutor.kt
@@ -183,7 +183,7 @@ object OpenLifeBidLogic {
 
         // The high bidder loses life equal to the high bid (routed through the life-loss
         // executor so prevention/replacement effects apply uniformly).
-        val loseLifeContext = EffectContext(sourceId = sourceId, controllerId = highBidder, opponentId = null)
+        val loseLifeContext = EffectContext(sourceId = sourceId, controllerId = highBidder)
         val lifeResult = executeEffect(
             state,
             LoseLifeEffect(DynamicAmount.Fixed(highBid), EffectTarget.PlayerRef(Player.You)),
@@ -198,7 +198,6 @@ object OpenLifeBidLogic {
             val winContext = EffectContext(
                 sourceId = sourceId,
                 controllerId = casterId,
-                opponentId = null,
                 targets = targets
             )
             val winResult = executeEffect(currentState, onWin, winContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextDrawStepExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextDrawStepExecutor.kt
@@ -28,12 +28,9 @@ class SkipNextDrawStepExecutor : EffectExecutor<SkipNextDrawStepEffect> {
         val targetPlayerId = when (target) {
             is EffectTarget.Controller -> context.controllerId
             is EffectTarget.PlayerRef -> {
-                when (target.player) {
-                    Player.You -> context.controllerId
-                    Player.Opponent, Player.TargetOpponent -> context.opponentId
-                        ?: return EffectResult.error(state, "No opponent found")
-                    else -> return EffectResult.error(state, "Unsupported player reference for SkipNextDrawStepEffect")
-                }
+                com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolvePlayerRef(target.player, context, state)
+                    ?: return EffectResult.error(state, "Cannot resolve player for SkipNextDrawStepEffect")
             }
             else -> return EffectResult.error(state, "Unsupported target for SkipNextDrawStepEffect")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextTurnExecutor.kt
@@ -27,12 +27,9 @@ class SkipNextTurnExecutor : EffectExecutor<SkipNextTurnEffect> {
         val targetPlayerId = when (target) {
             is EffectTarget.Controller -> context.controllerId
             is EffectTarget.PlayerRef -> {
-                when (target.player) {
-                    Player.You -> context.controllerId
-                    Player.Opponent, Player.TargetOpponent -> context.opponentId
-                        ?: return EffectResult.error(state, "No opponent found")
-                    else -> return EffectResult.error(state, "Unsupported player reference for SkipNextTurnEffect")
-                }
+                com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolvePlayerRef(target.player, context, state)
+                    ?: return EffectResult.error(state, "Cannot resolve player for SkipNextTurnEffect")
             }
             else -> return EffectResult.error(state, "Unsupported target for SkipNextTurnEffect")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TakeExtraTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TakeExtraTurnExecutor.kt
@@ -14,8 +14,8 @@ import kotlin.reflect.KClass
  * Executor for TakeExtraTurnEffect.
  * "Take an extra turn after this one."
  *
- * In a 2-player game, this is implemented by making the opponent skip their next turn,
- * which effectively gives the caster an extra turn.
+ * Implemented by making every other player skip their next turn, which inserts one
+ * extra turn for the taker regardless of player count.
  *
  * If loseAtEndStep is true (e.g., Last Chance), the caster will also lose the game
  * at the beginning of their next end step.
@@ -40,13 +40,16 @@ class TakeExtraTurnExecutor : EffectExecutor<TakeExtraTurnEffect> {
             return EffectResult.success(state)
         }
 
-        // In a 2-player game, "take an extra turn" means the other player skips their next turn
-        val otherPlayerId = state.getOpponent(turnTakerId)
-            ?: return EffectResult.error(state, "No opponent found")
-
-        // Add SkipNextTurnComponent to the other player
-        var newState = state.updateEntity(otherPlayerId) { container ->
-            container.with(SkipNextTurnComponent)
+        // "Take an extra turn" is modeled as every other player skipping their next turn,
+        // which inserts one extra turn for the taker regardless of player count.
+        val otherPlayerIds = state.getOpponents(turnTakerId)
+        if (otherPlayerIds.isEmpty()) {
+            return EffectResult.error(state, "No opponent found")
+        }
+        var newState = otherPlayerIds.fold(state) { acc, otherPlayerId ->
+            acc.updateEntity(otherPlayerId) { container ->
+                container.with(SkipNextTurnComponent)
+            }
         }
 
         // If loseAtEndStep is true, mark the turn-taker to lose at their next end step

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -109,7 +109,10 @@ class CreateTokenCopyOfTargetExecutor(
             // creature (e.g. an animated permanent exiled and reverted to its printed type) still
             // enters tapped but never attacking — see Mardu Siegebreaker's rulings.
             if (effect.attacking && tokenCard.typeLine.isCreature) {
-                val defenderId = newState.getOpponent(controllerId)
+                // The token joins the source's attack (CR 802.2a) — see CreateTokenExecutor.
+                val defenderId = com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolveDefendingPlayer(context, newState)
+                    ?: newState.getOpponents(controllerId).firstOrNull()
                 if (defenderId != null) {
                     components.add(AttackingComponent(defenderId))
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -149,8 +149,12 @@ class CreateTokenExecutor(
                 components.add(TappedComponent)
             }
             if (effect.attacking) {
-                // Token enters attacking — in 2-player games, the defender is the opponent
-                val defenderId = newState.getOpponent(tokenControllerId)
+                // Token enters attacking — it joins the attack of the source creature
+                // (CR 802.2a: defender per attacking creature), falling back to the sole
+                // active opponent outside combat-derived contexts.
+                val defenderId = com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolveDefendingPlayer(context, newState)
+                    ?: newState.getOpponents(tokenControllerId).firstOrNull()
                 if (defenderId != null) {
                     components.add(AttackingComponent(defenderId))
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -65,15 +65,39 @@ class CreateTokenExecutor(
         val baseCount = amountEvaluator.evaluate(state, effect.count, context)
         if (baseCount <= 0) return EffectResult.success(state)
 
-        // Resolve who receives the token — defaults to spell/ability controller
-        val controller = effect.controller
-        val tokenControllerId = if (controller != null) {
-            context.resolvePlayerTarget(controller, state)
-                ?: context.controllerId
-        } else {
-            context.controllerId
-        }
+        // Resolve who receives the token — defaults to the spell/ability controller. A
+        // multi-player reference ("each opponent creates ...") fans out: every resolved
+        // player creates their own token(s).
+        val tokenControllerIds = effect.controller
+            ?.let { context.resolvePlayerTargets(it, state) }
+            ?.takeIf { it.isNotEmpty() }
+            ?: listOf(context.controllerId)
 
+        var currentState = state
+        val allEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+        val allCreatedTokens = mutableListOf<EntityId>()
+        for (tokenControllerId in tokenControllerIds) {
+            val result = createTokensFor(currentState, effect, context, baseCount, tokenControllerId)
+            if (result.error != null) return result
+            currentState = result.state
+            allEvents.addAll(result.events)
+            allCreatedTokens.addAll(result.updatedCollections[CREATED_TOKENS].orEmpty())
+        }
+        return EffectResult(
+            state = currentState,
+            events = allEvents,
+            updatedCollections = mapOf(CREATED_TOKENS to allCreatedTokens)
+        )
+    }
+
+    /** Create [baseCount] tokens (pre-replacement) under [tokenControllerId]'s control. */
+    private fun createTokensFor(
+        state: GameState,
+        effect: CreateTokenEffect,
+        context: EffectContext,
+        baseCount: Int,
+        tokenControllerId: EntityId
+    ): EffectResult {
         // Apply token-count replacements (Doubling Season / Exalted Sunborn,
         // and per-N modifiers) before downstream replacements get a look.
         val count = TokenCreationReplacementHelper.applyCountReplacements(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ReturnCreaturesPutInGraveyardThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ReturnCreaturesPutInGraveyardThisTurnExecutor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.effects.zones
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -30,7 +31,7 @@ class ReturnCreaturesPutInGraveyardThisTurnExecutor : EffectExecutor<ReturnCreat
         effect: ReturnCreaturesPutInGraveyardThisTurnEffect,
         context: EffectContext
     ): EffectResult {
-        val playerId = resolvePlayer(effect.player, context) ?: return EffectResult.success(state)
+        val playerId = resolvePlayer(effect.player, context, state) ?: return EffectResult.success(state)
         val graveyardKey = ZoneKey(playerId, Zone.GRAVEYARD)
         val graveyardIds = state.getZone(graveyardKey)
 
@@ -71,12 +72,6 @@ class ReturnCreaturesPutInGraveyardThisTurnExecutor : EffectExecutor<ReturnCreat
         return EffectResult.success(newState, events)
     }
 
-    private fun resolvePlayer(player: Player, context: EffectContext) = when (player) {
-        is Player.You -> context.controllerId
-        is Player.Opponent -> context.opponentId
-        is Player.TargetOpponent -> context.opponentId
-        is Player.TargetPlayer -> context.opponentId
-        is Player.TriggeringPlayer -> context.triggeringEntityId
-        else -> context.controllerId
-    }
+    private fun resolvePlayer(player: Player, context: EffectContext, state: GameState) =
+        TargetResolutionUtils.resolvePlayerRef(player, context, state) ?: context.controllerId
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -801,8 +801,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         val playerId = context.playerId
         val projected = context.projected
 
-        val opponentId = state.turnOrder.firstOrNull { it != playerId } ?: return
-        val opponentPermanents = projected.getBattlefieldControlledBy(opponentId)
+        val opponentPermanents = state.getOpponents(playerId)
+            .flatMap { projected.getBattlefieldControlledBy(it) }
 
         for (entityId in opponentPermanents) {
             val container = state.getEntity(entityId) ?: continue
@@ -1129,7 +1129,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         val baseContext = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = null
         )
         val amount = if (ability.targetRequirements.isNotEmpty()) {
             maxReductionOverLegalTargets(reduction, ability, state, sourceId, controllerId, enumerationContext, evaluator)
@@ -1164,7 +1163,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             val targetContext = com.wingedsheep.engine.handlers.EffectContext(
                 sourceId = sourceId,
                 controllerId = controllerId,
-                opponentId = null,
                 targets = listOf(ChosenTarget.Permanent(targetId))
             )
             evaluator.evaluate(state, reduction, targetContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -589,11 +589,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
             // Resolve dynamic mana-value cap (e.g. "spell with mana value ≤ number of Elves
             // and Faeries you control"). Computed once per granter.
             val maxManaValueCap: Int? = grantAbility.maxManaValue?.let { amount ->
-                val opponentId = state.turnOrder.firstOrNull { it != playerId }
                 val effectContext = com.wingedsheep.engine.handlers.EffectContext(
                     sourceId = entityId,
                     controllerId = playerId,
-                    opponentId = opponentId
                 )
                 com.wingedsheep.engine.handlers.DynamicAmountEvaluator().evaluate(state, amount, effectContext)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -64,11 +64,9 @@ class CastPermissionUtils(
             is ActivationRestriction.DuringPhase -> state.phase == restriction.phase
             is ActivationRestriction.DuringStep -> state.step == restriction.step
             is ActivationRestriction.OnlyIfCondition -> {
-                val opponentId = state.turnOrder.firstOrNull { it != playerId }
                 val context = EffectContext(
                     sourceId = sourceId,
                     controllerId = playerId,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = 0
                 )
@@ -108,11 +106,9 @@ class CastPermissionUtils(
     ): Boolean {
         if (restrictions.isEmpty()) return true
 
-        val opponentId = state.turnOrder.firstOrNull { it != playerId }
         val context = EffectContext(
             sourceId = null,
             controllerId = playerId,
-            opponentId = opponentId,
             targets = emptyList(),
             xValue = 0
         )
@@ -296,7 +292,6 @@ class CastPermissionUtils(
                     val ctx = EffectContext(
                         sourceId = permanentId,
                         controllerId = controller,
-                        opponentId = state.turnOrder.firstOrNull { it != controller }
                     )
                     if (!conditionEvaluator.evaluate(state, condition, ctx)) continue
                 }
@@ -317,7 +312,7 @@ class CastPermissionUtils(
     private fun affectedPlayerMatches(affected: Player, controllerId: EntityId, castingPlayerId: EntityId): Boolean =
         when (affected) {
             is Player.You -> castingPlayerId == controllerId
-            is Player.Opponent, is Player.EachOpponent -> castingPlayerId != controllerId
+            is Player.EachOpponent -> castingPlayerId != controllerId
             is Player.Each, is Player.Any, is Player.ActivePlayerFirst -> true
             // Target-bound references (TargetPlayer, …) have no meaning for a continuous static.
             else -> false
@@ -381,11 +376,9 @@ class CastPermissionUtils(
         val spellDef = spellCard?.let { cardRegistry.getCard(it.cardDefinitionId) }
         val conditionalFlash = spellDef?.script?.conditionalFlash
         if (conditionalFlash != null) {
-            val opponentId = state.turnOrder.firstOrNull { it != spellOwner }
             val effectContext = EffectContext(
                 sourceId = spellCardId,
                 controllerId = spellOwner,
-                opponentId = opponentId
             )
             if (conditionEvaluator.evaluate(state, conditionalFlash, effectContext)) {
                 return true
@@ -484,11 +477,9 @@ class CastPermissionUtils(
                 when (ability) {
                     is com.wingedsheep.sdk.scripting.ConditionalStaticAbility -> {
                         if (!predicate(ability.ability)) continue
-                        val opponentId = state.turnOrder.firstOrNull { it != playerId }
                         val context = com.wingedsheep.engine.handlers.EffectContext(
                             sourceId = entityId,
                             controllerId = playerId,
-                            opponentId = opponentId
                         )
                         if (conditionEvaluator.evaluate(state, ability.condition, context)) return true
                     }
@@ -585,11 +576,9 @@ class CastPermissionUtils(
                 for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
                     if (ability is com.wingedsheep.sdk.scripting.ConditionalStaticAbility) {
                         if (ability.ability is MayPlayLandsFromGraveyard) {
-                            val opponentId = state.turnOrder.firstOrNull { it != playerId }
                             val context = com.wingedsheep.engine.handlers.EffectContext(
                                 sourceId = entityId,
                                 controllerId = playerId,
-                                opponentId = opponentId
                             )
                             if (conditionEvaluator.evaluate(state, ability.condition, context)) return true
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -292,7 +292,6 @@ class TargetEnumerationUtils(
             val context = EffectContext(
                 sourceId = sourceId,
                 controllerId = playerId,
-                opponentId = state.getOpponent(playerId)
             )
             DynamicAmountEvaluator().evaluate(state, dyn, context).coerceAtLeast(0)
         } catch (_: Exception) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
@@ -39,9 +39,9 @@ object SneakWindow {
 
     /** The defending player has performed the declare-blockers turn-based action this combat. */
     private fun blockersDeclared(state: GameState, playerId: EntityId): Boolean =
-        state.getOpponent(playerId)?.let { defender ->
-            state.getEntity(defender)?.get<BlockersDeclaredThisCombatComponent>()
-        } != null
+        state.getOpponents(playerId).any { defender ->
+            state.getEntity(defender)?.get<BlockersDeclaredThisCombatComponent>() != null
+        }
 
     /**
      * Unblocked attackers [playerId] controls — the legal pool for the "return an unblocked

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -688,7 +688,6 @@ internal class AttackPhaseManager(
                         val ctx = com.wingedsheep.engine.handlers.EffectContext(
                             sourceId = entityId,
                             controllerId = defenderId,
-                            opponentId = attackingPlayer,
                         )
                         val taxPerAttacker = maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerAttacker, ctx, projected))
                         totalGenericTax += taxPerAttacker * attackerCount

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -762,7 +762,6 @@ internal class BlockPhaseManager(
         val effectContext = EffectContext(
             sourceId = blockerId,
             controllerId = blockingPlayer,
-            opponentId = attackingPlayer
         )
         if (!conditionEvaluator.evaluate(state, restriction.condition, effectContext)) {
             return "${cardComponent.name} ${restriction.description}"
@@ -798,7 +797,6 @@ internal class BlockPhaseManager(
         val effectContext = EffectContext(
             sourceId = blockerId,
             controllerId = blockingPlayer,
-            opponentId = attackingPlayer
         )
         return !conditionEvaluator.evaluate(state, restriction.condition, effectContext)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -95,7 +95,7 @@ class DefenderAttackRule : AttackRestrictionRule {
         val cardComp = container.get<CardComponent>() ?: return errorMsg(ctx)
         val cardDef = ctx.cardRegistry.getCard(cardComp.cardDefinitionId) ?: return errorMsg(ctx)
 
-        val effectContext = EffectContext(sourceId = ctx.attackerId, controllerId = ctx.attackingPlayer, opponentId = null)
+        val effectContext = EffectContext(sourceId = ctx.attackerId, controllerId = ctx.attackingPlayer)
         val canAttackDespite = cardDef.staticAbilities
             .filterIsInstance<CanAttackDespiteDefender>()
             .filter { it.filter.scope is Scope.Self }
@@ -167,7 +167,6 @@ class CantAttackUnlessDefenderRule : AttackDefenderRule {
         val effectContext = EffectContext(
             sourceId = ctx.attackerId,
             controllerId = ctx.attackingPlayer,
-            opponentId = defendingPlayer
         )
         if (!conditionEvaluator.evaluate(ctx.state, restriction.condition, effectContext)) {
             return "${cardComponent.name} ${restriction.description}"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -238,7 +238,6 @@ internal class EffectApplicator(
                         val context = EffectContext(
                             sourceId = effect.sourceId,
                             controllerId = controllerId,
-                            opponentId = state.getOpponent(controllerId),
                             affectedEntityId = entityId
                         )
                         val intermediateProjected = buildIntermediateProjectedState(state, projectedValues)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -612,7 +612,6 @@ class StateProjector(
             val context = EffectContext(
                 sourceId = entityId,
                 controllerId = controllerId,
-                opponentId = state.getOpponent(controllerId)
             )
             val baseStats = cardComponent.baseStats ?: continue
             val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -272,7 +272,7 @@ class CostCalculator(
                 // Player-scoped conditions ("during your turn", "you've cast another spell", ...)
                 // evaluate against the caster. The cost modifier's source is a non-spell permanent
                 // (or the spell card itself for SelfCast), neither of which the condition needs.
-                val ctx = EffectContext(sourceId = null, controllerId = casterId, opponentId = null)
+                val ctx = EffectContext(sourceId = null, controllerId = casterId)
                 conditionEvaluator.evaluate(state, gating.condition, ctx)
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -47,7 +47,6 @@ class ManaAbilitySideEffectExecutor(
      * @param sourceId Permanent that was tapped.
      * @param producedColor Color the source produced for the payment, or null for colorless.
      * @param controllerId Player who controls the source / paid the cost.
-     * @param opponentId The opposing player (for `Player.Opponent`-shaped targets).
      */
     /**
      * Tap every source in [solution] (emitting [TappedEvent]) and run any
@@ -63,7 +62,6 @@ class ManaAbilitySideEffectExecutor(
     ): Pair<GameState, List<GameEvent>> {
         var currentState = state
         val events = mutableListOf<GameEvent>()
-        val opponentId = currentState.turnOrder.firstOrNull { it != controllerId }
         for (source in solution.sources) {
             currentState = currentState.updateEntity(source.entityId) { c ->
                 c.with(TappedComponent)
@@ -76,7 +74,6 @@ class ManaAbilitySideEffectExecutor(
                 sourceId = source.entityId,
                 producedColor = production?.color,
                 controllerId = controllerId,
-                opponentId = opponentId
             )
             currentState = after
             events.addAll(sideEvents)
@@ -89,7 +86,6 @@ class ManaAbilitySideEffectExecutor(
         sourceId: EntityId,
         producedColor: Color?,
         controllerId: EntityId,
-        opponentId: EntityId?
     ): Pair<GameState, List<GameEvent>> {
         val card = state.getEntity(sourceId)?.get<CardComponent>()
             ?: return state to emptyList()
@@ -106,7 +102,6 @@ class ManaAbilitySideEffectExecutor(
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = opponentId
         )
 
         var currentState = state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1261,11 +1261,9 @@ class ManaSolver(
         is ActivationRestriction.DuringPhase -> state.phase == restriction.phase
         is ActivationRestriction.DuringStep -> state.step == restriction.step
         is ActivationRestriction.OnlyIfCondition -> {
-            val opponentId = state.turnOrder.firstOrNull { it != playerId }
             val context = EffectContext(
                 sourceId = sourceId,
                 controllerId = playerId,
-                opponentId = opponentId,
                 targets = emptyList(),
                 xValue = 0
             )
@@ -1325,11 +1323,9 @@ class ManaSolver(
         playerId: EntityId
     ): Int {
         if (amount is DynamicAmount.Fixed) return amount.amount
-        val opponentId = state.turnOrder.firstOrNull { it != playerId }
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = playerId,
-            opponentId = opponentId,
             targets = emptyList(),
             xValue = null
         )
@@ -1412,12 +1408,10 @@ class ManaSolver(
 
                 val landController = state.getEntity(source.entityId)
                     ?.get<ControllerComponent>()?.playerId ?: playerId
-                val opponentId = state.turnOrder.firstOrNull { it != landController }
 
                 val context = EffectContext(
                     sourceId = entityId,
                     controllerId = landController,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = null
                 )
@@ -1490,11 +1484,9 @@ class ManaSolver(
                         state, state.projectedState, source.entityId, onSourceTap.sourceFilter, filterContext
                     )) continue
 
-                val opponentId = state.turnOrder.firstOrNull { it != tappingPlayerId }
                 val effectContext = EffectContext(
                     sourceId = entityId,
                     controllerId = tappingPlayerId,
-                    opponentId = opponentId,
                     targets = emptyList(),
                     xValue = null
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1188,7 +1188,6 @@ class StackResolver(
                     val context = EffectContext(
                         sourceId = spellId,
                         controllerId = controllerId,
-                        opponentId = newState.turnOrder.firstOrNull { it != controllerId }
                     )
                     !com.wingedsheep.engine.handlers.ConditionEvaluator().evaluate(
                         newState, entersTapped.unlessCondition!!, context
@@ -1380,7 +1379,6 @@ class StackResolver(
             val context = EffectContext(
                 sourceId = spellId,
                 controllerId = spellComponent.casterId,
-                opponentId = newState.getOpponent(spellComponent.casterId),
                 targets = targets,
                 // Position-preserving view (null in slots dropped by 608.2b) so positional
                 // references — ContextTarget(n), EntityReference.Target(n), ContextPlayer(n) —
@@ -1776,7 +1774,6 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
-            opponentId = state.getOpponent(abilityComponent.controllerId),
             targets = resolvedTargets2,
             triggerDamageAmount = abilityComponent.triggerDamageAmount,
             triggerCounterCount = abilityComponent.triggerCounterCount,
@@ -1871,7 +1868,6 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
-            opponentId = state.getOpponent(abilityComponent.controllerId),
             targets = activatedTargets,
             sacrificedPermanents = abilityComponent.sacrificedPermanents,
             xValue = abilityComponent.xValue,
@@ -1939,7 +1935,6 @@ class StackResolver(
                         val condContext = EffectContext(
                             sourceId = entityId,
                             controllerId = controllerId,
-                            opponentId = newState.turnOrder.firstOrNull { it != controllerId }
                         )
                         if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
                     }
@@ -1962,7 +1957,6 @@ class StackResolver(
                     val context = EffectContext(
                         sourceId = entityId,
                         controllerId = controllerId,
-                        opponentId = newState.turnOrder.firstOrNull { it != controllerId },
                         xValue = xValue,
                         totalManaSpent = totalManaSpent
                     )
@@ -2521,8 +2515,8 @@ class StackResolver(
         choice: EntersWithChoice
     ): ExecutionResult? {
         val chooserId = when (choice.chooser) {
-            com.wingedsheep.sdk.scripting.references.Player.Opponent ->
-                state.turnOrder.firstOrNull { it != controllerId } ?: controllerId
+            com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
+                state.getOpponents(controllerId).firstOrNull() ?: controllerId
             else -> controllerId
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerTargetRestriction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerTargetRestriction.kt
@@ -41,7 +41,6 @@ object PlayerTargetRestriction {
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = state.getOpponent(controllerId),
             candidatePlayerId = candidatePlayerId
         )
         return conditionEvaluator.evaluate(state, restriction, context)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -79,7 +79,6 @@ class TargetValidator {
                         val context = EffectContext(
                             sourceId = sourceId,
                             controllerId = casterId,
-                            opponentId = state.getOpponent(casterId),
                             xValue = xValue
                         )
                         DynamicAmountEvaluator().evaluate(state, dyn, context).coerceAtLeast(0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -318,11 +318,23 @@ data class GameState(
     }
 
     /**
-     * Get opponent of a player (for 2-player games).
+     * Players still in the game, in turn order — excludes players who have lost or left
+     * (CR 800.4a keeps them in [turnOrder] for entity history; every iteration helper
+     * must skip them).
      */
-    fun getOpponent(playerId: EntityId): EntityId? {
-        return turnOrder.find { it != playerId }
-    }
+    val activePlayers: List<EntityId>
+        get() = turnOrder.filter {
+            getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
+        }
+
+    /**
+     * Opponents of a player, in turn order, excluding players who have lost or left the
+     * game. There is deliberately no single-opponent helper: any code that needs one
+     * specific opponent must say which one (a chosen target, an iteration, or the
+     * per-creature defending player — CR 802.2a).
+     */
+    fun getOpponents(playerId: EntityId): List<EntityId> =
+        activePlayers.filter { it != playerId }
 
     /**
      * Returns the player who currently has *input authority* for [playerId] — that is,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermissions.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermissions.kt
@@ -80,11 +80,9 @@ fun MayPlayPermission.gateOpen(
     conditionEvaluator: ConditionEvaluator,
 ): Boolean {
     val condition = condition ?: return true
-    val opponentId = state.turnOrder.firstOrNull { it != controllerId }
     val context = EffectContext(
         sourceId = sourceId ?: cardId,
         controllerId = controllerId,
-        opponentId = opponentId,
     )
     return conditionEvaluator.evaluate(state, condition, context)
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1266,7 +1266,6 @@ class ClientStateTransformer(
             val context = EffectContext(
                 sourceId = spellEntityId,
                 controllerId = spellOnStack.casterId,
-                opponentId = state.getOpponent(spellOnStack.casterId),
                 xValue = spellOnStack.xValue,
                 wasKicked = spellOnStack.wasKicked,
                 wasBlightPaid = spellOnStack.wasBlightPaid,
@@ -1335,7 +1334,6 @@ class ClientStateTransformer(
         val context = EffectContext(
             sourceId = spellEntityId,
             controllerId = spellOnStack.casterId,
-            opponentId = state.getOpponent(spellOnStack.casterId),
             xValue = spellOnStack.xValue,
             sacrificedPermanents = spellOnStack.sacrificedPermanents,
             exiledCardCount = spellOnStack.exiledCardCount,
@@ -1428,7 +1426,6 @@ class ClientStateTransformer(
         val context = EffectContext(
             sourceId = abilityEntityId,
             controllerId = activated.controllerId,
-            opponentId = state.getOpponent(activated.controllerId),
             xValue = activated.xValue,
             sacrificedPermanents = activated.sacrificedPermanents,
             tappedPermanents = activated.tappedPermanents,
@@ -1476,7 +1473,6 @@ class ClientStateTransformer(
     ): EffectContext = EffectContext(
         sourceId = abilityEntityId,
         controllerId = triggered.controllerId,
-        opponentId = state.getOpponent(triggered.controllerId),
         xValue = triggered.xValue,
         triggerDamageAmount = triggered.triggerDamageAmount,
         triggerCounterCount = triggered.triggerCounterCount,
@@ -2517,7 +2513,6 @@ class ClientStateTransformer(
                 val context = com.wingedsheep.engine.handlers.EffectContext(
                     sourceId = null,
                     controllerId = controllerId,
-                    opponentId = state.turnOrder.firstOrNull { it != controllerId }
                 )
                 val evaluator = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
                 val leftVal = evaluator.evaluate(state, condition.left, context)
@@ -2616,7 +2611,7 @@ class ClientStateTransformer(
 
         return ClientCombatState(
             attackingPlayerId = attackingPlayerId ?: state.activePlayerId ?: return null,
-            defendingPlayerId = defendingPlayerId ?: state.getOpponent(attackingPlayerId!!) ?: return null,
+            defendingPlayerId = defendingPlayerId ?: state.getOpponents(attackingPlayerId!!).firstOrNull() ?: return null,
             attackers = attackers,
             blockers = blockers
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CastChoiceConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/CastChoiceConditionTest.kt
@@ -51,7 +51,7 @@ class CastChoiceConditionTest : FunSpec({
             .addToZone(ZoneKey(player, Zone.BATTLEFIELD), permanent)
     }
 
-    fun ctx() = EffectContext(sourceId = permanent, controllerId = player, opponentId = null)
+    fun ctx() = EffectContext(sourceId = permanent, controllerId = player)
 
     test("CastChoiceMade is true only when the slot holds a value") {
         val bag = CastChoicesComponent(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/EvaluateExistsControllerProjectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/EvaluateExistsControllerProjectionTest.kt
@@ -61,7 +61,6 @@ class EvaluateExistsControllerProjectionTest : FunSpec({
     fun contextFor(controllerId: EntityId, opponentId: EntityId) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = opponentId,
     )
 
     val youControlACreature = Exists(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionMatchesFilterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionMatchesFilterTest.kt
@@ -75,7 +75,6 @@ class FilterCollectionMatchesFilterTest : FunSpec({
     ) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = opponentId,
         pipeline = PipelineState(storedCollections = collection)
     )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsBattlefieldMatchingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsBattlefieldMatchingTest.kt
@@ -73,7 +73,6 @@ class GatherCardsBattlefieldMatchingTest : FunSpec({
     fun context(controllerId: EntityId) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = opponentId
     )
 
     fun gatherEffect(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsFromLinkedExileTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsFromLinkedExileTest.kt
@@ -41,7 +41,6 @@ class GatherCardsFromLinkedExileTest : FunSpec({
     fun context() = EffectContext(
         sourceId = sourceId,
         controllerId = playerId,
-        opponentId = opponentId
     )
 
     fun gatherEffect() = GatherCardsEffect(
@@ -184,7 +183,6 @@ class GatherCardsFromLinkedExileTest : FunSpec({
         val noSourceContext = EffectContext(
             sourceId = null,
             controllerId = playerId,
-            opponentId = opponentId
         )
 
         val result = executor.execute(state, gatherEffect(), noSourceContext)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionDestroyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionDestroyTest.kt
@@ -75,7 +75,6 @@ class MoveCollectionDestroyTest : FunSpec({
     ) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = opponentId,
         pipeline = PipelineState(storedCollections = mapOf(collectionName to cards))
     )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionToLibraryOwnerRoutingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionToLibraryOwnerRoutingTest.kt
@@ -72,7 +72,6 @@ class MoveCollectionToLibraryOwnerRoutingTest : FunSpec({
     fun context(controllerId: EntityId, collectionName: String, cards: List<EntityId>) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = opponentId,
         pipeline = PipelineState(storedCollections = mapOf(collectionName to cards))
     )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/ReturnLinkedExilePipelineTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/library/ReturnLinkedExilePipelineTest.kt
@@ -56,7 +56,6 @@ class ReturnLinkedExilePipelineTest : FunSpec({
     fun context() = EffectContext(
         sourceId = sourceId,
         controllerId = playerId,
-        opponentId = opponentId
     )
 
     fun createRegistry(): EffectExecutorRegistry {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutorTest.kt
@@ -76,7 +76,6 @@ class MoveToZoneEffectExecutorTest : FunSpec({
     fun context(targetId: EntityId, controllerId: EntityId) = EffectContext(
         sourceId = null,
         controllerId = controllerId,
-        opponentId = null,
         targets = listOf(ChosenTarget.Permanent(targetId))
     )
 
@@ -205,7 +204,6 @@ class MoveToZoneEffectExecutorTest : FunSpec({
         val ctx = EffectContext(
             sourceId = null,
             controllerId = playerId,
-            opponentId = null,
             targets = listOf(ChosenTarget.Permanent(cardId))
         )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiplayerSmokeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiplayerSmokeTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.handlers.effects.life.LoseLifeExecutor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.LossReason
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Phase 0 verification gate for `backlog/multiplayer.md`: the engine's core loop is
+ * N-player correct once the single-opponent context is gone. A four-player game
+ * initializes, priority round-trips through all four seats, a full turn cycle hands
+ * the turn to the next player in turn order, [GameState.getOpponents] excludes lost
+ * players, an `EachOpponent` effect fans out to all three opponents, and
+ * [Player.DefendingPlayer] resolves per CR 802.2a from the attack assignment.
+ */
+class MultiplayerSmokeTest : FunSpec({
+
+    val vanilla = CardDefinition.creature(
+        name = "Smoke Test Bear",
+        manaCost = com.wingedsheep.sdk.core.ManaCost.parse("{1}{G}"),
+        subtypes = setOf(com.wingedsheep.sdk.core.Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun initFourPlayerGame(): Pair<GameState, List<EntityId>> {
+        val registry = CardRegistry()
+        registry.register(vanilla)
+        val deck = Deck(cards = List(40) { "Smoke Test Bear" })
+        val result = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = (1..4).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    test("a four-player game initializes with four seats in turn order") {
+        val (state, players) = initFourPlayerGame()
+        players.size shouldBe 4
+        state.turnOrder shouldBe players
+        state.activePlayers shouldBe players
+        state.activePlayerId shouldBe players[0]
+    }
+
+    test("getOpponents returns the three other players in turn order") {
+        val (state, players) = initFourPlayerGame()
+        state.getOpponents(players[0]) shouldContainExactly listOf(players[1], players[2], players[3])
+        state.getOpponents(players[2]) shouldContainExactly listOf(players[0], players[1], players[3])
+    }
+
+    test("getOpponents and activePlayers exclude a player who has lost") {
+        val (state, players) = initFourPlayerGame()
+        val withLoss = state.updateEntity(players[1]) { c ->
+            c.with(PlayerLostComponent(LossReason.CONCESSION))
+        }
+        withLoss.activePlayers shouldContainExactly listOf(players[0], players[2], players[3])
+        withLoss.getOpponents(players[0]) shouldContainExactly listOf(players[2], players[3])
+    }
+
+    test("priority round-trips through all four players and a full turn cycle advances to the next seat") {
+        val (initial, players) = initFourPlayerGame()
+        val registry = CardRegistry().also { it.register(vanilla) }
+        val processor = ActionProcessor(registry)
+        var state = initial
+
+        val playersSeenWithPriority = mutableSetOf<EntityId>()
+        var safety = 0
+        // Drive the game until the turn passes to the second seat.
+        while (state.activePlayerId == players[0]) {
+            check(++safety < 500) { "turn never advanced (stuck at step ${state.step})" }
+            val prio = state.priorityPlayerId ?: break
+            playersSeenWithPriority.add(prio)
+            val action = when {
+                state.step == Step.DECLARE_ATTACKERS &&
+                    state.activePlayerId == prio &&
+                    state.getEntity(prio)?.has<AttackersDeclaredThisCombatComponent>() != true ->
+                    DeclareAttackers(prio, emptyMap())
+                state.step == Step.DECLARE_BLOCKERS && state.pendingDecision == null &&
+                    state.activePlayerId != prio -> DeclareBlockers(prio, emptyMap())
+                else -> PassPriority(prio)
+            }
+            val result = processor.process(state, action).result
+            check(result.isSuccess || result.isPaused) {
+                "action $action failed: ${result.error}"
+            }
+            state = result.newState
+        }
+
+        // Every seat held priority at least once during the first turn (CR 101.4 APNAP
+        // ordering means all four get a window before the turn ends).
+        playersSeenWithPriority shouldBe players.toSet()
+        // The next turn belongs to the next player in turn order.
+        state.activePlayerId shouldBe players[1]
+    }
+
+    test("an EachOpponent life-loss effect hits all three opponents and not the controller") {
+        val (state, players) = initFourPlayerGame()
+        val effect = LoseLifeEffect(
+            amount = DynamicAmount.Fixed(3),
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+        val context = EffectContext(sourceId = null, controllerId = players[0])
+        val result = LoseLifeExecutor().execute(state, effect, context)
+
+        fun life(s: GameState, p: EntityId) = s.getEntity(p)?.get<LifeTotalComponent>()?.life
+        life(result.state, players[0]) shouldBe 20
+        life(result.state, players[1]) shouldBe 17
+        life(result.state, players[2]) shouldBe 17
+        life(result.state, players[3]) shouldBe 17
+    }
+
+    test("Player.DefendingPlayer resolves to the player the source is attacking (CR 802.2a)") {
+        val (initial, players) = initFourPlayerGame()
+        // Materialize an attacker for player 0 declared against player 2 specifically.
+        val attackerId = EntityId.generate()
+        val container = com.wingedsheep.engine.state.ComponentContainer.of(
+            com.wingedsheep.engine.state.components.identity.CardComponent(
+                cardDefinitionId = "Smoke Test Bear",
+                name = "Smoke Test Bear",
+                manaCost = com.wingedsheep.sdk.core.ManaCost.parse("{1}{G}"),
+                typeLine = com.wingedsheep.sdk.core.TypeLine.parse("Creature — Bear"),
+                ownerId = players[0]
+            ),
+            com.wingedsheep.engine.state.components.identity.ControllerComponent(players[0]),
+            AttackingComponent(defenderId = players[2])
+        )
+        val onBattlefield = initial
+            .withEntity(attackerId, container)
+            .addToZone(
+                com.wingedsheep.engine.state.ZoneKey(players[0], com.wingedsheep.sdk.core.Zone.BATTLEFIELD),
+                attackerId
+            )
+        val context = EffectContext(sourceId = attackerId, controllerId = players[0])
+        TargetResolutionUtils.resolveDefendingPlayer(context, onBattlefield) shouldBe players[2]
+        TargetResolutionUtils.resolvePlayerRef(Player.DefendingPlayer, context, onBattlefield) shouldBe players[2]
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/APlayerLifeAtMostConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/APlayerLifeAtMostConditionTest.kt
@@ -33,7 +33,6 @@ class APlayerLifeAtMostConditionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = controller,
-            opponentId = state.getOpponent(controller),
             targets = emptyList(),
             xValue = 0
         )
@@ -54,14 +53,14 @@ class APlayerLifeAtMostConditionTest : FunSpec({
 
     test("true when an opponent is at or below the threshold") {
         val driver = createDriver()
-        val opponent = driver.state.getOpponent(driver.activePlayer!!)!!
+        val opponent = driver.getOpponent(driver.activePlayer!!)
         driver.setLifeTotal(opponent, 5)
         driver.evalAtMost(13) shouldBe true
     }
 
     test("boundary — true at exactly the threshold, false at threshold + 1") {
         val driver = createDriver()
-        val opponent = driver.state.getOpponent(driver.activePlayer!!)!!
+        val opponent = driver.getOpponent(driver.activePlayer!!)
         driver.setLifeTotal(driver.activePlayer!!, 14)
         driver.setLifeTotal(opponent, 14)
         driver.evalAtMost(13) shouldBe false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastFromZoneThisTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastFromZoneThisTurnTest.kt
@@ -96,7 +96,7 @@ class CastFromZoneThisTurnTest : FunSpec({
         val opp = driver.player2
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
         val evaluator = ConditionEvaluator()
-        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+        val ctx = EffectContext(sourceId = null, controllerId = you)
 
         // Cast a creature from the graveyard via forage — the only cast this turn.
         val adept = driver.putCreatureOnBattlefield(you, "Osteomancer Adept")
@@ -128,7 +128,7 @@ class CastFromZoneThisTurnTest : FunSpec({
         val you = driver.player1
         val opp = driver.player2
         val evaluator = ConditionEvaluator()
-        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+        val ctx = EffectContext(sourceId = null, controllerId = you)
 
         val instant = TypeLine.parse("Instant")
         val creature = TypeLine.parse("Creature")
@@ -170,7 +170,7 @@ class CastFromZoneThisTurnTest : FunSpec({
         val you = driver.player1
         val opp = driver.player2
         val evaluator = ConditionEvaluator()
-        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+        val ctx = EffectContext(sourceId = null, controllerId = you)
 
         // A face-down spell has no known characteristics (CR 708.2), but it was still cast from hand.
         val state = driver.state.copy(
@@ -201,7 +201,7 @@ class CastFromZoneThisTurnTest : FunSpec({
         val you = driver.player1
         val opp = driver.player2
         val evaluator = DynamicAmountEvaluator()
-        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+        val ctx = EffectContext(sourceId = null, controllerId = you)
 
         val instant = TypeLine.parse("Instant")
         val state = driver.state.copy(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastRestrictionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastRestrictionTest.kt
@@ -50,7 +50,6 @@ class CastRestrictionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = player2,
-            opponentId = player1,
             targets = emptyList(),
             xValue = 0
         )
@@ -80,7 +79,6 @@ class CastRestrictionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = player2,
-            opponentId = player1,
             targets = emptyList(),
             xValue = 0
         )
@@ -110,7 +108,6 @@ class CastRestrictionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = player1,
-            opponentId = player2,
             targets = emptyList(),
             xValue = 0
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DescendTrackerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DescendTrackerTest.kt
@@ -68,7 +68,6 @@ class DescendTrackerTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = controller,
-            opponentId = getOpponent(controller),
             targets = emptyList(),
             xValue = 0
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonbladeReaperTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonbladeReaperTest.kt
@@ -39,8 +39,8 @@ class EbonbladeReaperTest : FunSpec({
             trigger = Triggers.DealsCombatDamageToPlayer
             effect = Effects.LoseHalfLife(
                 roundUp = true,
-                target = EffectTarget.PlayerRef(Player.Opponent),
-                lifePlayer = Player.Opponent
+                target = EffectTarget.PlayerRef(Player.DefendingPlayer),
+                lifePlayer = Player.DefendingPlayer
             )
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCopyPreservationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCopyPreservationTest.kt
@@ -218,7 +218,6 @@ class ModalCopyPreservationTest : FunSpec({
         val context = EffectContext(
             sourceId = spellEntity,
             controllerId = p1,
-            opponentId = null
         )
 
         val executor = StormCopyEffectExecutor(cardRegistry = CardRegistry(), targetFinder = TargetFinder())

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
@@ -220,7 +220,6 @@ class OldManOfTheSeaScenarioTest : FunSpec({
         val ctx = EffectContext(
             sourceId = oldMan,
             controllerId = opponent,
-            opponentId = activePlayer,
         )
         driver.replaceState(
             driver.state.addFloatingEffect(
@@ -267,7 +266,7 @@ class OldManOfTheSeaScenarioTest : FunSpec({
         )
 
         // Temporary +2/+0 pump: power 2 → 4 > Old Man's 2. SBAs latch the steal off for good.
-        val ctx = EffectContext(sourceId = oldMan, controllerId = opponent, opponentId = activePlayer)
+        val ctx = EffectContext(sourceId = oldMan, controllerId = opponent)
         driver.replaceState(
             driver.state.addFloatingEffect(
                 layer = Layer.POWER_TOUGHNESS,
@@ -340,7 +339,6 @@ class OldManOfTheSeaScenarioTest : FunSpec({
         val ctx = EffectContext(
             sourceId = oldMan,
             controllerId = opponent,
-            opponentId = activePlayer,
         )
         driver.replaceState(
             driver.state.addFloatingEffect(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrcishBowmastersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrcishBowmastersTest.kt
@@ -270,7 +270,7 @@ class OrcishBowmastersTest : FunSpec({
         driver.setLifeTotal(p1, 20)
         driver.setLifeTotal(p2, 20)
 
-        // p1 (the controller) draws two cards — Player.Opponent binding means no firing.
+        // p1 (the controller) draws two cards — Player.EachOpponent binding means no firing.
         val draw2 = driver.putCardInHand(p1, "Draw Two Test")
         driver.castSpell(p1, draw2)
         driver.bothPass()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PermanentLeftBattlefieldThisTurnConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PermanentLeftBattlefieldThisTurnConditionTest.kt
@@ -43,7 +43,6 @@ class PermanentLeftBattlefieldThisTurnConditionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = player,
-            opponentId = getOpponent(player),
             targets = emptyList(),
             xValue = 0
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReplacementControllerProjectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReplacementControllerProjectionTest.kt
@@ -26,7 +26,7 @@ import io.kotest.core.spec.style.FunSpec
  * `DamageUtils` resolves the host's controller for every replacement scan; these tests steal
  * a replacement-effect permanent and assert the filter retargets to the thief. They cover the
  * two distinct comparison shapes:
- *  - `Player.You` / `Player.Opponent` against the losing player (`ModifyLifeLoss` — Bloodletter)
+ *  - `Player.You` / `Player.EachOpponent` against the losing player (`ModifyLifeLoss` — Bloodletter)
  *  - `RecipientFilter.You` against the damaged player (`PreventDamage`)
  */
 class ReplacementControllerProjectionTest : FunSpec({

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShagratLootBearerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShagratLootBearerScenarioTest.kt
@@ -59,7 +59,7 @@ class ShagratLootBearerScenarioTest : FunSpec({
         driver.state.getEntity(sword)?.get<CardComponent>()?.typeLine?.isEquipment shouldBe true
         driver.state.getEntity(aura)?.get<CardComponent>()?.typeLine?.isAura shouldBe true
 
-        val ctx = EffectContext(sourceId = shagrat, controllerId = you, opponentId = null)
+        val ctx = EffectContext(sourceId = shagrat, controllerId = you)
         val evaluator = DynamicAmountEvaluator()
         // Equipment-filtered count excludes the Aura …
         evaluator.evaluate(driver.state, DynamicAmounts.equipmentAttachedToSelf(), ctx) shouldBe 1

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakTest.kt
@@ -152,7 +152,7 @@ class SneakTest : FunSpec({
         ConditionEvaluator().evaluate(
             driver.state,
             SneakCostWasPaid,
-            EffectContext(sourceId = ninjaPerm, controllerId = attacker, opponentId = driver.getOpponent(attacker))
+            EffectContext(sourceId = ninjaPerm, controllerId = attacker)
         ).shouldBeTrue()
     }
 
@@ -254,7 +254,7 @@ class SneakTest : FunSpec({
         ConditionEvaluator().evaluate(
             driver.state,
             SneakCostWasPaid,
-            EffectContext(sourceId = ninjaPerm, controllerId = attacker, opponentId = driver.getOpponent(attacker))
+            EffectContext(sourceId = ninjaPerm, controllerId = attacker)
         ).shouldBeFalse()
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellsCastThisTurnAmountTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellsCastThisTurnAmountTest.kt
@@ -173,7 +173,7 @@ class SpellsCastThisTurnAmountTest : FunSpec({
     // Evaluator-level: per-player resolution, filter, and exclude-self matching
     // =========================================================================
 
-    test("evaluator: counts per player and honors Player.You vs Player.Opponent") {
+    test("evaluator: counts per player and honors Player.You vs Player.EachOpponent") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
@@ -195,7 +195,7 @@ class SpellsCastThisTurnAmountTest : FunSpec({
                 )
             )
         )
-        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+        val ctx = EffectContext(sourceId = null, controllerId = you)
 
         // Player.You, Any → both your spells.
         evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You), ctx) shouldBe 2
@@ -205,8 +205,8 @@ class SpellsCastThisTurnAmountTest : FunSpec({
             DynamicAmount.SpellsCastThisTurn(Player.You, GameObjectFilter.Noncreature),
             ctx
         ) shouldBe 1
-        // Player.Opponent, Any → the single opponent spell.
-        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.Opponent), ctx) shouldBe 1
+        // Player.EachOpponent → the single opponent spell.
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.EachOpponent), ctx) shouldBe 1
     }
 
     test("evaluator: excludeSelf drops the record whose sourceEntityId matches the source") {
@@ -229,7 +229,7 @@ class SpellsCastThisTurnAmountTest : FunSpec({
         )
 
         // Source is the spell with id 1003 (the resolving one) → excludeSelf counts the other 2.
-        val ctxSelf = EffectContext(sourceId = EntityId("1003"), controllerId = you, opponentId = null)
+        val ctxSelf = EffectContext(sourceId = EntityId("1003"), controllerId = you)
         evaluator.evaluate(
             state,
             DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true),
@@ -244,7 +244,7 @@ class SpellsCastThisTurnAmountTest : FunSpec({
         ) shouldBe 3
 
         // excludeSelf with a source that isn't in the list drops nothing.
-        val ctxOther = EffectContext(sourceId = EntityId("9999"), controllerId = you, opponentId = null)
+        val ctxOther = EffectContext(sourceId = EntityId("9999"), controllerId = you)
         evaluator.evaluate(
             state,
             DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormCopyInheritsAllDecisionsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormCopyInheritsAllDecisionsTest.kt
@@ -81,7 +81,7 @@ class StormCopyInheritsAllDecisionsTest : FunSpec({
                 spellEffect = DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
                 spellName = "X Bolt"
             ),
-            EffectContext(sourceId = spellEntity, controllerId = p1, opponentId = null)
+            EffectContext(sourceId = spellEntity, controllerId = p1)
         )
 
     fun copyComponent(state: GameState): SpellOnStackComponent {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormIllegalTargetFizzleTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormIllegalTargetFizzleTest.kt
@@ -98,7 +98,7 @@ class StormIllegalTargetFizzleTest : FunSpec({
                 spellTargetRequirements = listOf(requirement),
                 spellName = "Creature Bolt"
             ),
-            EffectContext(sourceId = spellEntity, controllerId = p1, opponentId = null)
+            EffectContext(sourceId = spellEntity, controllerId = p1)
         )
 
         result.isSuccess shouldBe true
@@ -139,7 +139,7 @@ class StormIllegalTargetFizzleTest : FunSpec({
                 spellTargetRequirements = listOf(requirement),
                 spellName = "Creature Bolt"
             ),
-            EffectContext(sourceId = spellEntity, controllerId = p1, opponentId = null)
+            EffectContext(sourceId = spellEntity, controllerId = p1)
         )
 
         result.isSuccess shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormModalRetargetingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormModalRetargetingTest.kt
@@ -98,7 +98,7 @@ class StormModalRetargetingTest : FunSpec({
                 spellEffect = DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
                 spellName = "Modal Storm"
             ),
-            EffectContext(sourceId = spellEntity, controllerId = p1, opponentId = null)
+            EffectContext(sourceId = spellEntity, controllerId = p1)
         )
 
         result.isPaused shouldBe true
@@ -139,7 +139,7 @@ class StormModalRetargetingTest : FunSpec({
                 spellEffect = DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
                 spellName = "Modal Storm"
             ),
-            EffectContext(sourceId = spellEntity, controllerId = p1, opponentId = null)
+            EffectContext(sourceId = spellEntity, controllerId = p1)
         )
 
         result.isSuccess shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TemurBattlecrierTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TemurBattlecrierTest.kt
@@ -111,7 +111,7 @@ class TemurBattlecrierTest : FunSpec({
                 modification = CostModification.ReduceGeneric(2),
                 gating = CostGating.OnlyIf(
                     Compare(
-                        DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
+                        DynamicAmount.AggregateBattlefield(Player.EachOpponent, GameObjectFilter.Creature),
                         ComparisonOperator.GTE,
                         DynamicAmount.Fixed(3),
                     ),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoidConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoidConditionTest.kt
@@ -42,7 +42,6 @@ class VoidConditionTest : FunSpec({
         val context = EffectContext(
             sourceId = null,
             controllerId = controller,
-            opponentId = getOpponent(controller),
             targets = emptyList(),
             xValue = 0
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildvinePummelerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildvinePummelerTest.kt
@@ -201,7 +201,6 @@ class WildvinePummelerTest : FunSpec({
         val ctx = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = wickermaw,
             controllerId = activePlayer,
-            opponentId = driver.getOpponent(activePlayer),
         )
         driver.replaceState(
             driver.state.addFloatingEffect(


### PR DESCRIPTION
Implements **Phase 0 of [`backlog/multiplayer.md`](../blob/main/backlog/multiplayer.md)** — the engine groundwork for 3–4 player free-for-all, done while everything is still verifiable against the 2-player test corpus. **No behavior change for 2-player games.**

## SDK (0.1)

- **`Player.Opponent` is deleted** (no deprecated alias — using it is now a compile error, which is stronger than the planned lint rule). Every player reference must say *which* player it means.
- **New `Player.DefendingPlayer`** (CR 802.2a): resolves through the source's `AttackingComponent.defenderId` (a creature attacking a planeswalker defends against its controller), falling back to the trigger's damaged player as last-known information for "deals combat damage to a player" triggers whose source left combat.
- **New `Player.AnOpponent`**, scoped strictly to genuinely non-targeted "an opponent" chooser shapes (Callous Oppressor's creature-type chooser, Risky Move's "choose … an opponent", `OpenLifeBid`). It resolves to the first opponent in turn order; the proper multiplayer choose-an-opponent flow is flagged in the backlog for Phase 1+.
- `CantCastSpells` / `CantActivateLoyaltyAbilities` lose their baked-in `PlayerRef(Opponent)` default; their executors fan out over multi-player references (Flamescroll Celebrant's "your opponents" now hits all opponents).

## Engine (0.2)

- **`EffectContext.opponentId` is gone** — the field, the continuation-frame copies, and ~140 construction sites.
- **`GameState.getOpponent` → `getOpponents(playerId)` + `activePlayers`**, both excluding `PlayerLostComponent` holders (the iteration contract Phase 1.2's leave-the-game processing builds on). There is deliberately no single-opponent helper left in the engine.
- **Central seam:** `TargetResolutionUtils.resolvePlayerRef(player, context, state)` is now the one single-player resolution for `Player` references; the per-executor `resolvePlayer` switch copies (GatherCards, GatherUntilMatch, MoveCollection, GatedEffect, …) delegate to it. `TargetOpponent`/`TargetPlayer` resolve from the **bound player target**, never turn order — the same fix flows into `DynamicAmountEvaluator` and `PredicateContext`.
- Genuine 2-player shortcuts rewritten with explicit semantics:
  - extra turns = every other **active** player skips their next turn (still exactly one inserted turn at any player count)
  - enters-attacking tokens join the source's attack assignment (CR 802.2a) instead of "the opponent"
  - "any player may activate" (Lethal Vapors) enumerates **all** opponents' permanents
  - `ConcedeHandler` derives the winner from the sole remaining opponent — full CR 800.4a leave-the-game processing is Phase 1.2
  - `Chooser.Opponent` (divvy/discard pipelines) resolves to the controller's first active opponent

## Cards (audit of all 27 `Player.Opponent` users; snapshots re-blessed)

| Classification | Cards |
|---|---|
| `EachOpponent` (exists / aggregation / event filters) | Khabál Ghoul, Beza, Haphazard Bombardment, Lashwhip Predator, Sothera, Crusading Knight, Marauding Knight, Kavu Runner, Skittish Kavu, Bloodletter of Aclazotz, Pygmy Kavu, Blessed Reversal, Decree of Silence, Flamescroll Celebrant |
| `DefendingPlayer` (attack / combat-damage triggers) | Alpharael, Specimen Freighter, Tsabo Tavoc, Cabal Executioner, Ebonblade Reaper, Xantid Swarm |
| `TriggeringPlayer` ("each opponent's upkeep … that player") | Fight or Flight, Sorin Solemn Visitor (emblem), Lavaborn Muse |
| `AnOpponent` (non-targeted chooser) | Callous Oppressor, Risky Move |
| Relational | Metamorphose ("that opponent" = the targeted permanent's controller) |

Two cards got real multiplayer-correctness fixes (identical in 1v1): **Betor, Kin to All** now iterates `EachOpponent` so each opponent loses half *their own* life, and **Lavaborn Muse** checks the upkeep player's hand instead of an aggregate.

## Deliberately out of scope (flagged, not fixed)

- The AI stays 1v1 via a module-local `soleOpponent` helper (`AiOpponent.kt`) — multiplayer AI is its own deferred project per the plan.
- Syphon Mind's "each opponent discards, you draw per discard" pattern still hits one opponent (needs cross-iteration count accumulation; TODO in `HandPatterns`).
- The `Conditions.OpponentControlsMore*` facades aggregate across opponents (per-opponent exists-comparison is a Phase 1 nuance; 2-player identical).
- mtgish emitter: amount/filter contexts render `EachOpponent`; bare non-targeted "Opponent" recipients now **decline → SCAFFOLD** instead of guessing.

## Verification gate (0.3)

- Full `./gradlew test` green across all modules.
- Card snapshot diffs are exactly the audited reclassifications (player-reference renames + the three structural card fixes above).
- `just coverage-verify POR` stays **158/158, 0-mismatch**.
- New **`MultiplayerSmokeTest`**: 4-player init, priority round-trips through all four seats, a full turn cycle hands the turn to the next seat, `getOpponents` returns 3 and excludes lost players, an `EachOpponent` life-loss fans out to all three opponents, and `DefendingPlayer` resolves per CR 802.2a.
- `docs/card-sdk-language-reference.md` gains the full `Player` reference catalog with the new vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)