### PR TITLE
Auto-recover the WebSocket connection when returning to a backgrounded tab

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -144,6 +144,11 @@ Related recovery contracts:
 - A `NOT_CONNECTED` error (server) means the socket is open but not associated with an
   authenticated session (e.g. the server restarted). The client recovers by re-sending `connect`
   with its stored token rather than surfacing the error.
+- `{"type": "sessionReplaced"}` (server) is sent to the *previous* socket when the same identity
+  (token) authenticates from a new socket — i.e. the player opened the game in another tab or
+  device. The server closes that socket right after sending; the receiving client stops all
+  auto-reconnect (reconnecting would steal the session straight back) and shows a takeover
+  overlay whose "Use here" button reclaims the session explicitly.
 
 ---
 

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -129,6 +129,22 @@ Sent when the user interacts with the UI.
 }
 ```
 
+### C. Connection Liveness (Client <-> Server)
+
+`{"type": "ping"}` (client) is always answered with `{"type": "pong"}` (server), regardless of
+authentication or game state. The client sends it when a backgrounded tab becomes visible while
+the socket still claims to be open: a socket can sit half-open after OS sleep without ever firing
+`close`, and a silent server (no message within 5s) tells the client to tear the socket down and
+reconnect. Any inbound message counts as proof of life, not just the pong.
+
+Related recovery contracts:
+
+- `{"type": "requestResync"}` (client) asks for a full `stateUpdate` instead of deltas — sent on
+  tab return and when a `stateVersion` gap is detected.
+- A `NOT_CONNECTED` error (server) means the socket is open but not associated with an
+  authenticated session (e.g. the server restarted). The client recovers by re-sending `connect`
+  with its stored token rather than surfacing the error.
+
 ---
 
 ## 3. Drafting Payload (REST / HTTP)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.gameserver.session.SessionRegistry
 import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.WebSocketSession
 import java.util.concurrent.TimeUnit
 
@@ -140,10 +141,21 @@ class ConnectionHandler(
             }
         }
 
+        // If the identity is still attached to a different live socket (same player opened
+        // another tab/device), tell that socket it lost the session and close it. Without
+        // this the old tab silently loses its mapping and every message it sends gets a
+        // confusing NOT_CONNECTED error — or worse, fights this socket for the session.
+        val replacedWs = identity.webSocketSession
         sessionRegistry.removeOldWsMapping(identity.token)
 
         identity.webSocketSession = session
         sessionRegistry.mapWsToToken(session.id, identity.token)
+
+        if (replacedWs != null && replacedWs.id != session.id && replacedWs.isOpen) {
+            logger.info("Session for ${identity.playerName} replaced by a new connection; notifying old socket ${replacedWs.id}")
+            sender.send(replacedWs, ServerMessage.SessionReplaced)
+            runCatching { replacedWs.close(CloseStatus.NORMAL) }
+        }
 
         val playerSession = PlayerSession(
             webSocketSession = session,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -387,6 +387,15 @@ sealed interface ClientMessage {
     @SerialName("requestResync")
     data object RequestResync : ClientMessage
 
+    /**
+     * Connection liveness probe. The server always answers with [ServerMessage.Pong],
+     * regardless of authentication or game state. Sent by the client when a backgrounded
+     * tab becomes visible again, to detect half-open sockets (e.g. after OS sleep).
+     */
+    @Serializable
+    @SerialName("ping")
+    data object Ping : ClientMessage
+
     // =========================================================================
     // Quick Game Lobby Messages
     // =========================================================================

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -998,6 +998,16 @@ sealed interface ServerMessage {
     @Serializable
     @SerialName("pong")
     data object Pong : ServerMessage
+
+    /**
+     * Sent to a socket whose identity just authenticated from a *different* socket
+     * (the same player opened the game in another tab or device). The receiving
+     * client must stop auto-reconnecting — winning the session back is an explicit
+     * user action — and the server closes this socket right after sending.
+     */
+    @Serializable
+    @SerialName("sessionReplaced")
+    data object SessionReplaced : ServerMessage
 }
 
 @Serializable

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -993,6 +993,11 @@ sealed interface ServerMessage {
     @Serializable
     @SerialName("onlinePlayersCount")
     data class OnlinePlayersCount(val count: Int) : ServerMessage
+
+    /** Reply to [ClientMessage.Ping] — always sent, regardless of auth or game state. */
+    @Serializable
+    @SerialName("pong")
+    data object Pong : ServerMessage
 }
 
 @Serializable

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.gameserver.handler.MessageSender
 import com.wingedsheep.gameserver.handler.QuickGameLobbyHandler
 import com.wingedsheep.gameserver.protocol.ClientMessage
 import com.wingedsheep.gameserver.protocol.ErrorCode
+import com.wingedsheep.gameserver.protocol.ServerMessage
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -70,6 +71,10 @@ class GameWebSocketHandler(
             logger.debug("Received message from ${session.id}: $clientMessage")
 
             when (clientMessage) {
+                // Liveness probe — answered unconditionally, even before authentication,
+                // so the client can distinguish a half-open socket from a healthy one.
+                is ClientMessage.Ping -> sender.send(session, ServerMessage.Pong)
+
                 is ClientMessage.Connect -> connectionHandler.handleConnect(session, clientMessage)
 
                 is ClientMessage.CreateGame,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
@@ -41,6 +41,29 @@ class GameConnectionTest : GameServerTestBase() {
                 }
             }
 
+            test("connecting from a second socket with the same token notifies and closes the first") {
+                val first = createClient()
+                first.connectAs("TabTester")
+                val token = first.messages.filterIsInstance<ServerMessage.Connected>().first().token
+
+                val second = createClient()
+                second.connect()
+                second.send(ClientMessage.Connect("TabTester", token))
+
+                eventually(5.seconds) {
+                    second.messages.any { it is ServerMessage.Reconnected } shouldBe true
+                }
+                eventually(5.seconds) {
+                    first.messages.any { it is ServerMessage.SessionReplaced } shouldBe true
+                }
+
+                // The winning socket keeps working.
+                second.send(ClientMessage.Ping)
+                eventually(5.seconds) {
+                    second.messages.any { it is ServerMessage.Pong } shouldBe true
+                }
+            }
+
             test("two players can create and join a game") {
                 val ctx = setupGame(skipMulligan = false)
                 ctx.sessionId shouldNotBe null

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
@@ -21,6 +21,26 @@ class GameConnectionTest : GameServerTestBase() {
                 connected.playerId shouldBe playerId
             }
 
+            test("ping is answered with pong before authentication") {
+                val client = createClient()
+                client.connect()
+                client.send(ClientMessage.Ping)
+
+                eventually(5.seconds) {
+                    client.messages.any { it is ServerMessage.Pong } shouldBe true
+                }
+            }
+
+            test("ping is answered with pong after authentication") {
+                val client = createClient()
+                client.connectAs("TestPlayer")
+                client.send(ClientMessage.Ping)
+
+                eventually(5.seconds) {
+                    client.messages.any { it is ServerMessage.Pong } shouldBe true
+                }
+            }
+
             test("two players can create and join a game") {
                 val ctx = setupGame(skipMulligan = false)
                 ctx.sessionId shouldNotBe null

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -14,6 +14,7 @@ import { DelveSelector } from './components/ui/DelveSelector'
 import { DamageDistributionModal } from './components/decisions/DamageDistributionModal'
 import { OpponentDecisionIndicator } from './components/ui/OpponentDecisionIndicator'
 import { DisconnectCountdown } from './components/ui/DisconnectCountdown'
+import { SessionReplacedOverlay } from './components/ui/SessionReplacedOverlay'
 import { MatchIntroAnimation } from './components/animations/MatchIntroAnimation'
 import { StandaloneConcedeButton } from './components/game/overlay'
 import { DeckBuilderOverlay } from './components/sealed/DeckBuilderOverlay'
@@ -45,6 +46,7 @@ export default function App() {
   const startCombat = useGameStore((state) => state.startCombat)
   const connect = useGameStore((state) => state.connect)
   const spectateGame = useGameStore((state) => state.spectateGame)
+  const sessionReplaced = useGameStore((state) => state.sessionReplaced)
   const hasConnectedRef = useRef(false)
 
   // Dev deep-link: /?spectate=<gameSessionId> connects and auto-spectates that game,
@@ -68,6 +70,9 @@ export default function App() {
 
   useEffect(() => {
     if (connectionStatus !== 'disconnected' || hasConnectedRef.current) return
+    // Another tab/device owns the session; reconnecting here would steal it back.
+    // The SessionReplacedOverlay's "Use here" is the only way back in.
+    if (sessionReplaced) return
     if (spectateParam) {
       // Spectate deep-link: connect as an isolated, ephemeral spectator (no shared token/name) so
       // it doesn't collide with the user's identity and each watch gets a fresh session.
@@ -81,7 +86,7 @@ export default function App() {
       hasConnectedRef.current = true
       connect(storedName)
     }
-  }, [connectionStatus, connect, spectateParam])
+  }, [connectionStatus, connect, spectateParam, sessionReplaced])
 
   // Once connected, honor a /?spectate=<gameId> deep-link (fire once).
   useEffect(() => {
@@ -347,6 +352,9 @@ export default function App() {
 
       {/* Spectator view (when watching another game — skip when ReplayViewer handles its own UI) */}
       {spectatingState && !spectatingState.isReplay && <SpectatorGameBoard />}
+
+      {/* Session takeover overlay (this tab's identity connected from another tab/device) */}
+      <SessionReplacedOverlay />
     </div>
   )
 }

--- a/web-client/src/components/tournament/TournamentEntryPage.tsx
+++ b/web-client/src/components/tournament/TournamentEntryPage.tsx
@@ -22,6 +22,7 @@ export function TournamentEntryPage() {
   const tournamentState = useGameStore((state) => state.tournamentState)
   const lastError = useGameStore((state) => state.lastError)
   const setPendingTournamentId = useGameStore((state) => state.setPendingTournamentId)
+  const sessionReplaced = useGameStore((state) => state.sessionReplaced)
 
   const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
   const [joining, setJoining] = useState(false)
@@ -42,14 +43,16 @@ export function TournamentEntryPage() {
       .catch(() => setFetchError('Tournament not found or no longer active.'))
   }, [lobbyId])
 
-  // Auto-connect if we have a stored name (returning user)
+  // Auto-connect if we have a stored name (returning user). Never while another
+  // tab/device owns the session — reconnecting would steal it back.
   useEffect(() => {
+    if (sessionReplaced) return
     const storedName = localStorage.getItem('argentum-player-name')
     if (storedName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
       hasConnectedRef.current = true
       connect(storedName)
     }
-  }, [connectionStatus, connect])
+  }, [connectionStatus, connect, sessionReplaced])
 
   // Auto-join lobby once connected
   useEffect(() => {

--- a/web-client/src/components/ui/SessionReplacedOverlay.tsx
+++ b/web-client/src/components/ui/SessionReplacedOverlay.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+
+/**
+ * Full-screen overlay shown when the server reports this tab's session was taken over
+ * by another tab or device. Auto-reconnect is stopped at that point (reconnecting would
+ * steal the session straight back and the tabs would fight); "Use here" reclaims it
+ * explicitly — the other tab then gets this same overlay.
+ */
+export function SessionReplacedOverlay() {
+  const sessionReplaced = useGameStore((s) => s.sessionReplaced)
+  const connect = useGameStore((s) => s.connect)
+  const [reclaiming, setReclaiming] = useState(false)
+
+  if (!sessionReplaced) return null
+
+  const storedName = localStorage.getItem('argentum-player-name')
+
+  const reclaim = () => {
+    if (!storedName) return
+    setReclaiming(true)
+    connect(storedName)
+  }
+
+  return (
+    <div style={styles.backdrop}>
+      <div style={styles.dialog}>
+        <div style={styles.title}>Opened in another tab</div>
+        <div style={styles.text}>
+          Your session is now active in a different tab or device.
+          {storedName ? ' You can take it back and continue playing here.' : ' Refresh the page to continue here.'}
+        </div>
+        {storedName && (
+          <button style={styles.button} onClick={reclaim} disabled={reclaiming}>
+            {reclaiming ? 'Reconnecting…' : 'Use here'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.75)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  dialog: {
+    backgroundColor: 'rgba(20, 20, 28, 0.97)',
+    border: '1px solid #ffc107',
+    borderRadius: 12,
+    padding: '28px 36px',
+    maxWidth: 380,
+    textAlign: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: '1.2em',
+    fontWeight: 600,
+    color: '#ffc107',
+  },
+  text: {
+    color: '#ccc',
+    lineHeight: 1.5,
+  },
+  button: {
+    padding: '10px 28px',
+    borderRadius: 8,
+    border: 'none',
+    backgroundColor: '#ffc107',
+    color: '#1a1a22',
+    fontWeight: 600,
+    fontSize: '1em',
+    cursor: 'pointer',
+  },
+}

--- a/web-client/src/network/messageHandlers.ts
+++ b/web-client/src/network/messageHandlers.ts
@@ -118,6 +118,8 @@ export interface MessageHandlers {
   onOnlinePlayersCount: (message: OnlinePlayersCountMessage) => void
   // Liveness handlers
   onPong: () => void
+  // Session takeover handlers
+  onSessionReplaced: () => void
 }
 
 /**
@@ -285,6 +287,9 @@ export function handleServerMessage(message: ServerMessage, handlers: MessageHan
       break
     case 'pong':
       handlers.onPong()
+      break
+    case 'sessionReplaced':
+      handlers.onSessionReplaced()
       break
     default: {
       // TypeScript exhaustiveness check

--- a/web-client/src/network/messageHandlers.ts
+++ b/web-client/src/network/messageHandlers.ts
@@ -116,6 +116,8 @@ export interface MessageHandlers {
   onQuickGameLobbyClosed: (message: QuickGameLobbyClosedMessage) => void
   // Presence handlers
   onOnlinePlayersCount: (message: OnlinePlayersCountMessage) => void
+  // Liveness handlers
+  onPong: () => void
 }
 
 /**
@@ -280,6 +282,9 @@ export function handleServerMessage(message: ServerMessage, handlers: MessageHan
       break
     case 'onlinePlayersCount':
       handlers.onOnlinePlayersCount(message)
+      break
+    case 'pong':
+      handlers.onPong()
       break
     default: {
       // TypeScript exhaustiveness check

--- a/web-client/src/network/websocket.ts
+++ b/web-client/src/network/websocket.ts
@@ -90,11 +90,9 @@ export class GameWebSocket {
     this.cancelReconnect()
     this.cancelLivenessCheck()
     this.teardownRecoveryHandlers()
-
-    if (this.ws) {
-      this.ws.close(1000, 'Client disconnected')
-      this.ws = null
-    }
+    // Detach handlers before closing: a message already queued on this socket must not
+    // dispatch after we've decided the connection is over.
+    this.discardSocket()
 
     this.lastStateVersion = null
     this.resyncRequested = false

--- a/web-client/src/network/websocket.ts
+++ b/web-client/src/network/websocket.ts
@@ -7,19 +7,25 @@ export interface WebSocketConfig {
   onMessage: (message: ServerMessage) => void
   onStatusChange: (status: ConnectionStatus) => void
   onError: (error: Event) => void
-  reconnectAttempts?: number
   reconnectDelay?: number
 }
+
+/** Reconnect backoff is capped here; the client never stops retrying on its own. */
+const MAX_RECONNECT_DELAY_MS = 30_000
+
+/** How long after a ping probe before a silent server means the socket is half-open. */
+const LIVENESS_TIMEOUT_MS = 5_000
 
 /**
  * WebSocket manager for game server communication.
  *
  * Handles:
  * - Connection lifecycle
- * - Automatic reconnection
+ * - Automatic reconnection (exponential backoff capped at 30s, retries indefinitely)
  * - Message serialization/deserialization
  * - Connection status tracking
- * - Visibility change detection (tab switch resync)
+ * - Tab visibility / network-online recovery: reconnects a dead socket immediately and
+ *   probes an apparently-open one with a ping to detect half-open sockets after OS sleep
  * - State version gap detection
  */
 export class GameWebSocket {
@@ -33,12 +39,17 @@ export class GameWebSocket {
   private lastStateVersion: number | null = null
   /** Whether resync has already been requested (debounce) */
   private resyncRequested = false
-  /** Bound handler for cleanup */
+  /** Bound handlers for cleanup */
   private visibilityHandler: (() => void) | null = null
+  private onlineHandler: (() => void) | null = null
+
+  /** Timestamp of the last message received from the server (liveness signal). */
+  private lastMessageAt = 0
+  /** Pending liveness verdict after a ping probe. */
+  private livenessTimeout: ReturnType<typeof setTimeout> | null = null
 
   constructor(config: WebSocketConfig) {
     this.config = {
-      reconnectAttempts: 5,
       reconnectDelay: 1000,
       ...config,
     }
@@ -53,13 +64,17 @@ export class GameWebSocket {
       return
     }
 
+    // Drop a stale CONNECTING/CLOSING socket so its late events can't fire against
+    // the new connection.
+    this.discardSocket()
+
     this.isIntentionallyClosed = false
     this.config.onStatusChange('connecting')
 
     try {
       this.ws = new WebSocket(this.config.url)
       this.setupEventHandlers()
-      this.setupVisibilityHandler()
+      this.setupRecoveryHandlers()
     } catch (error) {
       console.error('Failed to create WebSocket:', error)
       this.config.onStatusChange('disconnected')
@@ -73,7 +88,8 @@ export class GameWebSocket {
   disconnect(): void {
     this.isIntentionallyClosed = true
     this.cancelReconnect()
-    this.teardownVisibilityHandler()
+    this.cancelLivenessCheck()
+    this.teardownRecoveryHandlers()
 
     if (this.ws) {
       this.ws.close(1000, 'Client disconnected')
@@ -83,6 +99,22 @@ export class GameWebSocket {
     this.lastStateVersion = null
     this.resyncRequested = false
     this.config.onStatusChange('disconnected')
+  }
+
+  /**
+   * Tear down the current socket (if any) and reconnect immediately, resetting backoff.
+   * Used when an external signal (tab visible, network back online, failed liveness
+   * probe) tells us the connection is dead or suspect — waiting out a backoff timer
+   * or trusting `readyState` would leave the user staring at a broken session.
+   */
+  forceReconnect(reason: string): void {
+    if (this.isIntentionallyClosed) return
+    console.log(`[WebSocket] Forcing reconnect: ${reason}`)
+    this.cancelReconnect()
+    this.cancelLivenessCheck()
+    this.reconnectCount = 0
+    this.discardSocket()
+    this.connect()
   }
 
   /**
@@ -149,11 +181,13 @@ export class GameWebSocket {
       this.reconnectCount = 0
       this.lastStateVersion = null
       this.resyncRequested = false
+      this.lastMessageAt = Date.now()
       this.config.onStatusChange('connected')
     }
 
     this.ws.onclose = (event) => {
       console.log('WebSocket closed:', event.code, event.reason)
+      this.cancelLivenessCheck()
       this.config.onStatusChange('disconnected')
 
       if (!this.isIntentionallyClosed) {
@@ -167,6 +201,7 @@ export class GameWebSocket {
     }
 
     this.ws.onmessage = (event) => {
+      this.lastMessageAt = Date.now()
       try {
         const message = JSON.parse(event.data as string) as ServerMessage
         this.config.onMessage(message)
@@ -176,43 +211,96 @@ export class GameWebSocket {
     }
   }
 
-  /**
-   * Listen for tab visibility changes. When the tab becomes visible again,
-   * request a resync to recover any messages missed while backgrounded.
-   */
-  private setupVisibilityHandler(): void {
-    this.teardownVisibilityHandler()
-    this.visibilityHandler = () => {
-      if (document.visibilityState === 'visible' && this.isConnected()) {
-        console.log('[WebSocket] Tab became visible, requesting resync')
-        this.requestResync()
-      }
+  /** Detach handlers from the current socket and close it without status side effects. */
+  private discardSocket(): void {
+    const old = this.ws
+    if (!old) return
+    this.ws = null
+    old.onopen = null
+    old.onclose = null
+    old.onerror = null
+    old.onmessage = null
+    try {
+      old.close()
+    } catch {
+      // Already closed/closing — nothing to do.
     }
-    document.addEventListener('visibilitychange', this.visibilityHandler)
   }
 
-  private teardownVisibilityHandler(): void {
+  /**
+   * Listen for tab visibility changes and the network coming back online.
+   *
+   * On either signal: if the socket is dead, reconnect immediately (background-tab timer
+   * throttling can leave a scheduled reconnect pending long after the network is back).
+   * If the socket claims to be open on tab return, request a resync to recover missed
+   * messages — and verify the connection is actually alive with a ping probe, since a
+   * socket can sit half-open after OS sleep without ever firing `close`.
+   */
+  private setupRecoveryHandlers(): void {
+    this.teardownRecoveryHandlers()
+    this.visibilityHandler = () => {
+      if (document.visibilityState !== 'visible' || this.isIntentionallyClosed) return
+      if (!this.isConnected()) {
+        this.forceReconnect('tab became visible while disconnected')
+        return
+      }
+      console.log('[WebSocket] Tab became visible, requesting resync')
+      this.requestResync()
+      this.startLivenessCheck()
+    }
+    this.onlineHandler = () => {
+      if (this.isIntentionallyClosed || this.isConnected()) return
+      this.forceReconnect('network came back online')
+    }
+    document.addEventListener('visibilitychange', this.visibilityHandler)
+    window.addEventListener('online', this.onlineHandler)
+  }
+
+  private teardownRecoveryHandlers(): void {
     if (this.visibilityHandler) {
       document.removeEventListener('visibilitychange', this.visibilityHandler)
       this.visibilityHandler = null
     }
+    if (this.onlineHandler) {
+      window.removeEventListener('online', this.onlineHandler)
+      this.onlineHandler = null
+    }
+  }
+
+  /**
+   * Send a ping and reconnect if the server stays silent. Any inbound message counts
+   * as proof of life, not just the pong.
+   */
+  private startLivenessCheck(): void {
+    if (this.livenessTimeout) return
+    const probeSentAt = Date.now()
+    this.send({ type: 'ping' })
+    this.livenessTimeout = setTimeout(() => {
+      this.livenessTimeout = null
+      if (this.lastMessageAt < probeSentAt) {
+        this.forceReconnect('no server response to liveness probe')
+      }
+    }, LIVENESS_TIMEOUT_MS)
+  }
+
+  private cancelLivenessCheck(): void {
+    if (this.livenessTimeout) {
+      clearTimeout(this.livenessTimeout)
+      this.livenessTimeout = null
+    }
   }
 
   private scheduleReconnect(): void {
-    const maxAttempts = this.config.reconnectAttempts ?? 5
+    if (this.reconnectTimeout) return
+
     const delay = this.config.reconnectDelay ?? 1000
-
-    if (this.reconnectCount >= maxAttempts) {
-      console.log('Max reconnection attempts reached')
-      return
-    }
-
     this.reconnectCount++
-    const backoffDelay = delay * Math.pow(2, this.reconnectCount - 1)
+    const backoffDelay = Math.min(delay * Math.pow(2, this.reconnectCount - 1), MAX_RECONNECT_DELAY_MS)
 
-    console.log(`Reconnecting in ${backoffDelay}ms (attempt ${this.reconnectCount}/${maxAttempts})`)
+    console.log(`Reconnecting in ${backoffDelay}ms (attempt ${this.reconnectCount})`)
 
     this.reconnectTimeout = setTimeout(() => {
+      this.reconnectTimeout = null
       this.connect()
     }, backoffDelay)
   }

--- a/web-client/src/store/slices/connectionSlice.ts
+++ b/web-client/src/store/slices/connectionSlice.ts
@@ -25,6 +25,11 @@ export interface ConnectionSliceState {
   aiEnabled: boolean
   availableSets: readonly AvailableSet[]
   onlinePlayers: number | null
+  /**
+   * True when the server reported this socket's session was taken over by another
+   * tab/device. Auto-reconnect is stopped; the user reclaims via the takeover overlay.
+   */
+  sessionReplaced: boolean
 }
 
 export interface ConnectionSliceActions {
@@ -52,6 +57,7 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
   aiEnabled: false,
   availableSets: [],
   onlinePlayers: null,
+  sessionReplaced: false,
 
   // Actions
   connect: (playerName, options) => {
@@ -60,6 +66,8 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
     if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
       return
     }
+
+    set({ sessionReplaced: false })
 
     const existingWs = getWebSocket()
     if (existingWs) {
@@ -129,6 +137,7 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
     clearLobbyId()
     clearDeckState()
     set({
+      sessionReplaced: false,
       connectionStatus: 'disconnected',
       playerId: null,
       sessionId: null,

--- a/web-client/src/store/slices/connectionSlice.ts
+++ b/web-client/src/store/slices/connectionSlice.ts
@@ -10,6 +10,7 @@ import { createConnectMessage, ErrorCode } from '@/types'
 import {
   getWebSocket,
   setWebSocket,
+  setReauthHandler,
   clearLobbyId,
   clearDeckState,
 } from './shared'
@@ -77,22 +78,29 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
       ? createLoggingHandlers(handlers)
       : handlers
 
+    // Sends the connect (auth) message over the current socket. Used on every (re)open,
+    // and registered as the re-auth handler so a server NOT_CONNECTED error (server no
+    // longer recognizes this socket, e.g. after a restart) recovers automatically.
+    const sendAuth = () => {
+      // Check URL ?token= param first (for dev scenario links), then localStorage
+      const urlToken = new URLSearchParams(window.location.search).get('token')
+      if (urlToken) {
+        localStorage.setItem('argentum-token', urlToken)
+      }
+      // Spectator sessions connect tokenless (fresh identity every time) so a new spectate tab
+      // never reconnects as an existing identity and gets its old spectating game restored.
+      const token = spectator ? undefined : (urlToken ?? localStorage.getItem('argentum-token') ?? undefined)
+      const connectName = spectator ? playerName : (localStorage.getItem('argentum-player-name') ?? playerName)
+      getWebSocket()?.send(createConnectMessage(connectName, token))
+    }
+
     const ws = new GameWebSocket({
       url: getWebSocketUrl(),
       onMessage: (msg) => handleServerMessage(msg, wrappedHandlers),
       onStatusChange: (status) => {
         set({ connectionStatus: status })
         if (status === 'connected' && getWebSocket()) {
-          // Check URL ?token= param first (for dev scenario links), then localStorage
-          const urlToken = new URLSearchParams(window.location.search).get('token')
-          if (urlToken) {
-            localStorage.setItem('argentum-token', urlToken)
-          }
-          // Spectator sessions connect tokenless (fresh identity every time) so a new spectate tab
-          // never reconnects as an existing identity and gets its old spectating game restored.
-          const token = spectator ? undefined : (urlToken ?? localStorage.getItem('argentum-token') ?? undefined)
-          const connectName = spectator ? playerName : (localStorage.getItem('argentum-player-name') ?? playerName)
-          getWebSocket()?.send(createConnectMessage(connectName, token))
+          sendAuth()
         }
       },
       onError: () => {
@@ -107,6 +115,7 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
     })
 
     setWebSocket(ws)
+    setReauthHandler(sendAuth)
     ws.connect()
   },
 
@@ -114,6 +123,7 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
     const ws = getWebSocket()
     ws?.disconnect()
     setWebSocket(null)
+    setReauthHandler(null)
     localStorage.removeItem('argentum-token')
     localStorage.removeItem('argentum-player-name')
     clearLobbyId()

--- a/web-client/src/store/slices/handlers/connectionHandlers.ts
+++ b/web-client/src/store/slices/handlers/connectionHandlers.ts
@@ -6,7 +6,12 @@ import { entityId, createJoinLobbyMessage, createSpectateGameMessage } from '@/t
 import { getWebSocket, clearLobbyId, loadLobbyId } from '../shared'
 import type { SetState, GetState } from './types'
 
-type ConnectionHandlerKeys = 'onConnected' | 'onReconnected' | 'onOnlinePlayersCount' | 'onPong'
+type ConnectionHandlerKeys =
+  | 'onConnected'
+  | 'onReconnected'
+  | 'onOnlinePlayersCount'
+  | 'onPong'
+  | 'onSessionReplaced'
 
 export function createConnectionHandlers(set: SetState, get: GetState): Pick<MessageHandlers, ConnectionHandlerKeys> {
   return {
@@ -78,5 +83,16 @@ export function createConnectionHandlers(set: SetState, get: GetState): Pick<Mes
     // Liveness replies are consumed by GameWebSocket's last-message tracking; nothing
     // store-side to update.
     onPong: () => {},
+
+    onSessionReplaced: () => {
+      // Another tab/device took over this identity. Stop all auto-reconnect machinery —
+      // reconnecting would just steal the session back and the two tabs would fight.
+      // The takeover overlay offers an explicit "Use here" to reclaim.
+      // Set the flag BEFORE the status flips to 'disconnected', so auto-connect effects
+      // keyed on connectionStatus see it and stand down.
+      set({ sessionReplaced: true })
+      getWebSocket()?.disconnect()
+      set({ connectionStatus: 'disconnected' })
+    },
   }
 }

--- a/web-client/src/store/slices/handlers/connectionHandlers.ts
+++ b/web-client/src/store/slices/handlers/connectionHandlers.ts
@@ -6,17 +6,34 @@ import { entityId, createJoinLobbyMessage, createSpectateGameMessage } from '@/t
 import { getWebSocket, clearLobbyId, loadLobbyId } from '../shared'
 import type { SetState, GetState } from './types'
 
-type ConnectionHandlerKeys = 'onConnected' | 'onReconnected' | 'onOnlinePlayersCount'
+type ConnectionHandlerKeys = 'onConnected' | 'onReconnected' | 'onOnlinePlayersCount' | 'onPong'
 
 export function createConnectionHandlers(set: SetState, get: GetState): Pick<MessageHandlers, ConnectionHandlerKeys> {
   return {
     onConnected: (msg) => {
       localStorage.setItem('argentum-token', msg.token)
+      // A plain Connected (not Reconnected) after an auto-reconnect means the server has
+      // no memory of this identity (e.g. it restarted while the tab was backgrounded) —
+      // any session state from before is stale. Drop it so the user lands in the lobby
+      // instead of a dead game board.
+      const stale = get().sessionId !== null || get().gameState !== null
       set({
         connectionStatus: 'connected',
         playerId: entityId(msg.playerId),
         aiEnabled: msg.aiEnabled ?? false,
         availableSets: msg.availableSets ?? [],
+        ...(stale && {
+          sessionId: null,
+          opponentName: null,
+          gameState: null,
+          legalActions: [],
+          pendingDecision: null,
+          mulliganState: null,
+          waitingForOpponentMulligan: false,
+          deckBuildingState: null,
+          lobbyState: null,
+          tournamentState: null,
+        }),
       })
 
       // Auto-join tournament if we have a pending tournament ID (from /tournament/:lobbyId route)
@@ -57,5 +74,9 @@ export function createConnectionHandlers(set: SetState, get: GetState): Pick<Mes
     onOnlinePlayersCount: (msg) => {
       set({ onlinePlayers: msg.count })
     },
+
+    // Liveness replies are consumed by GameWebSocket's last-message tracking; nothing
+    // store-side to update.
+    onPong: () => {},
   }
 }

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -7,7 +7,7 @@ import type { EntityId } from '@/types'
 import type { ClientGameState, ClientEvent, LegalActionInfo, PendingDecision, OpponentDecisionStatus, PriorityModeValue, Step } from '@/types'
 import { trackEvent, setInGame } from '@/utils/analytics.ts'
 import { applyStateDelta } from '@/network/deltaApplicator.ts'
-import { getWebSocket, clearLobbyId } from '../shared'
+import { getWebSocket, clearLobbyId, requestReauth } from '../shared'
 import type { SetState, GetState } from './types'
 
 /**
@@ -567,6 +567,11 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
     },
 
     onError: (msg) => {
+      // NOT_CONNECTED means the server no longer recognizes this socket as an
+      // authenticated session (e.g. it restarted while the tab was backgrounded).
+      // Re-send the connect message with the stored token instead of surfacing the
+      // error — the server's reconnect path restores identity, game, and lobby state.
+      if (msg.code === 'NOT_CONNECTED' && requestReauth()) return
       if (msg.code === 'GAME_NOT_FOUND' || msg.message?.toLowerCase().includes('lobby')) {
         clearLobbyId()
       }

--- a/web-client/src/store/slices/shared.ts
+++ b/web-client/src/store/slices/shared.ts
@@ -27,6 +27,37 @@ export function setMessageHandlers(handlers: MessageHandlers | null): void {
 }
 
 // ============================================================================
+// Re-authentication
+// ============================================================================
+
+// Registered by connectionSlice when it opens a connection. Re-sends the connect
+// message (with the stored token) over the current socket — used to recover when the
+// server answers NOT_CONNECTED because it no longer recognizes this socket as an
+// authenticated session (e.g. after a server restart).
+let reauthHandler: (() => void) | null = null
+let lastReauthAt = 0
+
+const REAUTH_DEBOUNCE_MS = 5_000
+
+export function setReauthHandler(handler: (() => void) | null): void {
+  reauthHandler = handler
+  lastReauthAt = 0
+}
+
+/**
+ * Re-send the connect message if a handler is registered. Returns true when a
+ * re-auth is in flight (just sent or sent within the debounce window).
+ */
+export function requestReauth(): boolean {
+  if (!reauthHandler) return false
+  const now = Date.now()
+  if (now - lastReauthAt < REAUTH_DEBOUNCE_MS) return true
+  lastReauthAt = now
+  reauthHandler()
+  return true
+}
+
+// ============================================================================
 // Deck Building State Persistence
 // ============================================================================
 

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -732,6 +732,8 @@ export type GameStore = {
   aiEnabled: boolean
   availableSets: readonly AvailableSet[]
   onlinePlayers: number | null
+  /** True when another tab/device took over this identity; auto-reconnect is stopped. */
+  sessionReplaced: boolean
   connect: (playerName: string, options?: { spectator?: boolean }) => void
   disconnect: () => void
   setPendingTournamentId: (lobbyId: string | null) => void

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -310,6 +310,7 @@ export type {
   OnlinePlayersCountMessage,
   PingMessage,
   PongMessage,
+  SessionReplacedMessage,
   DeckFormat,
 } from './messages'
 export {

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -308,6 +308,8 @@ export type {
   SetQuickGameLobbyPublicMessage,
   SetQuickGameLobbyFormatMessage,
   OnlinePlayersCountMessage,
+  PingMessage,
+  PongMessage,
   DeckFormat,
 } from './messages'
 export {

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -76,6 +76,8 @@ export type ServerMessage =
   | OnlinePlayersCountMessage
   // Liveness
   | PongMessage
+  // Session takeover
+  | SessionReplacedMessage
 
 /**
  * Connection confirmed with assigned player ID.
@@ -2387,6 +2389,16 @@ export interface OnlinePlayersCountMessage {
  */
 export interface PongMessage {
   readonly type: 'pong'
+}
+
+/**
+ * This socket's identity just authenticated from a different socket (the player opened
+ * the game in another tab or device). The server closes this socket right after sending;
+ * the client must stop auto-reconnecting — taking the session back is an explicit user
+ * action (the "Use here" button).
+ */
+export interface SessionReplacedMessage {
+  readonly type: 'sessionReplaced'
 }
 
 export interface CreateQuickGameLobbyMessage {

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -74,6 +74,8 @@ export type ServerMessage =
   | QuickGameLobbyClosedMessage
   // Presence
   | OnlinePlayersCountMessage
+  // Liveness
+  | PongMessage
 
 /**
  * Connection confirmed with assigned player ID.
@@ -1587,6 +1589,8 @@ export type ClientMessage =
   | RequestUndoMessage
   // Resync
   | RequestResyncMessage
+  // Liveness
+  | PingMessage
   // Quick Game Lobby Messages
   | CreateQuickGameLobbyMessage
   | JoinQuickGameLobbyMessage
@@ -2076,6 +2080,15 @@ export interface RequestResyncMessage {
   readonly type: 'requestResync'
 }
 
+/**
+ * Connection liveness probe. The server always answers with a pong, regardless of
+ * authentication or game state. Sent when a backgrounded tab becomes visible again,
+ * to detect half-open sockets (e.g. after OS sleep).
+ */
+export interface PingMessage {
+  readonly type: 'ping'
+}
+
 // Lobby Message Factories
 export function createCreateTournamentLobbyMessage(
   setCodes: readonly string[],
@@ -2367,6 +2380,13 @@ export interface QuickGameLobbyClosedMessage {
 export interface OnlinePlayersCountMessage {
   readonly type: 'onlinePlayersCount'
   readonly count: number
+}
+
+/**
+ * Reply to a ping liveness probe — always sent, regardless of auth or game state.
+ */
+export interface PongMessage {
+  readonly type: 'pong'
 }
 
 export interface CreateQuickGameLobbyMessage {

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -12,6 +12,9 @@ try {
   // git may not be available (e.g. Docker build)
 }
 
+// Backend the dev server proxies to — override when the game server runs on a non-default port.
+const gameServerUrl = process.env.GAME_SERVER_URL || 'http://localhost:8080'
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -26,12 +29,12 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/game': {
-        target: 'http://localhost:8080',
+        target: gameServerUrl,
         ws: true,
         changeOrigin: true,
       },
       '/api': {
-        target: 'http://localhost:8080',
+        target: gameServerUrl,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Problem

Navigating away from a playing tab and coming back could leave the client stuck on a **"Not connected"** message until a manual refresh. Two root causes, both fixed here:

**1. Fragile reconnect lifecycle**
- The reconnect loop **gave up permanently after 5 attempts** (~31s of backoff) — easily exhausted by background-tab timer throttling or a server deploy.
- The `visibilitychange` handler only requested a resync when the socket was *already* open; it never revived a dead connection.
- A socket can sit **half-open** after OS sleep (readyState `OPEN`, but the server is gone) with nothing ever detecting it.
- The server's `NOT_CONNECTED` error surfaced as an error toast with no recovery path.

**2. Two tabs sharing one identity** (the likely actual trigger)
- Both tabs share `argentum-token` in localStorage. When tab B connects, `handleReconnect` silently remapped the identity to B's socket — tab A stayed open but unauthenticated, and every message it sent got `NOT_CONNECTED` → **"Not connected"**.

## Changes

**Client — `network/websocket.ts`**
- Reconnect retries **indefinitely**, exponential backoff capped at 30s (was: hard stop after 5 attempts).
- Tab becomes visible / browser fires `online` while disconnected → **immediate forced reconnect** (backoff reset, stale socket discarded with handlers detached so late events can't cross-fire).
- Tab becomes visible while the socket claims to be open → resync (as before) **plus a ping liveness probe**: if the server stays silent for 5s, the socket is half-open and gets torn down and reconnected. Any inbound message counts as proof of life.

**Client — store**
- A server `NOT_CONNECTED` error now triggers a debounced **re-auth** (re-sends `connect` with the stored token) instead of showing the toast.
- A plain `Connected` (not `Reconnected`) arriving while session state exists means the server lost the session (restart) — stale game/lobby state is cleared so the user lands in the lobby instead of a dead game board.

**Session takeover (two tabs / devices)**
- Server: when an identity authenticates from a different live socket, the old socket receives a new `sessionReplaced` message and is closed — instead of being silently orphaned.
- Client: on `sessionReplaced`, **all auto-reconnect stops** (otherwise the tabs would fight over the session) and a full-screen overlay explains what happened, with an explicit **"Use here"** button to reclaim. Reclaiming pushes the overlay to the other tab. Newest tab wins by default — same model as lichess/chess.com.

**Protocol / server**
- New `ping`/`pong` pair, answered unconditionally (even pre-auth) in `GameWebSocketHandler`.
- New `sessionReplaced` server message. Neither carries game events, so no `ClientEvent.kt` changes. Both documented in `docs/data-contracts.md` (§2C).

**Dev tooling**
- Vite proxy target overridable via `GAME_SERVER_URL` (run the dev client against a non-default server port).

## UI

The takeover overlay in the replaced tab (throwaway screenshots branch):

![Session replaced overlay](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ws-auto-recover-screenshots/session-replaced-overlay.png)

## Testing

- `GameConnectionTest`: ping→pong before and after auth; second socket with the same token gets the session, first socket receives `sessionReplaced` and the winner keeps working (all passing).
- `npm run typecheck` + production build clean.
- **Live verification** (Playwright driving system Chrome against the real stack):
  - *Server restart:* during a ~60s outage → 8 reconnect attempts with backoff capped at 30s, no give-up; tab-visible signal while disconnected → immediate forced reconnect; after the server returned → auto re-auth, lobby usable with no manual refresh.
  - *Healthy tab return:* resync + ping probe satisfied, no spurious reconnect.
  - *Two tabs, same identity:* older tab shows the takeover overlay with **zero** reconnect attempts (no session tug-of-war); "Use here" reclaims the session and the overlay moves to the other tab.
- Existing e2e flows are unaffected: every player gets a fresh context with its own token; the host-refresh test closes its old socket before reconnecting, so no replacement fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)