### PR TITLE
OTJ cards batch 1: Desperate Bloodseeker, Failed Fording, Nimble Brigand, Omenport Vigilante

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DesperateBloodseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DesperateBloodseeker.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Desperate Bloodseeker
+ * {1}{B}
+ * Creature — Vampire
+ * 2/2
+ * Lifelink
+ * When this creature enters, target player mills two cards.
+ */
+val DesperateBloodseeker = card("Desperate Bloodseeker") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 2
+    oracleText = "Lifelink\nWhen this creature enters, target player mills two cards."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(2, player)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Camille Alquier"
+        flavorText = "With no mammals around, some vampires tried to feed on cactusfolk, " +
+            "with horrible results for everyone involved."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg?1712355583"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FailedFording.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FailedFording.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Failed Fording
+ * {1}{U}
+ * Instant
+ *
+ * Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1.
+ *
+ * The "If you control a Desert, surveil 1" clause is a one-shot resolution-time state test, not
+ * an intervening-if trigger — modeled as a [ConditionalEffect] (lowers to a `Gate.WhenCondition`)
+ * chained after the bounce. The Desert check uses [Conditions.YouControl] over Lands with the
+ * Desert subtype.
+ */
+val FailedFording = card("Failed Fording") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent to its owner's hand. If you control a Desert, " +
+        "surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(permanent)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.YouControl(
+                        GameObjectFilter.Land.withSubtype(Subtype.DESERT)
+                    ),
+                    effect = Patterns.Library.surveil(1)
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "José Parodi"
+        flavorText = "\"We should have taken the blasted ferry!\"\n—Hope Hagan, prospector"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg?1712355418"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NimbleBrigand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NimbleBrigand.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+
+/**
+ * Nimble Brigand
+ * {2}{U}
+ * Creature — Human Rogue
+ * 1/3
+ * This creature can't be blocked if you've committed a crime this turn.
+ * Whenever this creature deals combat damage to a player, draw a card.
+ *
+ * The conditional evasion is a [ConditionalStaticAbility] wrapping [CantBeBlocked] (source-scoped)
+ * gated on [Conditions.YouCommittedCrimeThisTurn]; the crime-this-turn tracker is read each time
+ * the projected state is computed, so the creature becomes unblockable the moment you commit a
+ * crime and reverts at end of turn when the tracker resets.
+ */
+val NimbleBrigand = card("Nimble Brigand") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "This creature can't be blocked if you've committed a crime this turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n" +
+        "Whenever this creature deals combat damage to a player, draw a card."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CantBeBlocked(),
+            condition = Conditions.YouCommittedCrimeThisTurn
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Kim Sokol"
+        flavorText = "The hard part wasn't sneaking aboard. It was safely exiting with Slickshot flair."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg?1712355461"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "Whether you've committed a crime is checked as blocks are declared. Committing a crime after blockers are declared won't make Nimble Brigand unblocked.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OmenportVigilante.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OmenportVigilante.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Omenport Vigilante
+ * {1}{W}
+ * Creature — Human Mercenary
+ * 2/2
+ * This creature has double strike as long as you've committed a crime this turn.
+ *
+ * The conditional keyword is a [ConditionalStaticAbility] granting double strike to itself
+ * ([Filters.Self]) gated on [Conditions.YouCommittedCrimeThisTurn] — the crime-this-turn
+ * tracker is read each time the projected state is computed, so double strike appears the
+ * moment a crime is committed and disappears at end of turn when the tracker resets.
+ */
+val OmenportVigilante = card("Omenport Vigilante") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Mercenary"
+    power = 2
+    toughness = 2
+    oracleText = "This creature has double strike as long as you've committed a crime this turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.DOUBLE_STRIKE, Filters.Self),
+            condition = Conditions.YouCommittedCrimeThisTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Forrest Imel"
+        flavorText = "Freestriders took to patrolling near the Omenpaths, protecting new arrivals " +
+            "from the robbers and charlatans prowling for easy marks."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg?1712355310"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "Whether you've committed a crime this turn is checked continuously. Omenport Vigilante loses double strike at the start of the cleanup step, when \"this turn\" effects end.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1730,6 +1730,77 @@
     ]
 }
 
+// Desperate Bloodseeker
+{
+    "name": "Desperate Bloodseeker",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Lifelink\nWhen this creature enters, target player mills two cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Camille Alquier",
+        "flavorText": "With no mammals around, some vampires tried to feed on cactusfolk, with horrible results for everyone involved.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg?1712355583"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Discerning Peddler
 {
     "name": "Discerning Peddler",
@@ -2023,6 +2094,108 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Failed Fording
+{
+    "name": "Failed Fording",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonland permanent"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "land Desert"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeAs": "surveiled"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "surveiled",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "toGraveyard",
+                                "storeRemainder": "toTop",
+                                "selectedLabel": "Put in graveyard",
+                                "remainderLabel": "Put on top"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "order": "ControllerChooses"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "José Parodi",
+        "flavorText": "\"We should have taken the blasted ferry!\"\n—Hope Hagan, prospector",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg?1712355418"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4040,6 +4213,64 @@
     ]
 }
 
+// Nimble Brigand
+{
+    "name": "Nimble Brigand",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "This creature can't be blocked if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nWhenever this creature deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "CantBeBlocked",
+                "condition": "PlayerCommittedCrimeThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Kim Sokol",
+        "flavorText": "The hard part wasn't sneaking aboard. It was safely exiting with Slickshot flair.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg?1712355461",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Whether you've committed a crime is checked as blocks are declared. Committing a crime after blockers are declared won't make Nimble Brigand unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Oasis Gardener
 {
     "name": "Oasis Gardener",
@@ -4085,6 +4316,54 @@
         "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1712356276"
     },
     "colorIdentityOverride": []
+}
+
+// Omenport Vigilante
+{
+    "name": "Omenport Vigilante",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "This creature has double strike as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "PlayerCommittedCrimeThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Forrest Imel",
+        "flavorText": "Freestriders took to patrolling near the Omenpaths, protecting new arrivals from the robbers and charlatans prowling for easy marks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg?1712355310",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Whether you've committed a crime this turn is checked continuously. Omenport Vigilante loses double strike at the start of the cleanup step, when \"this turn\" effects end."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Outcaster Greenblade

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -268,6 +268,25 @@ private fun EmitCtx.youControlConditionDsl(condNode: JsonElement?): String? {
 }
 
 /**
+ * "you've committed a crime this turn" (`PlayerPassesFilter(You, CommitedACrimeThisTurn)`, OTJ) ->
+ * the `Conditions.YouCommittedCrimeThisTurn` DSL string, or null when the player isn't You / the
+ * filter isn't the bare crime predicate. Used by the [ifRuleBlock] static gates (Nimble Brigand's
+ * conditional unblockable, Omenport Vigilante's conditional double strike). The predicate reads the
+ * per-turn crime tracker each time the projected state is computed, so the gated ability appears the
+ * moment a crime is committed and reverts at cleanup.
+ */
+private fun EmitCtx.youCommittedCrimeConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val crime = args.getOrNull(1) as? JsonObject ?: return null
+    // The bare crime predicate carries no further args; a parameterized variant would change meaning.
+    if (crime.strField("_Players") != "CommitedACrimeThisTurn") return null
+    return "Conditions.YouCommittedCrimeThisTurn"
+}
+
+/**
  * `If{cond}[rules]` permanent rule -> one or more `staticAbility { ability = ... }` blocks gating a
  * continuous effect on a condition. Renders only the exact shapes we can express faithfully:
  *
@@ -323,16 +342,43 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
         return listOf(staticAbilityStmt(call("CanAttackDespiteDefender", arg("condition", Lit(condDsl)))))
     }
 
+    // Nimble Brigand: "This creature can't be blocked if you've committed a crime this turn."
+    //   If(PlayerPassesFilter(You, CommitedACrimeThisTurn))
+    //     [ PermanentRuleEffect(ThisPermanent, [ CantBeBlocked ]) ]
+    // -> ConditionalStaticAbility(CantBeBlocked(), Conditions.YouCommittedCrimeThisTurn). Only the
+    // SELF (ThisPermanent), bare CantBeBlocked inner rule gated on the crime predicate renders; any
+    // other permanent rule or condition declines -> SCAFFOLD. The conditional evasion (CR 509.1b is
+    // checked as blocks are declared) is left to the engine's projected-state read of the gate.
+    if (innerRule.strField("_Rule") == "PermanentRuleEffect" &&
+        jsonContains(innerRule, "_PermanentRule", "CantBeBlocked") &&
+        jsonContains(innerRule, "_Permanent", "ThisPermanent")
+    ) {
+        // A CantBeBlocked carrying any further args ("can't be blocked except by …") isn't the bare
+        // unblockable rule — decline rather than drop the exception.
+        val pr = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()?.singleOrNull()
+        if (pr == null || pr.strField("_PermanentRule") != "CantBeBlocked" || pr.size > 1) { reasons.add("If"); return null }
+        val condDsl = youCommittedCrimeConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        return listOf(staticAbilityStmt(call(
+            "ConditionalStaticAbility",
+            arg("ability", call("CantBeBlocked")),
+            arg("condition", Lit(condDsl)),
+        )))
+    }
+
     // Stoic Sphinx: "This creature has hexproof as long as you haven't cast a spell this turn."
     //   If(PlayerPassesFilter(You, HasntCastASpellThisTurn(AnySpell)))
     //     [ PermanentLayerEffect(ThisPermanent, [ AddAbility(<keyword>) ]) ]
     // -> ConditionalStaticAbility(GrantKeyword(Keyword.X, Filters.Self), Not(YouCastSpellsThisTurn(1))).
+    // Omenport Vigilante: "This creature has double strike as long as you've committed a crime this
+    //   turn." — same shape with a `CommitedACrimeThisTurn` gate.
     // Only the SELF "grant a single keyword to this permanent" inner shape renders; any other layer
     // effect (stat change, multi-keyword, group filter) declines -> SCAFFOLD.
     if (innerRule.strField("_Rule") == "PermanentLayerEffect" &&
         jsonContains(innerRule, "_Permanent", "ThisPermanent")
     ) {
-        val condDsl = youHaventCastASpellConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        val condDsl = youHaventCastASpellConditionDsl(cond)
+            ?: youCommittedCrimeConditionDsl(cond)
+            ?: run { reasons.add("If"); return null }
         val layerEffects = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
         val le = layerEffects?.singleOrNull()
         if (le == null || le.strField("_StaticLayerEffect") != "AddAbility") { reasons.add("If"); return null }
@@ -950,7 +996,10 @@ private fun isSelf(trig: JsonObject): Boolean {
     // Trophy Hunter's WasDealtDamageByPermanentThisTurn(ThisPermanent), "a creature with flying dealt
     // damage by THIS dies" — is NOT a self-trigger, so scope the check to the trigger's own subject
     // rather than a deep search that any nested ThisPermanent reference would satisfy.
-    val subject = trig["args"]
+    // Some triggers carry their subject as the FIRST of several args (the combat-damage-to-a-player
+    // trigger is `[SinglePermanent(ThisPermanent), AnyPlayer]`) — the subject is then args[0], not the
+    // whole args node. A plain SinglePermanent object stays the subject directly.
+    val subject = (trig["args"] as? JsonArray)?.firstOrNull() ?: trig["args"]
     return subject.strField("_Permanents") == "SinglePermanent" &&
         subject.field("args").strField("_Permanent") == "ThisPermanent"
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.call
@@ -172,6 +173,13 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): Dsl? {
         }
         "DiscardACardAtRandom" -> {
             return if (ptv != null) call("Patterns.Hand.discardRandom", arg("1"), arg(Lit(ptv))) else call("Patterns.Hand.discardRandom", arg("1"))
+        }
+        "MillNumberCards" -> {
+            // "target player mills N cards" (Desperate Bloodseeker's enters trigger). The milled player
+            // is the bound target; the count is a fixed Integer or a recognised dynamic amount. An
+            // unrenderable count scaffolds rather than guessing.
+            val amt = amountExpr(inner["args"]) ?: dynamicAmountExpr(amountNode(inner["args"])) ?: return null
+            return if (ptv != null) call("Patterns.Library.mill", arg(amt), arg(Lit(ptv))) else call("Patterns.Library.mill", arg(amt))
         }
         "SkipAllCombatPhasesTheirNextTurn" -> {
             return if (ptv != null) call("SkipCombatPhasesEffect", arg(Lit(ptv))) else call("SkipCombatPhasesEffect")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -101,14 +101,29 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     }
 
     // Inline `If{cond}[effects]` action (inside an ActionList) -> a `ConditionalEffect`. Renders only the
-    // one condition shape we can express faithfully: "if [the targeted permanent] had mana value N or
-    // less" (`PermanentPassesFilter(Ref_TargetPermanent, ManaValueIs(LessThanOrEqualTo Integer N))`),
-    // mapped to `Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(N))` — Consuming Ashes'
-    // "Exile target creature. If it had mana value 3 or less, surveil 2." Any other condition / target
-    // index / comparator declines (-> SCAFFOLD) rather than widening.
+    // condition shapes we can express faithfully:
+    //  - "if [the targeted permanent] had mana value N or less"
+    //    (`PermanentPassesFilter(Ref_TargetPermanent, ManaValueIs(LessThanOrEqualTo Integer N))`) ->
+    //    `Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(N))` — Consuming Ashes' "Exile target
+    //    creature. If it had mana value 3 or less, surveil 2."
+    //  - "if you control a <filter>" (`PlayerPassesFilter(You, ControlsA(<filter>))`) ->
+    //    `Conditions.YouControl(<filter>)` via [actionConditionDsl] — Failed Fording's "Return target
+    //    nonland permanent to its owner's hand. If you control a Desert, surveil 1."
+    // Any other condition / target index / comparator declines (-> SCAFFOLD) rather than widening.
     on("If") { node, args, tvar ->
         val a = args.asArr ?: return@on null
         val cond = a.getOrNull(0) as? JsonObject ?: return@on null
+        val inner = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
+        // "if you control a <filter>" — a resolution-time state test over your own board.
+        if (cond.strField("_Condition") == "PlayerPassesFilter") {
+            val condDsl = actionConditionDsl(cond) ?: return@on null
+            val edsl = renderEffectList(inner, tvar) ?: return@on null
+            return@on call(
+                "ConditionalEffect",
+                arg("condition", Lit(condDsl)),
+                arg("effect", edsl),
+            )
+        }
         if (cond.strField("_Condition") != "PermanentPassesFilter") return@on null
         val condArgs = cond["args"].asArr ?: return@on null
         // Subject must be the first targeted permanent (Ref_TargetPermanent / Ref_TargetPermanent1).
@@ -119,7 +134,6 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         val cmp = filter["args"] as? JsonObject ?: return@on null
         if (cmp.strField("_Comparison") != "LessThanOrEqualTo") return@on null
         val n = (cmp["args"].asInt()) ?: ((cmp["args"] as? JsonObject)?.get("args").asInt()) ?: return@on null
-        val inner = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
         val edsl = renderEffectList(inner, tvar) ?: return@on null
         call(
             "ConditionalEffect",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesperateBloodseekerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesperateBloodseekerScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DesperateBloodseeker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Desperate Bloodseeker (OTJ #86) — {1}{B} Creature — Vampire 2/2.
+ *
+ *   "Lifelink. When this creature enters, target player mills two cards."
+ *
+ * Casts the creature so its enters trigger fires, then resolves the trigger targeting the
+ * opponent and verifies exactly two cards were milled into their graveyard. Also confirms the
+ * creature has lifelink.
+ */
+class DesperateBloodseekerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(DesperateBloodseeker))
+        return driver
+    }
+
+    test("enters trigger mills two cards from the targeted player's library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 10), startingLife = 20)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val graveyardBefore = driver.getGraveyard(opponent).size
+
+        // Cast Desperate Bloodseeker from hand ({1}{B}).
+        val card = driver.putCardInHand(you, "Desperate Bloodseeker")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, card)
+
+        // Resolve the creature spell so it enters the battlefield and fires its enters trigger.
+        driver.bothPass()
+
+        // Resolve the enters trigger: choose the opponent as the player who mills.
+        driver.submitTargetSelection(you, listOf(opponent))
+        driver.bothPass()
+
+        // The opponent milled exactly two cards.
+        driver.getGraveyard(opponent).size shouldBe graveyardBefore + 2
+
+        // Lifelink is present on the resolved creature.
+        val bloodseeker = driver.getCreatures(you).first {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Desperate Bloodseeker"
+        }
+        val projected = StateProjector().project(driver.state)
+        projected.hasKeyword(bloodseeker, Keyword.LIFELINK) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FailedFordingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FailedFordingScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.FailedFording
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Failed Fording (OTJ #47) — {1}{U} Instant.
+ *
+ *   "Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1."
+ *
+ * Verifies the bounce always happens, and the surveil only triggers when the controller controls
+ * a Desert (a one-shot resolution-time `ConditionalEffect`, not an intervening-if trigger).
+ */
+class FailedFordingScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(FailedFording))
+        return driver
+    }
+
+    test("bounces the target; no surveil without a Desert") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val libTop = driver.putCardOnTopOfLibrary(me, "Island")
+
+        val card = driver.putCardInHand(me, "Failed Fording")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.castSpell(me, card, targets = listOf(bears))
+        driver.bothPass()
+
+        // No Desert -> no surveil decision; the spell resolves fully.
+        driver.isPaused shouldBe false
+        // Grizzly Bears returned to its owner's hand.
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(opp, Zone.BATTLEFIELD))
+            .contains(bears) shouldBe false
+        driver.getHand(opp).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+        } shouldBe true
+        // Library top untouched (no surveil).
+        driver.state.getLibrary(me).first() shouldBe libTop
+    }
+
+    test("with a Desert, also surveils 1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Control a Desert (Desert is itself a land with subtype Desert).
+        driver.putLandOnBattlefield(me, "Desert")
+
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val surveilTop = driver.putCardOnTopOfLibrary(me, "Island")
+
+        val card = driver.putCardInHand(me, "Failed Fording")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.castSpell(me, card, targets = listOf(bears))
+        driver.bothPass()
+
+        // Surveil 1 pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options.size shouldBe 1
+
+        // Put the looked-at card into the graveyard.
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(surveilTop)))
+        // No remainder to reorder for surveil 1 -> resolution completes (handle a possible
+        // trivial reorder decision defensively).
+        if (driver.isPaused && driver.pendingDecision is ReorderLibraryDecision) {
+            val reorder = driver.pendingDecision as ReorderLibraryDecision
+            driver.submitOrderedResponse(me, reorder.cards)
+        }
+        driver.isPaused shouldBe false
+
+        // The bounce happened and the surveil milled the top card.
+        driver.getHand(opp).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+        } shouldBe true
+        driver.getGraveyard(me).contains(surveilTop) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NimbleBrigandScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NimbleBrigandScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nimble Brigand (OTJ #58) — {2}{U} Creature — Human Rogue 1/3.
+ *
+ *   "This creature can't be blocked if you've committed a crime this turn.
+ *    Whenever this creature deals combat damage to a player, draw a card."
+ *
+ * The conditional evasion is a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] wrapping
+ * [com.wingedsheep.sdk.scripting.CantBeBlocked] gated on `YouCommittedCrimeThisTurn`. Verifies the
+ * CANT_BE_BLOCKED flag is absent before a crime and present once the controller commits one. The
+ * combat-damage draw uses the standard `DealsCombatDamageToPlayer` trigger + `DrawCards(1)`.
+ */
+class NimbleBrigandScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Nimble Brigand") {
+
+            test("is blockable until you've committed a crime this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nimble Brigand")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brigand = game.findPermanent("Nimble Brigand")!!
+
+                // No crime yet -> can still be blocked.
+                var projected = stateProjector.project(game.state)
+                projected.hasKeyword(brigand, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+
+                // Mark that the controller committed a crime this turn.
+                game.state = game.state.copy(
+                    playersWhoCommittedCrimeThisTurn = setOf(game.player1Id)
+                )
+
+                projected = stateProjector.project(game.state)
+                projected.hasKeyword(brigand, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+            }
+
+            test("an opponent's crime does not make it unblockable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nimble Brigand")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brigand = game.findPermanent("Nimble Brigand")!!
+
+                game.state = game.state.copy(
+                    playersWhoCommittedCrimeThisTurn = setOf(game.player2Id)
+                )
+
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(brigand, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenportVigilanteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenportVigilanteScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Omenport Vigilante (OTJ #21) — {1}{W} Creature — Human Mercenary 2/2.
+ *
+ *   "This creature has double strike as long as you've committed a crime this turn."
+ *
+ * The crime-conditional keyword is a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility]
+ * granting double strike to itself gated on `YouCommittedCrimeThisTurn`. Verifies the keyword is
+ * absent before a crime and present once the controller has committed one this turn.
+ */
+class OmenportVigilanteScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Omenport Vigilante") {
+
+            test("has no double strike until you've committed a crime this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Omenport Vigilante")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vigilante = game.findPermanent("Omenport Vigilante")!!
+
+                // No crime yet -> no double strike.
+                var projected = stateProjector.project(game.state)
+                projected.hasKeyword(vigilante, Keyword.DOUBLE_STRIKE) shouldBe false
+
+                // Mark that the controller committed a crime this turn.
+                game.state = game.state.copy(
+                    playersWhoCommittedCrimeThisTurn = setOf(game.player1Id)
+                )
+
+                projected = stateProjector.project(game.state)
+                projected.hasKeyword(vigilante, Keyword.DOUBLE_STRIKE) shouldBe true
+            }
+
+            test("an opponent's crime does not grant you double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Omenport Vigilante")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vigilante = game.findPermanent("Omenport Vigilante")!!
+
+                // Only the opponent committed a crime.
+                game.state = game.state.copy(
+                    playersWhoCommittedCrimeThisTurn = setOf(game.player2Id)
+                )
+
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(vigilante, Keyword.DOUBLE_STRIKE) shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards (Outlaws of Thunder Junction)

| Card | Cost | Behaviour |
|------|------|-----------|
| Desperate Bloodseeker | {1}{B} | Lifelink. When it enters, target player mills two cards. |
| Failed Fording | {1}{U} | Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1. |
| Nimble Brigand | {2}{U} | Can't be blocked while you've committed a crime this turn. Deals combat damage to a player → draw a card. |
| Omenport Vigilante | {1}{W} | Has double strike as long as you've committed a crime this turn. |

Each card has a passing Kotest scenario test. The OTJ `CardDefinitionSnapshot` golden was re-blessed for the four additions.

## mtgish emitter changes

All four cards now **auto-generate at AUTO tier**, faithful to the golden (`coverage-fidelity --emit`):

- **`renderPlayerAction`** (`PlayerContinuousHandlers.kt`) — handle `MillNumberCards` under a bound target player → `Patterns.Library.mill(n, targetPlayer)` (Desperate Bloodseeker's enters trigger).
- **`on("If")` action** (`ZoneHandlers.kt`) — also accept the `PlayerPassesFilter(You, ControlsA(<filter>))` "you control a `<filter>`" condition via `actionConditionDsl` → `ConditionalEffect`, in addition to the existing mana-value shape (Failed Fording's "if you control a Desert, surveil 1").
- **`ifRuleBlock`** (`CardStructure.kt`) — render the crime-gated self statics: `PermanentRuleEffect(ThisPermanent, CantBeBlocked)` and `PermanentLayerEffect(ThisPermanent, AddAbility)` gated on `CommitedACrimeThisTurn` → `ConditionalStaticAbility(..., Conditions.YouCommittedCrimeThisTurn)` (Nimble Brigand's conditional unblockable, Omenport Vigilante's conditional double strike). Added a `youCommittedCrimeConditionDsl` helper.
- **`isSelf`** (`CardStructure.kt`) — recognise a `SinglePermanent(ThisPermanent)` subject carried as the *first* of a multi-arg trigger (the combat-damage-to-a-player trigger is `[permanent, player]`), so Nimble Brigand's draw trigger renders instead of scaffolding.

No new SDK surface was added — the emitter only maps existing primitives — so `docs/card-sdk-language-reference.md` needs no change.

### SCAFFOLD declines
None. All four render whole at AUTO.

### Verification
- 4 scenario tests pass; `CardDefinitionSnapshotTest` + `CardLintTest` pass.
- `EmitterGoldenTest` green (POR, EOE); **POR deep gate 0 mismatch (158/158)**.
- Full `:mtgish-tooling` test suite passes.
- OTJ deep gate: the four cards are gameplay-equivalent to golden except a single **cosmetic** diff on Desperate Bloodseeker — the emitter's generic target-id label (`"target"`, which the gate normalizes) vs the hand-authored descriptive label (`"target player"`). Behaviour is identical; this is the same non-gameplay id-label class as the pre-existing OTJ `descriptionOverride` diffs, and OTJ is not a 0-mismatch-calibrated set.

⚠️ Touches the shared mtgish emitter + OTJ CardDefinitionSnapshot golden, which sibling PRs otj-cards-batch-2 and otj-cards-batch-3 also touch — merge the three serially and re-bless the OTJ snapshot once after the last merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)