### PR TITLE
OTJ batch 3: Honest Rutstein, Rictus Robber, Stingerback Terror, Tumbleweed Rising

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2815,6 +2815,12 @@ Numbers computed at resolution time.
 - `AggregateZone(player, zone, filter?, aggregation?)` — count cards in a zone.
 - `CountPermanentsOfType(player, subtype)` — count by creature type.
 - `CountCreaturesYouControl` — shorthand for "your creatures".
+- Facades: `DynamicAmounts.cardsInYourGraveyard()` / `creatureCardsInYourGraveyard()`
+  (graveyard counts), and `DynamicAmounts.cardsInYourHand()` — cards in your hand,
+  e.g. Stingerback Terror's "-1/-1 for each card in your hand" (multiply by `-1` and feed
+  both bonuses of a `GrantDynamicStatsEffect(GroupFilter.source(), …)`). Greatest power among
+  creatures you control is `DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxPower()`
+  (Tumbleweed Rising's X/X token, paired with `Effects.CreateDynamicToken`).
 
 ### Player & game
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -189,6 +189,14 @@ object DynamicAmounts {
         DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature)
 
     // =========================================================================
+    // Hand counting
+    // =========================================================================
+
+    /** The number of cards in your hand (e.g. Stingerback Terror's "-1/-1 for each card in your hand"). */
+    fun cardsInYourHand(): DynamicAmount =
+        DynamicAmount.Count(Player.You, Zone.HAND)
+
+    // =========================================================================
     // Opponent-relative counting
     // =========================================================================
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HonestRutstein.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HonestRutstein.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Honest Rutstein
+ * {1}{B}{G}
+ * Legendary Creature — Human Warlock
+ * 3/2
+ *
+ * When Honest Rutstein enters, return target creature card from your graveyard to your hand.
+ * Creature spells you cast cost {1} less to cast.
+ */
+val HonestRutstein = card("Honest Rutstein") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "When Honest Rutstein enters, return target creature card from your graveyard to your hand.\n" +
+        "Creature spells you cast cost {1} less to cast."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Move(creature, Zone.HAND)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Javier Charro"
+        flavorText = "\"No questions. No refunds.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg?1712356107"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RictusRobber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RictusRobber.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rictus Robber
+ * {3}{B}
+ * Creature — Zombie Rogue
+ * 4/3
+ *
+ * When this creature enters, if a creature died this turn, create a 2/2 blue and black
+ * Zombie Rogue creature token.
+ * Plot {2}{B}
+ */
+val RictusRobber = card("Rictus Robber") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Rogue"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, if a creature died this turn, create a 2/2 blue and " +
+        "black Zombie Rogue creature token.\n" +
+        "Plot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.plot("{2}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // Intervening "if": checked both on trigger and on resolution.
+        triggerCondition = Conditions.CreatureDiedThisTurn
+        effect = Effects.CreateToken(
+            count = 1,
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE, Color.BLACK),
+            creatureTypes = setOf("Zombie", "Rogue"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "Caio Monteiro"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg?1712355654"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/StingerbackTerror.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/StingerbackTerror.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stingerback Terror
+ * {2}{R}{R}
+ * Creature — Scorpion Dragon
+ * 7/7
+ *
+ * Flying, trample
+ * This creature gets -1/-1 for each card in your hand.
+ * Plot {2}{R}
+ */
+val StingerbackTerror = card("Stingerback Terror") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Scorpion Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying, trample\n" +
+        "This creature gets -1/-1 for each card in your hand.\n" +
+        "Plot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.plot("{2}{R}"))
+
+    staticAbility {
+        // -1/-1 for each card in your hand, applied to this creature itself.
+        val negHand = DynamicAmount.Multiply(DynamicAmounts.cardsInYourHand(), -1)
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = negHand,
+            toughnessBonus = negHand
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "147"
+        artist = "Slawomir Maniak"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg?1712355854"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TumbleweedRising.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TumbleweedRising.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Tumbleweed Rising
+ * {1}{G}
+ * Sorcery
+ *
+ * Create an X/X green Elemental creature token, where X is the greatest power
+ * among creatures you control.
+ * Plot {2}{G}
+ */
+val TumbleweedRising = card("Tumbleweed Rising") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create an X/X green Elemental creature token, where X is the greatest power " +
+        "among creatures you control.\n" +
+        "Plot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.plot("{2}{G}"))
+
+    spell {
+        // X is the greatest power among creatures you control (token created with that P/T).
+        val greatestPower = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxPower()
+        effect = Effects.CreateDynamicToken(
+            dynamicPower = greatestPower,
+            dynamicToughness = greatestPower,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elemental"),
+            imageUri = "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1712316611"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Jason Smith"
+        flavorText = "When weeds tumble against the wind, *run*."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg?1712356021"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3001,6 +3001,69 @@
     ]
 }
 
+// Honest Rutstein
+{
+    "name": "Honest Rutstein",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "When Honest Rutstein enters, return target creature card from your graveyard to your hand.\nCreature spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "Javier Charro",
+        "flavorText": "\"No questions. No refunds.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg?1712356107"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Inspiring Vantage
 {
     "name": "Inspiring Vantage",
@@ -4921,6 +4984,62 @@
     ]
 }
 
+// Rictus Robber
+{
+    "name": "Rictus Robber",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Rogue",
+    "oracleText": "When this creature enters, if a creature died this turn, create a 2/2 blue and black Zombie Rogue creature token.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLUE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie",
+                        "Rogue"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+                },
+                "triggerCondition": "CreatureDiedThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg?1712355654"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Riku of Many Paths
 {
     "name": "Riku of Many Paths",
@@ -6532,6 +6651,67 @@
     ]
 }
 
+// Stingerback Terror
+{
+    "name": "Stingerback Terror",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Scorpion Dragon",
+    "oracleText": "Flying, trample\nThis creature gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE",
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Hand"
+                    },
+                    "multiplier": -1
+                },
+                "toughnessBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Hand"
+                    },
+                    "multiplier": -1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "RARE",
+        "artist": "Slawomir Maniak",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg?1712355854"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Stoic Sphinx
 {
     "name": "Stoic Sphinx",
@@ -7104,6 +7284,60 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Tumbleweed Rising
+{
+    "name": "Tumbleweed Rising",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create an X/X green Elemental creature token, where X is the greatest power among creatures you control.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 0,
+            "toughness": 0,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Elemental"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1712316611",
+            "dynamicPower": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature",
+                "aggregation": "MAX",
+                "property": "POWER"
+            },
+            "dynamicToughness": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature",
+                "aggregation": "MAX",
+                "property": "POWER"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Jason Smith",
+        "flavorText": "When weeds tumble against the wind, *run*.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg?1712356021"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -680,6 +680,15 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
         val counter = counterNameForFilter(cond) ?: return null
         return "Conditions.Not(Conditions.SourceHasCounter(CounterTypeFilter.Named(\"$counter\")))"
     }
+    // "if a creature died this turn" — ACreatureOrPlaneswalkerDiedThisTurn over a bare creature-cardtype
+    // filter (Rictus Robber). Only the unrestricted "a creature" shape (no controller / subtype / count
+    // clause) maps to Conditions.CreatureDiedThisTurn; anything more specific declines -> SCAFFOLD.
+    if (cond.strField("_Condition") == "ACreatureOrPlaneswalkerDiedThisTurn") {
+        val filter = cond["args"] as? JsonObject
+        val bareCreature = filter?.strField("_Permanents") == "IsCardtype" &&
+            filter.field("args").asStr() == "Creature"
+        return if (bareCreature) "Conditions.CreatureDiedThisTurn" else null
+    }
     // "you control another outlaw" — ControlsA over And(Other(ThatEnteringPermanent), IsAnOutlaw). The
     // entering permanent is itself an outlaw, so this is exactly "two or more outlaws you control".
     youControlAnotherOutlawDsl(cond)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -205,6 +205,20 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
             return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourceToughness") else null
         "PowerOfPermanent" ->
             return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourcePower") else null
+        // "the greatest power among creatures you control" (Tumbleweed Rising's X/X token). The args are a
+        // permanent filter — only the exact "creatures you control" (And(IsCardtype Creature,
+        // ControlledByAPlayer You)) shape maps to the battlefield MAX-power facade; any other filter (a
+        // subtype, an opponent's creatures, "on the battlefield") declines -> SCAFFOLD rather than miscount.
+        "TheGreatestPowerAmongPermanents" -> {
+            val filterBlob = compact(node["args"])
+            val creaturesYouControl = node.firstArgWordTagged("IsCardtype") == "Creature" &&
+                "ControlledByAPlayer" in filterBlob && jsonContains(node["args"], "_Player", "You") &&
+                "IsCreatureType" !in filterBlob && "_Color" !in filterBlob && "\"Other\"" !in filterBlob &&
+                "Opponent" !in filterBlob
+            return if (creaturesYouControl) {
+                call("DynamicAmounts.battlefield", arg("Player.You"), arg("GameObjectFilter.Creature")).dot("maxPower")
+            } else null
+        }
         "LifeTotalOfPlayer" -> {
             val player = if (jsonContains(node, "_Player", "Opponent")) "Player.Opponent" else "Player.You"
             return call("DynamicAmount.LifeTotal", arg(player))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -9,8 +9,10 @@ import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.Sub
 import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.dot
@@ -198,9 +200,31 @@ private fun EmitCtx.selfDynamicStatsBlock(rule: JsonObject): List<Stmt>? {
         if (pt.size != 3) return null
         val powerMult = pt[0].asInt() ?: return null
         val toughnessMult = pt[1].asInt() ?: return null
+        val countNode = pt[2] as? JsonObject ?: return null
+
+        // "This creature gets +powerMult/+toughnessMult for each card in your hand" (Stingerback
+        // Terror: -1/-1 per card). The hand tally is a resolution-time `DynamicAmount.Count` over the
+        // You hand, via the `DynamicAmounts.cardsInYourHand()` facade. Only the You scope renders.
+        if (countNode.strField("_GameNumber") == "TheNumberOfCardsInPlayersHand") {
+            if (!jsonContains(countNode, "_Player", "You")) return null
+            val handCount: Dsl = call("DynamicAmounts.cardsInYourHand")
+            fun handBonus(mult: Int): Dsl =
+                if (mult == 1) handCount else call("DynamicAmount.Multiply", arg(handCount), arg("$mult"))
+            stmts.add(
+                staticAbilityStmt(
+                    call(
+                        "GrantDynamicStatsEffect",
+                        arg("filter", call("GroupFilter.source")),
+                        arg("powerBonus", handBonus(powerMult)),
+                        arg("toughnessBonus", handBonus(toughnessMult)),
+                    )
+                )
+            )
+            continue
+        }
+
         // The count must be a You-controlled battlefield tally; decline anything else (opponent /
         // each-player scope, or a filter the count path widens) so we never misrender the buff.
-        val countNode = pt[2] as? JsonObject ?: return null
         if (countNode.strField("_GameNumber") != "TheNumberOfPermanentsOnTheBattlefield") return null
         if (!jsonContains(countNode, "_Player", "You")) return null
         // Reject the predicates the land/type count filter path can't render faithfully (it silently
@@ -488,7 +512,7 @@ internal fun EmitCtx.cantBeBlockedExceptByFilter(ruleNode: JsonObject): String? 
  * A top-level `PlayerEffect(You, [...])` rule -> one `staticAbility { ability = ... }` per recognised
  * player-static. Only shapes with an exact controller-scoped StaticAbility render; anything else (the
  * top-of-library / cost-reduction player statics) scaffolds rather than guess. Currently: "you have
- * shroud" (True Believer).
+ * shroud" (True Believer); "creature spells you cast cost {N} less to cast" (Honest Rutstein).
  */
 internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"] as? JsonArray
@@ -501,9 +525,38 @@ internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<Stmt>? {
     for (e in effects) {
         val ability = when (e.strField("_PlayerEffect")) {
             "Shroud" -> Lit("GrantShroudToController")
+            // "[Filtered] spells you cast cost {N} less to cast" (Honest Rutstein: creature spells).
+            // Renders only a single bare generic reduction over a spell filter we can name exactly;
+            // a colored/dynamic reduction or a filter we can't express declines -> SCAFFOLD.
+            "DecreaseSpellCost" -> decreaseSpellCostAbility(e) ?: run { reasons.add("PlayerEffect"); return null }
             else -> { reasons.add("PlayerEffect"); return null }
         }
         stmts.add(staticAbilityStmt(ability))
     }
     return stmts
+}
+
+/**
+ * A `DecreaseSpellCost(<spell filter>, [<reduction symbols>])` player-static -> `ModifySpellCost(
+ * target = SpellCostTarget.YouCast(<filter>), modification = CostModification.ReduceGeneric(N))`. Only a
+ * single bare generic reduction over a spell filter we can name exactly (creature spells / any spell)
+ * renders; any colored symbol, a multi-symbol reduction, or an unrenderable filter returns null. */
+private fun EmitCtx.decreaseSpellCostAbility(effect: JsonObject): Dsl? {
+    val a = effect["args"].asArr ?: return null
+    val spellFilter = when (val spells = a.getOrNull(0) as? JsonObject) {
+        null -> "GameObjectFilter.Any"
+        else -> when {
+            jsonContains(spells, "_Spells", "AnySpell") -> "GameObjectFilter.Any"
+            spells.strField("_Spells") == "IsCardtype" && spells.field("args").asStr() == "Creature" -> "GameObjectFilter.Creature"
+            else -> return null
+        }
+    }
+    val symbols = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
+    val amount = symbols[0]["args"].asInt() ?: return null
+    return call(
+        "ModifySpellCost",
+        arg("target", call("SpellCostTarget.YouCast", arg(spellFilter))),
+        arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+    )
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -64,7 +64,16 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1, dynamicCou
             val a = spec["args"].asArr ?: return null
             val cardtypes = (a.getOrNull(3) as? JsonArray)?.mapNotNull { it.asStr() } ?: emptyList()
             if (cardtypes != listOf("Creature")) return null  // only plain creature tokens
-            val pt = (a.getOrNull(0) as? JsonObject)?.get("args").asArr ?: return null
+            val ptSpec = a.getOrNull(0) as? JsonObject ?: return null
+            // A `PTX` spec is an X/X token whose X is a game number ("Create an X/X … where X is the
+            // greatest power among creatures you control" — Tumbleweed Rising). Render it via
+            // `Effects.CreateDynamicToken(dynamicPower = …, dynamicToughness = …)`; the dynamic-token path
+            // can't carry abilities or a per-token count, so decline (-> SCAFFOLD) if either is present.
+            if (ptSpec.strField("_PT") == "PTX") {
+                if (count != 1 || dynamicCount != null) return null
+                return dynamicPtTokenDsl(ptSpec, a, controller)
+            }
+            val pt = ptSpec["args"].asArr ?: return null
             val power = pt.getOrNull(0).asInt() ?: return null
             val toughness = pt.getOrNull(1).asInt() ?: return null
             val colors = ((a.getOrNull(1) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
@@ -125,6 +134,34 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1, dynamicCou
         }
     }
     return null
+}
+
+/**
+ * A `PTX` token spec — "Create an X/X [color] [subtype] creature token, where X is <game number>"
+ * (Tumbleweed Rising) -> `Effects.CreateDynamicToken(dynamicPower = …, dynamicToughness = …, colors = …,
+ * creatureTypes = …)`. `PTX`'s args are `[{_PTXValue}, {_PTXValue}, <countNode>]`: both the power and
+ * toughness X resolve to the SAME [countNode] game number, rendered via [dynamicAmountExpr] (decline ->
+ * SCAFFOLD when it doesn't render exactly). Only the plain-creature, subtyped, no-ability shape renders;
+ * a token carrying granted abilities declines (the dynamic-token facade can't carry them). [outer] is the
+ * `TokenWithPT` arg list (colours at [1], subtypes at [4], abilities at [5]).
+ */
+private fun EmitCtx.dynamicPtTokenDsl(ptSpec: JsonObject, outer: JsonArray, controller: String?): Dsl? {
+    val ptArgs = ptSpec["args"].asArr ?: return null
+    if (ptArgs.size != 3) return null
+    val countNode = ptArgs.getOrNull(2) ?: return null
+    val dynamic = dynamicAmountExpr(countNode) ?: return null
+    val colors = ((outer.getOrNull(1) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
+        .mapNotNull { it.asStr()?.let(TOKEN_COLOR::get) }
+    val subs = ((outer.getOrNull(4) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
+        .mapNotNull { it.asStr() }
+    if (subs.isEmpty()) return null
+    // The dynamic-token facade has no ability list; an abilitied X/X token declines rather than drop them.
+    if ((outer.getOrNull(5) as? JsonArray)?.isNotEmpty() == true) return null
+    val parts = mutableListOf(arg("dynamicPower", dynamic), arg("dynamicToughness", dynamic))
+    if (colors.isNotEmpty()) parts.add(arg("colors", "setOf(${colors.joinToString(", ") { "Color.$it" }})"))
+    parts.add(arg("creatureTypes", "setOf(${subs.joinToString(", ") { "\"$it\"" }})"))
+    if (controller != null) parts.add(arg("controller", Lit(controller)))
+    return Call("Effects.CreateDynamicToken", parts)
 }
 
 /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjBatch3ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjBatch3ScenarioTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.HonestRutstein
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RictusRobber
+import com.wingedsheep.mtg.sets.definitions.otj.cards.StingerbackTerror
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TumbleweedRising
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for OTJ batch 3 cards: Tumbleweed Rising, Stingerback Terror,
+ * Rictus Robber, Honest Rutstein.
+ */
+class OtjBatch3ScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + TumbleweedRising + StingerbackTerror + RictusRobber + HonestRutstein
+        )
+        return driver
+    }
+
+    fun GameTestDriver.handCount(playerId: EntityId): Int =
+        state.getZone(playerId, Zone.HAND).size
+
+    fun GameTestDriver.tokenSubtypes(id: EntityId): Set<String> =
+        state.getEntity(id)?.get<CardComponent>()?.typeLine?.subtypes?.map { it.value }?.toSet() ?: emptySet()
+
+    // ---------------------------------------------------------------------
+    // Tumbleweed Rising
+    // ---------------------------------------------------------------------
+
+    test("Tumbleweed Rising creates an X/X Elemental where X is the greatest power among creatures you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Greatest power among my creatures: Grizzly Bears (2) and Savannah Lions (1) -> 2.
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(player, "Savannah Lions")
+
+        val spell = driver.putCardInHand(player, "Tumbleweed Rising")
+        driver.giveMana(player, Color.GREEN, 2)
+        driver.castSpell(player, spell)
+        driver.bothPass()
+
+        val token = driver.getCreatures(player).single { driver.tokenSubtypes(it).contains("Elemental") }
+        projector.getProjectedPower(driver.state, token) shouldBe 2
+        projector.getProjectedToughness(driver.state, token) shouldBe 2
+    }
+
+    // ---------------------------------------------------------------------
+    // Stingerback Terror
+    // ---------------------------------------------------------------------
+
+    test("Stingerback Terror gets -1/-1 for each card in your hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        repeat(3) { driver.putCardInHand(player, "Mountain") }
+        val handSize = driver.handCount(player)
+
+        val terror = driver.putCreatureOnBattlefield(player, "Stingerback Terror")
+
+        // Base 7/7 minus the current hand size.
+        projector.getProjectedPower(driver.state, terror) shouldBe (7 - handSize)
+        projector.getProjectedToughness(driver.state, terror) shouldBe (7 - handSize)
+    }
+
+    // ---------------------------------------------------------------------
+    // Rictus Robber
+    // ---------------------------------------------------------------------
+
+    test("Rictus Robber makes no token when no creature died this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val robber = driver.putCardInHand(player, "Rictus Robber")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 3)
+        driver.castSpell(player, robber)
+        driver.bothPass() // resolve the creature; intervening-if is false at trigger time -> no trigger
+
+        driver.getCreatures(player).size shouldBe 1
+    }
+
+    test("Rictus Robber makes a 2/2 Zombie Rogue token when a creature died this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Record that a creature died this turn (the engine increments this on death).
+        driver.replaceState(
+            driver.state.updateEntity(player) { container ->
+                container.with(CreaturesDiedThisTurnComponent(count = 1))
+            }
+        )
+
+        val robber = driver.putCardInHand(player, "Rictus Robber")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 3)
+        driver.castSpell(player, robber)
+        driver.bothPass() // resolve the creature spell -> ETB trigger goes on the stack
+        driver.bothPass() // resolve the ETB trigger -> create token
+
+        val creatures = driver.getCreatures(player)
+        creatures.size shouldBe 2
+        val token = creatures.single { driver.state.getEntity(it)?.get<TokenComponent>() != null }
+        driver.tokenSubtypes(token) shouldBe setOf("Zombie", "Rogue")
+        projector.getProjectedPower(driver.state, token) shouldBe 2
+        projector.getProjectedToughness(driver.state, token) shouldBe 2
+    }
+
+    // ---------------------------------------------------------------------
+    // Honest Rutstein
+    // ---------------------------------------------------------------------
+
+    test("Honest Rutstein returns a target creature card from your graveyard to your hand on ETB") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val deadBear = driver.putCardInGraveyard(player, "Grizzly Bears")
+
+        val rutstein = driver.putCardInHand(player, "Honest Rutstein")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 1)
+        val handAfterCast = driver.handCount(player) - 1 // Rutstein leaves hand when cast
+
+        driver.castSpell(player, rutstein)
+        driver.bothPass() // resolve creature -> ETB trigger goes on stack
+        // ETB targets the only creature card in the graveyard.
+        if (driver.state.pendingDecision != null) {
+            driver.submitTargetSelection(player, listOf(deadBear))
+        }
+        driver.bothPass() // resolve the ETB trigger
+
+        // The bear should be back in hand.
+        driver.state.getZone(player, Zone.HAND).contains(deadBear) shouldBe true
+        driver.handCount(player) shouldBe (handAfterCast + 1)
+    }
+})


### PR DESCRIPTION
## Cards (all with passing scenario tests in `OtjBatch3ScenarioTest`)

- **Honest Rutstein** `{1}{B}{G}` — ETB: return target creature card from your graveyard to hand; static "creature spells you cast cost {1} less".
- **Rictus Robber** `{3}{B}` — intervening-if ETB: if a creature died this turn, create a 2/2 blue-and-black Zombie Rogue; Plot `{2}{B}`.
- **Stingerback Terror** `{2}{R}{R}` — flying, trample; gets -1/-1 for each card in your hand; Plot `{2}{R}`.
- **Tumbleweed Rising** `{1}{G}` — create an X/X green Elemental where X is the greatest power among creatures you control; Plot `{2}{G}`.

## SDK addition

- `DynamicAmounts.cardsInYourHand()` → `Count(Player.You, Zone.HAND)` — for Stingerback Terror's "for each card in your hand". Documented in `docs/card-sdk-language-reference.md`. (Tumbleweed Rising reuses the existing `battlefield(You, Creature).maxPower()` facade.)

## mtgish emitter changes (all four promoted SCAFFOLD → AUTOGEN)

Each shape renders faithfully or declines to SCAFFOLD — no lossy approximations:

- `PlayerEffect` `DecreaseSpellCost` (single bare generic reduction over creature/any spell) → `ModifySpellCost(SpellCostTarget.YouCast(filter), CostModification.ReduceGeneric(N))` (Honest Rutstein).
- intervening-if `ACreatureOrPlaneswalkerDiedThisTurn` over a bare creature filter → `Conditions.CreatureDiedThisTurn` (Rictus Robber).
- `AdjustPTForEach` self-buff over `TheNumberOfCardsInPlayersHand(You)` → `GrantDynamicStatsEffect(GroupFilter.source(), …)` via `cardsInYourHand()` (Stingerback Terror).
- `TokenWithPT` `PTX` + `TheGreatestPowerAmongPermanents` (creatures you control) → `Effects.CreateDynamicToken(dynamicPower/dynamicToughness = battlefield(You, Creature).maxPower(), …)` (Tumbleweed Rising).

## Verification

- `OtjBatch3ScenarioTest` (5 tests) — pass.
- `:mtg-sets` `CardDefinitionSnapshotTest` + `CardLintTest` — pass (OTJ.json re-blessed with the 4 cards).
- `coverage-verify POR` — 158/158, **0 mismatch**.
- `EmitterGoldenTest` (POR + EOE) — unchanged/pass, so no emitter fixture re-bless needed.
- All four cards emit at AUTO and gameplay-tree-match the OTJ golden.

### SCAFFOLD declines / no new mismatches
No new shapes left as SCAFFOLD for these four cards. The OTJ compiled gate reports 16 pre-existing gameplay-tree mismatches (e.g. Armored Armadillo, Canyon Crab, Magebane Lizard) — all unrelated to this change (15 use none of the new shapes; Armored Armadillo's `PTX` is an `AdjustPTX` layer effect, not a `TokenWithPT` token, and its mismatch is a `descriptionOverride`). OTJ is `incomplete = true` and not in the 0-mismatch verify-all loop, so this gate was already failing before this PR.

⚠️ Touches the shared mtgish emitter + OTJ CardDefinitionSnapshot golden, which sibling PRs otj-cards-batch-1 and otj-cards-batch-2 also touch — merge the three serially and re-bless the OTJ snapshot once after the last merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)