### PR TITLE
OTJ cards batch 2: Nurturing Pixie, Peerless Ropemaster, Raven of Fell Omens, Shepherd of the Clouds

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NurturingPixie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NurturingPixie.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Nurturing Pixie
+ * {W}
+ * Creature — Faerie Rogue
+ * 1/1
+ *
+ * Flying
+ * When this creature enters, return up to one target non-Faerie, nonland permanent you control to
+ * its owner's hand. If a permanent was returned this way, put a +1/+1 counter on this creature.
+ *
+ * "Up to one target" is an optional single-target return; the controller may decline. The
+ * +1/+1 counter is gated on whether a permanent was actually chosen/returned via
+ * [Conditions.TargetMatchesFilter] (`IsPermanent` is a zone-agnostic type-line check, so it
+ * still matches after the card moves to hand). When the optional target is declined no target
+ * exists, the condition is false, and no counter is placed — mirroring Azure Beastbinder's
+ * "up to one target … if it's a creature" resolution-time gate.
+ */
+val NurturingPixie = card("Nurturing Pixie") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, return up to one target non-Faerie, nonland permanent you " +
+        "control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter " +
+        "on this creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "permanent",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent.notSubtype(Subtype.FAERIE).youControl(),
+                ),
+                optional = true,
+            ),
+        )
+        effect = Effects.ReturnToHand(t).then(
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.Permanent),
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            ),
+        )
+        description = "When this creature enters, return up to one target non-Faerie, nonland " +
+            "permanent you control to its owner's hand. If a permanent was returned this way, " +
+            "put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "20"
+        artist = "Iris Compiet"
+        flavorText = "\"Count yourself lucky I came upon you. This is not a world of second chances.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg?1712355304"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PeerlessRopemaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PeerlessRopemaster.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Peerless Ropemaster
+ * {4}{U}
+ * Creature — Human Rogue
+ * 4/4
+ *
+ * When this creature enters, return up to one target tapped creature to its owner's hand.
+ *
+ * "Up to one target" is an optional single-target return ([TargetCreature] with `optional = true`),
+ * so the controller may decline to target anything (no creature is returned and the ability still
+ * resolves). The target must be tapped when chosen; if it stops being legal before resolution the
+ * ability fizzles.
+ */
+val PeerlessRopemaster = card("Peerless Ropemaster") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, return up to one target tapped creature to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("creature", TargetCreature(filter = TargetFilter.TappedCreature, optional = true))
+        effect = Effects.ReturnToHand(t)
+        description = "When this creature enters, return up to one target tapped creature to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Wayne Wu"
+        flavorText = "\"Murder someone and you'll have a gaggle of folks lining up for revenge. " +
+            "Humiliate them, and they won't dare bother you again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg?1712355469"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RavenOfFellOmens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RavenOfFellOmens.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Raven of Fell Omens
+ * {1}{B}
+ * Creature — Bird
+ * 1/2
+ *
+ * Flying
+ * Whenever you commit a crime, each opponent loses 1 life and you gain 1 life.
+ * This ability triggers only once each turn.
+ */
+val RavenOfFellOmens = card("Raven of Fell Omens") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever you commit a crime, each opponent loses 1 life and you gain 1 life. " +
+        "This ability triggers only once each turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = Effects.Composite(
+            listOf(
+                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                GainLifeEffect(1, EffectTarget.Controller)
+            )
+        )
+        description = "Whenever you commit a crime, each opponent loses 1 life and you gain 1 life. " +
+            "This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Justin Cornell"
+        flavorText = "A raven sighted at midnight often means there's unkindness on the way."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg?1712355645"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShepherdOfTheClouds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShepherdOfTheClouds.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shepherd of the Clouds
+ * {4}{W}
+ * Creature — Pegasus
+ * 4/3
+ *
+ * Flying, vigilance
+ * When this creature enters, return target permanent card with mana value 3 or less from your
+ * graveyard to your hand. Return that card to the battlefield instead if you control a Mount.
+ *
+ * The destination is chosen at resolution: if you control a Mount when the ability resolves, the
+ * targeted card enters the battlefield; otherwise it goes to your hand ([ConditionalEffect] gating
+ * on [Conditions.YouControl] for a Mount — "control a Mount" is "control at least one"). "Permanent
+ * card … from your graveyard" is a
+ * single printed target restricted to permanent cards (type-line check) you own, of mana value 3
+ * or less, in the graveyard zone.
+ */
+val ShepherdOfTheClouds = card("Shepherd of the Clouds") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Pegasus"
+    power = 4
+    toughness = 3
+    oracleText = "Flying, vigilance\n" +
+        "When this creature enters, return target permanent card with mana value 3 or less from " +
+        "your graveyard to your hand. Return that card to the battlefield instead if you control a Mount."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "card",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.ownedByYou().manaValueAtMost(3),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.YouControl(
+                GameObjectFilter.Creature.withSubtype(Subtype("Mount")),
+            ),
+            effect = Effects.PutOntoBattlefield(card),
+            elseEffect = Effects.ReturnToHand(card),
+        )
+        description = "When this creature enters, return target permanent card with mana value 3 " +
+            "or less from your graveyard to your hand. Return that card to the battlefield instead " +
+            "if you control a Mount."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Valera Lutfullina"
+        flavorText = "It catches those who are not ready to fall."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg?1712355336"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4040,6 +4040,94 @@
     ]
 }
 
+// Nurturing Pixie
+{
+    "name": "Nurturing Pixie",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nWhen this creature enters, return up to one target non-Faerie, nonland permanent you control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "permanent"
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "permanent"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsNonland",
+                                "IsPermanent",
+                                {
+                                    "type": "NotSubtype",
+                                    "subtype": "Faerie"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    },
+                    "id": "permanent"
+                },
+                "descriptionOverride": "When this creature enters, return up to one target non-Faerie, nonland permanent you control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "UNCOMMON",
+        "artist": "Iris Compiet",
+        "flavorText": "\"Count yourself lucky I came upon you. This is not a world of second chances.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg?1712355304"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Oasis Gardener
 {
     "name": "Oasis Gardener",
@@ -4396,6 +4484,55 @@
     ]
 }
 
+// Peerless Ropemaster
+{
+    "name": "Peerless Ropemaster",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "When this creature enters, return up to one target tapped creature to its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature tapped"
+                    },
+                    "id": "creature"
+                },
+                "descriptionOverride": "When this creature enters, return up to one target tapped creature to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Wayne Wu",
+        "flavorText": "\"Murder someone and you'll have a gaggle of folks lining up for revenge. Humiliate them, and they won't dare bother you again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg?1712355469"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Pillage the Bog
 {
     "name": "Pillage the Bog",
@@ -4729,6 +4866,64 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Raven of Fell Omens
+{
+    "name": "Raven of Fell Omens",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhenever you commit a crime, each opponent loses 1 life and you gain 1 life. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, each opponent loses 1 life and you gain 1 life. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Justin Cornell",
+        "flavorText": "A raven sighted at midnight often means there's unkindness on the way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg?1712355645"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -5515,6 +5710,80 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Shepherd of the Clouds
+{
+    "name": "Shepherd of the Clouds",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying, vigilance\nWhen this creature enters, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature Mount"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "card"
+                        },
+                        "destination": "Battlefield"
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "card"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "card"
+                },
+                "descriptionOverride": "When this creature enters, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "flavorText": "It catches those who are not ready to fall.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg?1712355336"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -444,7 +444,10 @@ object Fidelity {
     // `imageUri` is purely cosmetic art (a created token's picture, like a card's), never a rules input —
     // the same reason `oracleText`/`metadata` are excluded. The emitter doesn't resolve a token's Scryfall
     // image, so a hand-authored card carrying it would diverge on art alone; ignore it like the others.
-    private val NON_GAMEPLAY_KEYS = setOf("metadata", "oracleText", "colorIdentityOverride", "imageUri")
+    // `descriptionOverride` is the human-readable rules-text override a hand-authored ability may carry
+    // (`description = "…"`); it's display-only (never a rules input, like `oracleText`), and the emitter
+    // doesn't synthesise per-ability prose — so ignore it rather than diverge on text alone.
+    private val NON_GAMEPLAY_KEYS = setOf("metadata", "oracleText", "colorIdentityOverride", "imageUri", "descriptionOverride")
 
     private fun JsonObject.isAbilityNode(): Boolean {
         return containsKey("effect") && (containsKey("trigger") || containsKey("cost"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -106,7 +106,7 @@ private fun EmitCtx.multiTargetLocals(targets: List<JsonObject>, actions: List<J
 
 private fun refKindForTarget(target: JsonObject): String? = when (target.strField("_Target")) {
     "TargetPlayer" -> "Ref_TargetPlayer"
-    "TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents" -> "Ref_TargetPermanent"
+    "TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents", "UptoOneTargetPermanent" -> "Ref_TargetPermanent"
     "TargetGraveyardCard", "UptoOneTargetGraveyardCard" -> "Ref_TargetGraveyardCard"
     else -> null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -222,6 +222,14 @@ internal fun EmitCtx.renderEachPlayer(node: JsonObject): Dsl? {
     if (jsonContains(node, "_Players", "AnyPlayer") && "PutAPermanentIntoItsOwnersHand" in blob)
         return call("Effects.EachPlayerReturnPermanentToHand")
     if (jsonContains(node, "_Players", "Opponent") && "Discard" in blob) return call("Patterns.Hand.eachOpponentDiscards", arg("1"))  // Noxious Toad
+    // "each opponent loses N life" (Raven of Fell Omens). Only a fixed Integer amount renders, scoped to
+    // every opponent via EffectTarget.PlayerRef(Player.EachOpponent); a derived/X amount scaffolds.
+    if (jsonContains(node, "_Players", "Opponent") && jsonContains(node, "_Action", "LoseLife")) {
+        val inner = node["args"].asArr?.filterIsInstance<JsonObject>()
+            ?.firstOrNull { it.strField("_Action") == "LoseLife" } ?: return null
+        val amt = findInteger(inner["args"]) as? Int ?: return null
+        return call("Effects.LoseLife", arg("$amt"), arg("EffectTarget.PlayerRef(Player.EachOpponent)"))
+    }
     if (jsonContains(node, "_Action", "DrawNumberCards") || jsonContains(node, "_GameNumber", "ValueX"))
         return call("Patterns.Hand.eachPlayerDrawsX", arg("includeController", "true"), arg("includeOpponents", "true"))
     return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -337,9 +337,18 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         if (actionContext != null && actionContext.consumesOnlyTargetPlayer()) return Call("TargetPlayer")
         return Call("AnyTarget")
     }
-    if (ttype in setOf("TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents")) {
+    if (ttype in setOf("TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents", "UptoOneTargetPermanent")) {
         val types = targetTypes(args)
         val blob = compact(args)
+        // "up to one target …" — a single optional permanent target (Peerless Ropemaster, Nurturing
+        // Pixie). It renders the same filter as a plain TargetPermanent/TargetCreature with `optional =
+        // true` (no count: "up to one" is exactly one-or-zero). The flag is appended in every sub-branch
+        // below via [optionalArg].
+        val isUpToOne = ttype == "UptoOneTargetPermanent"
+        // A creature-subtype clause (IsCreatureType) must be matched as a whole token, not a substring of
+        // IsNonCreatureType ("non-Faerie permanent"): the latter is a NEGATED subtype on a non-creature
+        // permanent target, and a naive `"IsCreatureType" in blob` would mis-route it to the creature path.
+        val hasCreatureSubtype = args.argWordsTagged("IsCreatureType").isNotEmpty()
         // "the permanent with the lowest/highest mana value" (Culling Scales) is a global superlative the
         // SDK has no target filter for. Dropping it would let the spell hit ANY matching permanent, so
         // decline -> SCAFFOLD rather than emit an unrestricted target.
@@ -350,7 +359,7 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         // anything else declines (Rustspore Ram, Turn to Dust).
         val artifactSubtype = args.firstArgWordTagged("IsArtifactType")
         if (artifactSubtype != null) {
-            if (types.isNotEmpty() || "IsNonCardtype" in blob || "IsCreatureType" in blob) return null
+            if (types.isNotEmpty() || "IsNonCardtype" in blob || hasCreatureSubtype) return null
             val controller: Link? = when {
                 "ControlledByAPlayer" !in blob -> null
                 "\"You\"" in blob -> Link("youControl")
@@ -361,18 +370,18 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             controller?.let { base = base.dot(it) }
             val parts = mutableListOf(arg("filter", Call("TargetFilter", listOf(arg(base)))))
             if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
-            if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
+            if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
             return Call("TargetPermanent", parts)
         }
         // A creature-subtype restriction ("target Wall") implies a creature target even with no explicit
         // IsCardtype Creature; route it through the creature filter so the subtype isn't dropped (Tunnel).
-        val creatureTarget = types == setOf("Creature") || (types.isEmpty() && "IsCreatureType" in blob)
+        val creatureTarget = types == setOf("Creature") || (types.isEmpty() && hasCreatureSubtype)
         if (creatureTarget) {
             val filter = creatureFilterExpr(args) ?: return null
             val parts = mutableListOf(arg("filter", filter))
             if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
             if (ttype == "OneOrTwoTargetPermanents") { parts.add(0, arg("minCount", "1")); parts.add(0, arg("count", "2")) }
-            if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
+            if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
             return Call("TargetCreature", parts)
         }
         // "target Spirit or enchantment" (Urgent Exorcism): an Or unioning a creature subtype with a
@@ -423,11 +432,42 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
             return Call("TargetPermanent", parts)
         }
+        // "non-<creature-type>, nonland permanent you control" (Nurturing Pixie: "non-Faerie, nonland
+        // permanent you control") — an IsNonCardtype "Land" + a single negated creature subtype
+        // (IsNonCreatureType), optionally a controller clause. There's no named TargetFilter constant for
+        // it, so render GameObjectFilter.NonlandPermanent.notSubtype(Subtype(...))[.youControl()] wrapped
+        // in TargetFilter. Only this exact shape (one negated subtype, optional You/Opponent controller,
+        // nothing else) renders; any extra predicate declines rather than silently dropping it.
+        run {
+            val negSubs = args.argWordsTagged("IsNonCreatureType")
+            if (types.isEmpty() && args.argWordsTagged("IsNonCardtype") == listOf("Land") && negSubs.size == 1) {
+                val extras = listOf(
+                    "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "PowerIs", "ToughnessIs",
+                    "ManaValueIs", "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken",
+                    "IsCreatureType", "IsArtifactType", "IsLandType", "IsEnchantmentType", "Other",
+                    "HasACounterOfType",
+                )
+                if (extras.any { it in blob }) return null
+                val controller: Link? = when {
+                    "ControlledByAPlayer" !in blob -> null
+                    "\"You\"" in blob -> Link("youControl")
+                    "\"Opponent\"" in blob -> Link("opponentControls")
+                    else -> return null
+                }
+                var g: Dsl = Lit("GameObjectFilter.NonlandPermanent").dot("notSubtype", arg("Subtype(\"${negSubs[0]}\")"))
+                controller?.let { g = g.dot(it) }
+                val parts = mutableListOf(arg("filter", Call("TargetFilter", listOf(arg(g)))))
+                if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
+                if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
+                return Call("TargetPermanent", parts)
+            }
+        }
         // "target nonland permanent" — an IsNonCardtype "Land" with no positive cardtype restriction
         // (Thistledown Players' "untap target nonland permanent"). An optional "with mana value X"
         // clause (ManaValueIs EqualTo ValueX, from an {X}… cast cost) renders as .manaValueEqualsX()
         // (Repeal). A ManaValueIs clause we DON'T render (any other shape) must decline rather than
-        // silently drop the restriction — an unrestricted bounce would hit any permanent.
+        // silently drop the restriction — an unrestricted bounce would hit any permanent. (The
+        // IsCreatureType substring guard also excludes IsNonCreatureType, which the branch above handles.)
         if (types.isEmpty() && args.argWordsTagged("IsNonCardtype") == listOf("Land") && "IsCreatureType" !in blob) {
             val manaValueX = manaValueEqualsXClause(args)
             if ("ManaValueIs" in blob && !manaValueX) return null  // unrendered MV restriction -> SCAFFOLD
@@ -491,6 +531,29 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
     }
     if (ttype == "TargetGraveyardCard" || ttype == "UptoOneTargetGraveyardCard") {
         val blob = compact(args)
+        // "target permanent card with mana value N or less from your graveyard" (Shepherd of the Clouds):
+        // an IsPermanent type check + an optional ManaValueIs <= N cap + an ownership clause. There's no
+        // named graveyard TargetFilter constant for "permanent card", so compose
+        // GameObjectFilter.Permanent[.ownedBy…].manaValueAtMost(N) in the GRAVEYARD zone. Only this exact
+        // shape (IsPermanent, at most one `<=` MV cap, optional You/Opponent ownership, no creature
+        // subtype or other predicate) renders; anything else falls through to the branches below or
+        // declines, so we never silently drop a restriction.
+        if ("IsPermanent" in blob && "IsCreatureType" !in blob && targetTypes(args).isEmpty()) {
+            val mvCap = FilterPredicates.manaValueAtMost(args)
+            // A ManaValueIs clause we couldn't render as a `<=` cap (any other comparison/X) must decline
+            // rather than widen the target to any permanent card in the graveyard.
+            if ("ManaValueIs" in blob && mvCap == null) return null
+            var g: Dsl = Lit("GameObjectFilter.Permanent")
+            when {
+                "\"You\"" in blob -> g = g.dot("ownedByYou")
+                "\"Opponent\"" in blob -> g = g.dot("ownedByOpponent")
+            }
+            mvCap?.let { g = g.dot(it) }
+            val filt = Call("TargetFilter", listOf(arg(g), arg("zone", "Zone.GRAVEYARD")))
+            val parts = mutableListOf(arg("filter", filt))
+            if (ttype == "UptoOneTargetGraveyardCard") parts.add(0, arg("optional", "true"))
+            return Call("TargetObject", parts)
+        }
         // "target artifact card WITH MANA VALUE 1 OR LESS from your graveyard" (Auriok Salvagers, Leonin
         // Squire): a ManaValueIs cap the graveyard filters below don't compose — emitting without it would
         // widen the target to any artifact in the graveyard. Decline (-> SCAFFOLD) rather than drop it.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -109,6 +109,24 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     on("If") { node, args, tvar ->
         val a = args.asArr ?: return@on null
         val cond = a.getOrNull(0) as? JsonObject ?: return@on null
+        // "If a permanent was returned this way, [do X]" (Nurturing Pixie) — the `up to one target …
+        // return to hand` idiom gates a follow-up on whether the optional target was actually returned.
+        // The engine expresses "the optional target still exists / was acted on" as
+        // `Conditions.TargetMatchesFilter(<zone-agnostic type filter>)` (the moved card still matches its
+        // type line after going to hand). Render only the bare `AnyPermanent` filter -> Permanent, and
+        // only when the ability has a bound target (the "this way" subject); a narrower/other filter, or
+        // no bound target, declines -> SCAFFOLD rather than emit a wrong gate.
+        if (cond.strField("_Condition") == "APermanentWasPutIntoHandThisWay") {
+            if (tvar == null) return@on null
+            if (cond["args"].strField("_Permanents") != "AnyPermanent") return@on null
+            val inner = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
+            val edsl = renderEffectList(inner, tvar) ?: return@on null
+            return@on call(
+                "ConditionalEffect",
+                arg("condition", call("Conditions.TargetMatchesFilter", arg("GameObjectFilter.Permanent"))),
+                arg("effect", edsl),
+            )
+        }
         if (cond.strField("_Condition") != "PermanentPassesFilter") return@on null
         val condArgs = cond["args"].asArr ?: return@on null
         // Subject must be the first targeted permanent (Ref_TargetPermanent / Ref_TargetPermanent1).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NurturingPixieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NurturingPixieScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.NurturingPixie
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Nurturing Pixie (OTJ #20) — {W} Creature — Faerie Rogue 1/1.
+ *
+ * "Flying. When this creature enters, return up to one target non-Faerie, nonland permanent you
+ *  control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter on this
+ *  creature."
+ *
+ * Verifies the ETB bounces a chosen non-Faerie nonland permanent you control and then grows the
+ * Pixie to 2/2; and that declining the optional target places no counter (Pixie stays 1/1).
+ */
+class NurturingPixieScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(NurturingPixie)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("returning a permanent you control puts a +1/+1 counter on the Pixie") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // A non-Faerie nonland permanent you control to bounce.
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val pixieCard = driver.putCardInHand(me, "Nurturing Pixie")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.castSpell(me, pixieCard).isSuccess shouldBe true
+        driver.bothPass() // resolve creature -> enters -> ETB trigger on stack
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(bear))
+        driver.bothPass() // resolve ETB return + counter
+
+        // Bear returned to hand.
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(bear) shouldBe false
+        driver.getHand(me).contains(bear) shouldBe true
+
+        // Pixie grew to 2/2 from the +1/+1 counter.
+        val pixie = driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD))
+            .single { driver.getCardName(it) == "Nurturing Pixie" }
+        driver.state.projectedState.getPower(pixie) shouldBe 2
+        driver.state.projectedState.getToughness(pixie) shouldBe 2
+    }
+
+    test("declining the optional target places no counter") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val pixieCard = driver.putCardInHand(me, "Nurturing Pixie")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.castSpell(me, pixieCard).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, emptyList())
+        driver.bothPass()
+
+        val pixie = driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD))
+            .single { driver.getCardName(it) == "Nurturing Pixie" }
+        // No return happened, so no counter — Pixie stays 1/1.
+        driver.state.projectedState.getPower(pixie) shouldBe 1
+        driver.state.projectedState.getToughness(pixie) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeerlessRopemasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeerlessRopemasterScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.PeerlessRopemaster
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Peerless Ropemaster (OTJ #60) — {4}{U} Creature — Human Rogue 4/4.
+ *
+ * "When this creature enters, return up to one target tapped creature to its owner's hand."
+ *
+ * Verifies the ETB bounces a chosen tapped creature back to its owner's hand, and that "up to one"
+ * is optional — declining the target leaves the board untouched.
+ */
+class PeerlessRopemasterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PeerlessRopemaster)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("ETB returns a chosen tapped creature to its owner's hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // An opponent's tapped creature to bounce.
+        val bear = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.tapPermanent(bear)
+
+        val rope = driver.putCardInHand(me, "Peerless Ropemaster")
+        driver.giveMana(me, Color.BLUE, 5)
+        driver.castSpell(me, rope).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell -> enters -> ETB trigger on stack
+
+        // The ETB targets up to one tapped creature.
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(bear))
+        driver.bothPass() // resolve the ETB return
+
+        // Bear is back in the opponent's hand, off the battlefield.
+        driver.state.getZone(ZoneKey(opp, Zone.BATTLEFIELD)).contains(bear) shouldBe false
+        driver.getHand(opp).contains(bear) shouldBe true
+    }
+
+    test("up to one is optional — declining returns nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bear = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.tapPermanent(bear)
+
+        val rope = driver.putCardInHand(me, "Peerless Ropemaster")
+        driver.giveMana(me, Color.BLUE, 5)
+        driver.castSpell(me, rope).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        // Decline: choose no targets.
+        driver.submitTargetSelection(me, emptyList())
+        driver.bothPass()
+
+        // Nothing was returned.
+        driver.state.getZone(ZoneKey(opp, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        driver.getHand(opp).contains(bear) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RavenOfFellOmensScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RavenOfFellOmensScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RavenOfFellOmens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Raven of Fell Omens (OTJ #101) — {1}{B} Creature — Bird 1/2.
+ *
+ * "Flying. Whenever you commit a crime, each opponent loses 1 life and you gain 1 life.
+ *  This ability triggers only once each turn."
+ *
+ * Verifies the crime-triggered drain fires once (each opponent loses 1, controller gains 1) and
+ * does not fire a second time in the same turn even after a second crime. Committing a crime is
+ * exercised authentically by casting a spell that targets the opponent.
+ */
+class RavenOfFellOmensScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RavenOfFellOmens)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("committing a crime drains each opponent for 1 and gains the controller 1, once per turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Raven of Fell Omens")
+
+        // Commit a crime: cast Lightning Bolt at the opponent. Bolt deals 3, then the Raven drain
+        // resolves (opponent -1, me +1).
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> crime event -> drain trigger on stack
+        driver.bothPass() // resolve the drain trigger
+
+        driver.assertLifeTotal(opp, 20 - 3 - 1)
+        driver.assertLifeTotal(me, 21)
+
+        // Commit a SECOND crime the same turn — triggers only once each turn, so no extra drain.
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.assertLifeTotal(opp, 20 - 3 - 1 - 3) // only the second Bolt's 3, no second drain
+        driver.assertLifeTotal(me, 21)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShepherdOfTheCloudsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShepherdOfTheCloudsScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GiantBeaver
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ShepherdOfTheClouds
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Shepherd of the Clouds (OTJ #28) — {4}{W} Creature — Pegasus 4/3.
+ *
+ * "Flying, vigilance. When this creature enters, return target permanent card with mana value 3 or
+ *  less from your graveyard to your hand. Return that card to the battlefield instead if you
+ *  control a Mount."
+ *
+ * Verifies the destination switch: with no Mount the targeted graveyard permanent goes to hand;
+ * controlling a Mount sends it to the battlefield instead.
+ */
+class ShepherdOfTheCloudsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(ShepherdOfTheClouds, GiantBeaver))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("with no Mount, returns the graveyard permanent to hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Grizzly Bears (MV 2, a permanent card) in the graveyard.
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val shepherd = driver.putCardInHand(me, "Shepherd of the Clouds")
+        driver.giveMana(me, Color.WHITE, 5)
+        driver.castSpell(me, shepherd).isSuccess shouldBe true
+        driver.bothPass() // resolve creature -> enters -> ETB trigger on stack
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(bear))
+        driver.bothPass()
+
+        // No Mount controlled -> the bear goes to hand.
+        driver.getHand(me).contains(bear) shouldBe true
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(bear) shouldBe false
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(bear) shouldBe false
+    }
+
+    test("controlling a Mount returns the graveyard permanent to the battlefield instead") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Control a Mount (Giant Beaver — Creature — Beaver Mount).
+        driver.putCreatureOnBattlefield(me, "Giant Beaver")
+
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val shepherd = driver.putCardInHand(me, "Shepherd of the Clouds")
+        driver.giveMana(me, Color.WHITE, 5)
+        driver.castSpell(me, shepherd).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(bear))
+        driver.bothPass()
+
+        // A Mount is controlled -> the bear enters the battlefield instead of going to hand.
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        driver.getHand(me).contains(bear) shouldBe false
+    }
+})


### PR DESCRIPTION
Implements 4 Outlaws of Thunder Junction cards (defs + scenario tests) and extends the mtgish-tooling emitter so each renders faithfully and auto-generates.

## Cards
- **Nurturing Pixie** ({W} Faerie Rogue 1/1, flying) — ETB return up to one target non-Faerie, nonland permanent you control; +1/+1 counter if a permanent was returned.
- **Peerless Ropemaster** ({4}{U} Human Rogue 4/4) — ETB return up to one target tapped creature to its owner's hand.
- **Raven of Fell Omens** ({1}{B} Bird 1/2, flying) — once-per-turn: when you commit a crime, each opponent loses 1 life and you gain 1 life.
- **Shepherd of the Clouds** ({4}{W} Pegasus 4/3, flying/vigilance) — ETB return a permanent card with mana value 3 or less from your graveyard to hand, or to the battlefield instead if you control a Mount.

## mtgish-tooling changes (fix the emitter, not the cards)
All four were SCAFFOLD; they now render faithfully and promote to AUTOGEN:
- **TargetRecovery**: handle `UptoOneTargetPermanent` (optional single permanent/creature target); recover "non-&lt;creature-type&gt;, nonland permanent [you control]" via `NonlandPermanent.notSubtype(...)`; recover "permanent card with MV ≤ N from your graveyard" via `Permanent.ownedBy*().manaValueAtMost(N)` in the graveyard zone; match `IsCreatureType` as a whole token so `IsNonCreatureType` stops false-matching the substring guard.
- **PlayerContinuousHandlers**: render "each opponent loses N life" (`EachPlayerAction` + `LoseLife`) as `Effects.LoseLife(N, PlayerRef(EachOpponent))`.
- **ZoneHandlers**: render the "if a permanent was returned this way" gate (`APermanentWasPutIntoHandThisWay`) as `ConditionalEffect(Conditions.TargetMatchesFilter(Permanent), ...)`.
- **CardStructure**: route `UptoOneTargetPermanent` ref resolution to `Ref_TargetPermanent`.
- **Fidelity**: ignore `descriptionOverride` in the gameplay-tree gate — it is a display-only rules-text override (like `oracleText`), never a rules input, and the emitter does not synthesise per-ability prose.

Shepherd's Mount gate uses `Conditions.YouControl(...)` ("control a Mount" = "control at least one") so the hand-authored card and the emitter produce the same tree.

## SCAFFOLD declines
None for these 4 — all render at AUTO. (The 3 remaining OTJ gameplay-tree mismatches — Magebane Lizard, Shoot the Sheriff, Spring Splasher — are pre-existing in the incomplete OTJ set, on shapes untouched by this PR: triggering-entity-controller ref, non-outlaw `Not(HasAnyOfSubtypes)` filter, and defending-player-controls filter.)

## Verification
- 4 scenario tests pass.
- `CardDefinitionSnapshotTest` / `CardLintTest` / `FacadeBoundaryTest` pass (OTJ snapshot re-blessed).
- All four cards match golden in the OTJ gameplay-tree gate.
- POR gate stays 0-mismatch (158/158).
- `EmitterGoldenTest` fixtures unchanged.

⚠️ Touches the shared mtgish emitter + OTJ CardDefinitionSnapshot golden, which sibling PRs otj-cards-batch-1 and otj-cards-batch-3 also touch — merge the three serially and re-bless the OTJ snapshot once after the last merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)