### PR TITLE
Fix Saddle ability not showing in the frontend

### DIFF
--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -190,6 +190,8 @@ function BattlefieldContent({
           return ids.has(a.sourceId)
         case 'CrewVehicle':
           return ids.has(a.vehicleId)
+        case 'SaddleMount':
+          return ids.has(a.mountId)
         case 'CastSpell':
           return ids.has(a.cardId)
         default:
@@ -618,6 +620,8 @@ function AttachmentsBrowser({
           return a.sourceId === cardId
         case 'CrewVehicle':
           return a.vehicleId === cardId
+        case 'SaddleMount':
+          return a.mountId === cardId
         case 'CastSpell':
           return a.cardId === cardId
         default:

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -276,7 +276,7 @@ function buildActionOptions(
     })
   }
 
-  // 7. Crew (for Vehicles)
+  // 7. Crew (for Vehicles) and Saddle (for Mounts) — both are tap-for-power keyword actions
   const crewActions = legalActions.filter((a) => a.action.type === 'CrewVehicle')
   crewActions.forEach((crewAction, index) => {
     options.push({
@@ -285,6 +285,18 @@ function buildActionOptions(
       manaCost: null,
       isAvailable: crewAction.isAffordable !== false,
       action: crewAction,
+      actionType: 'activate',
+    })
+  })
+
+  const saddleActions = legalActions.filter((a) => a.action.type === 'SaddleMount')
+  saddleActions.forEach((saddleAction, index) => {
+    options.push({
+      key: `saddle-${index}`,
+      label: saddleAction.description,
+      manaCost: null,
+      isAvailable: saddleAction.isAffordable !== false,
+      action: saddleAction,
       actionType: 'activate',
     })
   })

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -209,6 +209,8 @@ function cardIdForAction(info: LegalActionInfo): EntityId | undefined {
       return a.sourceId
     case 'CrewVehicle':
       return a.vehicleId
+    case 'SaddleMount':
+      return a.mountId
     case 'UnlockRoomDoor':
       return a.roomId
     default:


### PR DESCRIPTION
## Problem

The **Saddle** keyword (Mounts' tap-for-power ability, analogous to Crew for Vehicles) never appeared as an action in the web client. The server side was fully wired — `SaddleEnumerator` generates `SaddleMount` legal actions and `LegalActionEnricher` carries the `tapForPower` data through to the client DTO — but the action was silently dropped by the display layer.

## Root cause

Four client-side switch/filter sites only handled the analogous `CrewVehicle` action and had no `SaddleMount` branch:

| File | Site | Effect of the gap |
|------|------|-------------------|
| `web-client/src/components/ui/ActionMenu.tsx` | option-list builder filtered only `CrewVehicle` | **Saddle never appeared in the card action menu** (the visible bug) |
| `web-client/src/components/game/board/Battlefield.tsx` | `hasActionableAttachment` | saddle-able Mount not highlighted in attachment browser |
| `web-client/src/components/game/board/Battlefield.tsx` | `hasInteractiveAction` | no interactive indicator on the board |
| `web-client/src/store/selectors.ts` | `cardIdForAction` | action not anchored to its Mount for highlighting |

The tap-for-power *selection and submission* path already handled `SaddleMount` (`actionResolvers`, `selectionSlice`, `useInteraction`), which is why this was purely a missing-display issue.

## Fix

Added the parallel `SaddleMount` handling (keyed on `mountId`) at each of the four sites. No engine/server change needed.

## Testing

- `npm run typecheck` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)