### PR TITLE
Multiplayer Phase 2: N-player server sessions, DTOs, spectators

### DIFF
--- a/backlog/multiplayer.md
+++ b/backlog/multiplayer.md
@@ -311,6 +311,25 @@ their commander-damage rows (keep for history, irrelevant once they've left). 40
 
 ## Phase 2 — Server: sessions, DTOs, spectators
 
+**Status: landed.** The session/DTO/spectator layer is now seat-count agnostic. `GameSession` lost
+its `player1`/`player2` getters for `getPlayers()` + `getOpponentIds()`, gained a `maxPlayers` seat
+count (default 2) and a `seatInfos()` roster builder; every broadcast/cleanup loop iterates seats.
+The live player protocol was reshaped cleanly: `GameStarted(opponentName)` → `GameStarted(players:
+List<PlayerSeatInfo>)` (per-recipient roster; the client derives the opponent from the non-`isYou`
+seat), and `OpponentDecisionStatus` gained the deciding `playerId`. The spectator/replay surface is
+*additive* — `SpectatorStateUpdate` gained a `players` roster while keeping the legacy
+`player1`/`player2` 2-player projection, because the external `tournament-newspaper` tooling and the
+not-yet-migrated replay viewer still consume it (per "flag, don't fix"); `GameReplayRecord` now
+stores a `players` list. Disconnect/forfeit notifies *every* opponent and, in a >2 game, concedes
+the leaver and continues (CR 800.4a) instead of ending the match (relies on Phase 1.2 leave-game).
+The client wire layer (TS message types + `onGameStarted`) was updated in the same PR; the 2-player
+UI is untouched and comes out identical. Verified by `MultiplayerSessionTest` (4-player seating,
+per-recipient hand masking, spectator roster, 2-player degenerate parity) + the existing server
+suite. `StopOverrideInfo` kept its singular `opponentTurnStops` semantics (per-opponent stops
+deferred). **Deferred to a follow-up:** the scenario-builder N-seat widening (Phase 1.4) —
+`ScenarioBuilderService` / `POST /api/scenarios` and the engine `ScenarioTestBase` are still
+hardwired to two seats; N-player games are exercised at the `GameSession` level instead.
+
 ### 2.1 GameSession generalization
 
 - Delete the `player1`/`player2` getters (`GameSession.kt:165-166`); migrate every call site to iterate

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -59,7 +59,9 @@ For responsiveness, we may later add:
 1. **Connect** → `{ type: "connect", playerName: "Alice" }`
 2. **Connected** ← `{ type: "connected", playerId: "p1" }`
 3. **Create/Join** → `{ type: "createGame", deckList: {...} }`
-4. **Game Started** ← `{ type: "gameStarted", opponentName: "Bob" }`
+4. **Game Started** ← `{ type: "gameStarted", players: [{ playerId, name, seatIndex, isYou, isAi }, …] }`
+   (N-player seat roster from this recipient's perspective; "the opponent" is the non-`isYou` seat
+   in a 2-player game)
 5. **Mulligan Phase** ↔ `mulliganDecision` / `keepHand` / `mulligan`
 6. **Game Loop** ← `stateUpdate` with state, events, legalActions
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -162,7 +162,8 @@ class AiWebSocketSession(
             }
 
             is ServerMessage.GameStarted -> {
-                logger.info("AI received GameStarted: opponent={}", message.opponentName)
+                logger.info("AI received GameStarted: opponents={}",
+                    message.players.filter { !it.isYou }.map { it.name })
             }
 
             is ServerMessage.GameOver -> {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminController.kt
@@ -79,8 +79,8 @@ class AdminController(
 
     private fun GameReplayRecord.toSummary() = GameSummary(
         gameId = gameId,
-        player1Name = player1Name,
-        player2Name = player2Name,
+        player1Name = players.getOrNull(0)?.name ?: "",
+        player2Name = players.getOrNull(1)?.name ?: "",
         startedAt = startedAt.toString(),
         endedAt = endedAt.toString(),
         winnerName = winnerName,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PlayerReplayController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PlayerReplayController.kt
@@ -40,8 +40,8 @@ class PlayerReplayController(
         val summaries = gameHistoryRepository.findByPlayerId(playerId).map { record ->
             GameSummary(
                 gameId = record.gameId,
-                player1Name = record.player1Name,
-                player2Name = record.player2Name,
+                player1Name = record.players.getOrNull(0)?.name ?: "",
+                player2Name = record.players.getOrNull(1)?.name ?: "",
                 startedAt = record.startedAt.toString(),
                 endedAt = record.endedAt.toString(),
                 winnerName = record.winnerName,
@@ -76,8 +76,8 @@ class PlayerReplayController(
             gameHistoryRepository.findById(gameId)?.let { record ->
                 GameSummary(
                     gameId = record.gameId,
-                    player1Name = record.player1Name,
-                    player2Name = record.player2Name,
+                    player1Name = record.players.getOrNull(0)?.name ?: "",
+                    player2Name = record.players.getOrNull(1)?.name ?: "",
                     startedAt = record.startedAt.toString(),
                     endedAt = record.endedAt.toString(),
                     winnerName = record.winnerName,
@@ -103,7 +103,7 @@ class PlayerReplayController(
 
         // Verify the player was a participant OR is in the same tournament
         val playerId = identity.playerId.value
-        val isParticipant = record.player1Id == playerId || record.player2Id == playerId
+        val isParticipant = record.players.any { it.playerId == playerId }
         val isTournamentMember = lobbyId?.let { lid ->
             val tournament = lobbyRepository.findTournamentById(lid)
             tournament != null &&

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PublicReplayController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PublicReplayController.kt
@@ -41,8 +41,8 @@ class PublicReplayController(
 
         val response = PublicReplayResponse(
             gameId = record.gameId,
-            player1Name = record.player1Name,
-            player2Name = record.player2Name,
+            player1Name = record.players.getOrNull(0)?.name ?: "",
+            player2Name = record.players.getOrNull(1)?.name ?: "",
             winnerName = record.winnerName,
             startedAt = record.startedAt.toString(),
             endedAt = record.endedAt.toString(),

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/QuickGameController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/QuickGameController.kt
@@ -67,14 +67,16 @@ class QuickGameController(
         val live = gameRepository.findAll()
             .filter { it.publicSpectate && !it.isGameOver() }
             .mapNotNull { session ->
-                val names = session.getPlayerNames() ?: return@mapNotNull null
-                val life = session.getLifeTotals() ?: return@mapNotNull null
+                // Quick games are 2-player; the Live Games tile shows the two seats.
+                val names = session.getPlayerNames()
+                val life = session.getLifeTotals()
+                if (names.size < 2 || life.size < 2) return@mapNotNull null
                 LiveQuickGameDTO(
                     gameSessionId = session.sessionId,
-                    player1Name = names.first,
-                    player2Name = names.second,
-                    player1Life = life.first,
-                    player2Life = life.second,
+                    player1Name = names[0],
+                    player2Name = names[1],
+                    player1Life = life[0],
+                    player2Life = life[1],
                 )
             }
             .sortedBy { it.gameSessionId }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/TournamentController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/TournamentController.kt
@@ -108,16 +108,18 @@ class TournamentController(
                     val gameSessionId = match.gameSessionId ?: return@mapNotNull null
                     val session = gameRepository.findById(gameSessionId) ?: return@mapNotNull null
                     if (session.isGameOver()) return@mapNotNull null
-                    val names = session.getPlayerNames() ?: return@mapNotNull null
-                    val life = session.getLifeTotals() ?: return@mapNotNull null
+                    // Tournament matches are 2-player; the live tile shows the two seats.
+                    val names = session.getPlayerNames()
+                    val life = session.getLifeTotals()
+                    if (names.size < 2 || life.size < 2) return@mapNotNull null
                     LiveTournamentMatchDTO(
                         gameSessionId = gameSessionId,
                         lobbyId = lobby.lobbyId,
                         round = round,
-                        player1Name = names.first,
-                        player2Name = names.second,
-                        player1Life = life.first,
-                        player2Life = life.second,
+                        player1Name = names[0],
+                        player2Name = names[1],
+                        player1Life = life[0],
+                        player2Life = life[1],
                     )
                 }
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -123,7 +123,7 @@ class ConnectionHandler(
             }
         }
 
-        // Cancel in-game disconnect timer and notify opponent
+        // Cancel in-game disconnect timer and notify every opponent (2-player = the one opponent)
         if (identity.gameDisconnectTimer != null) {
             identity.gameDisconnectTimer?.cancel(false)
             identity.gameDisconnectTimer = null
@@ -132,10 +132,11 @@ class ConnectionHandler(
             if (gameSessionId != null) {
                 val gameSession = gameRepository.findById(gameSessionId)
                 if (gameSession != null) {
-                    val opponentId = gameSession.getOpponentId(identity.playerId)
-                    val opponentSession = if (opponentId != null) gameSession.getPlayerSession(opponentId) else null
-                    if (opponentSession?.isConnected == true) {
-                        sender.send(opponentSession.webSocketSession, ServerMessage.OpponentReconnected)
+                    gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                        val opponentSession = gameSession.getPlayerSession(opponentId)
+                        if (opponentSession?.isConnected == true) {
+                            sender.send(opponentSession.webSocketSession, ServerMessage.OpponentReconnected)
+                        }
                     }
                 }
             }
@@ -214,7 +215,7 @@ class ConnectionHandler(
             }
             "game" -> {
                 val gameSession = gameRepository.findById(gameSessionId!!)
-                logger.info("Reconnecting to game: found=${gameSession != null}, isStarted=${gameSession?.isStarted}, player1=${gameSession?.player1?.playerId?.value}, player2=${gameSession?.player2?.playerId?.value}")
+                logger.info("Reconnecting to game: found=${gameSession != null}, isStarted=${gameSession?.isStarted}, seats=${gameSession?.getPlayers()?.map { it.playerId.value }}")
                 if (gameSession != null) {
                     // Remove old player session if exists, then associate new one
                     if (gameSession.getPlayerSession(identity.playerId) != null) {
@@ -338,11 +339,13 @@ class ConnectionHandler(
                 if (gameSessionId != null) {
                     val gameSession = gameRepository.findById(gameSessionId)
                     if (gameSession != null && !gameSession.isGameOver()) {
-                        val opponentId = gameSession.getOpponentId(identity.playerId)
-                        val opponentSession = if (opponentId != null) gameSession.getPlayerSession(opponentId) else null
-                        if (opponentSession?.isConnected == true) {
-                            sender.send(opponentSession.webSocketSession,
-                                ServerMessage.OpponentDisconnected(secondsRemaining = GAME_DISCONNECT_SECONDS))
+                        // Notify every opponent that this seat dropped (2-player = the one opponent)
+                        gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                            val opponentSession = gameSession.getPlayerSession(opponentId)
+                            if (opponentSession?.isConnected == true) {
+                                sender.send(opponentSession.webSocketSession,
+                                    ServerMessage.OpponentDisconnected(secondsRemaining = GAME_DISCONNECT_SECONDS))
+                            }
                         }
 
                         identity.gameDisconnectTimer = sessionRegistry.disconnectScheduler.schedule({
@@ -409,14 +412,30 @@ class ConnectionHandler(
         if (gameSessionId != null) {
             val gameSession = gameRepository.findById(gameSessionId)
             if (gameSession != null) {
-                val opponentId = gameSession.getOpponentId(identity.playerId)
-                if (opponentId != null) {
-                    gameSession.playerConcedes(identity.playerId)
-                    handleGameOverCallback?.invoke(gameSession, GameOverReason.DISCONNECTION)
+                if (gameSession.getOpponentIds(identity.playerId).isNotEmpty()) {
+                    forfeitFromGame(gameSession, identity.playerId)
                 } else {
                     gameRepository.remove(gameSessionId)
                 }
             }
+        }
+    }
+
+    /**
+     * Forfeit [playerId] from [gameSession] on disconnect abandonment. Concedes the seat; if that
+     * ends the game (≤1 player remains, CR 104.2a) it is finalized, otherwise the game continues
+     * for the remaining seats (CR 800.4a) and we rebroadcast so they see the seat leave. In a
+     * 2-player game this always ends it — the degenerate case.
+     */
+    private fun forfeitFromGame(
+        gameSession: com.wingedsheep.gameserver.session.GameSession,
+        playerId: EntityId,
+    ) {
+        gameSession.playerConcedes(playerId)
+        if (gameSession.isGameOver()) {
+            handleGameOverCallback?.invoke(gameSession, GameOverReason.DISCONNECTION)
+        } else {
+            broadcastStateUpdateCallback?.invoke(gameSession, emptyList())
         }
     }
 
@@ -443,8 +462,7 @@ class ConnectionHandler(
         }
 
         logger.info("Game disconnect timeout for ${identity.playerName} — auto-conceding")
-        gameSession.playerConcedes(identity.playerId)
-        handleGameOverCallback?.invoke(gameSession, GameOverReason.DISCONNECTION)
+        forfeitFromGame(gameSession, identity.playerId)
     }
 
     /**
@@ -557,7 +575,8 @@ class ConnectionHandler(
 
         val gameSession = gameRepository.findById(gameSessionId)
         if (gameSession != null) {
-            val opponentId = gameSession.getOpponentId(playerSession.playerId)
+            // Anonymous (no-identity) disconnect path — these games are always 2-player.
+            val opponentId = gameSession.getOpponentIds(playerSession.playerId).firstOrNull()
             if (opponentId != null) {
                 val opponentSession = gameSession.getPlayerSession(opponentId)
                 if (opponentSession?.isConnected == true) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -286,15 +286,11 @@ class GamePlayHandler(
         // Save game state after starting (so gameState is persisted)
         gameRepository.save(gameSession)
 
-        val player1 = gameSession.player1
-        val player2 = gameSession.player2
-
-        if (player1 != null && player2 != null) {
-            sender.send(player1.webSocketSession, ServerMessage.GameStarted(player2.playerName))
-            sender.send(player2.webSocketSession, ServerMessage.GameStarted(player1.playerName))
-
-            sendMulliganDecision(gameSession, player1)
-            sendMulliganDecision(gameSession, player2)
+        // Send each seat the full roster from its own perspective, then its mulligan decision.
+        // 2-player is the degenerate case (one opponent in the roster).
+        for (player in gameSession.getPlayers()) {
+            sender.send(player.webSocketSession, ServerMessage.GameStarted(gameSession.seatInfos(player.playerId)))
+            sendMulliganDecision(gameSession, player)
         }
     }
 
@@ -479,7 +475,7 @@ class GamePlayHandler(
             }
         } else {
             // Notify players who have completed their mulligan that they're waiting
-            listOfNotNull(gameSession.player1, gameSession.player2).forEach { player ->
+            gameSession.getPlayers().forEach { player ->
                 if (gameSession.hasMulliganComplete(player.playerId)) {
                     sender.send(player.webSocketSession, ServerMessage.WaitingForOpponentMulligan)
                 }
@@ -548,8 +544,7 @@ class GamePlayHandler(
         val customMessage = events.filterIsInstance<PlayerLostEvent>().firstOrNull()?.message
         val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId)
 
-        gameSession.player1?.let { sender.send(it.webSocketSession, message) }
-        gameSession.player2?.let { sender.send(it.webSocketSession, message) }
+        gameSession.getPlayers().forEach { sender.send(it.webSocketSession, message) }
 
         // Notify spectators that the game has ended and return them to tournament overview
         for (spectator in gameSession.getSpectators()) {
@@ -577,9 +572,9 @@ class GamePlayHandler(
                 }
                 gameRepository.removeLobbyLink(gameSessionId)
 
-                // Clear currentGameSessionId for both players so they are
+                // Clear currentGameSessionId for all players so they are
                 // considered "waiting" and receive the active matches broadcast
-                listOfNotNull(gameSession.player1, gameSession.player2).forEach { player ->
+                gameSession.getPlayers().forEach { player ->
                     player.currentGameSessionId = null
                     sessionRegistry.getIdentityByWsId(player.webSocketSession.id)
                         ?.currentGameSessionId = null
@@ -598,8 +593,7 @@ class GamePlayHandler(
         val frameCount = gameSession.getReplayFrameCount()
         if (initialSnapshot != null && frameCount >= 5) {
             val winnerName = winnerId?.let { wId ->
-                listOfNotNull(gameSession.player1, gameSession.player2)
-                    .find { it.playerId == wId }?.playerName
+                gameSession.getPlayers().find { it.playerId == wId }?.playerName
             }
 
             // Look up tournament context for grouping replays
@@ -614,10 +608,9 @@ class GamePlayHandler(
 
             val record = GameReplayRecord(
                 gameId = gameSessionId,
-                player1Id = gameSession.player1?.playerId?.value ?: "",
-                player2Id = gameSession.player2?.playerId?.value ?: "",
-                player1Name = gameSession.player1?.playerName ?: "Player 1",
-                player2Name = gameSession.player2?.playerName ?: "Player 2",
+                players = gameSession.getPlayers().map {
+                    com.wingedsheep.gameserver.replay.ReplayPlayerInfo(it.playerId.value, it.playerName)
+                },
                 startedAt = gameSession.replayStartedAt ?: Instant.now(),
                 endedAt = Instant.now(),
                 winnerName = winnerName,
@@ -649,13 +642,12 @@ class GamePlayHandler(
     fun broadcastStateUpdate(gameSession: GameSession, events: List<GameEvent>) {
         val allEvents = processAutoPassLoop(gameSession, events)
 
-        val player1 = gameSession.player1
-        val player2 = gameSession.player2
+        val sessionPlayers = gameSession.getPlayers()
 
         // AI players must always receive full StateUpdate (never deltas) because
         // they don't reconstruct state from diffs — they need the complete picture.
         if (aiGameManager.hasAiPlayer(gameSession.sessionId)) {
-            listOfNotNull(player1, player2).forEach { session ->
+            sessionPlayers.forEach { session ->
                 if (session.webSocketSession is AiWebSocketSession) {
                     gameSession.clearLastSentState(session.playerId)
                 }
@@ -666,7 +658,7 @@ class GamePlayHandler(
         if (aiGameManager.hasAiPlayer(gameSession.sessionId)) {
             val state = gameSession.getStateForTesting()
             if (state != null && (state.step == com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS || state.step == com.wingedsheep.sdk.core.Step.DECLARE_BLOCKERS)) {
-                val aiPlayer = listOfNotNull(player1, player2).find { it.webSocketSession is AiWebSocketSession }
+                val aiPlayer = sessionPlayers.find { it.webSocketSession is AiWebSocketSession }
                 if (aiPlayer != null) {
                     val aiLegalActions = gameSession.getLegalActions(aiPlayer.playerId)
                     logger.info("AI combat state: step={}, priorityPlayer={}, aiPlayer={}, legalActions={}",
@@ -677,15 +669,10 @@ class GamePlayHandler(
         }
 
         try {
-            player1?.let { session ->
+            sessionPlayers.forEach { session ->
                 val update = gameSession.createStateUpdate(session.playerId, allEvents)
                 if (update != null) sender.send(session.webSocketSession, update)
-                else logger.warn("createStateUpdate returned null for player1")
-            }
-            player2?.let { session ->
-                val update = gameSession.createStateUpdate(session.playerId, allEvents)
-                if (update != null) sender.send(session.webSocketSession, update)
-                else logger.warn("createStateUpdate returned null for player2")
+                else logger.warn("createStateUpdate returned null for player ${session.playerId.value}")
             }
 
             // Update spectators
@@ -783,17 +770,11 @@ class GamePlayHandler(
 
         val gameSession = getGameSession(session, playerSession) ?: return
 
-        // Forward the attacker targets to the opponent
-        val opponent = if (gameSession.player1?.playerId == playerSession.playerId) {
-            gameSession.player2
-        } else {
-            gameSession.player1
-        }
-
+        // Forward the attacker targets to every opponent (2-player = the one opponent)
         val serverMessage = ServerMessage.OpponentAttackerTargets(message.selectedAttackers, message.attackerTargets)
 
-        if (opponent != null) {
-            sender.send(opponent.webSocketSession, serverMessage)
+        gameSession.getOpponentIds(playerSession.playerId).forEach { opponentId ->
+            gameSession.getPlayerSession(opponentId)?.let { sender.send(it.webSocketSession, serverMessage) }
         }
 
         // Also forward to all spectators so they can see attacker arrows in real-time
@@ -811,15 +792,11 @@ class GamePlayHandler(
 
         val gameSession = getGameSession(session, playerSession) ?: return
 
-        // Forward the blocker assignments to the opponent
-        val opponent = if (gameSession.player1?.playerId == playerSession.playerId) {
-            gameSession.player2
-        } else {
-            gameSession.player1
-        }
-
-        if (opponent != null) {
-            sender.send(opponent.webSocketSession, ServerMessage.OpponentBlockerAssignments(message.assignments))
+        // Forward the blocker assignments to every opponent (2-player = the one opponent)
+        gameSession.getOpponentIds(playerSession.playerId).forEach { opponentId ->
+            gameSession.getPlayerSession(opponentId)?.let {
+                sender.send(it.webSocketSession, ServerMessage.OpponentBlockerAssignments(message.assignments))
+            }
         }
 
         // Also forward to all spectators so they can see blocker arrows in real-time

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbySharedContext.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbySharedContext.kt
@@ -118,7 +118,7 @@ class LobbySharedContext(
             count = spectators.size,
             spectatorNames = spectators.map { it.playerName }
         )
-        listOfNotNull(gameSession.player1, gameSession.player2).forEach { player ->
+        gameSession.getPlayers().forEach { player ->
             val ws = player.webSocketSession
             if (ws.isOpen) {
                 sender.send(ws, message)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/SpectatingHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/SpectatingHandler.kt
@@ -43,11 +43,11 @@ class SpectatingHandler(
         ctx.broadcastSpectatorCount(gameSession)
 
         val playerNames = gameSession.getPlayerNames()
-        if (playerNames != null) {
+        if (playerNames.size >= 2) {
             ctx.sender.send(session, ServerMessage.SpectatingStarted(
                 gameSessionId = message.gameSessionId,
-                player1Name = playerNames.first,
-                player2Name = playerNames.second
+                player1Name = playerNames[0],
+                player2Name = playerNames[1]
             ))
         }
 
@@ -106,11 +106,11 @@ class SpectatingHandler(
         ctx.broadcastSpectatorCount(gameSession)
 
         val playerNames = gameSession.getPlayerNames()
-        if (playerNames != null) {
+        if (playerNames.size >= 2) {
             ctx.sender.send(session, ServerMessage.SpectatingStarted(
                 gameSessionId = gameSessionId,
-                player1Name = playerNames.first,
-                player2Name = playerNames.second
+                player1Name = playerNames[0],
+                player2Name = playerNames[1]
             ))
         }
 
@@ -194,15 +194,17 @@ class SpectatingHandler(
             val gameSessionId = match.gameSessionId ?: return@mapNotNull null
             val gameSession = ctx.gameRepository.findById(gameSessionId) ?: return@mapNotNull null
 
-            val playerNames = gameSession.getPlayerNames() ?: return@mapNotNull null
-            val lifeTotals = gameSession.getLifeTotals() ?: return@mapNotNull null
+            // ActiveMatchInfo is the tournament overview tile — tournament matches are 2-player.
+            val playerNames = gameSession.getPlayerNames()
+            val lifeTotals = gameSession.getLifeTotals()
+            if (playerNames.size < 2 || lifeTotals.size < 2) return@mapNotNull null
 
             ServerMessage.ActiveMatchInfo(
                 gameSessionId = gameSessionId,
-                player1Name = playerNames.first,
-                player2Name = playerNames.second,
-                player1Life = lifeTotals.first,
-                player2Life = lifeTotals.second
+                player1Name = playerNames[0],
+                player2Name = playerNames[1],
+                player1Life = lifeTotals[0],
+                player2Life = lifeTotals[1]
             )
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -55,11 +55,28 @@ sealed interface ServerMessage {
     data class GameCreated(val sessionId: String) : ServerMessage
 
     /**
-     * Game is starting with both players connected.
+     * One seat in a game, from the perspective of a specific recipient. The seat list is the
+     * single N-player source of truth for "who is at this table" — a 2-player game is the
+     * degenerate case (one [isYou] seat + one opponent). [seatIndex] drives stable UI ordering
+     * and seat colors; it is the player's index in the engine's turn order.
+     */
+    @Serializable
+    data class PlayerSeatInfo(
+        val playerId: String,
+        val name: String,
+        val seatIndex: Int,
+        /** True for the recipient's own seat. Always false in spectator/replay rosters. */
+        val isYou: Boolean = false,
+        val isAi: Boolean = false,
+    )
+
+    /**
+     * Game is starting. Carries the full seat roster (turn order) from this recipient's
+     * perspective; the client derives "the opponent(s)" from the non-[PlayerSeatInfo.isYou] seats.
      */
     @Serializable
     @SerialName("gameStarted")
-    data class GameStarted(val opponentName: String) : ServerMessage
+    data class GameStarted(val players: List<PlayerSeatInfo>) : ServerMessage
 
     /**
      * Game was cancelled before it started (by the creator).
@@ -74,6 +91,9 @@ sealed interface ServerMessage {
      */
     @Serializable
     data class OpponentDecisionStatus(
+        /** The seat that is actually deciding. Lets the client attribute the decision in an
+         *  N-player pod (whose spinner to show); for 2-player it's simply "the opponent". */
+        val playerId: String,
         val decisionType: String,
         val displayText: String,
         val sourceName: String? = null
@@ -789,6 +809,14 @@ sealed interface ServerMessage {
         val gameSessionId: String,
         /** Full ClientGameState for reusing GameBoard component (both hands masked) */
         val gameState: ClientGameState? = null,
+        /**
+         * N-player seat roster (turn order). The authoritative "who is at this table" list for
+         * spectators/replay; the per-player board state lives in [gameState] (already N-player).
+         * The [player1Id]/[player2Id]/[player1]/[player2] fields below are the legacy 2-player
+         * projection (first two seats), retained for the current spectator board, replay viewer,
+         * and the external `tournament-newspaper` tooling until the Phase 3 client migration.
+         */
+        val players: List<PlayerSeatInfo> = emptyList(),
         /** Player 1's entity ID */
         val player1Id: String? = null,
         /** Player 2's entity ID */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/GameHistoryRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/GameHistoryRepository.kt
@@ -26,5 +26,5 @@ class GameHistoryRepository {
         history.find { it.gameId == gameId }
 
     fun findByPlayerId(playerId: String): List<GameReplayRecord> =
-        history.filter { it.player1Id == playerId || it.player2Id == playerId }
+        history.filter { record -> record.players.any { it.playerId == playerId } }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/GameReplayRecord.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/GameReplayRecord.kt
@@ -9,12 +9,16 @@ import java.time.Instant
  * This is significantly more memory-efficient than storing full snapshots for every step,
  * since most of the game state (cards, zones) doesn't change between consecutive updates.
  */
+/** A single seat in a recorded replay, in turn order. */
+data class ReplayPlayerInfo(
+    val playerId: String,
+    val name: String,
+)
+
 data class GameReplayRecord(
     val gameId: String,
-    val player1Id: String,
-    val player2Id: String,
-    val player1Name: String,
-    val player2Name: String,
+    /** Every seat in turn order. 2-player is the degenerate case (two entries). */
+    val players: List<ReplayPlayerInfo>,
     val startedAt: Instant,
     val endedAt: Instant,
     val winnerName: String?,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
@@ -92,6 +92,7 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
             is SelectManaSourcesDecision -> "Selecting mana sources"
         }
         return ServerMessage.OpponentDecisionStatus(
+            playerId = decision.playerId.value,
             decisionType = decision::class.simpleName ?: "Unknown",
             displayText = displayText,
             sourceName = decision.context.sourceName

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -45,7 +45,13 @@ class GameSession(
     val sessionId: String = UUID.randomUUID().toString(),
     private val services: EngineServices,
     private val stateTransformer: ClientStateTransformer = ClientStateTransformer(services.cardRegistry),
-    private val useHandSmoother: Boolean = false
+    private val useHandSmoother: Boolean = false,
+    /**
+     * Number of seats this session fills before it is [isReady] to start. Defaults to 2 (the
+     * quick-game / sealed / tournament-match case, unchanged). Free-for-All lobbies (Phase 4)
+     * pass 3–4. The engine, sessions, and DTOs are seat-count agnostic; this is the only knob.
+     */
+    val maxPlayers: Int = 2,
 ) {
     /** Backward-compatible constructor: wraps a CardRegistry in EngineServices. */
     constructor(
@@ -55,7 +61,8 @@ class GameSession(
         useHandSmoother: Boolean = false,
         debugMode: Boolean = false,
         printingRegistry: com.wingedsheep.engine.registry.PrintingRegistry? = null,
-    ) : this(sessionId, EngineServices(cardRegistry, printingRegistry), if (debugMode) ClientStateTransformer(cardRegistry, debugMode = true) else stateTransformer, useHandSmoother)
+        maxPlayers: Int = 2,
+    ) : this(sessionId, EngineServices(cardRegistry, printingRegistry), if (debugMode) ClientStateTransformer(cardRegistry, debugMode = true) else stateTransformer, useHandSmoother, maxPlayers)
 
     private val cardRegistry: CardRegistry get() = services.cardRegistry
     // Lock for synchronizing state modifications to prevent lost updates
@@ -162,11 +169,15 @@ class GameSession(
         FULL_CONTROL
     }
 
-    val player1: PlayerSession? get() = players.values.firstOrNull()
-    val player2: PlayerSession? get() = players.values.drop(1).firstOrNull()
+    /**
+     * All seated players in join order (which is also turn order once the game starts). This is
+     * the single N-player accessor; broadcasts iterate it. Note the underlying map is a
+     * [LinkedHashMap], so iteration order is stable.
+     */
+    fun getPlayers(): List<PlayerSession> = players.values.toList()
 
-    val isFull: Boolean get() = players.size >= 2
-    val isReady: Boolean get() = players.size == 2 && deckLists.size == 2
+    val isFull: Boolean get() = players.size >= maxPlayers
+    val isReady: Boolean get() = players.size == maxPlayers && deckLists.size == maxPlayers
     val isStarted: Boolean get() = gameState != null
 
     /**
@@ -232,10 +243,11 @@ class GameSession(
     }
 
     /**
-     * Get the opponent's player ID.
+     * Get every other seated player's ID (all opponents of [playerId]). In a 2-player game this
+     * is a single-element list. Order follows seating/turn order.
      */
-    fun getOpponentId(playerId: EntityId): EntityId? {
-        return players.keys.firstOrNull { it != playerId }
+    fun getOpponentIds(playerId: EntityId): List<EntityId> {
+        return players.keys.filter { it != playerId }
     }
 
     /**
@@ -276,31 +288,45 @@ class GameSession(
     fun getSpectators(): Set<PlayerSession> = spectators.toSet()
 
     /**
-     * Get player names for spectator display.
+     * Player names in seat order, for spectator display.
      */
-    fun getPlayerNames(): Pair<String, String>? {
-        val p1 = player1 ?: return null
-        val p2 = player2 ?: return null
-        return Pair(p1.playerName, p2.playerName)
+    fun getPlayerNames(): List<String> = getPlayers().map { it.playerName }
+
+    /**
+     * Current life totals in seat order, for spectator display.
+     */
+    fun getLifeTotals(): List<Int> {
+        val state = gameState ?: return emptyList()
+        return getPlayers().map { player ->
+            state.getEntity(player.playerId)?.get<LifeTotalComponent>()?.life ?: 20
+        }
     }
 
     /**
-     * Get current life totals for spectator display.
+     * The N-player seat roster (turn order). [seatIndex] is the player's index in the engine's
+     * turn order once the game has started, falling back to join order before then. [viewerId],
+     * when given, flags that recipient's own seat ([PlayerSeatInfo.isYou]); spectators pass null.
      */
-    fun getLifeTotals(): Pair<Int, Int>? {
-        val state = gameState ?: return null
-        val p1Id = player1?.playerId ?: return null
-        val p2Id = player2?.playerId ?: return null
-        val p1Life = state.getEntity(p1Id)?.get<LifeTotalComponent>()?.life ?: 20
-        val p2Life = state.getEntity(p2Id)?.get<LifeTotalComponent>()?.life ?: 20
-        return Pair(p1Life, p2Life)
+    fun seatInfos(viewerId: EntityId? = null): List<ServerMessage.PlayerSeatInfo> {
+        val turnOrder = gameState?.turnOrder
+        val seated = getPlayers()
+        return seated.mapIndexed { joinIndex, player ->
+            val seatIndex = turnOrder?.indexOf(player.playerId)?.takeIf { it >= 0 } ?: joinIndex
+            ServerMessage.PlayerSeatInfo(
+                playerId = player.playerId.value,
+                name = player.playerName,
+                seatIndex = seatIndex,
+                isYou = viewerId != null && player.playerId == viewerId,
+                isAi = playerPersistenceInfo[player.playerId]?.isAi == true,
+            )
+        }.sortedBy { it.seatIndex }
     }
 
     fun buildSpectatorState(): ServerMessage.SpectatorStateUpdate? {
         val state = gameState ?: return null
-        val p1 = player1 ?: return null
-        val p2 = player2 ?: return null
-        return spectatorStateBuilder.buildState(state, p1, p2, sessionId)
+        val seated = getPlayers()
+        if (seated.size < 2) return null
+        return spectatorStateBuilder.buildState(state, seated, seatInfos(), sessionId)
     }
 
     /**
@@ -308,7 +334,7 @@ class GameSession(
      * Initializes the game with the new engine - mulligan phase is handled by the engine.
      */
     fun startGame(): GameState {
-        require(isReady) { "Game session not ready - need 2 players with deck lists" }
+        require(isReady) { "Game session not ready - need $maxPlayers players with deck lists" }
 
         val playerConfigs = players.map { (playerId, session) ->
             PlayerConfig(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
@@ -28,29 +28,41 @@ class SpectatorStateBuilder(
     private val cardRegistry: CardRegistry,
     private val stateTransformer: ClientStateTransformer
 ) {
+    /**
+     * Build a spectator view of an N-player game. [players] is every seated player in turn order;
+     * [seatRoster] is the lightweight seat list echoed to the client. The heavy per-player board
+     * state rides in the embedded [ClientGameState] (already N-player); the [SpectatorStateUpdate]'s
+     * `player1`/`player2` legacy fields are the first two seats, kept for the current spectator
+     * board, replay viewer, and the external `tournament-newspaper` tooling.
+     */
     fun buildState(
         state: GameState,
-        p1: PlayerSession,
-        p2: PlayerSession,
+        players: List<PlayerSession>,
+        seatRoster: List<ServerMessage.PlayerSeatInfo>,
         sessionId: String
     ): ServerMessage.SpectatorStateUpdate {
-        // Build full ClientGameState with both hands masked for GameBoard reuse
-        val spectatorClientState = buildClientGameState(state, p1.playerId, p2.playerId)
+        require(players.size >= 2) { "Spectator state needs at least 2 seated players" }
+        val p1 = players[0]
+        val p2 = players[1]
+
+        // Build full ClientGameState with every player's hand masked for GameBoard reuse
+        val spectatorClientState = buildClientGameState(state, players.map { it.playerId })
 
         // Build decision status if there's a pending decision
         val decisionStatus = state.pendingDecision?.let { decision ->
-            val decidingPlayer = if (decision.playerId == p1.playerId) p1 else p2
+            val decidingPlayer = players.firstOrNull { it.playerId == decision.playerId } ?: p1
             createDecisionStatus(decision, decidingPlayer.playerName)
         }
 
         return ServerMessage.SpectatorStateUpdate(
             gameSessionId = sessionId,
             gameState = spectatorClientState,
+            players = seatRoster,
             player1Id = p1.playerId.value,
             player2Id = p2.playerId.value,
             player1Name = p1.playerName,
             player2Name = p2.playerName,
-            // Legacy fields for backward compatibility
+            // Legacy fields for backward compatibility (first two seats)
             player1 = buildPlayerState(state, p1),
             player2 = buildPlayerState(state, p2),
             currentPhase = state.phase.name,
@@ -92,17 +104,14 @@ class SpectatorStateBuilder(
 
     private fun buildClientGameState(
         state: GameState,
-        player1Id: EntityId,
-        player2Id: EntityId
+        playerIds: List<EntityId>
     ): ClientGameState {
-        // Use player1's perspective as the "viewing player" for the transform,
-        // then mask player1's hand as well
-        val baseState = stateTransformer.transform(state, player1Id, isSpectator = true)
+        // Use the first seat's perspective as the "viewing player" for the transform,
+        // then mask every player's hand (spectators can't see any hand contents)
+        val baseState = stateTransformer.transform(state, playerIds.first(), isSpectator = true)
 
-        // Filter out hand cards from the cards map (spectators can't see either player's hand)
-        val player1Hand = state.getHand(player1Id).toSet()
-        val player2Hand = state.getHand(player2Id).toSet()
-        val allHandCards = player1Hand + player2Hand
+        // Filter out hand cards from the cards map (spectators can't see any player's hand)
+        val allHandCards = playerIds.flatMap { state.getHand(it) }.toSet()
         val visibleCards = baseState.cards.filterKeys { it !in allHandCards }
 
         // Update zones to hide hand contents but keep sizes

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
@@ -72,8 +72,12 @@ class GameConnectionTest : GameServerTestBase() {
                 val started1 = ctx.player1.client.messages.filterIsInstance<ServerMessage.GameStarted>().first()
                 val started2 = ctx.player2.client.messages.filterIsInstance<ServerMessage.GameStarted>().first()
 
-                started1.opponentName shouldBe ctx.player2.name
-                started2.opponentName shouldBe ctx.player1.name
+                // Each player gets the full seat roster from their own perspective; the opponent
+                // is the non-`isYou` seat (single opponent in a 2-player game).
+                started1.players.single { it.isYou }.name shouldBe ctx.player1.name
+                started1.players.single { !it.isYou }.name shouldBe ctx.player2.name
+                started2.players.single { it.isYou }.name shouldBe ctx.player2.name
+                started2.players.single { !it.isYou }.name shouldBe ctx.player1.name
             }
 
             test("joining non-existent game returns GAME_NOT_FOUND error") {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/DevScenarioAiTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/DevScenarioAiTest.kt
@@ -99,8 +99,7 @@ class DevScenarioAiTest(
         // AI is associated into GameSession.players right away (so broadcastStateUpdate
         // reaches it); the human seat only enters players when their WebSocket connects.
         val gameSession = gameRepository.findById(sessionId).shouldNotBeNull()
-        gameSession.player1?.playerId shouldBe player2Id
-        gameSession.player2?.playerId shouldBe null
+        gameSession.getPlayers().map { it.playerId } shouldBe listOf(player2Id)
 
         // Human identity is pre-registered with its returned token so the WS handshake
         // resolves it; the AI has its own synthetic token registered via SessionRegistry.register.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/MultiplayerSessionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/MultiplayerSessionTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * Phase 2 — the session/DTO/spectator layer must be seat-count agnostic. These tests drive a real
+ * N-player [GameSession] (no WebSocket plumbing) and assert the N-player accessors, per-recipient
+ * masking, the seat roster, and that 2-player is the degenerate case of the same code path.
+ */
+class MultiplayerSessionTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    /** Build and start a session with [count] seats, each with a 40-Forest deck. */
+    private fun startedSession(count: Int): Pair<GameSession, List<EntityId>> {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = count)
+        val ids = (1..count).map { EntityId.of("player-$it") }
+        ids.forEachIndexed { i, id ->
+            session.addPlayer(PlayerSession(mockWs("ws$i"), id, "Player${i + 1}"), mapOf("Forest" to 40))
+        }
+        session.startGame()
+        return session to ids
+    }
+
+    init {
+        test("a four-player session seats all four players and reports three opponents each") {
+            val (session, ids) = startedSession(4)
+
+            session.getPlayers().map { it.playerId } shouldContainExactlyInAnyOrder ids
+            for (id in ids) {
+                session.getOpponentIds(id) shouldContainExactlyInAnyOrder ids.filter { it != id }
+            }
+        }
+
+        test("seat roster is the turn order with the viewer's own seat flagged") {
+            val (session, ids) = startedSession(4)
+
+            val roster = session.seatInfos(viewerId = ids[0])
+            roster shouldHaveSize 4
+            roster.map { it.seatIndex } shouldBe listOf(0, 1, 2, 3)
+            roster.map { it.playerId } shouldContainExactlyInAnyOrder ids.map { it.value }
+            roster.count { it.isYou } shouldBe 1
+            roster.single { it.isYou }.playerId shouldBe ids[0].value
+            roster.none { it.isAi } shouldBe true
+        }
+
+        test("each recipient sees only their own hand; every opponent hand is masked") {
+            val (session, ids) = startedSession(4)
+
+            for (viewer in ids) {
+                val update = session.createStateUpdate(viewer, emptyList())
+                val state = (update as ServerMessage.StateUpdate).state
+                val handZones = state.zones.filter { it.zoneId.zoneType == Zone.HAND }
+                handZones shouldHaveSize 4
+                for (zone in handZones) {
+                    if (zone.zoneId.ownerId == viewer) {
+                        zone.isVisible shouldBe true
+                        zone.cardIds shouldHaveSize 7
+                    } else {
+                        // Opponent hand: count preserved, contents hidden.
+                        zone.isVisible shouldBe false
+                        zone.cardIds shouldHaveSize 0
+                        zone.size shouldBe 7
+                    }
+                }
+            }
+        }
+
+        test("spectator state carries the full seat roster and masks all hands") {
+            val (session, ids) = startedSession(4)
+
+            val spectator = session.buildSpectatorState()!!
+            spectator.players shouldHaveSize 4
+            spectator.players.map { it.playerId } shouldContainExactlyInAnyOrder ids.map { it.value }
+
+            // Every hand is hidden from spectators.
+            val handZones = spectator.gameState!!.zones.filter { it.zoneId.zoneType == Zone.HAND }
+            handZones.forEach {
+                it.isVisible shouldBe false
+                it.cardIds shouldHaveSize 0
+            }
+        }
+
+        test("two-player is the degenerate case: one opponent, two seats") {
+            val (session, ids) = startedSession(2)
+
+            session.getOpponentIds(ids[0]) shouldBe listOf(ids[1])
+            session.seatInfos(viewerId = ids[0]) shouldHaveSize 2
+            session.seatInfos(viewerId = ids[0]).single { it.isYou }.playerId shouldBe ids[0].value
+        }
+    }
+}

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -419,7 +419,10 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
     },
 
     onGameStarted: (msg) => {
-      trackEvent('game_started', { opponent_name: msg.opponentName })
+      // Derive "the opponent" from the seat roster — the first non-you seat. For 2-player this is
+      // the sole opponent; the N-player opponent rail is Phase 3 client work.
+      const opponentName = msg.players.find((p) => !p.isYou)?.name ?? 'Opponent'
+      trackEvent('game_started', { opponent_name: opponentName })
       setInGame(true)
 
       // Clear spectating state — active game takes priority
@@ -452,7 +455,7 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
       if (tournamentState && playerId) {
         round = tournamentState.currentRound
         const playerStanding = tournamentState.standings.find((s) => s.playerId === playerId)
-        const opponentStanding = tournamentState.standings.find((s) => s.playerName === msg.opponentName)
+        const opponentStanding = tournamentState.standings.find((s) => s.playerName === opponentName)
         if (playerStanding) {
           playerRecord = `${playerStanding.wins}-${playerStanding.losses}${playerStanding.draws > 0 ? `-${playerStanding.draws}` : ''}`
         }
@@ -463,7 +466,7 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
       set({
         matchIntro: {
           playerName,
-          opponentName: msg.opponentName,
+          opponentName,
           ...(round != null ? { round } : {}),
           ...(playerRecord != null ? { playerRecord } : {}),
           ...(opponentRecord != null ? { opponentRecord } : {}),
@@ -471,7 +474,7 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
       })
 
       set((state) => ({
-        opponentName: msg.opponentName,
+        opponentName,
         mulliganState: null,
         // Preserve the drafted deck in tournament mode so the player can still
         // view or save it from the standings screen between rounds and after

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -112,11 +112,24 @@ export interface GameCreatedMessage {
 }
 
 /**
- * Game is starting with both players connected.
+ * One seat in a game, from the recipient's perspective. The seat list is the N-player source of
+ * truth; a 2-player game is the degenerate case (one `isYou` seat + one opponent).
+ */
+export interface PlayerSeatInfo {
+  readonly playerId: string
+  readonly name: string
+  readonly seatIndex: number
+  readonly isYou: boolean
+  readonly isAi: boolean
+}
+
+/**
+ * Game is starting. Carries the full seat roster (turn order) from this recipient's perspective;
+ * derive "the opponent(s)" from the non-`isYou` seats.
  */
 export interface GameStartedMessage {
   readonly type: 'gameStarted'
-  readonly opponentName: string
+  readonly players: readonly PlayerSeatInfo[]
 }
 
 /**
@@ -131,6 +144,8 @@ export interface GameCancelledMessage {
  * Sent to the non-deciding player so they know the opponent is making a choice.
  */
 export interface OpponentDecisionStatus {
+  /** The seat actually deciding (lets an N-player pod show whose spinner). */
+  readonly playerId: string
   readonly decisionType: string
   readonly displayText: string
   readonly sourceName?: string | null
@@ -1434,7 +1449,9 @@ export interface SpectatorStateUpdateMessage {
   readonly gameSessionId: string
   /** Full ClientGameState for reusing GameBoard component (both hands masked) */
   readonly gameState?: ClientGameState | null
-  /** Player 1's entity ID */
+  /** N-player seat roster (turn order). The per-player board state lives in `gameState`. */
+  readonly players?: readonly PlayerSeatInfo[]
+  /** Player 1's entity ID (legacy 2-player projection = first seat) */
   readonly player1Id?: string | null
   /** Player 2's entity ID */
   readonly player2Id?: string | null


### PR DESCRIPTION
Implements **Phase 2 — Server: sessions, DTOs, spectators** from [`backlog/multiplayer.md`](../blob/main/backlog/multiplayer.md). Makes the game-server session/DTO/spectator layer seat-count agnostic so a 2-player game is the *degenerate case* of the N-player path — no `if (multiplayer)` branches.

## Approach (the design call)
The backlog calls the DTO reshape "breaking, do it in one PR," but the client UI is Phase 3 and 2-player must stay pixel-identical. The elegant split:
- **Break the live player protocol cleanly** where we own both ends, and update the client *wire layer* (not UI) in the same PR so the protocol is never half-migrated.
- **Stay additive on spectator/replay**, because the un-editable external `tournament-newspaper` tool and the not-yet-migrated replay viewer read that shape (the backlog says "flag, don't fix").

There are **no persisted replays to migrate** — `GameHistoryRepository` is in-memory — so no back-compat deserialization was needed.

## What changed
**`GameSession`** — dropped `player1`/`player2` getters for `getPlayers()` + `getOpponentIds()`; added `maxPlayers` (default 2) and a `seatInfos()` roster builder; `getPlayerNames()`/`getLifeTotals()` return seat-ordered lists. Every broadcast / mulligan / game-over loop iterates seats.

**DTOs (breaking, live protocol)** — `GameStarted(opponentName)` → `GameStarted(players: List<PlayerSeatInfo>)` (per-recipient roster: `playerId, name, seatIndex, isYou, isAi`); `OpponentDecisionStatus` gains the deciding `playerId`. `StopOverrideInfo.opponentTurnStops` kept singular (deferred).

**Spectator/replay (additive)** — `SpectatorStateUpdate` gains a `players` roster, keeps legacy `player1`/`player2` (first two seats); hand-masking iterates all seats. `GameReplayRecord` stores a `players` list; replay-metadata REST DTOs derive their 2-player fields from it.

**Disconnect/forfeit** — notifies every opponent; in a >2 game a forfeit concedes the leaver and the game *continues* (CR 800.4a, via Phase 1.2 leave-game) instead of ending the match.

**Client wire layer** — `messages.ts` (`PlayerSeatInfo`, reshaped `GameStarted`, `playerId` on decision status, `players` on spectator) + `onGameStarted` derives the opponent from the non-`isYou` seat. **2-player UI untouched.**

## Tests
- New `MultiplayerSessionTest`: real 4-player session — seats all four, three opponents each, per-recipient hand masking, spectator roster, and 2-player degenerate parity.
- Full `:game-server:test` green (incl. updated `GameConnectionTest`/`DevScenarioAiTest`); `web-client` typecheck green.

## Deferred (flagged, not in scope)
Scenario-builder N-seat widening (Phase 1.4) — `ScenarioBuilderService` / `POST /api/scenarios` and the engine `ScenarioTestBase` are still hardwired to two seats; N-player games are exercised at the `GameSession` level instead. Multi-opponent UI is Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)