### PR TITLE
Multiplayer Phase 3: client UI — viewed board strip + opponent rail

### DIFF
--- a/backlog/multiplayer.md
+++ b/backlog/multiplayer.md
@@ -326,9 +326,9 @@ The client wire layer (TS message types + `onGameStarted`) was updated in the sa
 UI is untouched and comes out identical. Verified by `MultiplayerSessionTest` (4-player seating,
 per-recipient hand masking, spectator roster, 2-player degenerate parity) + the existing server
 suite. `StopOverrideInfo` kept its singular `opponentTurnStops` semantics (per-opponent stops
-deferred). **Deferred to a follow-up:** the scenario-builder N-seat widening (Phase 1.4) —
-`ScenarioBuilderService` / `POST /api/scenarios` and the engine `ScenarioTestBase` are still
-hardwired to two seats; N-player games are exercised at the `GameSession` level instead.
+deferred). The scenario-builder N-seat widening (Phase 1.4) has since landed with Phase 3
+(`ScenarioRequest.players` → 3-4 seat hotseat sessions); the engine `ScenarioTestBase`
+remains two-seat.
 
 ### 2.1 GameSession generalization
 
@@ -367,6 +367,25 @@ opponent column); the DTO shape leaves room. Commander-damage rows already ride 
 ---
 
 ## Phase 3 — Client UI/UX (the centerpiece)
+
+**Status: landed.** One viewed board + opponent rail, exactly per the design below; the
+2-player layout is untouched (all multiplayer chrome is gated on `players.length > 2` —
+verified by screenshot parity + the existing suites). Shipped: `OpponentBoardArea` strip
+(slide + seat-colored edge flash), `OpponentRail` chips (life/hand/poison/commander-damage,
+active-turn ring, priority dot, deciding spinner via `decisionStatus.playerId`, life/hand
+attention pulses, tombstones), `boardView` store slice + follow-the-action (handler-level
+pending-input guard), keyboard `1-3` + swipe + pin, cross-seat targeting (chip halo +
+crosshair badge; view switches never cancel selections), combat UX (defender pick on first
+selection, sticky assignment, rail-chip/planeswalker-flyout reassign, confirm disabled
+until every attacker has a defender, seat-colored arrows/chevrons, bundled arrow + count
+badge to off-screen defenders' chips, CR 509.1b bystander-attacker dimming scoped by the
+DeclareBlockers action's seat), seat colors on stack borders + log names, spectator
+bottom-seat switcher (replays reuse the same path). Also landed here: the **Phase 1.4
+scenario-builder N-seat widening** (`ScenarioRequest.players` seat list → 3-4 player
+hotseat sessions; builder page grew pod-seat controls), which is the Phase 3 dev loop.
+Deferred: planeswalker-flyout long-press (touch), per-event chip pulses beyond life/hand
+deltas, log-entry click-to-slide, edge arrows (chips/keys/swipe cover switching), and a
+3-player Playwright e2e (rides with Phase 4's ship gate).
 
 ### 3.1 Layout: one viewed board + opponent rail
 

--- a/docs/e2e-test-patterns.md
+++ b/docs/e2e-test-patterns.md
@@ -93,6 +93,8 @@ test('card does X', async ({ createGame }) => {
 - `step`: Step name (e.g., `'UPKEEP'`, `'DECLARE_ATTACKERS'`)
 - `activePlayer` / `priorityPlayer`: `1` or `2`
 - `player1StopAtSteps` / `player2StopAtSteps`: Step names where auto-pass is disabled (e.g., `['UPKEEP']`)
+- `players`: N-player seat list `[{ name?, config? }, …]` (3-4 player pods, turn order; overrides the
+  two-seat fields). Pods of more than two seats start as `SELF` (single-client hotseat).
 
 ## GamePage Helpers
 

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -175,6 +175,53 @@ App
     └── DeathEffect
 ```
 
+## Multiplayer (3-4 player) board
+
+A game with more than two seats turns on the multiplayer chrome; a 2-player game renders
+exactly the classic layout (no rail, no strip, no seat colors — the multiplayer code paths
+are gated on `players.length > 2`).
+
+- **One viewed opponent + opponent rail.** The opponent half shows exactly one board at
+  full 2-player scale; the other opponents' boards live in a horizontally sliding strip
+  (`OpponentBoardArea`, one cell per living opponent, ordered by turn order after you) and
+  slide into view when selected. The always-visible `OpponentRail` (fixed at the top; its
+  height is added to the board's top offset) carries one chip per opponent: seat color,
+  name, life (also the floating ±delta anchor via `data-life-display`), hand count, poison,
+  commander-damage warning, active-turn ring, priority dot, deciding spinner
+  (`opponentDecisionStatus.playerId`), attention pulses, and a tombstone once a player has
+  left the game. In multiplayer the rail chip *is* the opponent's life orb — the center-HUD
+  `LifeDisplay` is not rendered for opponents, and the chip carries the `data-player-id` /
+  `data-life-id` anchors that arrows and animations query.
+- **Board switching**: rail-chip click (pins; re-click unpins), keyboard `1`/`2`/`3`,
+  horizontal swipe. Follow-the-action (`useMultiplayerView` + the `boardView` slice:
+  `viewedOpponentId`, `viewPinned`, `followAction`) slides automatically on coarse
+  boundaries — an opponent's turn starting, the attacker's board when you're attacked, the
+  priority seat in hotseat — and is refused inside `followViewTo` while any input is
+  pending (the camera never moves under an in-progress selection).
+- **Seat identity**: `styles/seatColors.ts` (Okabe-Ito, by seat index = turn-order index in
+  `gameState.players`) colors rail chips, combat arrows and chevrons, stack item borders
+  (caster), and log entry names.
+- **Targeting across seats**: a chip gets a halo when the in-progress selection has valid
+  targets on that opponent's board, and a crosshair badge when the player themself is a
+  valid target (badge click targets; chip body click only switches the view — a view
+  change never cancels a selection).
+- **Combat**: with >1 possible defender, the first attacker selection pops a defender pick;
+  assignment is sticky (`CombatState.stickyDefenderId`) and per-creature reassignable via
+  rail-chip clicks / the chip's planeswalker flyout. Confirm is disabled until every
+  selected attacker has an explicit defender. Arrows against the viewed defender render
+  per-creature in the defender's seat color; attacks on slid-away boards bundle into one
+  arrow to the defender's rail chip with a creature-count badge (`CombatArrows`), and any
+  card anchor on a slid-away board remaps to its controller's chip (also in
+  `TargetingArrows`). While you declare blocks, attackers aimed at other defenders render
+  dimmed (CR 509.1b — `CombatState.actingSeat` scopes `attackingCreatures` to attacks on
+  you).
+- **Spectator/replay** reuse the same layout anchored to a chosen bottom seat
+  (`spectatorBottomSeatId`, cycled from the spectator header); replays render through the
+  same `GameBoard spectatorMode` path.
+
+Dev loop: the scenario builder (`POST /api/scenarios`) accepts an N-player `players` seat
+list (3-4 seats ⇒ hotseat) — see `ScenarioSeat` in `ScenarioDtos.kt`.
+
 ## 3D Layout
 
 ### Coordinate System

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -189,9 +189,12 @@ are gated on `players.length > 2`).
   name, life (also the floating ±delta anchor via `data-life-display`), hand count, poison,
   commander-damage warning, active-turn ring, priority dot, deciding spinner
   (`opponentDecisionStatus.playerId`), attention pulses, and a tombstone once a player has
-  left the game. In multiplayer the rail chip *is* the opponent's life orb — the center-HUD
-  `LifeDisplay` is not rendered for opponents, and the chip carries the `data-player-id` /
-  `data-life-id` anchors that arrows and animations query.
+  left the game. The *viewed* opponent additionally keeps a full-size life orb in the
+  center HUD (seat-tinted to match their chip) — the familiar, biggest click target for
+  targeting and defender assignment. Anchors (`data-player-id` / `data-life-id` /
+  `data-life-display`) are carried by the orb for the viewed opponent and by the rail chip
+  for everyone else — never both, so arrows, damage floats, and player-target clicks
+  resolve unambiguously.
 - **Board switching**: rail-chip click (pins; re-click unpins), keyboard `1`/`2`/`3`,
   horizontal swipe. Follow-the-action (`useMultiplayerView` + the `boardView` slice:
   `viewedOpponentId`, `viewPinned`, `followAction`) slides automatically on coarse
@@ -207,7 +210,7 @@ are gated on `players.length > 2`).
   change never cancels a selection).
 - **Combat**: with >1 possible defender, the first attacker selection pops a defender pick;
   assignment is sticky (`CombatState.stickyDefenderId`) and per-creature reassignable via
-  rail-chip clicks / the chip's planeswalker flyout. Confirm is disabled until every
+  rail-chip clicks, the viewed opponent's life orb, or the chip's planeswalker flyout. Confirm is disabled until every
   selected attacker has an explicit defender. Arrows against the viewed defender render
   per-creature in the defender's seat color; attacks on slid-away boards bundle into one
   arrow to the defender's rail chip with a creature-count badge (`CombatArrows`), and any

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -30,12 +30,14 @@ import com.wingedsheep.sdk.scripting.ProtectionScope
 import org.springframework.stereotype.Service
 import java.util.concurrent.atomic.AtomicLong
 
-/** Result of building a scenario: the injectable state plus both seat ids. */
+/** Result of building a scenario: the injectable state plus the seat ids in turn order. */
 data class ScenarioBuildResult(
     val state: GameState,
-    val player1Id: EntityId,
-    val player2Id: EntityId
-)
+    val playerIds: List<EntityId>,
+) {
+    val player1Id: EntityId get() = playerIds[0]
+    val player2Id: EntityId get() = playerIds[1]
+}
 
 /**
  * Builds an injectable [GameState] from a [ScenarioRequest]. Shared by the dev and
@@ -102,8 +104,14 @@ class ScenarioBuilderService(
             }
         }
 
-        checkPlayer("player1", request.player1)
-        checkPlayer("player2", request.player2)
+        val seats = request.seats()
+        if (seats.size < 2 || seats.size > 4) {
+            errors += "Scenario needs 2-4 seats (got ${seats.size})."
+        }
+        if (seats.size > 2 && request.effectiveMode != ScenarioMode.SELF) {
+            errors += "Pods of more than two seats only support SELF (hotseat) mode."
+        }
+        seats.forEachIndexed { i, (_, config) -> checkPlayer("player${i + 1}", config) }
 
         if (enforceLimits && total > MAX_TOTAL_CARDS) {
             errors += "Scenario has too many cards ($total); max $MAX_TOTAL_CARDS."
@@ -113,11 +121,11 @@ class ScenarioBuilderService(
 
     /** Construct the scenario state. Assumes [validate] has already passed. */
     fun buildScenario(request: ScenarioRequest): ScenarioBuildResult {
+        val seats = request.seats()
         val builder = ScenarioBuilder(cardRegistry)
-        builder.withPlayers(request.player1Name ?: "Player1", request.player2Name ?: "Player2")
+        builder.withPlayers(seats.map { it.first })
 
-        applyPlayer(builder, 1, request.player1)
-        applyPlayer(builder, 2, request.player2)
+        seats.forEachIndexed { i, (_, config) -> applyPlayer(builder, i + 1, config) }
 
         request.phase?.let { phase ->
             val step = request.step ?: phaseToDefaultStep(phase)
@@ -126,8 +134,8 @@ class ScenarioBuilderService(
         request.activePlayer?.let { builder.withActivePlayer(it) }
         request.priorityPlayer?.let { builder.withPriorityPlayer(it) }
 
-        val (state, p1, p2) = builder.build()
-        return ScenarioBuildResult(state, p1, p2)
+        val (state, playerIds) = builder.build()
+        return ScenarioBuildResult(state, playerIds)
     }
 
     private fun applyPlayer(builder: ScenarioBuilder, n: Int, config: PlayerConfig?) {
@@ -169,41 +177,38 @@ class ScenarioBuilderService(
         private val entityIdCounter = AtomicLong(1000)
         private var state = GameState()
 
-        private var player1Id: EntityId? = null
-        private var player2Id: EntityId? = null
+        private val playerIds = mutableListOf<EntityId>()
 
-        fun withPlayers(player1Name: String, player2Name: String): ScenarioBuilder {
-            player1Id = EntityId.of("player-1")
-            player2Id = EntityId.of("player-2")
+        /** Seat number (1-based, turn order) → player entity id. */
+        private fun playerFor(playerNumber: Int): EntityId = playerIds[playerNumber - 1]
 
-            val p1Container = ComponentContainer.of(
-                PlayerComponent(player1Name),
-                LifeTotalComponent(20),
-                ManaPoolComponent(),
-                LandDropsComponent(remaining = 1, maxPerTurn = 1)
-            )
-
-            val p2Container = ComponentContainer.of(
-                PlayerComponent(player2Name),
-                LifeTotalComponent(20),
-                ManaPoolComponent(),
-                LandDropsComponent(remaining = 1, maxPerTurn = 1)
-            )
-
-            state = state
-                .withEntity(player1Id!!, p1Container)
-                .withEntity(player2Id!!, p2Container)
-                .copy(
-                    turnOrder = listOf(player1Id!!, player2Id!!),
-                    activePlayerId = player1Id,
-                    priorityPlayerId = player1Id,
-                    phase = Phase.PRECOMBAT_MAIN,
-                    step = Step.PRECOMBAT_MAIN,
-                    turnNumber = 1
+        fun withPlayers(names: List<String>): ScenarioBuilder {
+            require(names.size >= 2) { "Scenario needs at least two players" }
+            names.forEachIndexed { i, name ->
+                val playerId = EntityId.of("player-${i + 1}")
+                playerIds += playerId
+                state = state.withEntity(
+                    playerId,
+                    ComponentContainer.of(
+                        PlayerComponent(name),
+                        LifeTotalComponent(20),
+                        ManaPoolComponent(),
+                        LandDropsComponent(remaining = 1, maxPerTurn = 1)
+                    )
                 )
+            }
 
-            // Initialize empty zones for both players
-            for (playerId in listOf(player1Id!!, player2Id!!)) {
+            state = state.copy(
+                turnOrder = playerIds.toList(),
+                activePlayerId = playerIds[0],
+                priorityPlayerId = playerIds[0],
+                phase = Phase.PRECOMBAT_MAIN,
+                step = Step.PRECOMBAT_MAIN,
+                turnNumber = 1
+            )
+
+            // Initialize empty zones for every player
+            for (playerId in playerIds) {
                 for (zoneType in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.BATTLEFIELD, Zone.EXILE, Zone.COMMAND)) {
                     val zoneKey = ZoneKey(playerId, zoneType)
                     state = state.copy(zones = state.zones + (zoneKey to emptyList()))
@@ -214,7 +219,7 @@ class ScenarioBuilderService(
         }
 
         fun withCardInHand(playerNumber: Int, cardName: String): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.addToZone(ZoneKey(playerId, Zone.HAND), cardId)
             return this
@@ -232,7 +237,7 @@ class ScenarioBuilderService(
             chosenCreatureType: String? = null,
             chosenColor: String? = null
         ): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
 
             state = state.addToZone(ZoneKey(playerId, Zone.BATTLEFIELD), cardId)
@@ -323,21 +328,21 @@ class ScenarioBuilderService(
         }
 
         fun withCardInGraveyard(playerNumber: Int, cardName: String): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.addToZone(ZoneKey(playerId, Zone.GRAVEYARD), cardId)
             return this
         }
 
         fun withCardInLibrary(playerNumber: Int, cardName: String): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.addToZone(ZoneKey(playerId, Zone.LIBRARY), cardId)
             return this
         }
 
         fun withCardInExile(playerNumber: Int, cardName: String): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.addToZone(ZoneKey(playerId, Zone.EXILE), cardId)
             return this
@@ -349,7 +354,7 @@ class ScenarioBuilderService(
          * Supports multiple calls per player (Partner / Background).
          */
         fun withCommander(playerNumber: Int, cardName: String): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.updateEntity(cardId) { it.with(CommanderComponent(ownerId = playerId)) }
             state = state.addToZone(ZoneKey(playerId, Zone.COMMAND), cardId)
@@ -362,7 +367,7 @@ class ScenarioBuilderService(
         }
 
         fun withLifeTotal(playerNumber: Int, life: Int): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             state = state.updateEntity(playerId) { container ->
                 container.with(LifeTotalComponent(life))
             }
@@ -375,19 +380,19 @@ class ScenarioBuilderService(
         }
 
         fun withActivePlayer(playerNumber: Int): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             state = state.copy(activePlayerId = playerId, priorityPlayerId = playerId)
             return this
         }
 
         fun withPriorityPlayer(playerNumber: Int): ScenarioBuilder {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = playerFor(playerNumber)
             state = state.copy(priorityPlayerId = playerId)
             return this
         }
 
-        fun build(): Triple<GameState, EntityId, EntityId> {
-            return Triple(state, player1Id!!, player2Id!!)
+        fun build(): Pair<GameState, List<EntityId>> {
+            return state to playerIds.toList()
         }
 
         private fun createCard(cardName: String, ownerId: EntityId): EntityId {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
@@ -24,11 +24,24 @@ enum class ScenarioMode {
     TWO_PLAYER
 }
 
+/** One seat of an N-player scenario ([ScenarioRequest.players]). */
+data class ScenarioSeat(
+    val name: String? = null,
+    val config: PlayerConfig? = null,
+)
+
 data class ScenarioRequest(
     val player1Name: String? = "Player1",
     val player2Name: String? = "Player2",
     val player1: PlayerConfig? = null,
     val player2: PlayerConfig? = null,
+    /**
+     * N-player seats (3-4 player Free-for-All pods), in turn order. When set, it
+     * overrides the legacy `player1*`/`player2*` fields. Pods of more than two seats
+     * support [ScenarioMode.SELF] (single-client hotseat) only — AI and TWO_PLAYER
+     * stay two-seat.
+     */
+    val players: List<ScenarioSeat>? = null,
     val phase: Phase? = null,
     val step: Step? = null,
     val activePlayer: Int? = null,
@@ -57,6 +70,17 @@ data class ScenarioRequest(
     /** The effective mode, deriving from [aiPlayer] when [mode] is unset. */
     val effectiveMode: ScenarioMode
         get() = mode ?: if (aiPlayer != null) ScenarioMode.AI else ScenarioMode.TWO_PLAYER
+
+    /**
+     * The effective seat list, name + config per seat in turn order. The legacy
+     * two-seat fields map onto a two-entry list when [players] is unset.
+     */
+    fun seats(): List<Pair<String, PlayerConfig?>> =
+        players?.mapIndexed { i, seat -> (seat.name ?: "Player${i + 1}") to seat.config }
+            ?: listOf(
+                (player1Name ?: "Player1") to player1,
+                (player2Name ?: "Player2") to player2,
+            )
 }
 
 data class PlayerConfig(
@@ -102,7 +126,13 @@ data class ScenarioResponse(
     val player2: PlayerInfo,
     val message: String,
     /** Echoes the resolved mode so the client knows whether it controls one seat or both. */
-    val mode: ScenarioMode? = null
+    val mode: ScenarioMode? = null,
+    /**
+     * Full seat roster in turn order (N-player pods). Present whenever the scenario has
+     * more than two seats; `player1`/`player2` keep mirroring the first two for the
+     * existing 2-player tooling.
+     */
+    val players: List<PlayerInfo>? = null
 )
 
 data class PlayerInfo(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioSessionFactory.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioSessionFactory.kt
@@ -46,8 +46,11 @@ class ScenarioSessionFactory(
         includeDevUrls: Boolean = false,
     ): ScenarioResponse {
         val mode = request.effectiveMode
-        val p1Name = request.player1Name ?: "Player1"
-        val p2Name = request.player2Name ?: "Player2"
+        val seats = request.seats()
+        val seatNames = seats.map { it.first }
+        val seatIds = build.playerIds
+        val p1Name = seatNames[0]
+        val p2Name = seatNames.getOrElse(1) { "Player2" }
         val player1Id = build.player1Id
         val player2Id = build.player2Id
 
@@ -58,7 +61,8 @@ class ScenarioSessionFactory(
         )
         gameSession.injectStateForDevScenario(build.state)
 
-        // Per-step stop overrides (prevents auto-pass at specified steps).
+        // Per-step stop overrides (prevents auto-pass at specified steps). The stop
+        // fields are two-seat tooling; they keep applying to the first two seats.
         val p1Stops = request.player1StopAtSteps.orEmpty()
         val p1OppStops = request.player1OpponentStopAtSteps.orEmpty()
         if (p1Stops.isNotEmpty() || p1OppStops.isNotEmpty()) {
@@ -79,19 +83,26 @@ class ScenarioSessionFactory(
 
         return when (mode) {
             ScenarioMode.SELF -> {
-                // One human connection controls BOTH seats. Pre-register only player1's
-                // identity and route every seat's input authority to it.
+                // One human connection controls EVERY seat (2-4 player pods). Pre-register
+                // only player1's identity and route every seat's input authority to it.
                 val token = player1Token ?: newToken()
                 val identity = preRegister(token, player1Id, p1Name)
                 gameSession.enableHotseat(player1Id)
-                logger.info("Created hotseat scenario session ${gameSession.sessionId}")
+                val roster = seatIds.mapIndexed { i, id ->
+                    PlayerInfo(seatNames.getOrElse(i) { "Player${i + 1}" }, identity.token, id.value)
+                }
+                logger.info("Created hotseat scenario session ${gameSession.sessionId} (${seatIds.size} seats)")
                 ScenarioResponse(
                     sessionId = gameSession.sessionId,
-                    // Both PlayerInfo carry the same token: the one connection plays both seats.
-                    player1 = PlayerInfo(p1Name, identity.token, player1Id.value),
-                    player2 = PlayerInfo(p2Name, identity.token, player2Id.value),
-                    message = "Hotseat scenario created — you control both players.",
+                    // Every PlayerInfo carries the same token: the one connection plays all seats.
+                    player1 = roster[0],
+                    player2 = roster.getOrElse(1) { roster[0] },
+                    message = if (seatIds.size > 2)
+                        "Hotseat scenario created — you control all ${seatIds.size} players."
+                    else
+                        "Hotseat scenario created — you control both players.",
                     mode = mode,
+                    players = if (seatIds.size > 2) roster else null,
                 )
             }
 

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -27,7 +27,7 @@ import { randomBackground } from './utils/background'
 import { useNavigate } from 'react-router-dom'
 import { useGameStore } from './store/gameStore'
 import { useViewingPlayer, useBattlefieldCards } from './store/selectors'
-import type { EntityId } from './types'
+import type { ClientAttacker, EntityId } from './types'
 import { GameOverReason } from './types'
 
 export default function App() {
@@ -178,6 +178,8 @@ export default function App() {
       // Enter combat mode — pre-select mandatory attackers
       startCombat({
         mode: 'declareAttackers',
+        actingSeat: attackersAction?.action.type === 'DeclareAttackers' ? attackersAction.action.playerId : null,
+        stickyDefenderId: null,
         selectedAttackers: [...mandatoryAttackers],
         attackerTargets: {},
         validAttackTargets,
@@ -205,13 +207,24 @@ export default function App() {
       // Attacking creatures come from the server's authoritative combat state rather than
       // "the viewing player's opponent" — in single-client hotseat the seat we control (the
       // defender) can be the top row, so the attackers are the viewer's own creatures.
-      const attackingCreatures: EntityId[] = gameState?.combat?.attackers
-        .map((a) => a.creatureId) ?? []
+      // In multiplayer a defender may only block attackers attacking *them* or their
+      // planeswalkers (CR 509.1b) — scope to the acting defender's slice of the combat.
+      // In a 2-player game every attacker attacks the sole defender, so this keeps all.
+      const defendingSeat = blockersAction?.action.type === 'DeclareBlockers'
+        ? blockersAction.action.playerId
+        : null
+      const attacksSeat = (a: ClientAttacker): boolean => {
+        if (!defendingSeat) return true
+        if (a.attackingTarget.type === 'Player') return a.attackingTarget.playerId === defendingSeat
+        return gameState?.cards[a.attackingTarget.permanentId]?.controllerId === defendingSeat
+      }
+      const relevantAttackers = (gameState?.combat?.attackers ?? []).filter(attacksSeat)
+      const attackingCreatures: EntityId[] = relevantAttackers.map((a) => a.creatureId)
 
       // Find attackers that must be blocked by all (from combat state in game state)
-      const mustBeBlockedAttackers: EntityId[] = gameState?.combat?.attackers
+      const mustBeBlockedAttackers: EntityId[] = relevantAttackers
         .filter((a) => a.mustBeBlockedByAll)
-        .map((a) => a.creatureId) ?? []
+        .map((a) => a.creatureId)
 
       // Use server-provided mandatory blocker assignments (Provoke + MustBeBlockedByAll)
       const blockerAssignments: Record<EntityId, EntityId[]> = {}
@@ -229,6 +242,8 @@ export default function App() {
       // Enter combat mode
       startCombat({
         mode: 'declareBlockers',
+        actingSeat: blockersAction?.action.type === 'DeclareBlockers' ? blockersAction.action.playerId : null,
+        stickyDefenderId: null,
         selectedAttackers: [],
         attackerTargets: {},
         validAttackTargets: [],

--- a/web-client/src/components/combat/CombatArrows.tsx
+++ b/web-client/src/components/combat/CombatArrows.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
-import { selectGameState } from '@/store/selectors.ts'
+import { selectGameState, selectViewingPlayerId, useViewedOpponent } from '@/store/selectors.ts'
+import { seatColor } from '@/styles/seatColors'
 import type { EntityId } from '@/types'
 import { Step, ZoneType } from '@/types'
 
@@ -30,6 +31,20 @@ interface AttackerArrowData {
   start: Point
   end: Point
   attackerId: EntityId
+  /** Defender seat color in multiplayer; defaults to combat red. */
+  color?: string
+}
+
+/**
+ * Multiplayer: attacks against an off-screen defender bundle into one arrow from
+ * the attacker group's centroid to that defender's rail chip, with a count badge.
+ */
+interface BundledArrowData {
+  start: Point
+  end: Point
+  color: string
+  count: number
+  defenderId: EntityId
 }
 
 interface AttackIndicatorData {
@@ -37,6 +52,8 @@ interface AttackIndicatorData {
   y: number
   direction: 'up' | 'down'
   attackerId: EntityId
+  /** Defender seat color in multiplayer; defaults to combat red. */
+  color?: string
 }
 
 /**
@@ -160,9 +177,11 @@ function getCardEdgeCenter(cardId: EntityId): { topCenter: Point; bottomCenter: 
 }
 
 /**
- * Animated attack direction indicator — red triangles streaming toward the opponent.
+ * Animated attack direction indicator — triangles streaming toward the defender.
+ * Combat red in 2-player; the defender's seat color once assigned in multiplayer
+ * (the per-attacker "who is this hitting" chevron).
  */
-function AttackIndicator({ x, y, direction }: { x: number; y: number; direction: 'up' | 'down' }) {
+function AttackIndicator({ x, y, direction, color = '#ff4444' }: { x: number; y: number; direction: 'up' | 'down'; color?: string }) {
   const halfWidth = 10
   const triHeight = 12
   const dir = direction === 'up' ? -1 : 1
@@ -175,9 +194,9 @@ function AttackIndicator({ x, y, direction }: { x: number; y: number; direction:
       {/* Glow */}
       <polygon
         points={points}
-        fill="#ff4444"
+        fill={color}
         fillOpacity={0.15}
-        stroke="#ff4444"
+        stroke={color}
         strokeWidth={5}
         strokeOpacity={0.2}
         strokeLinejoin="round"
@@ -185,15 +204,20 @@ function AttackIndicator({ x, y, direction }: { x: number; y: number; direction:
       {/* Filled triangle */}
       <polygon
         points={points}
-        fill="#ff4444"
+        fill={color}
         fillOpacity={0.85}
-        stroke="#ff6666"
+        stroke={color}
         strokeWidth={1}
         strokeOpacity={0.6}
         strokeLinejoin="round"
       />
     </g>
   )
+}
+
+/** Is this viewport point horizontally on-screen (i.e., not on a slid-away board)? */
+function isOnScreen(p: Point): boolean {
+  return p.x >= -4 && p.x <= window.innerWidth + 4
 }
 
 /**
@@ -220,6 +244,11 @@ export function CombatArrows() {
   const gameStateCombat = gameState?.combat
   const currentStep = gameState?.currentStep
   const cards = gameState?.cards
+  const players = gameState?.players
+  const viewingPlayerId = useGameStore(selectViewingPlayerId)
+  const viewedOpponent = useViewedOpponent()
+  const viewedOpponentId = viewedOpponent?.playerId ?? null
+  const isMulti = (players?.length ?? 0) > 2
   const opponentAttackerTargets = useGameStore((state) => state.opponentAttackerTargets)
   const opponentBlockerAssignments = useGameStore((state) => state.opponentBlockerAssignments)
   const draggingBlockerId = useGameStore((state) => state.draggingBlockerId)
@@ -229,6 +258,7 @@ export function CombatArrows() {
   const [mousePos, setMousePos] = useState<Point | null>(null)
   const [arrows, setArrows] = useState<ArrowData[]>([])
   const [attackerArrows, setAttackerArrows] = useState<AttackerArrowData[]>([])
+  const [bundledArrows, setBundledArrows] = useState<BundledArrowData[]>([])
   const [attackIndicators, setAttackIndicators] = useState<AttackIndicatorData[]>([])
 
   // Check if we're still in combat phase
@@ -284,6 +314,26 @@ export function CombatArrows() {
     const updateArrows = () => {
       const newArrows: ArrowData[] = []
 
+      // Seat-identity color for a defending player ("whose seat is this hitting").
+      // Attacks against the viewing player stay combat red, as do all 2-player arrows.
+      const seatColorOf = (defenderId: EntityId): string => {
+        if (!isMulti || !players || defenderId === viewingPlayerId) return '#ff4444'
+        const idx = players.findIndex((p) => p.playerId === defenderId)
+        return idx >= 0 ? seatColor(idx).base : '#ff4444'
+      }
+
+      // Card anchor that survives the multiplayer board strip: a card on a
+      // slid-away opponent board resolves to its controller's rail chip instead
+      // of an off-viewport point (which would paint arrows across the screen edge).
+      const resolvePos = (cardId: EntityId): Point | null => {
+        const p = getCardCenter(cardId)
+        if (!p) return null
+        if (!isMulti || isOnScreen(p)) return p
+        const controller = cards?.[cardId]?.controllerId
+        if (!controller) return p
+        return getPlayerLifeCenter(controller) ?? p
+      }
+
       // Skip blocker arrows during damage order selection (that UI shows blockers separately)
       if (isSelectingDamageOrder) {
         setArrows([])
@@ -292,10 +342,10 @@ export function CombatArrows() {
         // Use local blocker assignments (real-time feedback during declaration)
         for (const [blockerIdStr, attackerIds] of Object.entries(combatState.blockerAssignments)) {
           const blockerId = blockerIdStr as EntityId
-          const blockerPos = getCardCenter(blockerId)
+          const blockerPos = resolvePos(blockerId)
 
           for (const attackerId of attackerIds) {
-            const attackerPos = getCardCenter(attackerId)
+            const attackerPos = resolvePos(attackerId)
 
             if (blockerPos && attackerPos) {
               newArrows.push({
@@ -321,8 +371,8 @@ export function CombatArrows() {
 
             if (!attackerOnBattlefield) continue
 
-            const blockerPos = getCardCenter(blockerId)
-            const attackerPos = getCardCenter(attackerId)
+            const blockerPos = resolvePos(blockerId)
+            const attackerPos = resolvePos(attackerId)
 
             if (blockerPos && attackerPos) {
               newArrows.push({
@@ -363,8 +413,8 @@ export function CombatArrows() {
             continue
           }
 
-          const blockerPos = getCardCenter(blocker.creatureId)
-          const attackerPos = getCardCenter(blocker.blockingAttacker)
+          const blockerPos = resolvePos(blocker.creatureId)
+          const attackerPos = resolvePos(blocker.blockingAttacker)
 
           if (blockerPos && attackerPos) {
             const arrow: ArrowData = {
@@ -383,36 +433,59 @@ export function CombatArrows() {
 
       setArrows(newArrows)
 
-      // Compute attacker arrows (visible to all players and spectators during combat)
-      // Only show attacker arrows when planeswalkers exist — otherwise red triangle indicators suffice
+      // Compute attacker arrows (visible to all players and spectators during combat).
+      // 2-player: only when planeswalkers exist — red triangle indicators suffice
+      // otherwise. Multiplayer: always — "whose spell, at whom" needs the arrows.
+      // Attacks against a defender whose board is slid away bundle into one arrow
+      // per defender, from the attacker group's centroid to their rail chip.
       const newAttackerArrows: AttackerArrowData[] = []
+      const bundleAcc = new Map<EntityId, { starts: Point[]; end: Point; count: number }>()
+
+      const pushAttackArrow = (attackerId: EntityId, targetId: EntityId) => {
+        const attackerPos = getCardCenter(attackerId)
+        if (!attackerPos) return
+        // The target is a planeswalker (a card) or a player; the defending player
+        // is the planeswalker's controller (CR 802.2a) or the player themself.
+        const targetCard = cards?.[targetId]
+        const defenderId = targetCard ? targetCard.controllerId : targetId
+        if (isMulti && defenderId !== viewingPlayerId && defenderId !== viewedOpponentId) {
+          // Off-screen defender → bundle to their rail chip.
+          const chip = getPlayerLifeCenter(defenderId)
+          if (!chip) return
+          const acc = bundleAcc.get(defenderId) ?? { starts: [], end: chip, count: 0 }
+          acc.starts.push(attackerPos)
+          acc.count++
+          bundleAcc.set(defenderId, acc)
+          return
+        }
+        const cardPos = targetCard ? getCardCenter(targetId) : null
+        const targetPos = (cardPos && (!isMulti || isOnScreen(cardPos)) ? cardPos : null)
+          ?? getPlayerLifeCenter(defenderId)
+        if (!targetPos) return
+        newAttackerArrows.push({
+          start: attackerPos,
+          end: targetPos,
+          attackerId,
+          color: seatColorOf(defenderId),
+        })
+      }
+
       const hasPlaneswalkerOnBattlefield = cards && Object.values(cards).some(
         (card) => card.zone?.zoneType === ZoneType.BATTLEFIELD && card.cardTypes.includes('PLANESWALKER'),
       )
-      if (hasPlaneswalkerOnBattlefield && gameStateCombat && gameStateCombat.attackers.length > 0) {
+      if ((hasPlaneswalkerOnBattlefield || isMulti) && gameStateCombat && gameStateCombat.attackers.length > 0) {
         for (const attacker of gameStateCombat.attackers) {
           // Check if attacker is still on battlefield
           const attackerCard = cards?.[attacker.creatureId]
           if (attackerCard?.zone?.zoneType !== ZoneType.BATTLEFIELD) {
             continue
           }
-
-          const attackerPos = getCardCenter(attacker.creatureId)
-          // Get the target - either a player or planeswalker
-          let targetPos: Point | null = null
-          if (attacker.attackingTarget.type === 'Player') {
-            targetPos = getPlayerLifeCenter(attacker.attackingTarget.playerId)
-          } else if (attacker.attackingTarget.type === 'Planeswalker') {
-            targetPos = getCardCenter(attacker.attackingTarget.permanentId)
-          }
-
-          if (attackerPos && targetPos) {
-            newAttackerArrows.push({
-              start: attackerPos,
-              end: targetPos,
-              attackerId: attacker.creatureId,
-            })
-          }
+          pushAttackArrow(
+            attacker.creatureId,
+            attacker.attackingTarget.type === 'Player'
+              ? attacker.attackingTarget.playerId
+              : attacker.attackingTarget.permanentId,
+          )
         }
       }
 
@@ -422,16 +495,7 @@ export function CombatArrows() {
           const attackerId = attackerIdStr as EntityId
           // Only show if this attacker is still selected
           if (!combatState.selectedAttackers.includes(attackerId)) continue
-          const attackerPos = getCardCenter(attackerId)
-          // Target can be a planeswalker (card) or a player (life display)
-          const targetPos = getCardCenter(targetId) ?? getPlayerLifeCenter(targetId)
-          if (attackerPos && targetPos) {
-            newAttackerArrows.push({
-              start: attackerPos,
-              end: targetPos,
-              attackerId,
-            })
-          }
+          pushAttackArrow(attackerId, targetId)
         }
       }
 
@@ -440,43 +504,58 @@ export function CombatArrows() {
         for (const [attackerIdStr, targetId] of Object.entries(opponentAttackerTargets.attackerTargets)) {
           const attackerId = attackerIdStr as EntityId
           if (!opponentAttackerTargets.selectedAttackers.includes(attackerId)) continue
-          const attackerPos = getCardCenter(attackerId)
-          const targetPos = getCardCenter(targetId) ?? getPlayerLifeCenter(targetId)
-          if (attackerPos && targetPos) {
-            newAttackerArrows.push({
-              start: attackerPos,
-              end: targetPos,
-              attackerId,
-            })
-          }
+          pushAttackArrow(attackerId, targetId)
         }
       }
       setAttackerArrows(newAttackerArrows)
+      setBundledArrows(
+        Array.from(bundleAcc.entries()).map(([defenderId, acc]) => ({
+          defenderId,
+          count: acc.count,
+          end: acc.end,
+          start: {
+            x: acc.starts.reduce((s, p) => s + p.x, 0) / acc.starts.length,
+            y: acc.starts.reduce((s, p) => s + p.y, 0) / acc.starts.length,
+          },
+          color: seatColorOf(defenderId),
+        })),
+      )
 
       // Compute attack direction indicators (red triangles)
       const newIndicators: AttackIndicatorData[] = []
       const viewportCenterY = window.innerHeight / 2
 
+      // Seat color for an indicator given the attack's target id (player or planeswalker).
+      const indicatorColorFor = (targetId: EntityId | undefined): string => {
+        if (!targetId) return '#ff4444'
+        const targetCard = cards?.[targetId]
+        return seatColorOf(targetCard ? targetCard.controllerId : targetId)
+      }
+
       if (combatState?.mode === 'declareAttackers' && combatState.selectedAttackers.length > 0) {
-        // During declare attackers: show for locally selected attackers (skip those with planeswalker targets — they have arrows)
+        // During declare attackers: show for locally selected attackers. 2-player skips
+        // attackers with explicit (planeswalker) targets — they have arrows; multiplayer
+        // keeps them as the seat-colored "who is this hitting" chevron on the card.
         for (const attackerId of combatState.selectedAttackers) {
-          if (combatState.attackerTargets[attackerId]) continue
+          const targetId = combatState.attackerTargets[attackerId]
+          if (targetId && !isMulti) continue
           const edge = getCardEdgeCenter(attackerId)
           if (edge) {
             const direction = edge.centerY > viewportCenterY ? 'up' : 'down'
             const pos = direction === 'up' ? edge.topCenter : edge.bottomCenter
-            newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId })
+            newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId, color: indicatorColorFor(targetId) })
           }
         }
       } else if (opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && !gameStateCombat) {
         // Opponent's real-time attacker selections (for defending player and spectators)
         for (const attackerId of opponentAttackerTargets.selectedAttackers) {
-          if (opponentAttackerTargets.attackerTargets[attackerId]) continue
+          const targetId = opponentAttackerTargets.attackerTargets[attackerId]
+          if (targetId && !isMulti) continue
           const edge = getCardEdgeCenter(attackerId)
           if (edge) {
             const direction = edge.centerY > viewportCenterY ? 'up' : 'down'
             const pos = direction === 'up' ? edge.topCenter : edge.bottomCenter
-            newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId })
+            newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId, color: indicatorColorFor(targetId) })
           }
         }
       } else if (gameStateCombat && gameStateCombat.attackers.length > 0) {
@@ -489,7 +568,17 @@ export function CombatArrows() {
           if (edge) {
             const direction = edge.centerY > viewportCenterY ? 'up' : 'down'
             const pos = direction === 'up' ? edge.topCenter : edge.bottomCenter
-            newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId: attacker.creatureId })
+            newIndicators.push({
+              x: pos.x,
+              y: pos.y,
+              direction,
+              attackerId: attacker.creatureId,
+              color: indicatorColorFor(
+                attacker.attackingTarget.type === 'Player'
+                  ? attacker.attackingTarget.playerId
+                  : attacker.attackingTarget.permanentId,
+              ),
+            })
           }
         }
       }
@@ -500,7 +589,7 @@ export function CombatArrows() {
     updateArrows()
     const interval = setInterval(updateArrows, 100)
     return () => clearInterval(interval)
-  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, cards, isSpectating, isSelectingDamageOrder])
+  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, cards, isSpectating, isSelectingDamageOrder, players, isMulti, viewedOpponentId, viewingPlayerId])
 
   // Don't render during full-screen overlay decisions
   if (hasOverlayDecision) {
@@ -543,25 +632,59 @@ export function CombatArrows() {
         zIndex: 2000, // Above spectator container (1500)
       }}
     >
-      {/* Attack direction indicators (red triangles pointing toward opponent) */}
-      {attackIndicators.map(({ x, y, direction, attackerId }) => (
+      {/* Attack direction indicators (triangles pointing toward the defender,
+          seat-colored once assigned in multiplayer) */}
+      {attackIndicators.map(({ x, y, direction, attackerId, color }) => (
         <AttackIndicator
           key={`indicator-${attackerId}`}
           x={x}
           y={y}
           direction={direction}
+          {...(color ? { color } : {})}
         />
       ))}
 
-      {/* Attacker arrows (unblocked attackers to defending player) */}
-      {attackerArrows.map(({ start, end, attackerId }) => (
+      {/* Attacker arrows (attackers to the defending player / planeswalker) */}
+      {attackerArrows.map(({ start, end, attackerId, color }) => (
         <Arrow
           key={`attacker-${attackerId}`}
           start={start}
           end={end}
-          color="#ff4444"
+          color={color ?? '#ff4444'}
         />
       ))}
+
+      {/* Bundled attack arrows to off-screen defenders' rail chips, with a
+          creature-count badge near the chip end */}
+      {bundledArrows.map(({ start, end, color, count, defenderId }) => {
+        // Badge on the bezier at t=0.7 (closer to the chip)
+        const midX = (start.x + end.x) / 2
+        const midY = (start.y + end.y) / 2
+        const dist = Math.hypot(end.x - start.x, end.y - start.y)
+        const controlY = midY - Math.min(dist * 0.2, 60)
+        const t = 0.7
+        const mt = 1 - t
+        const badgeX = mt * mt * start.x + 2 * mt * t * midX + t * t * end.x
+        const badgeY = mt * mt * start.y + 2 * mt * t * controlY + t * t * end.y
+        return (
+          <g key={`bundle-${defenderId}`}>
+            <Arrow start={start} end={end} color={color} />
+            <circle cx={badgeX} cy={badgeY} r={12} fill="#000000" fillOpacity={0.85} stroke={color} strokeWidth={1.5} />
+            <text
+              x={badgeX}
+              y={badgeY + 4.5}
+              textAnchor="middle"
+              fill={color}
+              fontSize={13}
+              fontWeight={700}
+              fontFamily="system-ui, sans-serif"
+              style={{ pointerEvents: 'none' }}
+            >
+              {count}
+            </text>
+          </g>
+        )
+      })}
 
       {/* Blocker assignments */}
       {arrows.map(({ start, end, blockerId, damageOrder, damageAmount }) => (

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1,7 +1,10 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useRef } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
-import { useViewingPlayer, useOpponent, useStackCards, selectPriorityMode, useGhostCards, useRevealedLibraryTopCard, useBattlefieldCards } from '@/store/selectors'
+import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useSeatIndex, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards } from '@/store/selectors'
+import { seatColor } from '@/styles/seatColors'
+import { useMultiplayerView } from '@/hooks/useMultiplayerView'
+import { OpponentRail, OPPONENT_RAIL_HEIGHT } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
 import { StepStrip } from '../ui/StepStrip'
 import { ManaPool } from '../ui/ManaPool'
@@ -19,7 +22,7 @@ import { useResponsive } from '@/hooks/useResponsive'
 import { ManaSymbol } from '../ui/ManaSymbols'
 
 // Import extracted components
-import { Battlefield, CardRow, CommandZone, StackDisplay, ZonePile, ResponsiveContext } from './board'
+import { Battlefield, CardRow, CommandZone, OpponentBoardArea, StackDisplay, ZonePile, ResponsiveContext } from './board'
 import { RenderProfiler } from '@/utils/renderProfiler'
 import { CardPreview } from './card'
 import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, ConcedeButton, FullscreenButton, SpectatorCountBadge } from './overlay'
@@ -72,9 +75,33 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const cancelManaSelection = useGameStore((state) => state.cancelManaSelection)
   const { executeAction } = useInteraction()
 
+  // In spectator mode, use spectatingState.gameState
+  const gameState = spectatorMode ? spectatingState?.gameState : playerGameState
+
+  // Multiplayer (3-4 player) view state. In a 2-player game none of this renders —
+  // no rail, no board strip, no extra top offset — so the layout is unchanged.
+  const opponents = useOpponents()
+  const viewedOpponent = useViewedOpponent()
+  const isMulti = (gameState?.players.length ?? 0) > 2
+  const railHeight = isMulti ? OPPONENT_RAIL_HEIGHT : 0
+  // Everything anchored to the viewport top (opponent hand, grid row 1, labels)
+  // shifts down by the rail height in multiplayer.
+  const effectiveTopOffset = topOffset + railHeight
+  useMultiplayerView(isMulti, opponents)
+  const stripOpponents = useMemo(() => opponents.filter((o) => !o.hasLost), [opponents])
+  const viewedStripIndex = Math.max(
+    0,
+    stripOpponents.findIndex((o) => o.playerId === viewedOpponent?.playerId),
+  )
+  const viewedSeatIndex = useSeatIndex(viewedOpponent?.playerId ?? null)
+  const viewedSeatColor = seatColor(Math.max(0, viewedSeatIndex))
+  const stripTouchX = useRef<number | null>(null)
+
   // Card counts per battlefield zone — used by useResponsive to decide when wrapping
-  // will occur and shrink cards so the wrapped rows fit vertically.
-  const battlefieldCards = useBattlefieldCards()
+  // will occur and shrink cards so the wrapped rows fit vertically. In multiplayer
+  // the viewed opponent's board drives the shared sizing (each off-screen
+  // Battlefield measures its own slot independently anyway).
+  const battlefieldCards = useBattlefieldCards(isMulti ? viewedOpponent?.playerId ?? null : null)
   const zoneRowCounts = useMemo(
     () => [
       battlefieldCards.playerCreatures.length + battlefieldCards.playerPlaneswalkers.length,
@@ -85,7 +112,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     [battlefieldCards]
   )
 
-  const responsive = useResponsive(topOffset, zoneRowCounts)
+  const responsive = useResponsive(effectiveTopOffset, zoneRowCounts)
+  // Grid row 1: keeps the battlefield clear of the fixed/absolute opponent hand.
+  const oppHandReservation =
+    responsive.smallCardHeight + effectiveTopOffset + responsive.opponentHandBattlefieldGap
 
   // Confirm mana selection: if pipeline is active, advance it; otherwise build
   // modified LegalActionInfo with Explicit payment and route through executeAction
@@ -120,9 +150,6 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     executeAction(modifiedActionInfo)
   }, [manaSelectionState, cancelManaSelection, executeAction])
 
-  // In spectator mode, use spectatingState.gameState
-  const gameState = spectatorMode ? spectatingState?.gameState : playerGameState
-
   const viewingPlayer = useViewingPlayer()
   const opponent = useOpponent()
   const stackCards = useStackCards()
@@ -132,13 +159,21 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const youAreHijacking = !spectatorMode ? (gameState?.youAreHijacking ?? null) : null
   const youAreHijackedBy = !spectatorMode ? (gameState?.youAreHijackedBy ?? null) : null
   // Single-client hotseat (play against yourself): this connection controls every seat.
-  // When the seat currently to act is the opponent (top) row, reuse the hijack rendering to
-  // make that row interactive and dim our own — the board emphasis flips between seats as
-  // priority alternates, like pass-and-play.
+  // When the seat currently to act is an opponent row, reuse the hijack rendering to
+  // make that row interactive and dim our own — the board emphasis flips between seats
+  // as priority alternates, like pass-and-play.
   const hotseat = !spectatorMode && (gameState?.hotseat ?? false)
-  const hotseatControllingOpponent =
-    hotseat && !!opponent && gameState?.priorityPlayerId === opponent.playerId
-  const isHijacking = !!youAreHijacking || hotseatControllingOpponent
+  // The opponent seat (if any) this client is currently driving: the Mindslaver
+  // victim, or — in hotseat — whichever opponent seat holds priority.
+  const hijackControlledOpponentId =
+    youAreHijacking ??
+    (hotseat &&
+    gameState?.priorityPlayerId &&
+    viewingPlayer &&
+    gameState.priorityPlayerId !== viewingPlayer.playerId
+      ? gameState.priorityPlayerId
+      : null)
+  const isHijacking = hijackControlledOpponentId !== null
   const isHijacked = !!youAreHijackedBy
   // Soft purple wash for the battlefield row currently under hijack control. We avoid
   // a hard outline (which clipped at the zone-pile column on the right) — instead a
@@ -150,12 +185,6 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     boxShadow: 'inset 0 0 0 1px rgba(168, 85, 247, 0.28), inset 0 0 24px rgba(168, 85, 247, 0.12)',
     transition: 'background 0.2s, box-shadow 0.2s',
   }
-  const opponentRevealedTopCard = useRevealedLibraryTopCard(opponent?.playerId ?? null)
-  const opponentGhostCards = useMemo(
-    () => opponentRevealedTopCard ? [opponentRevealedTopCard] : [],
-    [opponentRevealedTopCard]
-  )
-
   // For spectator mode, we need to find players differently since playerId won't match
   const spectatorPlayer1 = spectatorMode && gameState
     ? gameState.players.find(p => p.playerId === spectatingState?.player1Id) ?? gameState.players[0]
@@ -164,9 +193,14 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     ? gameState.players.find(p => p.playerId === spectatingState?.player2Id) ?? gameState.players[1]
     : null
 
-  // In spectator mode, use player1 as "bottom" player and player2 as "top" (opponent)
+  // In spectator mode, use player1 as "bottom" player and player2 as "top" (opponent).
+  // In multiplayer the viewed slot holds whichever opponent the camera is on.
   const effectiveViewingPlayer = spectatorMode ? spectatorPlayer1 : viewingPlayer
-  const effectiveOpponent = spectatorMode ? spectatorPlayer2 : opponent
+  const effectiveOpponent = isMulti
+    ? viewedOpponent
+    : spectatorMode
+      ? spectatorPlayer2
+      : opponent
 
   if (!gameState || (!spectatorMode && (!playerId || !viewingPlayer))) {
     return null
@@ -382,9 +416,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // Hand reservation rows (1 and 5) keep the battlefield rows from sliding
       // under the position:fixed hand overlays. Both 1fr rows then receive
       // identical heights → symmetric card sizes for player and opponent.
-      gridTemplateRows: `${
-        responsive.smallCardHeight + topOffset + responsive.opponentHandBattlefieldGap
-      }px minmax(0, 1fr) auto minmax(0, 1fr) ${
+      gridTemplateRows: `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
         (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
       }px`,
     }}>
@@ -399,64 +431,105 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       {!spectatorMode && <ConcedeButton />}
 
 
-      {/* Opponent hand - fixed at top of screen. The face-up promotion during a
-          Mindslaver-style hijack is itself the strongest signal that the controller
-          is driving V's hand — no extra wrapper outline is needed. */}
-      {effectiveOpponent && (
-        <div
-          data-zone="opponent-hand"
-          style={{
-            position: 'fixed',
-            top: topOffset,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            zIndex: 50,
-          }}
-        >
-          <CardRow
-            zoneId={hand(effectiveOpponent.playerId)}
-            faceDown={!isHijacking}
-            small
-            inverted
-            interactive={isHijacking}
-            ghostCards={isHijacking ? [] : opponentGhostCards}
-          />
-        </div>
+      {/* Opponent half. 2-player: today's exact markup (fixed hand at the top +
+          board area on grid row 2), via OpponentBoardArea's grid layout.
+          Multiplayer: an always-visible opponent rail + a horizontally sliding
+          strip of full-size boards, one per living opponent, in turn order. */}
+      {!isMulti && effectiveOpponent && (
+        <OpponentBoardArea
+          opponent={effectiveOpponent}
+          layout="grid"
+          topOffset={effectiveTopOffset}
+          spectatorMode={spectatorMode}
+          isHijacking={isHijacking}
+          hijackedSurfaceStyle={hijackedSurfaceStyle}
+        />
+      )}
+      {isMulti && (
+        <>
+          <OpponentRail topOffset={topOffset} spectatorMode={spectatorMode} />
+          <div
+            data-opponent-strip
+            style={{
+              gridRow: '1 / 3',
+              position: 'relative',
+              overflow: 'hidden',
+              minHeight: 0,
+              minWidth: 0,
+            }}
+            onTouchStart={(e) => {
+              stripTouchX.current = e.touches[0]?.clientX ?? null
+            }}
+            onTouchEnd={(e) => {
+              const start = stripTouchX.current
+              stripTouchX.current = null
+              const end = e.changedTouches[0]?.clientX ?? null
+              if (start == null || end == null) return
+              const store = useGameStore.getState()
+              // A swipe must not fight an in-progress card drag.
+              if (store.draggingCardId || store.draggingAttackerId || store.draggingBlockerId) return
+              const dx = end - start
+              if (Math.abs(dx) < 48) return
+              const next = stripOpponents[viewedStripIndex + (dx < 0 ? 1 : -1)]
+              if (next) store.viewOpponent(next.playerId)
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                width: '100%',
+                height: '100%',
+                transform: `translateX(-${viewedStripIndex * 100}%)`,
+                transition: 'transform 220ms cubic-bezier(0.4, 0, 0.2, 1)',
+              }}
+            >
+              {stripOpponents.map((o) => (
+                <OpponentBoardArea
+                  key={o.playerId}
+                  opponent={o}
+                  layout="strip"
+                  topOffset={effectiveTopOffset}
+                  handReservation={oppHandReservation}
+                  spectatorMode={spectatorMode}
+                  isHijacking={hijackControlledOpponentId === o.playerId}
+                  hijackedSurfaceStyle={hijackedSurfaceStyle}
+                />
+              ))}
+            </div>
+            {/* Seat-colored edge flash on board arrival */}
+            {viewedOpponent && (
+              <div
+                key={viewedOpponent.playerId}
+                aria-hidden
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  pointerEvents: 'none',
+                  borderRadius: 10,
+                  boxShadow: `inset 0 0 0 2px ${viewedSeatColor.base}, inset 0 0 26px ${viewedSeatColor.soft}`,
+                  opacity: 0,
+                  animation: 'seatEdgeFlash 700ms ease-out',
+                }}
+              />
+            )}
+          </div>
+        </>
       )}
 
-      {/* Spectator mode: floating player name labels on the left side */}
-      {spectatorMode && effectiveOpponent && (
+      {/* Spectator mode: floating opponent name label (2-player only — the rail
+          carries opponent identity in multiplayer) */}
+      {spectatorMode && !isMulti && effectiveOpponent && (
         <div
           style={{
             ...styles.spectatorNameLabel,
             position: 'fixed',
-            top: topOffset + responsive.smallCardHeight + responsive.opponentHandBattlefieldGap + 8,
+            top: effectiveTopOffset + responsive.smallCardHeight + responsive.opponentHandBattlefieldGap + 8,
             left: 16,
           }}
         >
           {effectiveOpponent.name}
         </div>
       )}
-
-      {/* Opponent area (grid row 2) — opp-hand reservation lives in row 1, so
-          no padding is needed here. Equal-height with row 4 → equal cards. */}
-      <div style={styles.opponentArea}>
-        <div style={{ ...styles.playerRowWithZones, alignItems: 'flex-start' }}>
-          {/* Opponent command zone (left side) — Commander format only; renders nothing otherwise. */}
-          {effectiveOpponent && <CommandZone player={effectiveOpponent} isOpponent />}
-
-          <div style={{
-            ...styles.playerMainArea,
-            ...(isHijacking ? hijackedSurfaceStyle : null),
-          }}>
-            {/* Opponent battlefield - lands first (closer to opponent), then creatures */}
-            <Battlefield isOpponent spectatorMode={spectatorMode} />
-          </div>
-
-          {/* Opponent deck/graveyard (right side) */}
-          {effectiveOpponent && <ZonePile player={effectiveOpponent} isOpponent />}
-        </div>
-      </div>
 
       {/* Center - Life totals, phase indicator, and stack.
           Grid row 2 — a reserved partition that the opponent/player areas
@@ -477,11 +550,16 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         width: 'auto',
         columnGap: responsive.isMobile ? 6 : 16,
       }}>
-        {/* Opponent life (left side) */}
+        {/* Opponent life (left side). In multiplayer the life orb is absorbed by
+            the opponent rail (the chip carries the same data + anchors); the
+            transient per-board extras (effect badges, floating mana) stay here
+            for the viewed opponent. */}
         <div style={{ ...styles.centerLifeSection, ...styles.centerLifeSectionLeft }}>
           {effectiveOpponent && (
             <>
-              <LifeDisplay life={effectiveOpponent.life} playerId={effectiveOpponent.playerId} playerName={effectiveOpponent.name} spectatorMode={spectatorMode} poisonCounters={effectiveOpponent.poisonCounters} commanderDamage={effectiveOpponent.commanderDamage ?? []} />
+              {!isMulti && (
+                <LifeDisplay life={effectiveOpponent.life} playerId={effectiveOpponent.playerId} playerName={effectiveOpponent.name} spectatorMode={spectatorMode} poisonCounters={effectiveOpponent.poisonCounters} commanderDamage={effectiveOpponent.commanderDamage ?? []} />
+              )}
               {!responsive.isMobile && <ActiveEffectsBadges effects={effectiveOpponent.activeEffects} />}
               {!responsive.isMobile && effectiveOpponent.manaPool && <ManaPool manaPool={effectiveOpponent.manaPool} />}
             </>
@@ -804,6 +882,76 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         </div>
       )}
 
+      {/* Multiplayer defender pick — pops on the first attacker selection until a
+          defender is chosen; assignment then turns sticky (rail-chip clicks
+          override per attacker). Confirm stays disabled while any selected
+          attacker has no defender, so attacks are never silently misdirected. */}
+      {!spectatorMode && isMulti && combatState?.mode === 'declareAttackers' &&
+        combatState.selectedAttackers.some((id) => !combatState.attackerTargets[id]) && (() => {
+          const unassignedCount = combatState.selectedAttackers.filter((id) => !combatState.attackerTargets[id]).length
+          const living = opponents.filter((o) => !o.hasLost)
+          return (
+            <div style={{
+              position: 'fixed',
+              bottom: 110,
+              right: 16,
+              zIndex: 110,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 6,
+              alignItems: 'flex-end',
+            }}>
+              <div style={{
+                background: 'rgba(0, 0, 0, 0.9)',
+                border: '1px solid #ef5350',
+                borderRadius: 8,
+                padding: '6px 12px',
+                color: '#ffb3b3',
+                fontSize: responsive.isMobile ? 11 : 12,
+                fontWeight: 600,
+              }}>
+                Attack which player?{combatState.selectedAttackers.length > 1 ? ` (${unassignedCount} unassigned)` : ''}
+              </div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {living.map((o) => {
+                  const idx = gameState.players.findIndex((p) => p.playerId === o.playerId)
+                  const seat = seatColor(Math.max(0, idx))
+                  return (
+                    <button
+                      key={o.playerId}
+                      onClick={() => useGameStore.getState().assignDefenderToSelectedAttackers(o.playerId)}
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        height: 30,
+                        padding: '0 12px',
+                        borderRadius: 999,
+                        border: `2px solid ${seat.base}`,
+                        background: 'rgba(10, 12, 20, 0.92)',
+                        color: seat.bright,
+                        fontSize: responsive.isMobile ? 11 : 12,
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      <span aria-hidden style={{
+                        width: 9,
+                        height: 9,
+                        borderRadius: '50%',
+                        background: seat.base,
+                        boxShadow: `0 0 5px ${seat.base}`,
+                      }} />
+                      {o.name}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })()}
+
       {/* Combat buttons (bottom-right) */}
       {isInCombatMode && combatState?.mode === 'declareAttackers' && (
         <div style={styles.combatButtonContainer}>
@@ -834,17 +982,28 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             </>
           ) : (
             <>
-              <button
-                onClick={confirmCombat}
-                style={{
-                  ...styles.floatingBarButton,
-                  ...styles.combatActionButton,
-                  backgroundColor: '#c62828',
-                  border: '1px solid #ef5350',
-                }}
-              >
-                Attack with {combatState.selectedAttackers.length}
-              </button>
+              {(() => {
+                // Multiplayer: every attacker needs an explicit defender first.
+                const awaitingDefender = isMulti &&
+                  combatState.selectedAttackers.some((id) => !combatState.attackerTargets[id])
+                return (
+                  <button
+                    onClick={confirmCombat}
+                    disabled={awaitingDefender}
+                    title={awaitingDefender ? 'Choose a defender for every attacker first' : undefined}
+                    style={{
+                      ...styles.floatingBarButton,
+                      ...styles.combatActionButton,
+                      backgroundColor: '#c62828',
+                      border: '1px solid #ef5350',
+                      opacity: awaitingDefender ? 0.5 : 1,
+                      cursor: awaitingDefender ? 'not-allowed' : 'pointer',
+                    }}
+                  >
+                    Attack with {combatState.selectedAttackers.length}
+                  </button>
+                )
+              })()}
               <button
                 onClick={clearAttackers}
                 style={{

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -550,16 +550,22 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         width: 'auto',
         columnGap: responsive.isMobile ? 6 : 16,
       }}>
-        {/* Opponent life (left side). In multiplayer the life orb is absorbed by
-            the opponent rail (the chip carries the same data + anchors); the
-            transient per-board extras (effect badges, floating mana) stay here
-            for the viewed opponent. */}
+        {/* Opponent life (left side). In multiplayer this is the *viewed*
+            opponent's orb, seat-tinted to match their rail chip — a full-size
+            targeting click target in the familiar spot (the chip carries the
+            anchors for the other, off-screen opponents). */}
         <div style={{ ...styles.centerLifeSection, ...styles.centerLifeSectionLeft }}>
           {effectiveOpponent && (
             <>
-              {!isMulti && (
-                <LifeDisplay life={effectiveOpponent.life} playerId={effectiveOpponent.playerId} playerName={effectiveOpponent.name} spectatorMode={spectatorMode} poisonCounters={effectiveOpponent.poisonCounters} commanderDamage={effectiveOpponent.commanderDamage ?? []} />
-              )}
+              <LifeDisplay
+                life={effectiveOpponent.life}
+                playerId={effectiveOpponent.playerId}
+                playerName={effectiveOpponent.name}
+                spectatorMode={spectatorMode}
+                poisonCounters={effectiveOpponent.poisonCounters}
+                commanderDamage={effectiveOpponent.commanderDamage ?? []}
+                {...(isMulti ? { seatColor: viewedSeatColor.base } : {})}
+              />
               {!responsive.isMobile && <ActiveEffectsBadges effects={effectiveOpponent.activeEffects} />}
               {!responsive.isMobile && effectiveOpponent.manaPool && <ManaPool manaPool={effectiveOpponent.manaPool} />}
             </>

--- a/web-client/src/components/game/GameLog.tsx
+++ b/web-client/src/components/game/GameLog.tsx
@@ -1,4 +1,5 @@
 import { useGameStore, type LogEntry } from '@/store/gameStore.ts'
+import { seatColor } from '@/styles/seatColors'
 import React, { useState, useRef, useEffect } from 'react'
 
 /**
@@ -7,6 +8,15 @@ import React, { useState, useRef, useEffect } from 'react'
 export function GameLog() {
   const eventLog = useGameStore((state) => state.eventLog)
   const playerId = useGameStore((state) => state.playerId)
+  // Multiplayer: log entries take the actor's seat color ("who did that?" is the
+  // dominant question in a pod). 2-player keeps the classic cyan/orange split.
+  const players = useGameStore((state) => state.gameState?.players)
+  const isMulti = (players?.length ?? 0) > 2
+  const seatColorFor = (entryPlayerId: string | null): string | null => {
+    if (!isMulti || !players || !entryPlayerId || entryPlayerId === playerId) return null
+    const idx = players.findIndex((p) => p.playerId === entryPlayerId)
+    return idx >= 0 ? seatColor(idx).base : null
+  }
   const [expanded, setExpanded] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -41,14 +51,19 @@ export function GameLog() {
           <div style={styles.empty}>No events yet</div>
         )}
         {eventLog.map((entry, i) => (
-          <LogEntryRow key={i} entry={entry} isPlayer={entry.playerId === playerId} />
+          <LogEntryRow
+            key={i}
+            entry={entry}
+            isPlayer={entry.playerId === playerId}
+            seatColor={seatColorFor(entry.playerId)}
+          />
         ))}
       </div>
     </div>
   )
 }
 
-function LogEntryRow({ entry, isPlayer }: { entry: LogEntry; isPlayer: boolean }) {
+function LogEntryRow({ entry, isPlayer, seatColor }: { entry: LogEntry; isPlayer: boolean; seatColor: string | null }) {
   if (entry.type === 'turn') {
     return (
       <div style={styles.turnSeparator}>
@@ -63,7 +78,7 @@ function LogEntryRow({ entry, isPlayer }: { entry: LogEntry; isPlayer: boolean }
       ? '#888'
       : isPlayer
         ? '#5bc0de'
-        : '#e07050'
+        : seatColor ?? '#e07050'
 
   return (
     <div style={{ ...styles.entry, color }}>

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -1,0 +1,669 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type React from 'react'
+import { useGameStore } from '@/store/gameStore'
+import {
+  selectGameState,
+  useOpponents,
+  useViewedOpponent,
+  useSeatIndex,
+} from '@/store/selectors'
+import { seatColor } from '@/styles/seatColors'
+import type { ClientCard, ClientPlayer } from '@/types'
+import { useResponsiveContext } from './board/shared'
+
+/** Height of the rail band; GameBoard adds this to its top offset in multiplayer. */
+export const OPPONENT_RAIL_HEIGHT = 34
+
+/**
+ * The opponent rail — the multiplayer overview guarantee. One chip per opponent,
+ * always visible: seat color, name, life (the floating ±delta anchor), hand count,
+ * poison, commander-damage warning, active-turn ring, priority dot, deciding
+ * spinner, attention pulses. Chips are also the player-level click target:
+ * - click → slide that opponent's board into view (pins; re-click unpins)
+ * - crosshair badge → target the player (never mixed with the view-switch click)
+ * - during attack declaration with attackers selected → assign them this defender
+ * - tombstone (grayed, skull) once the player has left the game
+ *
+ * Renders only in games with more than two players — the 2-player layout is sacred.
+ */
+export function OpponentRail({
+  topOffset,
+  spectatorMode = false,
+}: {
+  topOffset: number
+  spectatorMode?: boolean
+}) {
+  const opponents = useOpponents()
+  const viewedOpponent = useViewedOpponent()
+  const viewPinned = useGameStore((state) => state.viewPinned)
+  const followAction = useGameStore((state) => state.followAction)
+  const toggleFollowAction = useGameStore((state) => state.toggleFollowAction)
+
+  if (opponents.length <= 1) return null
+
+  return (
+    <div
+      data-opponent-rail
+      style={{
+        position: 'fixed',
+        top: topOffset,
+        left: 0,
+        right: 0,
+        height: OPPONENT_RAIL_HEIGHT,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        zIndex: 120,
+        pointerEvents: 'none',
+        // Leave the top corners free for the fullscreen / spectator-count /
+        // concede buttons that live at left/right edges.
+        padding: '0 150px',
+      }}
+    >
+      <style>{`
+        @keyframes railChipPulse {
+          0% { box-shadow: 0 0 0 0 var(--pulse-color), 0 0 10px var(--pulse-color); }
+          100% { box-shadow: 0 0 0 10px rgba(0,0,0,0), 0 0 0 rgba(0,0,0,0); }
+        }
+        @keyframes railSpin { to { transform: rotate(360deg); } }
+        @keyframes railHalo {
+          0%, 100% { box-shadow: 0 0 4px 1px var(--halo-color); }
+          50% { box-shadow: 0 0 10px 3px var(--halo-color); }
+        }
+        @keyframes seatEdgeFlash {
+          0% { opacity: 0.9; }
+          100% { opacity: 0; }
+        }
+      `}</style>
+      {opponents.map((opponent) => (
+        <RailChip
+          key={opponent.playerId}
+          opponent={opponent}
+          isViewed={viewedOpponent?.playerId === opponent.playerId}
+          viewPinned={viewPinned}
+          spectatorMode={spectatorMode}
+        />
+      ))}
+      {!spectatorMode && (
+        <button
+          onClick={toggleFollowAction}
+          title={
+            followAction
+              ? 'Follow the action: the view slides to the active board automatically. Click for a manual camera.'
+              : 'Manual camera: the view only moves when you switch boards. Click to follow the action.'
+          }
+          style={{
+            pointerEvents: 'auto',
+            height: 22,
+            padding: '0 8px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            borderRadius: 999,
+            border: `1px solid ${followAction ? 'rgba(110, 200, 255, 0.5)' : '#444'}`,
+            background: followAction ? 'rgba(20, 50, 80, 0.8)' : 'rgba(25, 25, 35, 0.8)',
+            color: followAction ? '#9fd8ff' : '#777',
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span aria-hidden style={{ fontSize: 11 }}>{followAction ? '◉' : '○'}</span>
+          Follow
+        </button>
+      )}
+    </div>
+  )
+}
+
+/** Tiny card-back glyph for the hand count (cross-platform safe, unlike 🂠). */
+function HandCountIcon({ color = '#8899bb' }: { color?: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 11,
+        borderRadius: 2,
+        border: `1px solid ${color}`,
+        background: 'linear-gradient(135deg, rgba(120,140,200,0.35), rgba(40,50,90,0.6))',
+        flexShrink: 0,
+      }}
+    />
+  )
+}
+
+function RailChip({
+  opponent,
+  isViewed,
+  viewPinned,
+  spectatorMode,
+}: {
+  opponent: ClientPlayer
+  isViewed: boolean
+  viewPinned: boolean
+  spectatorMode: boolean
+}) {
+  const responsive = useResponsiveContext()
+  const gameState = useGameStore(selectGameState)
+  const viewOpponent = useGameStore((state) => state.viewOpponent)
+  const unpinView = useGameStore((state) => state.unpinView)
+
+  // Targeting plumbing — mirrors LifeDisplay's player-click handling so a rail
+  // chip is a full substitute for the absorbed opponent life orb.
+  const targetingState = useGameStore((state) => state.targetingState)
+  const pendingDecision = useGameStore((state) => state.pendingDecision)
+  const addTarget = useGameStore((state) => state.addTarget)
+  const removeTarget = useGameStore((state) => state.removeTarget)
+  const submitTargetsDecision = useGameStore((state) => state.submitTargetsDecision)
+  const decisionSelectionState = useGameStore((state) => state.decisionSelectionState)
+  const toggleDecisionSelection = useGameStore((state) => state.toggleDecisionSelection)
+  const distributeState = useGameStore((state) => state.distributeState)
+  const incrementDistribute = useGameStore((state) => state.incrementDistribute)
+  const decrementDistribute = useGameStore((state) => state.decrementDistribute)
+
+  // Combat (defender assignment + planeswalker flyout)
+  const combatState = useGameStore((state) => state.combatState)
+  const assignDefender = useGameStore((state) => state.assignDefenderToSelectedAttackers)
+  const draggingAttackerId = useGameStore((state) => state.draggingAttackerId)
+
+  const opponentDecisionStatus = useGameStore((state) => state.opponentDecisionStatus)
+
+  const playerId = opponent.playerId
+  const seatIndex = useSeatIndex(playerId)
+  const seat = seatColor(Math.max(0, seatIndex))
+
+  const isActiveTurn = gameState?.activePlayerId === playerId && !opponent.hasLost
+  const hasPriority = gameState?.priorityPlayerId === playerId && !opponent.hasLost
+  const isDeciding = opponentDecisionStatus?.playerId === playerId
+
+  /* ── Targeting state (player as target) ──────────────────────────────── */
+  const isValidTargetingTarget = targetingState?.validTargets.includes(playerId) ?? false
+  const isTargetingSelected = targetingState?.selectedTargets.includes(playerId) ?? false
+  const isChooseTargetsDecision = pendingDecision?.type === 'ChooseTargetsDecision'
+  const isSingleRequirementDecision = isChooseTargetsDecision && pendingDecision.targetRequirements.length === 1
+  const decisionLegalTargets = isSingleRequirementDecision ? (pendingDecision.legalTargets[0] ?? []) : []
+  const isValidDecisionTarget = decisionLegalTargets.includes(playerId)
+  const isValidDecisionSelection = decisionSelectionState?.validOptions.includes(playerId) ?? false
+  const isSelectedDecisionOption = decisionSelectionState?.selectedOptions.includes(playerId) ?? false
+  const isPlayerTargetable = isValidTargetingTarget || isValidDecisionTarget || isValidDecisionSelection
+  const isPlayerTargetSelected = isTargetingSelected || isSelectedDecisionOption
+
+  const isDistributeTarget = distributeState?.targets.includes(playerId) ?? false
+  const distributeAllocated = isDistributeTarget ? (distributeState?.distribution[playerId] ?? 0) : 0
+  const distributeTotal = distributeState
+    ? Object.values(distributeState.distribution).reduce((sum, v) => sum + v, 0)
+    : 0
+  const distributeRemaining = distributeState ? distributeState.totalAmount - distributeTotal : 0
+
+  /* ── "Contains targets" halo: their board (off-screen or not) holds valid
+        targets of the in-progress selection ─────────────────────────────── */
+  const boardHasTargets = useMemo(() => {
+    if (!gameState || opponent.hasLost) return false
+    const ids = targetingState?.validTargets ?? decisionSelectionState?.validOptions
+    if (!ids || ids.length === 0) return false
+    return ids.some((id) => gameState.cards[id]?.controllerId === playerId)
+  }, [gameState, targetingState?.validTargets, decisionSelectionState?.validOptions, playerId, opponent.hasLost])
+
+  /* ── Combat: this chip is a defender drop/click target while declaring ── */
+  const declaringAttackers = combatState?.mode === 'declareAttackers'
+  const hasSelectedAttackers = declaringAttackers && (combatState?.selectedAttackers.length ?? 0) > 0
+  const isDefenderTarget =
+    !spectatorMode &&
+    !opponent.hasLost &&
+    declaringAttackers &&
+    (combatState?.validAttackTargets.includes(playerId) ?? false)
+  const isDefenderAssignTarget = isDefenderTarget && (hasSelectedAttackers || draggingAttackerId !== null)
+  const assignedCount = useMemo(() => {
+    if (!declaringAttackers || !combatState || !gameState) return 0
+    return Object.entries(combatState.attackerTargets).filter(([, targetId]) => {
+      if (targetId === playerId) return true
+      return gameState.cards[targetId]?.controllerId === playerId
+    }).length
+  }, [declaringAttackers, combatState, gameState, playerId])
+
+  // Planeswalker flyout: this opponent's planeswalkers that are legal attack targets.
+  const attackablePlaneswalkers = useMemo<readonly ClientCard[]>(() => {
+    if (!declaringAttackers || !combatState || !gameState) return []
+    return combatState.validAttackTargets
+      .map((id) => gameState.cards[id])
+      .filter((c): c is ClientCard => !!c && c.controllerId === playerId)
+  }, [declaringAttackers, combatState, gameState, playerId])
+  const [hovered, setHovered] = useState(false)
+
+  /* ── Attention pulse on life / hand changes ─────────────────────────── */
+  const prevLifeRef = useRef(opponent.life)
+  const prevHandRef = useRef(opponent.handSize)
+  const [pulse, setPulse] = useState<{ color: string; key: number } | null>(null)
+  useEffect(() => {
+    const lifeDelta = opponent.life - prevLifeRef.current
+    const handChanged = opponent.handSize !== prevHandRef.current
+    prevLifeRef.current = opponent.life
+    prevHandRef.current = opponent.handSize
+    if (lifeDelta < 0) {
+      setPulse({ color: 'rgba(255, 68, 68, 0.55)', key: Date.now() })
+    } else if (lifeDelta > 0 || handChanged) {
+      setPulse({ color: seat.soft, key: Date.now() })
+    }
+  }, [opponent.life, opponent.handSize, seat.soft])
+
+  const worstCommanderDamage = useMemo(() => {
+    const entries = opponent.commanderDamage ?? []
+    if (entries.length === 0) return null
+    return entries.reduce((worst, e) => (e.amount > worst.amount ? e : worst))
+  }, [opponent.commanderDamage])
+
+  const handleChipClick = () => {
+    if (spectatorMode) {
+      if (!opponent.hasLost) viewOpponent(playerId)
+      return
+    }
+    // Defender assignment takes precedence while declaring attackers with a
+    // selection — assigning is an input action, not a view change.
+    if (isDefenderTarget && hasSelectedAttackers) {
+      assignDefender(playerId)
+      return
+    }
+    if (opponent.hasLost) return
+    if (isViewed) {
+      // Re-click the viewed chip toggles the pin (Esc also unpins).
+      if (viewPinned) unpinView()
+      else viewOpponent(playerId)
+      return
+    }
+    // A view change never cancels an in-progress selection.
+    viewOpponent(playerId)
+  }
+
+  // Mirrors LifeDisplay.handleClick — the chip's crosshair badge is the
+  // player-level target click in multiplayer.
+  const handleTargetClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (targetingState) {
+      if (isTargetingSelected) {
+        removeTarget(playerId)
+        return
+      }
+      if (isValidTargetingTarget) {
+        addTarget(playerId)
+        return
+      }
+    }
+    if (isChooseTargetsDecision && isValidDecisionTarget) {
+      submitTargetsDecision({ 0: [playerId] })
+      return
+    }
+    if (isValidDecisionSelection) {
+      toggleDecisionSelection(playerId)
+    }
+  }
+
+  const compact = responsive.isMobile
+  const tomb = opponent.hasLost
+
+  const borderColor = tomb
+    ? '#3a3a44'
+    : isDefenderAssignTarget
+      ? '#ff4444'
+      : isViewed
+        ? seat.bright
+        : seat.base
+  const background = tomb
+    ? 'rgba(18, 18, 24, 0.85)'
+    : isViewed
+      ? `linear-gradient(180deg, ${seat.soft}, rgba(10, 12, 20, 0.92))`
+      : 'rgba(10, 12, 20, 0.88)'
+
+  const ringShadow = [
+    isActiveTurn ? `0 0 0 2px ${seat.bright}, 0 0 10px ${seat.soft}` : null,
+    isDefenderAssignTarget ? '0 0 12px rgba(255, 68, 68, 0.6)' : null,
+  ].filter(Boolean).join(', ')
+
+  const lifeDanger = opponent.life <= 5
+
+  return (
+    <div style={{ position: 'relative', pointerEvents: 'auto' }}>
+      <div
+        data-rail-chip={playerId}
+        data-player-id={playerId}
+        data-life-id={playerId}
+        data-life-display={playerId}
+        role="button"
+        title={chipTitle(opponent)}
+        onClick={handleChipClick}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          position: 'relative',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: compact ? 4 : 7,
+          height: compact ? 22 : 26,
+          padding: compact ? '0 7px' : '0 11px',
+          borderRadius: 999,
+          border: `${isViewed ? 2 : 1}px solid ${borderColor}`,
+          background,
+          color: tomb ? '#666' : '#dde3f0',
+          cursor: tomb && !spectatorMode ? 'default' : 'pointer',
+          userSelect: 'none',
+          whiteSpace: 'nowrap',
+          filter: tomb ? 'grayscale(1)' : 'none',
+          opacity: tomb ? 0.6 : 1,
+          transition: 'border-color 150ms, background 150ms, opacity 200ms',
+          ...(ringShadow ? { boxShadow: ringShadow } : {}),
+          ...(boardHasTargets && !isViewed
+            ? {
+                animation: 'railHalo 1.2s ease-in-out infinite',
+                ['--halo-color' as string]: 'rgba(0, 187, 255, 0.7)',
+              }
+            : {}),
+        }}
+      >
+        {/* Attention pulse overlay — keyed so each event restarts the animation
+            without remounting the chip (which would drop hover state). */}
+        {pulse && (
+          <span
+            key={pulse.key}
+            aria-hidden
+            style={{
+              position: 'absolute',
+              inset: 0,
+              borderRadius: 999,
+              pointerEvents: 'none',
+              animation: 'railChipPulse 650ms ease-out',
+              ['--pulse-color' as string]: pulse.color,
+            }}
+          />
+        )}
+        {/* Viewed marker / seat dot / skull */}
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: tomb ? 'transparent' : seat.base,
+            boxShadow: tomb ? 'none' : `0 0 5px ${seat.base}`,
+            fontSize: 10,
+            flexShrink: 0,
+          }}
+        >
+          {tomb ? '💀' : ''}
+        </span>
+
+        {/* Name (hidden on phones — the seat dot + position carries identity) */}
+        {!compact && (
+          <span
+            style={{
+              maxWidth: 110,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.02em',
+              color: tomb ? '#666' : seat.bright,
+            }}
+          >
+            {opponent.name}
+            {isViewed && viewPinned && !spectatorMode && (
+              <span aria-hidden title="Pinned — follow-the-action paused" style={{ marginLeft: 4 }}>📌</span>
+            )}
+          </span>
+        )}
+
+        {/* Life — also the anchor for floating ±life deltas (data-life-display) */}
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 3,
+            fontSize: compact ? 11 : 13,
+            fontWeight: 800,
+            fontVariantNumeric: 'tabular-nums',
+            color: tomb ? '#555' : lifeDanger ? '#ff5555' : '#ffffff',
+            textDecoration: tomb ? 'line-through' : 'none',
+          }}
+        >
+          <span aria-hidden style={{ color: tomb ? '#555' : '#ff6b6b', fontSize: compact ? 10 : 12 }}>❤</span>
+          {opponent.life}
+        </span>
+
+        {/* Hand count */}
+        {!tomb && (
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 3,
+              fontSize: compact ? 10 : 12,
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+              color: '#9fb0d0',
+            }}
+          >
+            <HandCountIcon />
+            {opponent.handSize}
+          </span>
+        )}
+
+        {/* Poison */}
+        {!tomb && opponent.poisonCounters > 0 && (
+          <span
+            title={`${opponent.poisonCounters}/10 poison counters`}
+            style={{ fontSize: compact ? 10 : 11, fontWeight: 800, color: '#71f5a7' }}
+          >
+            ☠{opponent.poisonCounters}
+          </span>
+        )}
+
+        {/* Commander damage (worst pair; full rows in the tooltip) */}
+        {!tomb && worstCommanderDamage && worstCommanderDamage.amount > 0 && (
+          <span
+            title={(opponent.commanderDamage ?? [])
+              .map((e) => `${e.commanderName}: ${e.amount}/${e.threshold}`)
+              .join('\n')}
+            style={{
+              fontSize: compact ? 10 : 11,
+              fontWeight: 800,
+              fontVariantNumeric: 'tabular-nums',
+              color:
+                worstCommanderDamage.threshold - worstCommanderDamage.amount <= 3
+                  ? '#ff5555'
+                  : worstCommanderDamage.threshold - worstCommanderDamage.amount <= 7
+                    ? '#ffae7a'
+                    : '#b9925f',
+            }}
+          >
+            ⚔{worstCommanderDamage.amount}/{worstCommanderDamage.threshold}
+          </span>
+        )}
+
+        {/* Attack assignment count while declaring attackers */}
+        {!tomb && declaringAttackers && assignedCount > 0 && (
+          <span
+            title={`${assignedCount} attacker${assignedCount === 1 ? '' : 's'} assigned to ${opponent.name}`}
+            style={{ fontSize: compact ? 10 : 11, fontWeight: 800, color: '#ff8888' }}
+          >
+            ⚔︎→{assignedCount}
+          </span>
+        )}
+
+        {/* Deciding spinner / priority dot / (turn ring is the border glow) */}
+        {isDeciding ? (
+          <span
+            aria-hidden
+            title={opponentDecisionStatus?.displayText ?? 'Deciding'}
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              border: '2px solid rgba(255, 193, 7, 0.3)',
+              borderTopColor: '#ffc107',
+              animation: 'railSpin 0.9s linear infinite',
+              flexShrink: 0,
+            }}
+          />
+        ) : hasPriority && !isActiveTurn ? (
+          <span
+            aria-hidden
+            title="Holding priority"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: '#ffc107',
+              boxShadow: '0 0 5px rgba(255, 193, 7, 0.8)',
+              flexShrink: 0,
+            }}
+          />
+        ) : null}
+
+        {/* Crosshair badge — targets the player; the rest of the chip only switches the view */}
+        {!spectatorMode && (isPlayerTargetable || isPlayerTargetSelected) && (
+          <button
+            onClick={handleTargetClick}
+            title={isPlayerTargetSelected ? `Unselect ${opponent.name}` : `Target ${opponent.name}`}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              border: `2px solid ${isPlayerTargetSelected ? '#ffff00' : '#ff4444'}`,
+              background: isPlayerTargetSelected ? 'rgba(120, 120, 0, 0.5)' : 'rgba(80, 10, 10, 0.7)',
+              color: isPlayerTargetSelected ? '#ffff66' : '#ff7777',
+              fontSize: 11,
+              lineHeight: 1,
+              cursor: 'pointer',
+              padding: 0,
+              boxShadow: isPlayerTargetSelected
+                ? '0 0 10px rgba(255, 255, 0, 0.7)'
+                : '0 0 8px rgba(255, 68, 68, 0.7)',
+              flexShrink: 0,
+            }}
+          >
+            ⊕
+          </button>
+        )}
+
+        {/* Inline distribute controls (damage split across players) */}
+        {!spectatorMode && isDistributeTarget && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }} onClick={(e) => e.stopPropagation()}>
+            <button
+              onClick={() => decrementDistribute(playerId)}
+              disabled={distributeAllocated <= (distributeState?.minPerTarget ?? 0)}
+              style={distributeButtonStyle(distributeAllocated > (distributeState?.minPerTarget ?? 0), '#dc2626')}
+            >
+              -
+            </button>
+            <span style={{ color: '#fff', fontSize: 11, fontWeight: 800, minWidth: 12, textAlign: 'center' }}>
+              {distributeAllocated}
+            </span>
+            <button
+              onClick={() => incrementDistribute(playerId)}
+              disabled={distributeRemaining <= 0}
+              style={distributeButtonStyle(distributeRemaining > 0, '#16a34a')}
+            >
+              +
+            </button>
+          </span>
+        )}
+      </div>
+
+      {/* Planeswalker flyout — assign attacks to this player's planeswalkers
+          without sliding their board in. */}
+      {hovered && isDefenderTarget && hasSelectedAttackers && attackablePlaneswalkers.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            marginTop: 4,
+            display: 'flex',
+            gap: 6,
+            padding: 6,
+            borderRadius: 8,
+            background: 'rgba(8, 10, 18, 0.95)',
+            border: `1px solid ${seat.base}`,
+            boxShadow: '0 4px 14px rgba(0, 0, 0, 0.5)',
+            zIndex: 130,
+          }}
+        >
+          {attackablePlaneswalkers.map((pw) => (
+            <button
+              key={pw.id}
+              onClick={(e) => {
+                e.stopPropagation()
+                assignDefender(pw.id)
+                setHovered(false)
+              }}
+              title={`Attack ${pw.name}`}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 2,
+                padding: '4px 6px',
+                borderRadius: 6,
+                border: '1px solid rgba(255, 120, 120, 0.5)',
+                background: 'rgba(60, 12, 12, 0.7)',
+                color: '#ffb3b3',
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: 'pointer',
+                maxWidth: 110,
+              }}
+            >
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 100 }}>
+                {pw.name}
+              </span>
+              {pw.counters.LOYALTY != null && <span style={{ color: '#e0c068' }}>◆ {pw.counters.LOYALTY}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function distributeButtonStyle(enabled: boolean, activeColor: string): React.CSSProperties {
+  return {
+    width: 16,
+    height: 16,
+    borderRadius: 3,
+    border: 'none',
+    backgroundColor: enabled ? activeColor : '#333',
+    color: enabled ? 'white' : '#666',
+    fontSize: 11,
+    fontWeight: 'bold',
+    cursor: enabled ? 'pointer' : 'not-allowed',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+    lineHeight: 1,
+  }
+}
+
+function chipTitle(opponent: ClientPlayer): string {
+  const lines = [
+    opponent.name,
+    `Life ${opponent.life} · Hand ${opponent.handSize} · Library ${opponent.librarySize} · Graveyard ${opponent.graveyardSize}`,
+  ]
+  if (opponent.poisonCounters > 0) lines.push(`Poison ${opponent.poisonCounters}/10`)
+  for (const e of opponent.commanderDamage ?? []) {
+    lines.push(`⚔ ${e.commanderName}: ${e.amount}/${e.threshold}`)
+  }
+  if (opponent.hasLost) lines.push('Eliminated')
+  return lines.join('\n')
+}

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -330,9 +330,18 @@ function RailChip({
     <div style={{ position: 'relative', pointerEvents: 'auto' }}>
       <div
         data-rail-chip={playerId}
-        data-player-id={playerId}
-        data-life-id={playerId}
-        data-life-display={playerId}
+        // The viewed opponent's full-size life orb (center HUD) carries the
+        // player anchors while their board is in view — the chip only anchors
+        // arrows / damage floats / target clicks for off-screen opponents.
+        // Duplicate anchors would make querySelector pick whichever comes
+        // first in the DOM.
+        {...(!isViewed
+          ? {
+              'data-player-id': playerId,
+              'data-life-id': playerId,
+              'data-life-display': playerId,
+            }
+          : {})}
         role="button"
         title={chipTitle(opponent)}
         onClick={handleChipClick}

--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -40,9 +40,18 @@ const ATTACHMENT_COLLAPSE_THRESHOLD = 3
  * styles.ts) and overrides ResponsiveContext with slot-derived card sizes
  * via useSlotSizedResponsive — so cards never overflow into the center HUD.
  */
-export function Battlefield({ isOpponent, spectatorMode = false }: { isOpponent: boolean; spectatorMode?: boolean }) {
+export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
+  isOpponent: boolean
+  /**
+   * Scope an opponent battlefield to one seat's permanents (multiplayer opponent
+   * boards). Omitted → all non-viewing-player permanents (the 2-player shape; in a
+   * 2-player game the two are identical).
+   */
+  playerId?: EntityId
+  spectatorMode?: boolean
+}) {
   const slotRef = useRef<HTMLDivElement>(null)
-  const cards = useBattlefieldCards()
+  const cards = useBattlefieldCards(isOpponent ? playerId : undefined)
   const lands = isOpponent ? cards.opponentLands : cards.playerLands
   const creatures = isOpponent ? cards.opponentCreatures : cards.playerCreatures
   const planeswalkers = isOpponent ? cards.opponentPlaneswalkers : cards.playerPlaneswalkers

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react'
+import type React from 'react'
+import type { ClientPlayer } from '@/types'
+import { hand } from '@/types'
+import { useRevealedLibraryTopCard } from '@/store/selectors'
+import { Battlefield } from './Battlefield'
+import { CardRow } from './HandZone'
+import { CommandZone } from './CommandZone'
+import { ZonePile } from './ZonePiles'
+import { styles } from './styles'
+
+/**
+ * One opponent's half of the board: hand fan (top), command zone | battlefield |
+ * zone piles. This is today's 2-player opponent half, parameterized by player.
+ *
+ * Two layouts:
+ * - `grid` — the classic 2-player placement: the hand is position:fixed at the
+ *   viewport top and the board area is a direct grid child on row 2. Renders the
+ *   exact markup GameBoard always had, so the 2-player game is pixel-identical.
+ * - `strip` — a multiplayer slide item: the component renders a full-height
+ *   strip cell; the hand is absolutely positioned inside it (so it slides with
+ *   the board) above a reservation band matching grid row 1, and the board area
+ *   fills the rest. Card scale machinery (slot sizing) is identical in both.
+ */
+export function OpponentBoardArea({
+  opponent,
+  layout,
+  topOffset,
+  handReservation = 0,
+  spectatorMode,
+  isHijacking,
+  hijackedSurfaceStyle,
+}: {
+  opponent: ClientPlayer
+  layout: 'grid' | 'strip'
+  topOffset: number
+  /** Strip layout only: height of the hand reservation band (grid row 1 height). */
+  handReservation?: number
+  spectatorMode: boolean
+  /** This opponent's seat is currently driven by this client (Mindslaver / hotseat). */
+  isHijacking: boolean
+  hijackedSurfaceStyle?: React.CSSProperties
+}) {
+  const revealedTopCard = useRevealedLibraryTopCard(opponent.playerId)
+  const ghostCards = useMemo(
+    () => (revealedTopCard ? [revealedTopCard] : []),
+    [revealedTopCard]
+  )
+
+  /* Opponent hand — fixed at top of screen in grid layout; absolute inside the
+     strip cell in strip layout (a strip cell starts at the viewport top, so the
+     same `top` offset lands in the same place — but the hand travels with its
+     board during slides). The face-up promotion during a Mindslaver-style hijack
+     is itself the strongest signal that the controller is driving this hand. */
+  const handBlock = (
+    <div
+      data-zone="opponent-hand"
+      style={{
+        position: layout === 'grid' ? 'fixed' : 'absolute',
+        top: topOffset,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 50,
+      }}
+    >
+      <CardRow
+        zoneId={hand(opponent.playerId)}
+        faceDown={!isHijacking}
+        small
+        inverted
+        interactive={isHijacking}
+        ghostCards={isHijacking ? [] : ghostCards}
+      />
+    </div>
+  )
+
+  const boardBlock = (
+    <div
+      style={
+        layout === 'grid'
+          ? styles.opponentArea
+          : {
+              // styles.opponentArea minus the grid-row binding — the strip cell
+              // provides the vertical slot instead.
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
+              minHeight: 0,
+              overflow: 'hidden',
+              flex: 1,
+              width: '100%',
+            }
+      }
+    >
+      <div style={{ ...styles.playerRowWithZones, alignItems: 'flex-start' }}>
+        {/* Opponent command zone (left side) — Commander format only; renders nothing otherwise. */}
+        <CommandZone player={opponent} isOpponent />
+
+        <div
+          style={{
+            ...styles.playerMainArea,
+            ...(isHijacking ? hijackedSurfaceStyle : null),
+          }}
+        >
+          {/* Opponent battlefield - lands first (closer to opponent), then creatures */}
+          <Battlefield isOpponent playerId={opponent.playerId} spectatorMode={spectatorMode} />
+        </div>
+
+        {/* Opponent deck/graveyard (right side) */}
+        <ZonePile player={opponent} isOpponent />
+      </div>
+    </div>
+  )
+
+  if (layout === 'grid') {
+    return (
+      <>
+        {handBlock}
+        {boardBlock}
+      </>
+    )
+  }
+
+  return (
+    <div
+      data-opponent-board={opponent.playerId}
+      style={{
+        flex: '0 0 100%',
+        minWidth: '100%',
+        height: '100%',
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {handBlock}
+      {/* Reservation band mirrors grid row 1 so the board area below aligns
+          exactly with the 2-player opponent area (grid row 2). */}
+      <div style={{ height: handReservation, flexShrink: 0 }} aria-hidden />
+      {boardBlock}
+    </div>
+  )
+}

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -1,5 +1,7 @@
+import type React from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
-import { useStackCards } from '@/store/selectors.ts'
+import { useStackCards, selectGameState } from '@/store/selectors.ts'
+import { seatColor } from '@/styles/seatColors'
 import type { EntityId } from '@/types'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { ActiveEffectBadges } from '../card/CardOverlays'
@@ -23,6 +25,16 @@ export function StackDisplay() {
   const toggleDecisionSelection = useGameStore((state) => state.toggleDecisionSelection)
   const pendingDecision = useGameStore((state) => state.pendingDecision)
   const gameState = useGameStore((state) => state.gameState)
+  // Multiplayer: stack items carry their caster's seat color (left border) so
+  // "whose spell is that" reads at a glance. Inactive in 2-player games.
+  const players = useGameStore((state) => selectGameState(state)?.players)
+  const isMulti = (players?.length ?? 0) > 2
+  const seatBorderFor = (controllerId: EntityId): React.CSSProperties => {
+    if (!isMulti || !players) return {}
+    const idx = players.findIndex((p) => p.playerId === controllerId)
+    if (idx < 0) return {}
+    return { borderLeft: `3px solid ${seatColor(idx).base}`, borderRadius: 6 }
+  }
 
   // Trigger YesNo: show source card in stack area when a triggered ability has a triggering entity
   const isTriggerYesNo = pendingDecision?.type === 'YesNoDecision'
@@ -118,6 +130,7 @@ export function StackDisplay() {
                     ...styles.stackItem,
                     marginTop: index === 0 ? 0 : -stackImageHeight + cardOffset, // Overlap cards, showing cardOffset pixels of each
                     zIndex: index + 1, // Later cards (higher index = cast later) on top
+                    ...seatBorderFor(card.controllerId),
                     ...(isValidTarget && !isSelectedTarget ? {
                       boxShadow: '0 0 12px 4px rgba(255, 200, 0, 0.8)',
                       borderRadius: 6,

--- a/web-client/src/components/game/board/index.ts
+++ b/web-client/src/components/game/board/index.ts
@@ -1,4 +1,5 @@
 export { Battlefield } from './Battlefield'
+export { OpponentBoardArea } from './OpponentBoardArea'
 export { CardRow, HandFan } from './HandZone'
 export { CommandZone } from './CommandZone'
 export { StackDisplay } from './StackZone'

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -385,6 +385,16 @@ function GameCardImpl({
   const isSelectedAsBlocker = isInBlockerMode && !!(combatState?.blockerAssignments[card.id]?.length)
   const isAttackingInBlockerMode = isInBlockerMode && opponentForCombat && combatState.attackingCreatures.includes(card.id)
   const isMustBeBlocked = isInBlockerMode && opponentForCombat && combatState.mustBeBlockedAttackers.includes(card.id)
+  // Multiplayer: an attacker in this combat that is attacking a *different*
+  // defender — you can't block it (CR 509.1b), so render it dimmed while you
+  // declare blocks. `attackingCreatures` is already scoped to attacks on the
+  // acting defender, so in a 2-player game this is never true.
+  const isBystanderAttacker = useGameStore((state) => {
+    if (!isInBlockerMode || !opponentForCombat) return false
+    if (combatState?.attackingCreatures.includes(card.id)) return false
+    const combat = (state.spectatingState?.gameState ?? state.gameState)?.combat
+    return combat?.attackers.some((a) => a.creatureId === card.id) ?? false
+  })
 
   // For attacker mode: check if this is an opponent's planeswalker that can be attacked
   const isValidPlaneswalkerTarget = isInAttackerMode && opponentForCombat && combatState.validAttackTargets.includes(card.id)
@@ -1150,7 +1160,7 @@ function GameCardImpl({
         boxShadow: card.isCommander && !faceDown
           ? `${boxShadow}, 0 0 6px 2px rgba(212, 175, 55, 0.6), 0 0 14px 4px rgba(212, 175, 55, 0.3)`
           : boxShadow,
-        opacity: isPhasedOut ? 0.4 : isBeingDragged ? 0.6 : isGhost ? 0.55 : (inHand && isInTargetingMode && !isValidTarget && !isBeingCast) ? 0.35 : 1,
+        opacity: isPhasedOut ? 0.4 : isBeingDragged ? 0.6 : isGhost ? 0.55 : isBystanderAttacker ? 0.45 : (inHand && isInTargetingMode && !isValidTarget && !isBeingCast) ? 0.35 : 1,
         // Phased-out permanents (Rule 702.26) are treated as though they don't exist —
         // desaturate so they read as "not really there" while still showing the board slot.
         ...(isPhasedOut ? { filter: 'grayscale(0.7)' } : {}),

--- a/web-client/src/components/game/overlay/LifeDisplay.tsx
+++ b/web-client/src/components/game/overlay/LifeDisplay.tsx
@@ -171,8 +171,14 @@ export function LifeDisplay({
   // (otherwise the name itself already carries the same information) and when
   // not spectating (there's no "you" in spectator mode).
   const showRoleTag = !spectatorMode && !!playerName
-  const roleColor = isPlayer ? 'rgba(74, 154, 234, 0.7)' : 'rgba(255, 158, 70, 0.8)'
-  const roleBorder = isPlayer ? 'rgba(74, 154, 234, 0.35)' : 'rgba(255, 158, 70, 0.4)'
+  // Seat-tinted in multiplayer (SEAT_COLORS are 6-digit hex, so appending an
+  // alpha byte gives the translucent variants the tag uses).
+  const roleColor = isPlayer
+    ? 'rgba(74, 154, 234, 0.7)'
+    : seatColor ? `${seatColor}CC` : 'rgba(255, 158, 70, 0.8)'
+  const roleBorder = isPlayer
+    ? 'rgba(74, 154, 234, 0.35)'
+    : seatColor ? `${seatColor}66` : 'rgba(255, 158, 70, 0.4)'
 
   // On phones the side-by-side name labels push past the screen edges (the
   // step strip leaves them no room) — show a small name *under* the orb

--- a/web-client/src/components/game/overlay/LifeDisplay.tsx
+++ b/web-client/src/components/game/overlay/LifeDisplay.tsx
@@ -17,6 +17,7 @@ export function LifeDisplay({
   spectatorMode = false,
   poisonCounters = 0,
   commanderDamage,
+  seatColor,
 }: {
   life: number
   isPlayer?: boolean
@@ -25,6 +26,11 @@ export function LifeDisplay({
   spectatorMode?: boolean
   poisonCounters?: number
   commanderDamage?: readonly ClientCommanderDamage[]
+  /**
+   * Multiplayer: the player's seat-identity color — tints the orb border and
+   * name so the viewed opponent's orb visibly matches their rail chip.
+   */
+  seatColor?: string
 }) {
   const responsive = useResponsiveContext()
   const targetingState = useGameStore((state) => state.targetingState)
@@ -38,10 +44,23 @@ export function LifeDisplay({
   const decisionSelectionState = useGameStore((state) => state.decisionSelectionState)
   const toggleDecisionSelection = useGameStore((state) => state.toggleDecisionSelection)
   const draggingAttackerId = useGameStore((state) => state.draggingAttackerId)
+  const combatState = useGameStore((state) => state.combatState)
+  const assignDefenderToSelectedAttackers = useGameStore((state) => state.assignDefenderToSelectedAttackers)
+  const isMultiplayer = useGameStore(
+    (state) => ((state.spectatingState?.gameState ?? state.gameState)?.players.length ?? 0) > 2,
+  )
 
-  // Check if an attacker is being dragged and this is the opponent's life display
+  // Check if an attacker is being dragged and this is the opponent's life display.
+  // In multiplayer the orb is also a click target while attackers are selected
+  // (assign-defender), so it highlights for both gestures.
   const isDraggingAttacker = draggingAttackerId !== null
-  const isAttackDropTarget = isDraggingAttacker && !isPlayer
+  const isDefenderClickTarget =
+    isMultiplayer &&
+    !isPlayer &&
+    combatState?.mode === 'declareAttackers' &&
+    combatState.selectedAttackers.length > 0 &&
+    combatState.validAttackTargets.includes(playerId)
+  const isAttackDropTarget = (isDraggingAttacker && !isPlayer) || isDefenderClickTarget
 
   // Check if this player is a valid target in current targeting mode
   const isValidTargetingTarget = targetingState?.validTargets.includes(playerId) ?? false
@@ -72,6 +91,20 @@ export function LifeDisplay({
   const isSelected = isTargetingSelected || isSelectedDecisionOption
 
   const handleClick = () => {
+    // Multiplayer attack declaration: clicking a defender's orb assigns the
+    // selected attackers to them (same gesture as the rail chips, biggest
+    // target). 2-player keeps its implicit sole-defender default untouched.
+    if (
+      isMultiplayer &&
+      !isPlayer &&
+      combatState?.mode === 'declareAttackers' &&
+      combatState.selectedAttackers.length > 0 &&
+      combatState.validAttackTargets.includes(playerId)
+    ) {
+      assignDefenderToSelectedAttackers(playerId)
+      return
+    }
+
     // Handle inline distribute mode - click to add damage
     if (isDistributeTarget && distributeRemaining > 0) {
       incrementDistribute(playerId)
@@ -118,9 +151,9 @@ export function LifeDisplay({
           ? '#ff4444' // Red glow if valid target
           : isAttackDropTarget
             ? '#ff4444' // Red highlight when attacker being dragged
-            : isPlayer ? '#3a7aba' : '#e08038'
+            : isPlayer ? '#3a7aba' : seatColor ?? '#e08038'
 
-  const cursor = isValidTarget || isDistributeTarget ? 'pointer' : 'default'
+  const cursor = isValidTarget || isDistributeTarget || isDefenderClickTarget ? 'pointer' : 'default'
   const boxShadow = isDistributeTarget && distributeAllocated > 0
     ? '0 0 16px rgba(255, 107, 53, 0.7), 0 0 32px rgba(255, 107, 53, 0.4)'
     : isDistributeTarget
@@ -163,7 +196,7 @@ export function LifeDisplay({
           fontSize: 12,
           fontWeight: 700,
           letterSpacing: '0.5px',
-          color: isPlayer ? '#4a9aea' : '#ff9e46',
+          color: isPlayer ? '#4a9aea' : seatColor ?? '#ff9e46',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -269,7 +302,7 @@ export function LifeDisplay({
             fontSize: 9,
             fontWeight: 700,
             letterSpacing: '0.4px',
-            color: isPlayer ? '#4a9aea' : '#ff9e46',
+            color: isPlayer ? '#4a9aea' : seatColor ?? '#ff9e46',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',

--- a/web-client/src/components/scenario/ScenarioBuilderPage.tsx
+++ b/web-client/src/components/scenario/ScenarioBuilderPage.tsx
@@ -21,6 +21,7 @@ import type {
   ScenarioBattlefieldCard,
   ScenarioCreateResponse,
   ScenarioMode,
+  ScenarioSeatSpec,
   ScenarioSpec,
   ScenarioZone,
 } from './types'
@@ -60,7 +61,7 @@ const MODE_HINT: Record<ScenarioMode, string> = {
 
 // --- spec <-> builder conversions ----------------------------------------------------------
 
-function toSpec(p1: BuilderPlayer, p2: BuilderPlayer, opts: {
+function toSpec(p1: BuilderPlayer, p2: BuilderPlayer, extraSeats: ScenarioSeatSpec[], opts: {
   phase: string
   activePlayer: number
   mode: ScenarioMode
@@ -83,7 +84,18 @@ function toSpec(p1: BuilderPlayer, p2: BuilderPlayer, opts: {
     activePlayer: opts.activePlayer,
     mode: opts.mode,
   }
-  if (opts.mode === 'AI') spec.aiPlayer = 2
+  if (extraSeats.length > 0) {
+    // N-player pod: send the full seat list (the server prefers it over the
+    // legacy two-seat fields). Pods only support hotseat.
+    spec.players = [
+      { name: p1.name, config: playerConfig(p1) },
+      { name: p2.name, config: playerConfig(p2) },
+      ...extraSeats,
+    ]
+    spec.mode = 'SELF'
+  } else if (opts.mode === 'AI') {
+    spec.aiPlayer = 2
+  }
   return spec
 }
 
@@ -111,6 +123,9 @@ export function ScenarioBuilderPage() {
 
   const [p1, setP1] = useState<BuilderPlayer>(() => emptyPlayer('Player 1'))
   const [p2, setP2] = useState<BuilderPlayer>(() => emptyPlayer('Player 2'))
+  // Seats 3-4 of an N-player pod. Named here; their boards are edited via the
+  // JSON editor (the visual panels stay two-seat). A pod always starts hotseat.
+  const [extraSeats, setExtraSeats] = useState<ScenarioSeatSpec[]>([])
   const [phase, setPhase] = useState<string>('PRECOMBAT_MAIN')
   const [activePlayer, setActivePlayer] = useState<number>(1)
   const [mode, setMode] = useState<ScenarioMode>('SELF')
@@ -209,8 +224,18 @@ export function ScenarioBuilderPage() {
   }, [searchParams])
 
   const applySpec = useCallback((spec: ScenarioSpec) => {
-    setP1(playerFromSpec(spec.player1Name ?? 'Player 1', spec.player1))
-    setP2(playerFromSpec(spec.player2Name ?? 'Player 2', spec.player2))
+    const seats = spec.players
+    if (seats && seats.length >= 2) {
+      // N-player spec: first two seats land in the editable panels, the rest
+      // ride along as extra pod seats.
+      setP1(playerFromSpec(seats[0]?.name ?? 'Player 1', seats[0]?.config))
+      setP2(playerFromSpec(seats[1]?.name ?? 'Player 2', seats[1]?.config))
+      setExtraSeats(seats.slice(2).map((s) => ({ ...s })))
+    } else {
+      setP1(playerFromSpec(spec.player1Name ?? 'Player 1', spec.player1))
+      setP2(playerFromSpec(spec.player2Name ?? 'Player 2', spec.player2))
+      setExtraSeats([])
+    }
     if (spec.phase) setPhase(spec.phase)
     if (spec.activePlayer) setActivePlayer(spec.activePlayer)
     if (spec.mode) setMode(spec.mode)
@@ -265,8 +290,8 @@ export function ScenarioBuilderPage() {
 
   // --- actions -------------------------------------------------------------
   const currentSpec = useCallback(
-    () => toSpec(p1, p2, { phase, activePlayer, mode }),
-    [p1, p2, phase, activePlayer, mode],
+    () => toSpec(p1, p2, extraSeats, { phase, activePlayer, mode }),
+    [p1, p2, extraSeats, phase, activePlayer, mode],
   )
 
   const handleLoadJson = useCallback(() => {
@@ -493,13 +518,59 @@ export function ScenarioBuilderPage() {
           <div style={S.settingsTitle}>Settings</div>
           <label style={S.field}>
             <span style={S.smallLabel}>Opponent</span>
-            <select value={mode} style={S.select} onChange={(e) => setMode(e.target.value as ScenarioMode)}>
+            <select
+              value={extraSeats.length > 0 ? 'SELF' : mode}
+              style={S.select}
+              disabled={extraSeats.length > 0}
+              onChange={(e) => setMode(e.target.value as ScenarioMode)}
+            >
               <option value="SELF">Yourself (hotseat)</option>
               <option value="AI">AI</option>
               <option value="TWO_PLAYER">Two players</option>
             </select>
-            <span style={S.hint}>{MODE_HINT[mode]}</span>
+            <span style={S.hint}>
+              {extraSeats.length > 0
+                ? 'Pods of 3-4 seats always start as hotseat — you control every seat.'
+                : MODE_HINT[mode]}
+            </span>
           </label>
+          <div style={S.field}>
+            <span style={S.smallLabel}>Pod seats (3-4 player)</span>
+            {extraSeats.map((seat, i) => (
+              <div key={i} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <input
+                  style={{ ...S.select, flex: 1 }}
+                  value={seat.name ?? ''}
+                  placeholder={`Player ${i + 3}`}
+                  onChange={(e) =>
+                    setExtraSeats((prev) =>
+                      prev.map((s, j) => (j === i ? { ...s, name: e.target.value } : s)),
+                    )
+                  }
+                />
+                <button
+                  style={S.ghostBtn}
+                  title="Remove this seat"
+                  onClick={() => setExtraSeats((prev) => prev.filter((_, j) => j !== i))}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            {extraSeats.length < 2 && (
+              <button
+                style={S.ghostBtn}
+                onClick={() =>
+                  setExtraSeats((prev) => [...prev, { name: `Player ${prev.length + 3}` }])
+                }
+              >
+                + Add seat
+              </button>
+            )}
+            <span style={S.hint}>
+              Extra seats start with an empty board (20 life) — give them cards via the JSON editor.
+            </span>
+          </div>
           <label style={S.field}>
             <span style={S.smallLabel}>Phase</span>
             <select value={phase} style={S.select} onChange={(e) => setPhase(e.target.value)}>

--- a/web-client/src/components/scenario/types.ts
+++ b/web-client/src/components/scenario/types.ts
@@ -27,12 +27,23 @@ export interface ScenarioPlayerConfig {
   commanders?: string[]
 }
 
+/** One seat of an N-player scenario (matches backend `ScenarioSeat`). */
+export interface ScenarioSeatSpec {
+  name?: string
+  config?: ScenarioPlayerConfig
+}
+
 /** Full scenario request (matches backend `ScenarioRequest`). */
 export interface ScenarioSpec {
   player1Name?: string
   player2Name?: string
   player1?: ScenarioPlayerConfig
   player2?: ScenarioPlayerConfig
+  /**
+   * N-player seats (3-4 player pods), in turn order. Overrides the legacy two-seat
+   * fields when present. Pods of more than two seats start as SELF (hotseat).
+   */
+  players?: ScenarioSeatSpec[]
   phase?: string
   step?: string
   activePlayer?: number
@@ -54,6 +65,8 @@ export interface ScenarioCreateResponse {
   player2: ScenarioPlayerInfo
   message: string
   mode?: ScenarioMode
+  /** Full seat roster in turn order (present for pods of more than two seats). */
+  players?: ScenarioPlayerInfo[]
 }
 
 /** The zones a card can be added to in the builder. */

--- a/web-client/src/components/spectating/SpectatorGameBoard.tsx
+++ b/web-client/src/components/spectating/SpectatorGameBoard.tsx
@@ -48,9 +48,24 @@ const HEADER_HEIGHT = 55
 export function SpectatorGameBoard() {
   const spectatingState = useGameStore((state) => state.spectatingState)
   const stopSpectating = useGameStore((state) => state.stopSpectating)
+  const spectatorBottomSeatId = useGameStore((state) => state.spectatorBottomSeatId)
+  const setSpectatorBottomSeat = useGameStore((state) => state.setSpectatorBottomSeat)
 
   // Not spectating - render nothing
   if (!spectatingState) return null
+
+  // Multiplayer pods: the header gains a seat-switcher that cycles which seat's
+  // perspective anchors the bottom half (the rail + board strip carry the rest).
+  const players = spectatingState.gameState?.players ?? []
+  const isMultiPod = players.length > 2
+  const bottomSeatId = spectatorBottomSeatId ?? spectatingState.player1Id
+  const bottomSeat = players.find((p) => p.playerId === bottomSeatId) ?? players[0] ?? null
+  const cycleSeat = () => {
+    if (players.length === 0 || !bottomSeat) return
+    const idx = players.findIndex((p) => p.playerId === bottomSeat.playerId)
+    const next = players[(idx + 1) % players.length]
+    if (next) setSpectatorBottomSeat(next.playerId)
+  }
 
   // Loading state - waiting for server to send game state
   if (!spectatingState.gameState) {
@@ -79,6 +94,12 @@ export function SpectatorGameBoard() {
           player1Name={spectatingState.player1Name}
           player2Name={spectatingState.player2Name}
           onBack={stopSpectating}
+          {...(isMultiPod
+            ? {
+                matchupOverride: players.map((p) => p.name).join(' · '),
+                seatSwitcher: { bottomName: bottomSeat?.name ?? '?', onCycle: cycleSeat },
+              }
+            : {})}
         />
         <div style={styles.gameBoardContainer}>
           <GameBoard spectatorMode topOffset={HEADER_HEIGHT} />
@@ -136,10 +157,16 @@ function SpectatorHeader({
   player1Name,
   player2Name,
   onBack,
+  matchupOverride,
+  seatSwitcher,
 }: {
   player1Name: string
   player2Name: string
   onBack: () => void
+  /** Multiplayer pods: full roster text instead of "A vs B". */
+  matchupOverride?: string
+  /** Multiplayer pods: cycle which seat's perspective anchors the bottom half. */
+  seatSwitcher?: { bottomName: string; onCycle: () => void }
 }) {
   return (
     <div style={styles.header}>
@@ -149,11 +176,21 @@ function SpectatorHeader({
       <div style={styles.headerCenter}>
         <div style={styles.spectatingLabel}>Spectating</div>
         <div style={styles.matchupText}>
-          {player1Name} vs {player2Name}
+          {matchupOverride ?? `${player1Name} vs ${player2Name}`}
         </div>
       </div>
-      {/* Spacer to balance the back button */}
-      <div style={styles.headerSpacer} />
+      {seatSwitcher ? (
+        <button
+          onClick={seatSwitcher.onCycle}
+          title="Cycle which player's view anchors the bottom of the board"
+          style={{ ...styles.backButton, whiteSpace: 'nowrap' }}
+        >
+          View: {seatSwitcher.bottomName} ⟳
+        </button>
+      ) : (
+        /* Spacer to balance the back button */
+        <div style={styles.headerSpacer} />
+      )}
     </div>
   )
 }

--- a/web-client/src/components/targeting/TargetingArrows.tsx
+++ b/web-client/src/components/targeting/TargetingArrows.tsx
@@ -163,15 +163,32 @@ function findParentHost(cardId: EntityId, gameState: ClientGameState | null): En
 }
 
 /**
+ * Multiplayer: a card on a slid-away opponent board has an off-viewport anchor —
+ * remap it to its controller's rail chip (which carries `data-player-id`) so the
+ * arrow says "whose spell, at whom" instead of pointing off the screen edge.
+ * In a 2-player game nothing is off-screen and this is a no-op.
+ */
+function remapOffscreenAnchor(p: Point, cardId: EntityId, gameState: ClientGameState | null): Point {
+  if (!gameState || gameState.players.length <= 2) return p
+  if (p.x >= -4 && p.x <= window.innerWidth + 4) return p
+  const controller = gameState.cards[cardId]?.controllerId
+  if (!controller) return p
+  return getPlayerCenter(controller) ?? p
+}
+
+/**
  * Resolve a card to an arrow anchor point. Falls back to the card's parent host when the
  * attachment/linked-exile is collapsed and not rendered directly in the DOM — without the
  * fallback, arrows silently drop for targets inside a collapsed stack.
  */
 function resolveCardAnchor(cardId: EntityId, gameState: ClientGameState | null): Point | null {
   const direct = getCardCenter(cardId)
-  if (direct) return direct
+  if (direct) return remapOffscreenAnchor(direct, cardId, gameState)
   const parentId = findParentHost(cardId, gameState)
-  if (parentId) return getCardCenter(parentId)
+  if (parentId) {
+    const parent = getCardCenter(parentId)
+    if (parent) return remapOffscreenAnchor(parent, parentId, gameState)
+  }
   return null
 }
 
@@ -242,7 +259,8 @@ export function TargetingArrows() {
   const stackCards = useStackCards()
   const pendingDecision = useGameStore((state) => state.pendingDecision)
   const lastDamageDistribution = useGameStore((state) => state.lastDamageDistribution)
-  const gameState = useGameStore((state) => state.gameState)
+  // Spectator-aware: anchors must resolve against the state being rendered.
+  const gameState = useGameStore((state) => state.spectatingState?.gameState ?? state.gameState)
   const [arrows, setArrows] = useState<TargetArrow[]>([])
 
   // Hide arrows during full-screen overlay decisions (e.g., ChooseColorDecision)

--- a/web-client/src/components/ui/OpponentDecisionIndicator.tsx
+++ b/web-client/src/components/ui/OpponentDecisionIndicator.tsx
@@ -7,6 +7,13 @@ import { useGameStore } from '@/store/gameStore.ts'
 export function OpponentDecisionIndicator() {
   const opponentDecisionStatus = useGameStore((s) => s.opponentDecisionStatus)
   const opponentName = useGameStore((s) => s.opponentName)
+  // The status carries the deciding seat's id — name it directly (with N players
+  // "the opponent" is ambiguous; in 2-player this resolves to the same name).
+  const decidingName = useGameStore((s) => {
+    const id = s.opponentDecisionStatus?.playerId
+    if (!id) return null
+    return s.gameState?.players.find((p) => p.playerId === id)?.name ?? null
+  })
 
   if (!opponentDecisionStatus) return null
 
@@ -15,7 +22,7 @@ export function OpponentDecisionIndicator() {
       <div style={styles.spinner} />
       <div>
         <div style={styles.text}>
-          {opponentName ?? 'Opponent'} is {opponentDecisionStatus.displayText.toLowerCase()}
+          {decidingName ?? opponentName ?? 'Opponent'} is {opponentDecisionStatus.displayText.toLowerCase()}
         </div>
         {opponentDecisionStatus.sourceName && (
           <div style={styles.sourceText}>

--- a/web-client/src/hooks/useMultiplayerView.ts
+++ b/web-client/src/hooks/useMultiplayerView.ts
@@ -1,0 +1,83 @@
+import { useEffect } from 'react'
+import { useGameStore } from '@/store/gameStore'
+import { selectGameState, selectViewingPlayerId } from '@/store/selectors'
+import type { ClientPlayer } from '@/types'
+
+/**
+ * Multiplayer camera controls: follow-the-action and keyboard board switching.
+ *
+ * Follow-the-action moves the viewed opponent board only on *coarse* boundaries —
+ * an opponent's turn starting, or the attacking player's board when you're being
+ * attacked — and is refused inside `followViewTo` whenever the player has any
+ * pending input (the camera never moves under an in-progress selection) or has
+ * pinned the view.
+ *
+ * Keyboard: 1..9 select the Nth living opponent (in rail order); Esc unpins.
+ */
+export function useMultiplayerView(enabled: boolean, opponents: readonly ClientPlayer[]) {
+  const gameState = useGameStore(selectGameState)
+  const viewingPlayerId = useGameStore(selectViewingPlayerId)
+  const followViewTo = useGameStore((state) => state.followViewTo)
+
+  const activePlayerId = gameState?.activePlayerId ?? null
+  const priorityPlayerId = gameState?.priorityPlayerId ?? null
+  const hotseat = gameState?.hotseat ?? false
+  const combat = gameState?.combat ?? null
+
+  // Turn boundary: slide to the active opponent when their turn starts.
+  useEffect(() => {
+    if (!enabled || !activePlayerId || !viewingPlayerId) return
+    if (activePlayerId === viewingPlayerId) return
+    followViewTo(activePlayerId)
+  }, [enabled, activePlayerId, viewingPlayerId, followViewTo])
+
+  // Being attacked: slide to the attacking player's board.
+  useEffect(() => {
+    if (!enabled || !combat || !viewingPlayerId || !gameState) return
+    if (combat.attackingPlayerId === viewingPlayerId) return
+    const attacksMe = combat.attackers.some((a) =>
+      a.attackingTarget.type === 'Player'
+        ? a.attackingTarget.playerId === viewingPlayerId
+        : gameState.cards[a.attackingTarget.permanentId]?.controllerId === viewingPlayerId
+    )
+    if (attacksMe) followViewTo(combat.attackingPlayerId)
+  }, [enabled, combat, viewingPlayerId, gameState, followViewTo])
+
+  // Hotseat dev loop: the single connection acts for whichever seat holds
+  // priority — keep that seat's board in view so its permanents are clickable.
+  useEffect(() => {
+    if (!enabled || !hotseat || !priorityPlayerId || !viewingPlayerId) return
+    if (priorityPlayerId === viewingPlayerId) return
+    followViewTo(priorityPlayerId)
+  }, [enabled, hotseat, priorityPlayerId, viewingPlayerId, followViewTo])
+
+  // Keyboard switching.
+  useEffect(() => {
+    if (!enabled) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      if (target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) return
+      const store = useGameStore.getState()
+      if (e.key >= '1' && e.key <= '9') {
+        // Number keys also activate abilities while a card's action menu is open —
+        // that interaction wins.
+        if (store.selectedCardId) return
+        const living = opponents.filter((o) => !o.hasLost)
+        const picked = living[Number(e.key) - 1]
+        if (picked) store.viewOpponent(picked.playerId)
+      } else if (e.key === 'Escape') {
+        // Esc means "cancel" inside selection modes; only unpin when idle.
+        if (
+          !store.targetingState &&
+          !store.decisionSelectionState &&
+          !store.manaSelectionState &&
+          !store.combatState
+        ) {
+          store.unpinView()
+        }
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [enabled, opponents])
+}

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -9,6 +9,7 @@ import type {
   ZoneId,
 } from '@/types'
 import { ZoneType, zoneIdEquals, graveyard, library } from '@/types'
+import { seatColor, type SeatColor } from '@/styles/seatColors'
 
 /**
  * Select the game state (works for both normal play and spectating).
@@ -29,10 +30,13 @@ export const selectIsSpectating = (state: GameStore) => state.spectatingState !=
 
 /**
  * Select the viewing player ID.
- * In spectator mode, returns player1Id as the "viewing" player (bottom of screen).
+ * In spectator mode, returns the seat anchoring the bottom of the screen — the
+ * seat-switcher override when set, else the stream's player1Id.
  */
 export const selectViewingPlayerId = (state: GameStore) =>
-  (state.spectatingState?.player1Id as EntityId | null) ?? state.playerId
+  (state.spectatingState
+    ? ((state.spectatorBottomSeatId ?? state.spectatingState.player1Id) as EntityId | null)
+    : null) ?? state.playerId
 
 /**
  * Select all legal actions.
@@ -183,6 +187,10 @@ export function useViewingPlayer(): ClientPlayer | null {
 
 /**
  * Hook to get the opponent player.
+ *
+ * 2-player shape: returns the sole opponent. In a multiplayer game this returns the
+ * first opponent in turn order — multiplayer-aware components should use
+ * [useOpponents] / [useViewedOpponent] instead.
  */
 export function useOpponent(): ClientPlayer | null {
   const gameState = useGameStore(selectGameState)
@@ -191,6 +199,73 @@ export function useOpponent(): ClientPlayer | null {
     if (!gameState || !playerId) return null
     return gameState.players.find((p) => p.playerId !== playerId) ?? null
   }, [gameState, playerId])
+}
+
+const EMPTY_PLAYERS: readonly ClientPlayer[] = Object.freeze([])
+
+/**
+ * True when the game has more than two seats — the switch that turns on the
+ * multiplayer chrome (opponent rail, board strip, seat colors). A 2-player game
+ * must render exactly as before.
+ */
+export const selectIsMultiplayerGame = (state: GameStore): boolean => {
+  const gameState = state.spectatingState?.gameState ?? state.gameState
+  return (gameState?.players.length ?? 0) > 2
+}
+
+/**
+ * All opponents of the viewing player, rotated to read in play order *after* the
+ * viewing player (server orders `players` by turn order). Includes players who
+ * have lost — they keep their seat for stable ordering and render as tombstones;
+ * filter `hasLost` where only live boards matter.
+ */
+export function useOpponents(): readonly ClientPlayer[] {
+  const gameState = useGameStore(selectGameState)
+  const playerId = useGameStore(selectViewingPlayerId)
+  return useMemo(() => {
+    if (!gameState || !playerId) return EMPTY_PLAYERS
+    const players = gameState.players
+    const selfIndex = players.findIndex((p) => p.playerId === playerId)
+    if (selfIndex === -1) return players.filter((p) => p.playerId !== playerId)
+    return [...players.slice(selfIndex + 1), ...players.slice(0, selfIndex)]
+  }, [gameState, playerId])
+}
+
+/**
+ * The opponent whose board occupies the viewed slot. Resolves the boardView
+ * selection with fallbacks: an eliminated or unknown selection falls back to the
+ * first opponent still in the game (or the first opponent, if all have lost).
+ */
+export function useViewedOpponent(): ClientPlayer | null {
+  const opponents = useOpponents()
+  const viewedOpponentId = useGameStore((state) => state.viewedOpponentId)
+  return useMemo(() => {
+    if (opponents.length === 0) return null
+    const selected = opponents.find((p) => p.playerId === viewedOpponentId)
+    if (selected && !selected.hasLost) return selected
+    return opponents.find((p) => !p.hasLost) ?? opponents[0] ?? null
+  }, [opponents, viewedOpponentId])
+}
+
+/**
+ * Seat index of a player = its index in the turn-ordered roster. Drives stable
+ * seat colors and rail ordering. -1 when unknown.
+ */
+export function useSeatIndex(playerId: EntityId | null): number {
+  const gameState = useGameStore(selectGameState)
+  return useMemo(() => {
+    if (!gameState || !playerId) return -1
+    return gameState.players.findIndex((p) => p.playerId === playerId)
+  }, [gameState, playerId])
+}
+
+/**
+ * The stable seat-identity color for a player (rail chip, combat arrows, stack
+ * borders, log names). Falls back to seat 0's hue for unknown players.
+ */
+export function useSeatColor(playerId: EntityId | null): SeatColor {
+  const seatIndex = useSeatIndex(playerId)
+  return seatColor(Math.max(0, seatIndex))
 }
 
 const EMPTY_ACTIONS: readonly LegalActionInfo[] = Object.freeze([])
@@ -353,8 +428,12 @@ function battlefieldCardsEqual(a: BattlefieldCards, b: BattlefieldCards): boolea
  * change the visible battlefield (hand draws, phase changes, etc.), we return the previous
  * object ref. That lets `Battlefield` and its downstream `useMemo`s bail out entirely —
  * without this, every server message replaces every card ref and forces a re-render.
+ *
+ * `opponentId` scopes the opponent* groups to one seat's permanents (a multiplayer
+ * opponent board). When omitted, the opponent groups hold everything the viewing
+ * player doesn't control — the 2-player shape, unchanged.
  */
-export function useBattlefieldCards(): BattlefieldCards {
+export function useBattlefieldCards(opponentId?: EntityId | null): BattlefieldCards {
   const gameState = useGameStore(selectGameState)
   const playerId = useGameStore(selectViewingPlayerId)
   const previousRef = useRef<BattlefieldCards | null>(null)
@@ -398,7 +477,9 @@ export function useBattlefieldCards(): BattlefieldCards {
 
     const isNotAttached = (c: ClientCard) => !c.attachedTo
     const playerCards = cards.filter((c) => c.controllerId === playerId)
-    const opponentCards = cards.filter((c) => c.controllerId !== playerId)
+    const opponentCards = opponentId
+      ? cards.filter((c) => c.controllerId === opponentId)
+      : cards.filter((c) => c.controllerId !== playerId)
 
     const isLand = (c: ClientCard) => c.cardTypes.includes('LAND')
     const isCreature = (c: ClientCard) => c.cardTypes.includes('CREATURE')
@@ -444,7 +525,7 @@ export function useBattlefieldCards(): BattlefieldCards {
     }
     previousRef.current = result
     return result
-  }, [gameState, playerId])
+  }, [gameState, playerId, opponentId])
 }
 
 /**

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -420,13 +420,14 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
 
     onGameStarted: (msg) => {
       // Derive "the opponent" from the seat roster — the first non-you seat. For 2-player this is
-      // the sole opponent; the N-player opponent rail is Phase 3 client work.
+      // the sole opponent; the N-player UI derives everything from gameState.players directly.
       const opponentName = msg.players.find((p) => !p.isYou)?.name ?? 'Opponent'
-      trackEvent('game_started', { opponent_name: opponentName })
+      trackEvent('game_started', { opponent_name: opponentName, seats: msg.players.length })
       setInGame(true)
 
-      // Clear spectating state — active game takes priority
+      // Clear spectating state — active game takes priority. Fresh game, fresh camera.
       set({ spectatingState: null })
+      get().resetBoardView()
 
       // Load persisted stop overrides and send to server
       try {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -115,6 +115,20 @@ export interface TargetingState {
  */
 export interface CombatState {
   mode: 'declareAttackers' | 'declareBlockers'
+  /**
+   * The seat this declaration is being made for, from the legal action's
+   * `playerId`. Matters in multiplayer: a hotseat connection declares for the
+   * acting seat, and a defender's blocks are scoped to the attackers attacking
+   * *them* (CR 509.1b). Null when unknown (legacy 2-player fallbacks apply).
+   */
+  actingSeat: EntityId | null
+  /**
+   * Multiplayer declare-attackers: the last defender the player assigned —
+   * newly selected attackers default to it (sticky assignment). Null until the
+   * first defender pick; never set in 2-player games (the sole opponent is the
+   * implicit default).
+   */
+  stickyDefenderId: EntityId | null
   /** Selected attackers (creature IDs) */
   selectedAttackers: readonly EntityId[]
   /** Attack target per attacker: attacker ID -> defender ID (player or planeswalker). If absent, defaults to opponent player. */
@@ -886,6 +900,18 @@ export type GameStore = {
   advancePipeline: (result: PhaseResult) => void
   cancelPipeline: () => void
 
+  // Board view slice (multiplayer viewed-opponent board + follow-the-action camera)
+  viewedOpponentId: EntityId | null
+  viewPinned: boolean
+  followAction: boolean
+  spectatorBottomSeatId: EntityId | null
+  viewOpponent: (playerId: EntityId, opts?: { pin?: boolean }) => void
+  unpinView: () => void
+  toggleFollowAction: () => void
+  followViewTo: (playerId: EntityId) => void
+  setSpectatorBottomSeat: (playerId: EntityId | null) => void
+  resetBoardView: () => void
+
   // UI slice
   selectedCardId: EntityId | null
   targetingState: TargetingState | null
@@ -961,6 +987,7 @@ export type GameStore = {
   startDraggingAttacker: (attackerId: EntityId, hasBanding?: boolean) => void
   stopDraggingAttacker: () => void
   setAttackTarget: (attackerId: EntityId, targetId: EntityId) => void
+  assignDefenderToSelectedAttackers: (defenderId: EntityId) => void
   startDraggingCard: (cardId: EntityId) => void
   stopDraggingCard: () => void
   confirmCombat: () => void

--- a/web-client/src/store/slices/ui/boardViewSlice.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.ts
@@ -1,0 +1,121 @@
+/**
+ * Board-view sub-slice — which opponent's board occupies the viewed slot in a
+ * multiplayer (3-4 player) game, plus the follow-the-action camera settings.
+ *
+ * Written by rail-chip clicks, keyboard (1/2/3), swipe, and the follow-the-action
+ * rules. In a 2-player game none of this state is consulted — the sole opponent is
+ * always the viewed board and the rail doesn't render.
+ */
+import type { SliceCreator, EntityId } from '../types'
+
+const FOLLOW_ACTION_KEY = 'argentum-follow-action'
+
+function loadFollowAction(): boolean {
+  try {
+    return localStorage.getItem(FOLLOW_ACTION_KEY) !== 'false'
+  } catch {
+    return true
+  }
+}
+
+export interface BoardViewSliceState {
+  /**
+   * The opponent whose board is slid into view. Null = default (first opponent
+   * after the viewing player in turn order). Selectors fall back when this player
+   * has lost or left the game.
+   */
+  viewedOpponentId: EntityId | null
+  /**
+   * True when the player manually selected a board — suspends follow-the-action
+   * until unpinned (re-click the viewed chip / Esc).
+   */
+  viewPinned: boolean
+  /** Follow-the-action camera setting (persisted). Default on. */
+  followAction: boolean
+  /**
+   * Spectator/replay: which seat anchors the bottom half of the board. Null =
+   * the stream's default (`spectatingState.player1Id`). Set by the spectator
+   * seat-switcher in multiplayer pods.
+   */
+  spectatorBottomSeatId: EntityId | null
+}
+
+export interface BoardViewSliceActions {
+  /** Manual board select (chip click, keyboard, swipe). Pins by default. */
+  viewOpponent: (playerId: EntityId, opts?: { pin?: boolean }) => void
+  /** Unpin the camera (re-enables follow-the-action). */
+  unpinView: () => void
+  /** Toggle the follow-the-action setting (persisted). */
+  toggleFollowAction: () => void
+  /**
+   * Follow-the-action write. Refused at the handler (not at render time) when the
+   * view is pinned, following is off, or the player has any pending input — the
+   * camera must never move under an in-progress selection.
+   */
+  followViewTo: (playerId: EntityId) => void
+  /** Spectator/replay: anchor the bottom half to a seat (null = stream default). */
+  setSpectatorBottomSeat: (playerId: EntityId | null) => void
+  /** Reset on game start / leave. */
+  resetBoardView: () => void
+}
+
+export type BoardViewSlice = BoardViewSliceState & BoardViewSliceActions
+
+export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => ({
+  viewedOpponentId: null,
+  viewPinned: false,
+  followAction: loadFollowAction(),
+  spectatorBottomSeatId: null,
+
+  viewOpponent: (playerId, opts) => {
+    const { gameState, playerId: ownId } = get()
+    // Only opponents occupy the viewed slot — your half is sacred.
+    if (playerId === ownId && !get().spectatingState) return
+    if (gameState && !gameState.players.some((p) => p.playerId === playerId)) return
+    set({ viewedOpponentId: playerId, viewPinned: opts?.pin ?? true })
+  },
+
+  unpinView: () => set({ viewPinned: false }),
+
+  toggleFollowAction: () => {
+    const next = !get().followAction
+    try {
+      localStorage.setItem(FOLLOW_ACTION_KEY, String(next))
+    } catch {
+      // Private mode — setting just won't persist.
+    }
+    set({ followAction: next })
+  },
+
+  followViewTo: (playerId) => {
+    const state = get()
+    if (!state.followAction || state.viewPinned) return
+    if (state.viewedOpponentId === playerId) return
+    // Never move the camera while the player has a pending input or an
+    // in-progress selection (stale-UI-suppression applies to camera movement).
+    // declare-blockers is the one exception: sliding the attacker's board in is
+    // exactly what a defender needs, and blocking happens on your own (always
+    // visible) half — so only an in-progress *attack* declaration blocks it.
+    if (
+      state.targetingState ||
+      state.decisionSelectionState ||
+      state.pendingDecision ||
+      state.combatState?.mode === 'declareAttackers' ||
+      state.distributeState ||
+      state.counterDistributionState ||
+      state.manaSelectionState ||
+      state.delveSelectionState ||
+      state.tapForPowerSelectionState ||
+      state.pipelineState
+    ) {
+      return
+    }
+    set({ viewedOpponentId: playerId })
+  },
+
+  setSpectatorBottomSeat: (playerId) =>
+    set({ spectatorBottomSeatId: playerId, viewedOpponentId: null, viewPinned: false }),
+
+  resetBoardView: () =>
+    set({ viewedOpponentId: null, viewPinned: false, spectatorBottomSeatId: null }),
+})

--- a/web-client/src/store/slices/ui/combatSlice.ts
+++ b/web-client/src/store/slices/ui/combatSlice.ts
@@ -18,15 +18,17 @@ import { getWebSocket } from '../shared'
 /**
  * The seat a combat declaration should be tagged with. Normally the connection's own seat;
  * in single-client hotseat the one connection declares for whichever seat the server is
- * asking — the active player for attackers, the defending player for blockers.
+ * asking — the acting seat recorded from the legal action, falling back to the active
+ * player for attackers / the (2-player) defending player for blockers.
  */
 function combatActingSeat(
-  mode: string,
+  combatState: { mode: string; actingSeat: EntityId | null },
   connectionSeat: EntityId,
   gameState: ClientGameState | null,
 ): EntityId {
   if (!gameState?.hotseat) return connectionSeat
-  if (mode === 'declareAttackers') return gameState.activePlayerId
+  if (combatState.actingSeat) return combatState.actingSeat
+  if (combatState.mode === 'declareAttackers') return gameState.activePlayerId
   return (
     gameState.combat?.defendingPlayerId ??
     gameState.players.find((p) => p.playerId !== gameState.activePlayerId)?.playerId ??
@@ -54,6 +56,12 @@ export interface CombatSliceActions {
   startCombat: (state: CombatState) => void
   toggleAttacker: (creatureId: EntityId) => void
   setAttackTarget: (attackerId: EntityId, targetId: EntityId) => void
+  /**
+   * Multiplayer defender pick: assign every currently selected attacker to
+   * [defenderId] (a player or planeswalker) and make it the sticky default for
+   * attackers selected afterwards. Driven by rail-chip / defender-pick clicks.
+   */
+  assignDefenderToSelectedAttackers: (defenderId: EntityId) => void
   assignBlocker: (blockerId: EntityId, attackerId: EntityId) => void
   removeBlockerAssignment: (blockerId: EntityId) => void
   clearBlockerAssignments: () => void
@@ -123,10 +131,13 @@ export const createCombatSlice: SliceCreator<CombatSlice> = (set, get) => ({
         ? state.combatState.selectedAttackers.filter((id) => id !== creatureId)
         : [...state.combatState.selectedAttackers, creatureId]
 
-      // Clean up attackerTargets if deselecting
+      // Clean up attackerTargets if deselecting; sticky-assign on select when a
+      // defender has already been picked this declaration (multiplayer).
       const newTargets = { ...state.combatState.attackerTargets }
       if (isSelected) {
         delete newTargets[creatureId]
+      } else if (state.combatState.stickyDefenderId && !newTargets[creatureId]) {
+        newTargets[creatureId] = state.combatState.stickyDefenderId
       }
 
       // Prune bands when an attacker is deselected: drop the creature from every band,
@@ -170,6 +181,29 @@ export const createCombatSlice: SliceCreator<CombatSlice> = (set, get) => ({
         combatState: {
           ...state.combatState,
           attackerTargets: newTargets,
+        },
+      }
+    })
+  },
+
+  assignDefenderToSelectedAttackers: (defenderId) => {
+    set((state) => {
+      if (!state.combatState || state.combatState.mode !== 'declareAttackers') {
+        return state
+      }
+      const newTargets = { ...state.combatState.attackerTargets }
+      for (const attackerId of state.combatState.selectedAttackers) {
+        newTargets[attackerId] = defenderId
+      }
+      getWebSocket()?.send(createUpdateAttackerTargetsMessage(
+        [...state.combatState.selectedAttackers],
+        newTargets,
+      ))
+      return {
+        combatState: {
+          ...state.combatState,
+          attackerTargets: newTargets,
+          stickyDefenderId: defenderId,
         },
       }
     })
@@ -268,19 +302,25 @@ export const createCombatSlice: SliceCreator<CombatSlice> = (set, get) => ({
     const { combatState, playerId, gameState } = get()
     if (!combatState || !playerId) return
     // In hotseat the single connection declares for whichever seat the server is asking:
-    // the active player for attackers, the defending player for blockers.
-    const actingSeat = combatActingSeat(combatState.mode, playerId, gameState)
+    // the acting seat from the legal action (active player / defending player fallback).
+    const actingSeat = combatActingSeat(combatState, playerId, gameState)
 
     if (combatState.mode === 'declareAttackers') {
       if (!gameState) return
 
-      const opponent = gameState.players.find((p) => p.playerId !== actingSeat)
-      if (!opponent) return
+      // Default defender for attackers without an explicit assignment: the sticky
+      // defender (multiplayer pick), else the first opponent still in the game —
+      // which in a 2-player game is the sole opponent, as before.
+      const defaultDefender =
+        combatState.stickyDefenderId ??
+        gameState.players.find((p) => p.playerId !== actingSeat && !p.hasLost)?.playerId ??
+        gameState.players.find((p) => p.playerId !== actingSeat)?.playerId
+      if (!defaultDefender) return
 
       const attackers: Record<EntityId, EntityId> = {}
       for (const attackerId of combatState.selectedAttackers) {
-        // Use per-attacker target if set, otherwise default to opponent player
-        attackers[attackerId] = combatState.attackerTargets[attackerId] ?? opponent.playerId
+        // Use per-attacker target if set, otherwise default to the defender above
+        attackers[attackerId] = combatState.attackerTargets[attackerId] ?? defaultDefender
       }
 
       // Drop bands that no longer satisfy CR 702.22 (after attacker deselection /
@@ -337,7 +377,7 @@ export const createCombatSlice: SliceCreator<CombatSlice> = (set, get) => ({
   cancelCombat: () => {
     const { combatState, playerId, gameState } = get()
     if (!combatState || !playerId) return
-    const actingSeat = combatActingSeat(combatState.mode, playerId, gameState)
+    const actingSeat = combatActingSeat(combatState, playerId, gameState)
 
     if (combatState.mode === 'declareAttackers') {
       const action = {

--- a/web-client/src/store/slices/ui/index.ts
+++ b/web-client/src/store/slices/ui/index.ts
@@ -8,6 +8,7 @@
  * - distributionSlice: Damage distribution, distribute decisions, counter distribution
  * - animationSlice: Card selection, hover, animations, reveals, match intro
  * - pipelineSlice: Action pipeline coordinator (multi-phase action flow)
+ * - boardViewSlice: Multiplayer viewed-opponent board + follow-the-action camera
  */
 import { createTargetingSlice } from './targetingSlice'
 import { createCombatSlice } from './combatSlice'
@@ -15,6 +16,7 @@ import { createSelectionSlice } from './selectionSlice'
 import { createDistributionSlice } from './distributionSlice'
 import { createAnimationSlice } from './animationSlice'
 import { createPipelineSlice } from './pipelineSlice'
+import { createBoardViewSlice } from './boardViewSlice'
 import type { SliceCreator } from '../types'
 
 export interface UISliceState {
@@ -31,8 +33,9 @@ import type { SelectionSlice } from './selectionSlice'
 import type { DistributionSlice } from './distributionSlice'
 import type { AnimationSlice } from './animationSlice'
 import type { PipelineSlice } from './pipelineSlice'
+import type { BoardViewSlice } from './boardViewSlice'
 
-export type UISlice = TargetingSlice & CombatSlice & SelectionSlice & DistributionSlice & AnimationSlice & PipelineSlice
+export type UISlice = TargetingSlice & CombatSlice & SelectionSlice & DistributionSlice & AnimationSlice & PipelineSlice & BoardViewSlice
 
 export const createUISlice: SliceCreator<UISlice> = (...args) => ({
   ...createTargetingSlice(...args),
@@ -41,4 +44,5 @@ export const createUISlice: SliceCreator<UISlice> = (...args) => ({
   ...createDistributionSlice(...args),
   ...createAnimationSlice(...args),
   ...createPipelineSlice(...args),
+  ...createBoardViewSlice(...args),
 })

--- a/web-client/src/styles/seatColors.ts
+++ b/web-client/src/styles/seatColors.ts
@@ -1,0 +1,33 @@
+/**
+ * Seat identity colors for multiplayer (3-4 player) games.
+ *
+ * Four fixed, colorblind-safe hues (Okabe-Ito palette) assigned by seat index
+ * (= index in ClientGameState.players, which the server orders by turn order).
+ * Used consistently everywhere a player's identity matters in a pod: opponent
+ * rail chips, viewed-board edge flash, combat arrows, stack item borders, log
+ * entry names. One legend, everywhere.
+ *
+ * Only surfaced in games with more than two players — the 2-player UI keeps its
+ * existing your-vs-opponent color language untouched.
+ */
+export interface SeatColor {
+  /** Main identity color */
+  base: string
+  /** Brighter variant for rings/glows */
+  bright: string
+  /** Translucent variant for surfaces/washes */
+  soft: string
+}
+
+export const SEAT_COLORS: readonly SeatColor[] = [
+  { base: '#E69F00', bright: '#FFC846', soft: 'rgba(230, 159, 0, 0.22)' }, // amber
+  { base: '#56B4E9', bright: '#8ED4FF', soft: 'rgba(86, 180, 233, 0.22)' }, // sky blue
+  { base: '#CC79A7', bright: '#F0A3CF', soft: 'rgba(204, 121, 167, 0.22)' }, // orchid
+  { base: '#009E73', bright: '#2FD1A4', soft: 'rgba(0, 158, 115, 0.22)' }, // teal
+]
+
+/** Color for a seat index (wraps for safety; pods are capped at 4 seats). */
+export function seatColor(seatIndex: number): SeatColor {
+  const n = SEAT_COLORS.length
+  return SEAT_COLORS[((seatIndex % n) + n) % n]!
+}


### PR DESCRIPTION
Implements **Phase 3 — Client UI/UX (the centerpiece)** from `backlog/multiplayer.md`: the 3-4 player Free-for-All board. One opponent's board is shown full-size at a time and the others **slide into view** when selected; the overview guarantee is an always-visible **opponent rail** of summary chips. Every multiplayer code path is gated on `players.length > 2`, so the 2-player game renders its exact existing layout.

Also lands the previously deferred **Phase 1.4 dev loop**: `ScenarioRequest` accepts an N-player `players` seat list, so a 4-seat scenario starts as a single-client hotseat pod — that's how everything below was verified live.

## Layout: one viewed board + opponent rail (§3.1–3.3)

The opponent half becomes a horizontally sliding strip of full-size `OpponentBoardArea` cells (today's opponent half extracted; `grid` layout reproduces the 2-player markup byte-for-byte, `strip` cells hold one living opponent each, in turn order). The rail chips carry seat color, name, life, hand count, poison, commander-damage warning, active-turn ring, priority dot, deciding spinner, attention pulses, and tombstones. The **viewed opponent keeps a full-size life orb** in the classic center-HUD spot, seat-tinted to match their chip — the familiar, biggest click target for targeting and defender assignment. Player anchors (`data-player-id`/`data-life-id`/`data-life-display`) live on the orb for the viewed opponent and on the rail chip for everyone else — never both — so damage floats, arrows, and player-target clicks resolve unambiguously.

![4-player board with opponent rail](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-1-default.png)

Switching: rail-chip click (pins; re-click unpins), keyboard `1`–`3`, swipe, with a seat-colored edge flash on arrival. Follow-the-action slides on coarse boundaries only (turn start, being attacked, hotseat priority seat) and is **refused at the handler** while any input is pending.

![Board switched to another opponent via rail chip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-2-switched.png)

## Combat UX (§3.6)

Declare attackers with >1 possible defender: the first selection pops a one-time defender pick, assignment is sticky, and rail-chip clicks, the viewed defender's life orb, or the chip's planeswalker flyout reassign per-creature. **Confirm is disabled until every selected attacker has an explicit defender** — attacks are never silently misdirected.

![Defender pick on first attacker selection](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-4-defender-pick.png)

Attacks against the viewed defender render per-creature arrows in that defender's seat color; attacks against an off-screen defender bundle into **one arrow to their rail chip with a creature-count badge** (here: 1 attacker assigned to Cleo, whose board is slid away — her chip also shows the `⚔︎→1` assignment count):

![Bundled seat-colored arrow to an off-screen defender's chip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-5-assigned.png)

Assigning by clicking the viewed defender's seat-tinted life orb — the per-creature arrow renders in their seat color:

![Orb click assigns the defender; seat-colored per-creature arrow](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-8-orb-assign.png)

After confirmation the APNAP priority round runs and the defender's block decision opens (hotseat acts for each seat in turn). Attackers aimed at *other* defenders render dimmed (CR 509.1b); block scope and hotseat seat attribution come from the DeclareBlockers legal action's `playerId`:

![Defender's block decision — attacker highlighted, hotseat acting as Cleo](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp4p-6-blocks.png)

## Cross-seat targeting (§3.4), seat identity (§3.5), spectator (§3.8)

- Chip **halo** when the in-progress selection has valid targets on that opponent's board; **crosshair badge** targets the player while the chip body only switches the view (a view change never cancels a selection). Card anchors on slid-away boards remap to the controller's chip in `TargetingArrows` too.
- Seat colors (colorblind-safe Okabe-Ito, by turn-order seat index) on chips, arrows, attack chevrons, **stack item borders** (caster), and **log entry names**.
- Spectator/replay reuse the layout, with a bottom-seat switcher in the spectator header.

## 2-player parity

No rail, no strip, classic center-HUD life orb — verified by screenshot and the existing suites:

![2-player layout unchanged](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-phase3-screenshots/mp2p-parity.png)

## Verification

- Live 4-player hotseat pod (via the new N-seat scenario API): board switching, keyboard, defender pick → sticky assignment → bundled arrow → attack confirmation → APNAP priority → defender block decision.
- 2-player hotseat screenshot parity (`[data-opponent-rail]` absent, opponent `LifeDisplay` present).
- `game-server` test suite green; web-client `typecheck` + production build green.
- Playwright e2e not run locally (default ports were occupied by another running stack); the suite exercises only 2-player flows, which are behind the `players.length > 2` gate.

**Deferred** (noted in the backlog status): edge arrows, per-event chip pulses beyond life/hand deltas, log click-to-slide, touch long-press planeswalker flyout, and the 3-player Playwright e2e (part of Phase 4's ship gate).

> Screenshots are served from the throwaway `multiplayer-phase3-screenshots` branch — delete it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
