### PR TITLE
SOS: modal charm cards + mtgish emitter support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LoreholdCharm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LoreholdCharm.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Lorehold Charm
+ * {R}{W}
+ * Instant
+ * Choose one —
+ * • Each opponent sacrifices a nontoken artifact of their choice.
+ * • Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.
+ * • Creatures you control get +1/+1 and gain trample until end of turn.
+ */
+val LoreholdCharm = card("Lorehold Charm") {
+    manaCost = "{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Each opponent sacrifices a nontoken artifact of their choice.\n• Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.\n• Creatures you control get +1/+1 and gain trample until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Each opponent sacrifices a nontoken artifact of their choice") {
+                effect = Effects.Sacrifice(
+                    filter = GameObjectFilter.Artifact.nontoken(),
+                    target = EffectTarget.PlayerRef(Player.EachOpponent)
+                )
+            }
+            mode("Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield") {
+                val t = target(
+                    "target artifact or creature card with mana value 2 or less from your graveyard",
+                    TargetObject(
+                        filter = TargetFilter(
+                            GameObjectFilter.Artifact.ownedByYou().manaValueAtMost(2)
+                                .or(GameObjectFilter.Creature.ownedByYou().manaValueAtMost(2)),
+                            zone = Zone.GRAVEYARD
+                        )
+                    )
+                )
+                effect = Effects.PutOntoBattlefield(t)
+            }
+            mode("Creatures you control get +1/+1 and gain trample until end of turn") {
+                effect = Patterns.Group.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl) then
+                    Patterns.Group.grantKeywordToAll(Keyword.TRAMPLE, Filters.Group.creaturesYouControl)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "200"
+        artist = "Ksenia Kim"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fe70295-e550-4577-a341-dab6c25aabfd.jpg?1775938389"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PrismariCharm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PrismariCharm.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Prismari Charm
+ * {U}{R}
+ * Instant
+ * Choose one —
+ * • Surveil 2, then draw a card.
+ * • Prismari Charm deals 1 damage to each of one or two targets.
+ * • Return target nonland permanent to its owner's hand.
+ */
+val PrismariCharm = card("Prismari Charm") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Surveil 2, then draw a card.\n• Prismari Charm deals 1 damage to each of one or two targets.\n• Return target nonland permanent to its owner's hand."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Surveil 2, then draw a card") {
+                effect = Patterns.Library.surveil(2) then Effects.DrawCards(1)
+            }
+            mode("Prismari Charm deals 1 damage to each of one or two targets") {
+                target = AnyTarget(count = 2, minCount = 1)
+                effect = ForEachTargetEffect(
+                    effects = listOf(Effects.DealDamage(1, EffectTarget.ContextTarget(0)))
+                )
+            }
+            mode("Return target nonland permanent to its owner's hand") {
+                val t = target("target nonland permanent", Targets.NonlandPermanent)
+                effect = Effects.ReturnToHand(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f6c2a5e-fe13-407c-aadd-c9caf2884ff1.jpg?1775938465"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SilverquillCharm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SilverquillCharm.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Silverquill Charm
+ * {W}{B}
+ * Instant
+ * Choose one —
+ * • Put two +1/+1 counters on target creature.
+ * • Exile target creature with power 2 or less.
+ * • Each opponent loses 3 life and you gain 3 life.
+ */
+val SilverquillCharm = card("Silverquill Charm") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Put two +1/+1 counters on target creature.\n• Exile target creature with power 2 or less.\n• Each opponent loses 3 life and you gain 3 life."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Put two +1/+1 counters on target creature") {
+                val t = target("target creature", TargetCreature())
+                effect = Effects.AddCounters("+1+1", 2, t)
+            }
+            mode("Exile target creature with power 2 or less") {
+                val t = target(
+                    "target creature with power 2 or less",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtMost(2)))
+                )
+                effect = Effects.Exile(t)
+            }
+            mode("Each opponent loses 3 life and you gain 3 life") {
+                effect = Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent)) then
+                    Effects.GainLife(3, EffectTarget.Controller)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Ksenia Kim"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3eb73579-f1c6-4762-81d2-9568ab501fac.jpg?1775938570"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1123,6 +1123,135 @@
     ]
 }
 
+// Lorehold Charm
+{
+    "name": "Lorehold Charm",
+    "manaCost": "{R}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Each opponent sacrifices a nontoken artifact of their choice.\n• Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.\n• Creatures you control get +1/+1 and gain trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "artifact nontoken",
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    },
+                    "description": "Each opponent sacrifices a nontoken artifact of their choice"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or creature card with mana value 2 or less from your graveyard"
+                        },
+                        "destination": "Battlefield"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "ManaValueAtMost",
+                                                            "max": 2
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsCreature",
+                                                        {
+                                                            "type": "ManaValueAtMost",
+                                                            "max": 2
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "controllerPredicate": "OwnedByYou"
+                                },
+                                "zone": "Graveyard"
+                            },
+                            "id": "target artifact or creature card with mana value 2 or less from your graveyard"
+                        }
+                    ],
+                    "description": "Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "TRAMPLE",
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Creatures you control get +1/+1 and gain trample until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "UNCOMMON",
+        "artist": "Ksenia Kim",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fe70295-e550-4577-a341-dab6c25aabfd.jpg?1775938389"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
 // Masterful Flourish
 {
     "name": "Masterful Flourish",
@@ -1477,6 +1606,135 @@
     ]
 }
 
+// Prismari Charm
+{
+    "name": "Prismari Charm",
+    "manaCost": "{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Surveil 2, then draw a card.\n• Prismari Charm deals 1 damage to each of one or two targets.\n• Return target nonland permanent to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "surveiled"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "surveiled",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "toGraveyard",
+                                "storeRemainder": "toTop",
+                                "selectedLabel": "Put in graveyard",
+                                "remainderLabel": "Put on top"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "order": "ControllerChooses"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Surveil 2, then draw a card"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "count": 2,
+                            "minCount": 1
+                        }
+                    ],
+                    "description": "Prismari Charm deals 1 damage to each of one or two targets"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target nonland permanent"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "nonland permanent"
+                            },
+                            "id": "target nonland permanent"
+                        }
+                    ],
+                    "description": "Return target nonland permanent to its owner's hand"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Inkognit",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f6c2a5e-fe13-407c-aadd-c9caf2884ff1.jpg?1775938465"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Proctor's Gaze
 {
     "name": "Proctor's Gaze",
@@ -1818,6 +2076,98 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Silverquill Charm
+{
+    "name": "Silverquill Charm",
+    "manaCost": "{W}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Put two +1/+1 counters on target creature.\n• Exile target creature with power 2 or less.\n• Each opponent loses 3 life and you gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1+1",
+                        "count": 2,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Put two +1/+1 counters on target creature"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature with power 2 or less"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature pow<=2"
+                            },
+                            "id": "target creature with power 2 or less"
+                        }
+                    ],
+                    "description": "Exile target creature with power 2 or less"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Each opponent loses 3 life and you gain 3 life"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Ksenia Kim",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eb73579-f1c6-4762-81d2-9568ab501fac.jpg?1775938570"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -485,13 +485,113 @@ private fun EmitCtx.castTimeCaptureSpell(card: JsonObject): List<Stmt>? {
     return listOf(Sub(Block("spell", stmts)))
 }
 
+/**
+ * Split a modal spell's oracle text into its per-mode bullet strings. mtgish carries no per-mode
+ * label, but the engine's `mode("…")` wants the printed bullet text, so derive it from Scryfall's
+ * oracle text: drop the "Choose one —" (or "Choose up to N —") header line, then split on the `•`
+ * bullet marker. Returns null if the oracle text is absent or has no bullets — the renderer then
+ * declines (→ SCAFFOLD) rather than invent labels.
+ */
+private fun EmitCtx.modeBullets(): List<String>? {
+    val oracle = oracleText ?: return null
+    if ("•" !in oracle) return null
+    return oracle.substringAfter("•").let { "•$it" }
+        .split("•")
+        .map { it.trim().removeSuffix(".").trim() }
+        .filter { it.isNotEmpty() }
+        .takeIf { it.isNotEmpty() }
+}
+
+/**
+ * One arm of a `Modal_ChooseOne` spell → the body statements of a `mode("<bullet>") { … }` block.
+ *
+ * Handles the arm shapes seen in the charm corpus, reusing the same machinery the non-modal spell path
+ * uses so a mode renders exactly as the equivalent stand-alone spell would:
+ *  - `ActionList` (no target) → `effect = <renderEffectList>`.
+ *  - `Targeted` with a single conventional target (`TargetPermanent`/`TargetGraveyardCard`/`TargetPlayer`/
+ *    …) → `val t = target("target", <node>)` + `effect = <renderEffectList(…, "t")>`.
+ *  - `Targeted` with `BetweenOneAndNumberAnyTargets` + a fixed `SpellDealsDamage` to `Ref_AnyTargets`
+ *    ("deals N damage to each of one or two targets") → `target = AnyTarget(count, minCount = 1)` +
+ *    `effect = ForEachTargetEffect(listOf(Effects.DealDamage(N, ContextTarget(0))))`.
+ *
+ * Returns null for any arm shape it can't render exactly, so the whole card declines to SCAFFOLD
+ * rather than emit a partial modal.
+ */
+private fun EmitCtx.modalArmBody(arm: JsonObject): List<Stmt>? {
+    val kind = arm.strField("_Actions")
+    if (kind == "ActionList") {
+        val actions = arm["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+        val effect = renderEffectList(actions, null) ?: return null
+        return listOf(Assign("effect", effect))
+    }
+    if (kind != "Targeted") return null
+    val (targets, actions) = targetedArms(arm) ?: return null
+    if (targets == null || actions == null) return null
+    if (targets.size != 1) return null
+    val target = targets[0]
+
+    // "deals N damage to each of one or two targets": a `BetweenOneAndNumberAnyTargets` target whose only
+    // action is a fixed `SpellDealsDamage` to `Ref_AnyTargets`. The engine models this as a fixed-amount
+    // `ForEachTargetEffect`, NOT the bound-single-target `DealDamageEffect` the generic SpellDealsDamage
+    // handler would emit — so render it here and decline anything else on this target shape.
+    if (target.strField("_Target") == "BetweenOneAndNumberAnyTargets") {
+        val max = findInteger(target) as? Int ?: return null
+        val damage = actions.singleOrNull()?.takeIf { it.strField("_Action") == "SpellDealsDamage" } ?: return null
+        val amt = (findInteger(damage["args"]) as? Int) ?: return null
+        if (!jsonContains(damage, "_DamageRecipient", "Ref_AnyTargets")) return null
+        val forEach = call(
+            "ForEachTargetEffect",
+            arg(call("listOf", arg(call("Effects.DealDamage", arg("$amt"), arg("EffectTarget.ContextTarget(0)"))))),
+        )
+        return listOf(
+            Assign("target", call("AnyTarget", arg("count", "$max"), arg("minCount", "1"))),
+            Assign("effect", forEach),
+        )
+    }
+
+    val tnode = targetExpr(target, actions) ?: run { reasons.add("target:${target.strField("_Target")}"); return null }
+    val effect = renderEffectList(actions, "t") ?: return null
+    return listOf(
+        Local("t", call("target", arg("\"target\""), arg(tnode))),
+        Assign("effect", effect),
+    )
+}
+
+/**
+ * "Choose one —" modal spell (`SpellActions { Modal_ChooseOne([arm, arm, …]) }`) → a
+ * `spell { modal(chooseCount = 1) { mode("…") { … } … } }` block. Each arm is rendered by
+ * [modalArmBody]; the mode labels come from the oracle-text bullets ([modeBullets]). Declines (→
+ * SCAFFOLD) unless every arm renders AND the bullet count matches the arm count, so a card never emits
+ * with a missing or mislabeled mode.
+ */
+internal fun EmitCtx.modalChooseOneSpell(card: JsonObject): List<Stmt>? {
+    val spellActions = (card["Rules"].asArr ?: return null).filterIsInstance<JsonObject>()
+        .firstNotNullOfOrNull { rule ->
+            (rule["args"] as? JsonObject)?.takeIf { it.strField("_Actions") == "Modal_ChooseOne" }
+        } ?: return null
+    val arms = spellActions["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    if (arms.isEmpty()) return null
+
+    val bullets = modeBullets() ?: run { reasons.add("modal-spell"); return null }
+    if (bullets.size != arms.size) { reasons.add("modal-spell"); return null }
+
+    val modeBlocks = arms.mapIndexed { i, arm ->
+        val body = modalArmBody(arm) ?: run { reasons.add("modal-spell"); return null }
+        Sub(Block("mode(\"${bullets[i]}\")", body))
+    }
+    return listOf(Sub(Block("spell", listOf(Sub(Block("modal(chooseCount = 1)", modeBlocks))))))
+}
+
 internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
     // "As you cast this spell" cast-time captures arrive as a `Modal_IfElse` envelope; render them
     // (the cast-time form) before the generic modal guard below scaffolds everything `Modal_*`.
     castTimeCaptureSpell(card)?.let { return it }
-    // Modal spells ("Choose one —", "Choose up to four", …) carry a `Modal_*` envelope whose children
-    // are the individual modes. The generic envelope path below would grab only the FIRST mode and
-    // silently drop the rest, so scaffold the whole card rather than emit one arm of a modal spell.
+    // "Choose one —" modal spells (`Modal_ChooseOne`) render to the engine's modal DSL — one
+    // `mode("<bullet>") { … }` per arm. Render them before the generic `Modal_*` scaffold guard.
+    modalChooseOneSpell(card)?.let { return it }
+    // Other modal spells ("Choose up to four", entwine, escalate, …) carry a `Modal_*` envelope whose
+    // children are the individual modes. The generic envelope path below would grab only the FIRST mode
+    // and silently drop the rest, so scaffold the whole card rather than emit one arm of a modal spell.
     if ("\"Modal_" in compact(card["Rules"])) { reasons.add("modal-spell"); return null }
     // One-line `effect =` shortcuts, then whole-block shortcuts, then the generic envelope path.
     eachplayerMaydraw(card)?.let { return spellOf(it) }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -230,6 +230,15 @@ internal fun EmitCtx.renderEachPlayer(node: JsonObject): Dsl? {
     if (jsonContains(node, "_Players", "AnyPlayer") && "PutAPermanentIntoItsOwnersHand" in blob)
         return call("Effects.EachPlayerReturnPermanentToHand")
     if (jsonContains(node, "_Players", "Opponent") && "Discard" in blob) return call("Patterns.Hand.eachOpponentDiscards", arg("1"))  // Noxious Toad
+    // "Each opponent sacrifices a <filter> of their choice" (Lorehold Charm). The sacrificing player
+    // chooses, scoped to every opponent via ForceSacrificeEffect over EffectTarget.PlayerRef(EachOpponent).
+    // Only a renderable filter and a count-of-one form render; anything else scaffolds.
+    if (jsonContains(node, "_Players", "Opponent") && jsonContains(node, "_Action", "SacrificeAPermanent")) {
+        val inner = node["args"].asArr?.filterIsInstance<JsonObject>()
+            ?.firstOrNull { it.strField("_Action") == "SacrificeAPermanent" } ?: return null
+        val filter = gameObjectFilterExpr(inner["args"]) ?: return null
+        return call("Effects.Sacrifice", arg("filter", filter), arg("target", "EffectTarget.PlayerRef(Player.EachOpponent)"))
+    }
     // "each opponent loses N life" (Raven of Fell Omens). Only a fixed Integer amount renders, scoped to
     // every opponent via EffectTarget.PlayerRef(Player.EachOpponent); a derived/X amount scaffolds.
     if (jsonContains(node, "_Players", "Opponent") && jsonContains(node, "_Action", "LoseLife")) {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -96,6 +96,30 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         call("AddCountersEffect", arg("counterType", counter), arg("count", "1"), arg("target", tgt))
     }
 
+    on("PutNumberCountersOfTypeOnPermanent") { _, args, tvar ->
+        // "Put N +1/+1 (or -1/-1) counters on <permanent>." — the plural form of
+        // PutACounterOfTypeOnPermanent. IR args are [<N>, <counterType>, <permanent ref>]. Only the
+        // bare ±1/±1 PTCounter and the keyword counters we name render with a fixed integer N; any
+        // other counter kind or a derived count scaffolds rather than guess.
+        val arr = args.asArr ?: return@on null
+        val count = findInteger(arr.getOrNull(0)) as? Int ?: return@on null
+        val counterNode = arr.getOrNull(1) as? JsonObject ?: return@on null
+        val counter = when (counterNode.strField("_CounterType")) {
+            "PTCounter" -> {
+                val pt = counterNode["args"].asArr ?: return@on null
+                when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
+                    Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
+                    Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
+                    else -> return@on null
+                }
+            }
+            "FlyingCounter" -> "Counters.FLYING"
+            else -> return@on null
+        }
+        val tgt = refTarget(arr.getOrNull(2), tvar) ?: return@on null
+        call("AddCountersEffect", arg("counterType", counter), arg("count", "$count"), arg("target", tgt))
+    }
+
     on("Earthbend") { _, args, tvar ->
         // Earthbend N (TLA keyword action): "target land becomes a 0/0 creature with haste that's still
         // a land. Put N +1/+1 counters on it. When it dies or is exiled, return it to the battlefield

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -554,6 +554,37 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             if (ttype == "UptoOneTargetGraveyardCard") parts.add(0, arg("optional", "true"))
             return Call("TargetObject", parts)
         }
+        // "target artifact or creature card with mana value N or less from your graveyard" (Lorehold
+        // Charm): an `Or[IsCardtype X, IsCardtype Y]` over two single-card-types, plus a `<=` MV cap and
+        // an optional ownership clause, no creature subtype. The typed branches below handle a single
+        // card type only, so compose the OR explicitly:
+        // `GameObjectFilter.X[.ownedBy…].manaValueAtMost(N).or(GameObjectFilter.Y[.ownedBy…].manaValueAtMost(N))`.
+        // Only the two-type OR with both types in [graveyardCardtypeFilters] renders; anything else falls
+        // through (a single-type ManaValueIs cap declines at the guard below), so no restriction is dropped.
+        run {
+            val ts = targetTypes(args).toList()
+            if (ts.size == 2 && ts.all { it in graveyardCardtypeFilters } &&
+                "IsCreatureType" !in blob && "\"Or\"" in blob) {
+                val mvCap = FilterPredicates.manaValueAtMost(args)
+                if ("ManaValueIs" in blob && mvCap == null) return null
+                val owner: Link? = when {
+                    "\"You\"" in blob -> Link("ownedByYou")
+                    "\"Opponent\"" in blob -> Link("ownedByOpponent")
+                    else -> null
+                }
+                fun typeFilter(t: String): Dsl {
+                    var g: Dsl = Lit("GameObjectFilter.${graveyardCardtypeFilters.getValue(t)}")
+                    owner?.let { g = g.dot(it) }
+                    mvCap?.let { g = g.dot(it) }
+                    return g
+                }
+                val combined = typeFilter(ts[0]).dot("or", arg(typeFilter(ts[1])))
+                val filt = Call("TargetFilter", listOf(arg(combined), arg("zone", "Zone.GRAVEYARD")))
+                val parts = mutableListOf(arg("filter", filt))
+                if (ttype == "UptoOneTargetGraveyardCard") parts.add(0, arg("optional", "true"))
+                return Call("TargetObject", parts)
+            }
+        }
         // "target artifact card WITH MANA VALUE 1 OR LESS from your graveyard" (Auriok Salvagers, Leonin
         // Squire): a ManaValueIs cap the graveyard filters below don't compose — emitting without it would
         // widen the target to any artifact in the graveyard. Decline (-> SCAFFOLD) rather than drop it.
@@ -592,6 +623,17 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
     }
     return null
 }
+
+/** Card types that map to a same-named `GameObjectFilter.<Type>` constant — for composing an
+ *  `Or`-of-card-types graveyard target (e.g. "artifact or creature card …", Lorehold Charm). */
+private val graveyardCardtypeFilters = mapOf(
+    "Artifact" to "Artifact",
+    "Creature" to "Creature",
+    "Enchantment" to "Enchantment",
+    "Instant" to "Instant",
+    "Land" to "Land",
+    "Sorcery" to "Sorcery",
+)
 
 private val graveyardSingleTypeFilters = mapOf(
     "Artifact" to "Artifact",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoreholdCharmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoreholdCharmTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.LoreholdCharm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Lorehold Charm (SOS #200).
+ *
+ * Lorehold Charm {R}{W}
+ * Instant
+ * Choose one —
+ * • Each opponent sacrifices a nontoken artifact of their choice.
+ * • Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.
+ * • Creatures you control get +1/+1 and gain trample until end of turn.
+ */
+class LoreholdCharmTest : FunSpec({
+
+    val SmallArtifact = CardDefinition.artifact(
+        name = "Small Artifact",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val SmallCreature = CardDefinition.creature(
+        name = "Lorehold Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LoreholdCharm, SmallArtifact, SmallCreature))
+        return driver
+    }
+
+    // Select a mode by its text. The engine prunes modes with no legal target, so we
+    // can't rely on a fixed index — match the option string instead.
+    fun castAndChooseMode(driver: GameTestDriver, caster: com.wingedsheep.sdk.model.EntityId, modePrefix: String) {
+        driver.giveMana(caster, Color.RED, 1)
+        driver.giveMana(caster, Color.WHITE, 1)
+        val charm = driver.putCardInHand(caster, "Lorehold Charm")
+        driver.castSpell(caster, charm)
+        val modeDecision = driver.pendingDecision
+        modeDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val idx = modeDecision.options.indexOfFirst { it.startsWith(modePrefix) }
+        require(idx >= 0) { "Mode '$modePrefix' not offered; options=${modeDecision.options}" }
+        driver.submitDecision(caster, OptionChosenResponse(modeDecision.id, idx))
+    }
+
+    test("mode 1 - each opponent sacrifices a nontoken artifact of their choice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(opp, "Small Artifact")
+
+        castAndChooseMode(driver, me, "Each opponent sacrifices")
+        driver.bothPass()
+
+        // The opponent's only nontoken artifact is auto-sacrificed.
+        driver.findPermanent(opp, "Small Artifact") shouldBe null
+    }
+
+    test("mode 2 - return a mana-value-2-or-less artifact or creature from graveyard to battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val deadBear = driver.putCardInGraveyard(me, "Lorehold Bear")
+
+        castAndChooseMode(driver, me, "Return target artifact")
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        targetDecision.legalTargets[0]!!.contains(deadBear) shouldBe true
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(deadBear))))
+        driver.bothPass()
+
+        // The bear is back on the battlefield under our control.
+        driver.findPermanent(me, "Lorehold Bear") shouldBe deadBear
+    }
+
+    test("mode 3 - creatures you control get +1/+1 and gain trample until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(me, "Lorehold Bear") // 2/2
+
+        castAndChooseMode(driver, me, "Creatures you control")
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(bear) shouldBe 3
+        projected.getToughness(bear) shouldBe 3
+        projected.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrismariCharmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrismariCharmTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.PrismariCharm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Prismari Charm (SOS #211).
+ *
+ * Prismari Charm {U}{R}
+ * Instant
+ * Choose one —
+ * • Surveil 2, then draw a card.
+ * • Prismari Charm deals 1 damage to each of one or two targets.
+ * • Return target nonland permanent to its owner's hand.
+ */
+class PrismariCharmTest : FunSpec({
+
+    val BigCreature = CardDefinition.creature(
+        name = "Prismari Ox",
+        manaCost = ManaCost.parse("{2}{R}"),
+        subtypes = emptySet(),
+        power = 3,
+        toughness = 3
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PrismariCharm, BigCreature))
+        return driver
+    }
+
+    fun castAndChooseMode(driver: GameTestDriver, caster: EntityId, modePrefix: String) {
+        driver.giveMana(caster, Color.BLUE, 1)
+        driver.giveMana(caster, Color.RED, 1)
+        val charm = driver.putCardInHand(caster, "Prismari Charm")
+        driver.castSpell(caster, charm)
+        val modeDecision = driver.pendingDecision
+        modeDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val idx = modeDecision.options.indexOfFirst { it.startsWith(modePrefix) }
+        require(idx >= 0) { "Mode '$modePrefix' not offered; options=${modeDecision.options}" }
+        driver.submitDecision(caster, OptionChosenResponse(modeDecision.id, idx))
+    }
+
+    test("mode 1 - surveil 2 then draw a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed a known library top so surveil presents two cards.
+        driver.putCardOnTopOfLibrary(me, "Island")
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+
+        val handBefore = driver.getHandSize(me)
+        castAndChooseMode(driver, me, "Surveil 2")
+        driver.bothPass()
+
+        // Surveil 2 pauses for the keep/graveyard choice — keep both on top (bin none).
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options.size shouldBe 2
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = emptyList()))
+
+        // Then order the kept cards back on top.
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        driver.submitOrderedResponse(me, reorder.cards)
+
+        // Net effect of surveil-then-draw: hand grows by one (the drawn card).
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+
+    test("mode 2 - deals 1 damage to each of two targets") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ox = driver.putCreatureOnBattlefield(opp, "Prismari Ox") // 3/3
+
+        castAndChooseMode(driver, me, "Prismari Charm deals")
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        // Two targets: the opponent's ox and the opponent themselves.
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(ox, opp))))
+        driver.bothPass()
+
+        driver.state.getEntity(ox)?.get<DamageComponent>()?.amount shouldBe 1
+        driver.getLifeTotal(opp) shouldBe 19
+    }
+
+    test("mode 3 - return target nonland permanent to its owner's hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ox = driver.putCreatureOnBattlefield(opp, "Prismari Ox")
+
+        castAndChooseMode(driver, me, "Return target nonland")
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        targetDecision.legalTargets[0]!!.contains(ox) shouldBe true
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(ox))))
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Prismari Ox") shouldBe null
+        driver.findCardInHand(opp, "Prismari Ox") shouldBe ox
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilverquillCharmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilverquillCharmTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.SilverquillCharm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Silverquill Charm (SOS #225).
+ *
+ * Silverquill Charm {W}{B}
+ * Instant
+ * Choose one —
+ * • Put two +1/+1 counters on target creature.
+ * • Exile target creature with power 2 or less.
+ * • Each opponent loses 3 life and you gain 3 life.
+ */
+class SilverquillCharmTest : FunSpec({
+
+    val SmallCreature = CardDefinition.creature(
+        name = "Silverquill Pupil",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1
+    )
+
+    val BigCreature = CardDefinition.creature(
+        name = "Silverquill Brute",
+        manaCost = ManaCost.parse("{3}"),
+        subtypes = emptySet(),
+        power = 4,
+        toughness = 4
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SilverquillCharm, SmallCreature, BigCreature))
+        return driver
+    }
+
+    fun castAndChooseMode(driver: GameTestDriver, caster: EntityId, modePrefix: String) {
+        driver.giveMana(caster, Color.WHITE, 1)
+        driver.giveMana(caster, Color.BLACK, 1)
+        val charm = driver.putCardInHand(caster, "Silverquill Charm")
+        driver.castSpell(caster, charm)
+        val modeDecision = driver.pendingDecision
+        modeDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val idx = modeDecision.options.indexOfFirst { it.startsWith(modePrefix) }
+        require(idx >= 0) { "Mode '$modePrefix' not offered; options=${modeDecision.options}" }
+        driver.submitDecision(caster, OptionChosenResponse(modeDecision.id, idx))
+    }
+
+    test("mode 1 - put two +1/+1 counters on target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pupil = driver.putCreatureOnBattlefield(me, "Silverquill Pupil") // 1/1
+
+        castAndChooseMode(driver, me, "Put two +1/+1 counters")
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(pupil))))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(pupil) shouldBe 3
+        projected.getToughness(pupil) shouldBe 3
+    }
+
+    test("mode 2 - exile target creature with power 2 or less; big creature is not a legal target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pupil = driver.putCreatureOnBattlefield(opp, "Silverquill Pupil") // 1/1
+        val brute = driver.putCreatureOnBattlefield(opp, "Silverquill Brute") // 4/4
+
+        castAndChooseMode(driver, me, "Exile target creature")
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val legal = targetDecision.legalTargets[0]!!
+        legal.contains(pupil) shouldBe true
+        legal.contains(brute) shouldBe false
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(pupil))))
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Silverquill Pupil") shouldBe null
+    }
+
+    test("mode 3 - each opponent loses 3 life and you gain 3 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        castAndChooseMode(driver, me, "Each opponent loses")
+        driver.bothPass()
+
+        driver.getLifeTotal(opp) shouldBe 17
+        driver.getLifeTotal(me) shouldBe 23
+    }
+})


### PR DESCRIPTION
## Cards

Three "Choose one —" modal charm instants from **Secrets of Strixhaven** (SOS), implemented via the established `modal(chooseCount = 1) { mode { } }` DSL using only existing effects/patterns (no new SDK building blocks):

- **Lorehold Charm** `{R}{W}` — each opponent sacrifices a nontoken artifact of their choice / return an artifact-or-creature card with MV ≤ 2 from your graveyard to the battlefield / creatures you control get +1/+1 and gain trample EOT.
- **Prismari Charm** `{U}{R}` — surveil 2 then draw a card / deal 1 damage to each of one or two targets / return a nonland permanent to its owner's hand.
- **Silverquill Charm** `{W}{B}` — two +1/+1 counters on target creature / exile a creature with power ≤ 2 / each opponent loses 3 life and you gain 3 life.

Each card ships a rules-engine scenario test exercising all three modes. All 9 mode tests pass. (Mode selection in tests matches by bullet text, since the engine prunes modes with no legal target and indices shift.)

## mtgish emitter changes

Promote these charms — and "Choose one —" modal spells generally — from **SCAFFOLD → AUTOGEN** by teaching the emitter the modal-spell family. Render correctly or decline; modes emitted in printed order:

- **`CardStructure.kt`** — render `Modal_ChooseOne` as `spell { modal(chooseCount = 1) { mode("<bullet>") { … } } }`. Mode labels come from the oracle-text bullets. Each arm reuses the non-modal target/effect machinery; the "deals N damage to each of one or two targets" arm (`BetweenOneAndNumberAnyTargets` + fixed `SpellDealsDamage`) renders the fixed-amount `ForEachTargetEffect` form rather than the bound-single-target `DealDamageEffect`. Declines (→ SCAFFOLD) unless **every** arm renders and the bullet count matches the arm count — never a partial or mislabeled modal.
- **`TapLayerStateHandlers.kt`** — add `PutNumberCountersOfTypeOnPermanent` (the plural N-counter form of the existing `PutACounterOfTypeOnPermanent`).
- **`PlayerContinuousHandlers.kt`** — render "each opponent sacrifices a `<filter>` of their choice" via `Effects.Sacrifice(filter, EffectTarget.PlayerRef(Player.EachOpponent))`.
- **`TargetRecovery.kt`** — compose an `Or`-of-card-types graveyard target with a `≤` mana-value cap ("artifact or creature card with mana value 2 or less from your graveyard").

## Verification

- `just coverage-fidelity --emit` for all three charms → **fidelity tier: AUTO** (complete render).
- `just coverage-verify SOS` → **GATE PASS** (39/39 emitted cards compile + gameplay-tree match, 0 mismatch, 0 capability mismatch).
- `just coverage-verify POR` → **GATE PASS unchanged** (158/158, 0-mismatch) — emitter changes are additive and don't regress Portal.
- `:mtgish-tooling` test suite green, including `EmitterGoldenTest` (no golden drift, so no fixture re-bless).
- `CardDefinitionSnapshotTest` re-blessed: SOS golden diff is **only the 3 new cards** (350 insertions, nothing else changed).
- `CardLintTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)