### PR TITLE
SOS: trigger-shape cards + mtgish emitter support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1116,8 +1116,11 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.InstantOrSorcery` — instant-or-sorcery card.
 
 **Chained predicates** — `.youControl()`, `.controlledByOpponent()`, `.opponent()`, `.withSubtype(...)`,
-`.withKeyword(...)`, `.ofColor(...)`, `.tapped()`, `.untapped()`, `.power(n)`, `.minPower(n)`, `.maxPower(n)`; plus
-`TargetFilter.excludeSelf` to exclude the source.
+`.withKeyword(...)`, `.ofColor(...)`, `.tapped()`, `.untapped()`, `.power(n)`, `.minPower(n)`, `.maxPower(n)`,
+`.targetsMatching(subfilter)` (a spell/ability on the stack that targets at least one object matching
+`subfilter` — `CardPredicate.TargetsMatching`; e.g. `GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)`
+for "an instant or sorcery spell that targets a creature" — Forum Necroscribe, Lecturing Scornmage);
+plus `TargetFilter.excludeSelf` to exclude the source.
 
 ### Named multi-target binding
 
@@ -2992,6 +2995,12 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
   - `MODES_CHOSEN_ON_TRIGGERING_SPELL` — number of mode picks recorded on the cast that fired
     the trigger (Riku of Many Paths). Counts selections, not distinct modes, so Spree with
     the same mode twice reads as `2`.
+  - `MANA_SPENT_ON_TRIGGERING_SPELL` — total mana spent to cast the spell that fired the
+    trigger (Aberrant Manawurm's "+X/+0 ... where X is the amount of mana spent to cast that
+    spell", Expressive Firedancer's "if five or more mana was spent"). Distinct from
+    `DynamicAmount.TotalManaSpent`, which reads the *current resolving object's own* cast — this
+    reads the **triggering** spell's cast (the payoff lives on a separate permanent). Populated
+    from `SpellCastEvent.totalManaSpent`; `0` for non-cast triggers.
   - `TRIGGER_SCRY_COUNT` — cards looked at by the scry that fired the trigger (Celeborn the
     Wise, Elrond Master of Healing). Equals the scry N parameter.
   - `TRIGGER_EXCESS_DAMAGE_AMOUNT` — damage past lethal in the trigger payload (CR 120.4a).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -208,6 +208,16 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.IsNonartifact
     )
 
+    /**
+     * Restrict to spells/abilities on the stack that target at least one object matching
+     * [subfilter]. Used for "an instant or sorcery spell that targets a creature" (Repartee —
+     * Forum Necroscribe, Lecturing Scornmage) and "target spell that targets a land you control"
+     * (Teferi's Response). Player targets are skipped (CR — they have no game-object filter).
+     */
+    fun targetsMatching(subfilter: GameObjectFilter) = copy(
+        cardPredicates = cardPredicates + CardPredicate.TargetsMatching(subfilter)
+    )
+
     /** Add a keyword requirement */
     fun withKeyword(keyword: Keyword) = copy(
         cardPredicates = cardPredicates + CardPredicate.HasKeyword(keyword)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -133,6 +133,15 @@ enum class ContextPropertyKey(val description: String) {
      */
     MODES_CHOSEN_ON_TRIGGERING_SPELL("the number of times you chose a mode for that spell"),
     /**
+     * Total mana spent to cast the spell that fired this trigger. Distinct from
+     * [DynamicAmount.TotalManaSpent], which reads the *current resolving object's* own cast —
+     * this reads the **triggering** spell's cast (a "Whenever you cast an instant or sorcery
+     * spell, …, where X is the amount of mana spent to cast that spell" payoff that lives on a
+     * separate permanent). Populated from `SpellCastEvent.totalManaSpent`. `0` when the trigger
+     * was not driven by a spell cast. Used by Aberrant Manawurm and Expressive Firedancer.
+     */
+    MANA_SPENT_ON_TRIGGERING_SPELL("the amount of mana spent to cast that spell"),
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Equals the
      * scry N parameter unless the library held fewer cards. Read by "Whenever you scry,
      * ... for each card looked at" payoffs (Celeborn the Wise, Elrond Master of Healing).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AberrantManawurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AberrantManawurm.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aberrant Manawurm
+ * {3}{G}
+ * Creature — Wurm
+ * 2/5
+ * Trample
+ * Whenever you cast an instant or sorcery spell, this creature gets +X/+0 until end of turn,
+ * where X is the amount of mana spent to cast that spell.
+ *
+ * X reads `DynamicAmount.ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL)` — the mana spent on
+ * the *triggering* spell (distinct from `DynamicAmount.TotalManaSpent`, which is the resolving
+ * object's own cast). The +X/+0 lasts until end of turn (the `ModifyStats` default duration).
+ */
+val AberrantManawurm = card("Aberrant Manawurm") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 2
+    toughness = 5
+    oracleText = "Trample\nWhenever you cast an instant or sorcery spell, this creature gets " +
+        "+X/+0 until end of turn, where X is the amount of mana spent to cast that spell."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(
+            power = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+            toughness = DynamicAmount.Fixed(0),
+            target = EffectTarget.Self,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Lars Grant-West"
+        flavorText = "\"What is the equation for terror?\"\n—Lost research note, Paradox Gardens"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/797131cf-d80d-4050-bebd-2ce1d7fae5d0.jpg?1775937935"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ExpressiveFiredancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ExpressiveFiredancer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Expressive Firedancer
+ * {1}{R}
+ * Creature — Human Sorcerer
+ * 2/2
+ * Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of
+ * turn. If five or more mana was spent to cast that spell, this creature also gains double
+ * strike until end of turn.
+ *
+ * "Opus" is an ability word (flavor only). The +1/+1 is unconditional; the double strike is
+ * gated by a `Compare` of `ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5` — the mana
+ * spent on the *triggering* spell.
+ */
+val ExpressiveFiredancer = card("Expressive Firedancer") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Sorcerer"
+    power = 2
+    toughness = 2
+    oracleText = "Opus — Whenever you cast an instant or sorcery spell, this creature gets " +
+        "+1/+1 until end of turn. If five or more mana was spent to cast that spell, this " +
+        "creature also gains double strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self) then
+            ConditionalEffect(
+                condition = Compare(
+                    left = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Fixed(5),
+                ),
+                effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self),
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Billy Christian"
+        flavorText = "\"Now, let your movements respond to the music! Yes, just like that!\"\n" +
+            "—Introduction to Interpretation"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/259b8c45-6241-4206-a34e-34c7f401f47b.jpg?1775937734"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ForumNecroscribe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ForumNecroscribe.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Forum Necroscribe
+ * {5}{B}
+ * Creature — Troll Warlock
+ * 5/4
+ * Ward—Discard a card.
+ * Repartee — Whenever you cast an instant or sorcery spell that targets a creature, return
+ * target creature card from your graveyard to the battlefield.
+ *
+ * "Repartee" is an ability word (flavor only). The trigger is a standard
+ * `youCastSpell(InstantOrSorcery)` narrowed by `CardPredicate.TargetsMatching(Creature)` so it
+ * fires only when the cast spell targets a creature; it then reanimates a creature card from
+ * your graveyard. (The trigger goes on the stack above the spell that caused it, so it can
+ * resolve and reanimate before that spell does.)
+ */
+val ForumNecroscribe = card("Forum Necroscribe") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Troll Warlock"
+    power = 5
+    toughness = 4
+    oracleText = "Ward—Discard a card.\n" +
+        "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, " +
+        "return target creature card from your graveyard to the battlefield."
+
+    keywordAbility(KeywordAbility.wardDiscard())
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)
+        )
+        val returned = target(
+            "target creature card from your graveyard",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard),
+        )
+        effect = Effects.Move(returned, Zone.BATTLEFIELD)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Randy Vargas"
+        flavorText = "She had watched many arguments wither on the Forum floor. Now, it was " +
+            "time to call on them to prove her point."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67504a12-7414-4209-bf1c-624b4db19d52.jpg?1775937497"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LecturingScornmage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LecturingScornmage.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lecturing Scornmage
+ * {B}
+ * Creature — Human Warlock
+ * 1/1
+ * Repartee — Whenever you cast an instant or sorcery spell that targets a creature, put a +1/+1
+ * counter on this creature.
+ *
+ * "Repartee" is an ability word (flavor only). The trigger is a standard
+ * `youCastSpell(InstantOrSorcery)` narrowed by `CardPredicate.TargetsMatching(Creature)` so it
+ * fires only when one of the cast spell's chosen targets is a creature.
+ */
+val LecturingScornmage = card("Lecturing Scornmage") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 1
+    toughness = 1
+    oracleText = "Repartee — Whenever you cast an instant or sorcery spell that targets a " +
+        "creature, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Tuan Duong Chu"
+        flavorText = "\"I expected better from you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad07091e-8c24-43af-8ce8-031847bcaf30.jpg?1775937516"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1,3 +1,62 @@
+// Aberrant Manawurm
+{
+    "name": "Aberrant Manawurm",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Trample\nWhenever you cast an instant or sorcery spell, this creature gets +X/+0 until end of turn, where X is the amount of mana spent to cast that spell.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "ContextProperty",
+                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"What is the equation for terror?\"\n—Lost research note, Paradox Gardens",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/797131cf-d80d-4050-bebd-2ce1d7fae5d0.jpg?1775937935"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Banishing Betrayal
 {
     "name": "Banishing Betrayal",
@@ -653,6 +712,89 @@
     ]
 }
 
+// Expressive Firedancer
+{
+    "name": "Expressive Firedancer",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Sorcerer",
+    "oracleText": "Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn. If five or more mana was spent to cast that spell, this creature also gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "GrantKeyword",
+                                "keyword": "DOUBLE_STRIKE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Billy Christian",
+        "flavorText": "\"Now, let your movements respond to the music! Yes, just like that!\"\n—Introduction to Interpretation",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/259b8c45-6241-4206-a34e-34c7f401f47b.jpg?1775937734"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fields of Strife
 {
     "name": "Fields of Strife",
@@ -760,6 +902,83 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Forum Necroscribe
+{
+    "name": "Forum Necroscribe",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Troll Warlock",
+    "oracleText": "Ward—Discard a card.\nRepartee — Whenever you cast an instant or sorcery spell that targets a creature, return target creature card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": "WardCost.Discard"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "TargetsMatching",
+                                "subfilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "flavorText": "She had watched many arguments wither on the Forum floor. Now, it was time to call on them to prove her point.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67504a12-7414-4209-bf1c-624b4db19d52.jpg?1775937497"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -1120,6 +1339,64 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Lecturing Scornmage
+{
+    "name": "Lecturing Scornmage",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "TargetsMatching",
+                                "subfilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Tuan Duong Chu",
+        "flavorText": "\"I expected better from you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad07091e-8c24-43af-8ce8-031847bcaf30.jpg?1775937516"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -29,6 +29,13 @@ internal fun BridgeBuilder.keywords() {
     // the integer case auto-renders, while "firebending X (X = its power)" carries an XValue node and
     // the emitter declines it (-> SCAFFOLD). This entry only marks the capability covered.
     supported("Firebending", "keyword ability: Firebending N -> keywordAbility(KeywordAbility.firebending(N)) (CR 702.189)")
+    // Ward (CR 702.21) — a PARAMETERIZED keyword ability: the cost rides in the rule's args
+    // (`Ward—Discard a card`, `Ward {2}`, `Ward—Pay N life`, `Ward—Sacrifice <filter>`). Like Saddle,
+    // it must be `supported`, not `keyword`: a bare `keywords(Keyword.WARD)` would drop the cost. The
+    // emitter's `rname == "Ward"` branch renders `keywordAbility(KeywordAbility.ward(...)/wardDiscard()/
+    // wardLife(N)/wardSacrifice(filter))` for the cost shapes it can express; richer/compound costs
+    // decline -> SCAFFOLD. This entry only marks the capability covered (never blocking).
+    supported("Ward", "keyword ability: Ward—<cost> (CR 702.21) -> keywordAbility(KeywordAbility.ward(...)/wardDiscard()/wardLife(N)/wardSacrifice(filter))")
 
     composed("Landwalk", "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)")
     // Equip is a keyword ability, but the engine has no `Keyword.EQUIP` enum member: `equipAbility(cost)`

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -925,7 +925,15 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     if (jsonContains(trig, "_Trigger", "WhenAPlayerCastsASpell")) {
         val argv = trig["args"].asArr
         val scope = castScope(argv?.getOrNull(0) as? JsonObject) ?: return null
-        val category = spellCastCategory(argv?.getOrNull(1) as? JsonObject) ?: return null
+        val spellsNode = argv?.getOrNull(1) as? JsonObject
+        // "an instant or sorcery spell that targets a creature" (Repartee — Forum Necroscribe,
+        // Lecturing Scornmage): an And of the base spell-type filter + a `TargetsAPermanent`
+        // clause. Recover the base category and a `targetsMatching(<filter>)` subfilter; the
+        // whole thing renders only when BOTH render exactly (decline -> SCAFFOLD otherwise).
+        spellCastTargetsMatching(spellsNode)?.let { (category, sub) ->
+            return castTriggerDsl(scope, category, targetsMatching = sub)
+        }
+        val category = spellCastCategory(spellsNode) ?: return null
         return castTriggerDsl(scope, category)
     }
 
@@ -972,19 +980,51 @@ private fun spellCastCategory(spells: JsonObject?): String? = when (spells?.strF
     else -> null
 }
 
+/** The base [GameObjectFilter] expression for a cast-trigger category, or null for "any" (no filter). */
+private fun categoryFilter(category: String): String? = when (category) {
+    "any" -> null
+    "creature" -> "GameObjectFilter.Creature"
+    "noncreature" -> "GameObjectFilter.Noncreature"
+    "enchantment" -> "GameObjectFilter.Enchantment"
+    "instantOrSorcery" -> "GameObjectFilter.InstantOrSorcery"
+    "historic" -> "GameObjectFilter.Historic"
+    else -> null
+}
+
+/**
+ * "a [type] spell that targets a [permanent]" (Repartee — Forum Necroscribe, Lecturing Scornmage):
+ * the spell filter is an `And` of a base spell-type filter + a `TargetsAPermanent(<perm filter>)`
+ * clause. Returns `(baseCategory, targetsMatchingFilterExpr)` when BOTH halves render exactly, else
+ * null so the trigger declines -> SCAFFOLD rather than dropping the "targets a creature" clause.
+ */
+private fun EmitCtx.spellCastTargetsMatching(spells: JsonObject?): Pair<String, String>? {
+    if (spells?.strField("_Spells") != "And") return null
+    val parts = spells["args"].asArr.orEmpty().filterIsInstance<JsonObject>()
+    if (parts.size != 2) return null
+    val targetsNode = parts.firstOrNull { it.strField("_Spells") == "TargetsAPermanent" } ?: return null
+    val baseNode = parts.firstOrNull { it !== targetsNode } ?: return null
+    val category = spellCastCategory(baseNode) ?: return null
+    val sub = gameObjectFilterDsl(targetsNode["args"]) ?: return null
+    return category to sub
+}
+
 /** (scope, category) -> the exact `Triggers.*` constant/factory. You has named constants; the
  *  any-player / opponent scopes use the `anyPlayerCasts` / `opponentCasts` factories with a
- *  [GameObjectFilter]. */
-private fun castTriggerDsl(scope: CastScope, category: String): String? {
-    val filter = when (category) {
-        "any" -> null
-        "creature" -> "GameObjectFilter.Creature"
-        "noncreature" -> "GameObjectFilter.Noncreature"
-        "enchantment" -> "GameObjectFilter.Enchantment"
-        "instantOrSorcery" -> "GameObjectFilter.InstantOrSorcery"
-        "historic" -> "GameObjectFilter.Historic"
-        else -> return null
+ *  [GameObjectFilter]. When [targetsMatching] is set ("... that targets a creature"), the base
+ *  filter is narrowed with `.targetsMatching(<filter>)` and the factory form is always used (the
+ *  bare `Triggers.YouCastInstantOrSorcery`-style constants carry no spell filter). */
+private fun castTriggerDsl(scope: CastScope, category: String, targetsMatching: String? = null): String? {
+    val baseFilter = categoryFilter(category)
+    if (targetsMatching != null) {
+        // No bare "any spell that targets …" shape appears in the corpus; require a typed base filter.
+        val composed = (baseFilter ?: return null) + ".targetsMatching($targetsMatching)"
+        return when (scope) {
+            CastScope.YOU -> "Triggers.youCastSpell(spellFilter = $composed)"
+            CastScope.ANY -> "Triggers.anyPlayerCasts($composed)"
+            CastScope.OPPONENT -> "Triggers.opponentCasts($composed)"
+        }
     }
+    val filter = baseFilter
     return when (scope) {
         CastScope.YOU -> when (category) {
             "any" -> "Triggers.YouCastSpell"
@@ -998,6 +1038,39 @@ private fun castTriggerDsl(scope: CastScope, category: String): String? {
         CastScope.ANY -> if (filter == null) "Triggers.AnyPlayerCastsSpell" else "Triggers.anyPlayerCasts($filter)"
         CastScope.OPPONENT -> if (filter == null) "Triggers.OpponentCastsSpell" else "Triggers.opponentCasts($filter)"
     }
+}
+
+/**
+ * "Ward—<cost>" (CR 702.21) -> `keywordAbility(KeywordAbility.ward(...) / wardDiscard() / wardLife(N)
+ * / wardSacrifice(filter))`. The rule's `args` is the ward cost; only the cost shapes the SDK exposes
+ * render exactly — mana (`Ward {N}`), discard-a-card, pay-N-life, and sacrifice-a-<filter>. Any other
+ * cost (compound `And`, dynamic life, sacrifice-N) declines -> SCAFFOLD rather than approximating the
+ * ward cost. Forum Necroscribe ("Ward—Discard a card") + the broad Ward {N} / Ward—Pay N life corpus.
+ */
+internal fun EmitCtx.wardKeywordLine(rule: JsonObject): List<Stmt>? {
+    val cost = rule["args"] as? JsonObject ?: return null
+    val ability: Dsl = when (cost.strField("_Cost")) {
+        // Pure-mana Ward keeps the existing `KeywordAbility.Ward(WardCost.Mana("{x}"))` rendering so the
+        // large mana-Ward corpus golden stays byte-identical.
+        "PayMana" -> {
+            val mana = renderMana(cost.field("args"))
+            if (mana.isEmpty()) return null
+            call("KeywordAbility.Ward", arg(call("WardCost.Mana", arg("\"$mana\""))))
+        }
+        "DiscardACard" -> call("KeywordAbility.wardDiscard")
+        "DiscardACardAtRandom" -> call("KeywordAbility.wardDiscard", arg("random", "true"))
+        "PayLife" -> {
+            // Only a fixed integer life cost renders; dynamic life (PowerOfPermanent, X) declines.
+            val n = (cost["args"].asInt()) ?: ((cost["args"] as? JsonObject)?.get("args").asInt()) ?: return null
+            call("KeywordAbility.wardLife", arg("$n"))
+        }
+        "SacrificeAPermanent" -> {
+            val filter = gameObjectFilterDsl(cost.field("args")) ?: return null
+            call("KeywordAbility.wardSacrifice", arg(Lit(filter)))
+        }
+        else -> return null  // compound / dynamic ward costs -> SCAFFOLD
+    }
+    return listOf(Eval(call("keywordAbility", arg(ability))))
 }
 
 /** True when a trigger's subject IS this permanent — ThisPermanent present, but NOT merely as the

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -193,6 +193,14 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // "gain that much life", Thrashing Mudspawn's "lose that much life").
         "Trigger_AmountOfDamageDealt" ->
             return call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT"))
+        // "the amount of mana spent to cast that spell" on a `WhenAPlayerCastsASpell` trigger
+        // (Aberrant Manawurm's "+X/+0 ... where X is the amount of mana spent to cast that spell").
+        // Only the triggering-spell subject (`Trigger_ThatSpell`) maps to the context key; any other
+        // spell subject declines -> SCAFFOLD rather than misread a different cast's mana.
+        "AmountOfManaSpentToCastSpell" ->
+            return if (jsonContains(node["args"], "_Spell", "Trigger_ThatSpell"))
+                call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL"))
+            else null
         "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
         // "the number of [filter] cards in your graveyard" (Rise of the Varmints' Varmint count). The
         // count's args are a `_CardsInGraveyard` filter — typically `And(IsCardtype Creature,

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -175,13 +175,12 @@ object Emitter {
                 // "firebending X (X = its power)" carries an XValue node -> findInteger returns "X" ->
                 // `as? Int` is null -> scaffold, rather than guessing.
                 rname == "Firebending" -> block = (findInteger(rule["args"]) as? Int)?.let { listOf(Eval(call("firebending", arg("$it")))) }
-                // Ward {cost} (CR 702.21) carries a `_Cost` arg. Only the pure-mana shape renders as
-                // `KeywordAbility.Ward(WardCost.Mana("{x}"))`; Ward—Pay life / Ward—Discard / other
-                // costs return null -> scaffold rather than drop the cost. A bare WARD enum keyword
-                // would lose the cost entirely, so this must never fall through to the keyword case.
-                rname == "Ward" -> block = manaKeywordCost(rule)?.let {
-                    listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.Ward", arg(call("WardCost.Mana", arg("\"$it\""))))))))
-                }
+                // Ward—<cost> (CR 702.21) carries a `_Cost` arg. `wardKeywordLine` renders the cost
+                // shapes the SDK exposes — mana (`Ward {x}`), discard-a-card, pay-N-life, sacrifice-a-
+                // <filter>; compound/dynamic costs return null -> scaffold rather than drop the cost. A
+                // bare WARD enum keyword would lose the cost entirely, so this must never fall through
+                // to the keyword case.
+                rname == "Ward" -> block = ctx.wardKeywordLine(rule)
                 // Plot {cost} (CR 718, OTJ) carries a `_Cost: PayMana` arg -> KeywordAbility.plot("{cost}").
                 // Pure-mana only; a non-mana plot cost (none printed) declines -> scaffold.
                 rname == "Plot" -> block = manaKeywordCost(rule)?.let {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -141,6 +141,34 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
                 arg("effect", edsl),
             )
         }
+        // "If [N] or more mana was spent to cast that spell, [do X]" (Expressive Firedancer) — a
+        // `SpellPassesFilter(Trigger_ThatSpell, AnAmountOfManaWasSpentToCastIt{>= N})` gate on the
+        // triggering spell's mana. Renders a `Compare(ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL),
+        // >=, Fixed(N))`. Only the triggering spell + a `GreaterThanOrEqualTo` Integer compare render;
+        // any other spell subject / comparator declines -> SCAFFOLD rather than misread the threshold.
+        if (cond.strField("_Condition") == "SpellPassesFilter") {
+            val cargs = cond["args"].asArr ?: return@on null
+            if ((cargs.getOrNull(0) as? JsonObject)?.strField("_Spell") != "Trigger_ThatSpell") return@on null
+            val spellFilter = cargs.getOrNull(1) as? JsonObject ?: return@on null
+            if (spellFilter.strField("_Spells") != "AnAmountOfManaWasSpentToCastIt") return@on null
+            val cmp = spellFilter["args"] as? JsonObject ?: return@on null
+            if (cmp.strField("_Comparison") != "GreaterThanOrEqualTo") return@on null
+            val n = (cmp["args"].asInt()) ?: ((cmp["args"] as? JsonObject)?.get("args").asInt()) ?: return@on null
+            val edsl = renderEffectList(inner, tvar) ?: return@on null
+            return@on call(
+                "ConditionalEffect",
+                arg(
+                    "condition",
+                    call(
+                        "Compare",
+                        arg(call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL"))),
+                        arg("ComparisonOperator.GTE"),
+                        arg(call("DynamicAmount.Fixed", arg("$n"))),
+                    ),
+                ),
+                arg("effect", edsl),
+            )
+        }
         if (cond.strField("_Condition") != "PermanentPassesFilter") return@on null
         val condArgs = cond["args"].asArr ?: return@on null
         // Subject must be the first targeted permanent (Ref_TargetPermanent / Ref_TargetPermanent1).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -68,7 +68,10 @@ data class TriggeredAbilityContinuation(
     /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,
     /** Damage past lethal dealt to the trigger's creature recipient (CR 120.4a). Null for non-damage triggers. */
-    val triggerExcessDamageAmount: Int? = null
+    val triggerExcessDamageAmount: Int? = null,
+    /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
+     *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
+    val triggerManaSpentOnTriggeringSpell: Int? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -70,6 +70,13 @@ data class TriggerContext(
      */
     val modesChosenCount: Int? = null,
     /**
+     * For SpellCastEvent triggers — total mana spent to cast the triggering spell. `null` when
+     * the trigger was not driven by a spell cast. Read by
+     * `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL` so abilities like Aberrant Manawurm
+     * and Expressive Firedancer can scale by "the amount of mana spent to cast that spell."
+     */
+    val manaSpentOnTriggeringSpell: Int? = null,
+    /**
      * Power of the creature the trigger's source (an Aura/Equipment) was attached to, captured
      * when the trigger fired. Carried as last-known information (CR 608.2h) so that an
      * "enchanted creature deals damage equal to its power" ability still uses the right power
@@ -128,7 +135,8 @@ data class TriggerContext(
                 is SpellCastEvent -> TriggerContext(
                     triggeringEntityId = event.spellEntityId,
                     triggeringPlayerId = event.casterId,
-                    modesChosenCount = event.chosenModesCount.takeIf { it > 0 }
+                    modesChosenCount = event.chosenModesCount.takeIf { it > 0 },
+                    manaSpentOnTriggeringSpell = event.totalManaSpent.takeIf { it > 0 }
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is com.wingedsheep.engine.core.ScriedEvent -> TriggerContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1153,7 +1153,8 @@ class TriggerMatcher(
                 triggerLastKnownPower = trigger.triggerContext.lastKnownPower,
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,
                 triggerScryCount = trigger.triggerContext.scryCount,
-                triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount
+                triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
+                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
             )
             conditionEvaluator.evaluate(state, condition, context)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -426,7 +426,8 @@ class TriggerProcessor(
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,
                 triggerModesChosenCount = trigger.triggerContext.modesChosenCount,
                 triggerScryCount = trigger.triggerContext.scryCount,
-                triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount
+                triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
+                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
             )
             ability.effect.runtimeDescription { amount -> evaluator.evaluate(state, amount, context) }
         } catch (_: Exception) {
@@ -472,7 +473,8 @@ class TriggerProcessor(
             triggerModesChosenCount = trigger.triggerContext.modesChosenCount,
             enchantedCreatureLastKnownPower = trigger.triggerContext.enchantedCreatureLastKnownPower,
             triggerScryCount = trigger.triggerContext.scryCount,
-            triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount
+            triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
+            triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
         )
 
         // Push the continuation onto the stack
@@ -524,7 +526,8 @@ class TriggerProcessor(
             triggerModesChosenCount = trigger.triggerContext.modesChosenCount,
             enchantedCreatureLastKnownPower = trigger.triggerContext.enchantedCreatureLastKnownPower,
             triggerScryCount = trigger.triggerContext.scryCount,
-            triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount
+            triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
+            triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
         )
 
         return stackResolver.putTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -463,6 +463,8 @@ class DynamicAmountEvaluator(
 
         ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL -> context.triggerModesChosenCount ?: 0
 
+        ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL -> context.triggerManaSpentOnTriggeringSpell ?: 0
+
         ContextPropertyKey.TRIGGER_SCRY_COUNT -> context.triggerScryCount ?: 0
 
         ContextPropertyKey.TRIGGER_EXCESS_DAMAGE_AMOUNT -> context.triggerExcessDamageAmount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -165,6 +165,12 @@ data class EffectContext(
      */
     val triggerModesChosenCount: Int? = null,
     /**
+     * Total mana spent to cast the spell that fired this trigger. Read by
+     * `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL` (Aberrant Manawurm, Expressive
+     * Firedancer). Distinct from [totalManaSpent], which is the *resolving object's own* cast.
+     */
+    val triggerManaSpentOnTriggeringSpell: Int? = null,
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Read by
      * `ContextPropertyKey.TRIGGER_SCRY_COUNT` (Celeborn the Wise, Elrond Master of Healing).
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -97,7 +97,8 @@ class EffectAndTriggerContinuationResumer(
                 lastKnownPower = continuation.lastKnownPower,
                 lastKnownToughness = continuation.lastKnownToughness,
                 triggerScryCount = continuation.triggerScryCount,
-                triggerExcessDamageAmount = continuation.triggerExcessDamageAmount
+                triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
+                triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell
             )
             val stackResult = services.stackResolver.putTriggeredAbility(state, elseComponent, emptyList())
             if (!stackResult.isSuccess) return stackResult
@@ -143,7 +144,8 @@ class EffectAndTriggerContinuationResumer(
             triggerModesChosenCount = continuation.triggerModesChosenCount,
             enchantedCreatureLastKnownPower = continuation.enchantedCreatureLastKnownPower,
             triggerScryCount = continuation.triggerScryCount,
-            triggerExcessDamageAmount = continuation.triggerExcessDamageAmount
+            triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
+            triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell
         )
 
         val stackResult = services.stackResolver.putTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1790,6 +1790,7 @@ class StackResolver(
             triggerModesChosenCount = abilityComponent.triggerModesChosenCount,
             triggerScryCount = abilityComponent.triggerScryCount,
             triggerExcessDamageAmount = abilityComponent.triggerExcessDamageAmount,
+            triggerManaSpentOnTriggeringSpell = abilityComponent.triggerManaSpentOnTriggeringSpell,
             xValue = abilityComponent.xValue,
             damageDistribution = abilityComponent.damageDistribution,
             chosenModes = abilityComponent.chosenModes,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -125,6 +125,9 @@ data class TriggeredAbilityOnStackComponent(
     val triggerScryCount: Int? = null,
     /** Damage past lethal dealt to the trigger's creature recipient (CR 120.4a). Null for non-damage triggers. */
     val triggerExcessDamageAmount: Int? = null,
+    /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
+     *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
+    val triggerManaSpentOnTriggeringSpell: Int? = null,
     // Modal fields — populated when this triggered ability is a copy of a modal spell (700.2g).
     // Copies inherit the original's chosen modes; targets either inherit too (StormCopy default)
     // or are re-chosen by the copy controller while modes stay fixed.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1485,7 +1485,8 @@ class ClientStateTransformer(
         triggerLastKnownPower = triggered.lastKnownPower,
         triggerLastKnownToughness = triggered.lastKnownToughness,
         triggerScryCount = triggered.triggerScryCount,
-        triggerExcessDamageAmount = triggered.triggerExcessDamageAmount
+        triggerExcessDamageAmount = triggered.triggerExcessDamageAmount,
+        triggerManaSpentOnTriggeringSpell = triggered.triggerManaSpentOnTriggeringSpell
     )
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosTriggerShapeCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosTriggerShapeCardsScenarioTest.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the four Secrets of Strixhaven "cast an instant or sorcery" trigger-shape
+ * cards. They share the new [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL]
+ * context key (mana spent on the *triggering* spell) and the
+ * `GameObjectFilter.targetsMatching(...)` Repartee filter (instant/sorcery that targets a creature).
+ */
+class SosTriggerShapeCardsScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Aberrant Manawurm — +X/+0 where X = mana spent on the triggering spell") {
+
+            test("casting Blaze for X=4 (5 total mana) gives the Wurm +5/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aberrant Manawurm") // 2/5
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Grizzly Bears") // a creature to burn
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Aberrant Manawurm")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Wurm starts as a 2/5") {
+                    projector.getProjectedPower(game.state, wurm) shouldBe 2
+                }
+
+                // Blaze with X=4 → 5 mana spent ({4}{R}); target the opposing creature.
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+                game.resolveStack() // resolve the cast-trigger (and Blaze)
+
+                withClue("Wurm gets +X/+0 where X = 5 mana spent → 2+5 = 7 power") {
+                    projector.getProjectedPower(game.state, wurm) shouldBe 7
+                }
+                withClue("Toughness is unchanged (+X/+0)") {
+                    projector.getProjectedToughness(game.state, wurm) shouldBe 5
+                }
+            }
+        }
+
+        context("Expressive Firedancer — +1/+1, plus double strike if 5+ mana spent") {
+
+            test("a 1-mana spell gives +1/+1 but no double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Expressive Firedancer") // 2/2
+                    .withCardInHand(1, "Lightning Bolt") // {R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dancer = game.findPermanent("Expressive Firedancer")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Firedancer gets +1/+1 → 3/3") {
+                    projector.getProjectedPower(game.state, dancer) shouldBe 3
+                    projector.getProjectedToughness(game.state, dancer) shouldBe 3
+                }
+                withClue("Only 1 mana spent → no double strike") {
+                    projector.project(game.state).hasKeyword(dancer, Keyword.DOUBLE_STRIKE) shouldBe false
+                }
+            }
+
+            test("a 5-mana spell gives +1/+1 AND double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Expressive Firedancer") // 2/2
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dancer = game.findPermanent("Expressive Firedancer")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Firedancer gets +1/+1 → 3/3") {
+                    projector.getProjectedPower(game.state, dancer) shouldBe 3
+                    projector.getProjectedToughness(game.state, dancer) shouldBe 3
+                }
+                withClue("5 mana spent → gains double strike") {
+                    projector.project(game.state).hasKeyword(dancer, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+            }
+        }
+
+        context("Lecturing Scornmage — Repartee +1/+1 counter only when the spell targets a creature") {
+
+            test("instant targeting a creature puts a +1/+1 counter on the Scornmage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lecturing Scornmage") // 1/1
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scornmage = game.findPermanent("Lecturing Scornmage")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Repartee fires: a +1/+1 counter is placed") {
+                    val counters = game.state.getEntity(scornmage)
+                        ?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 1
+                }
+            }
+
+            test("instant targeting a player does NOT trigger Repartee") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lecturing Scornmage") // 1/1
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scornmage = game.findPermanent("Lecturing Scornmage")!!
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", targetPlayerNumber = 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Spell targeted a player, not a creature → no counter") {
+                    val counters = game.state.getEntity(scornmage)
+                        ?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+        }
+
+        context("Forum Necroscribe — Repartee reanimates a creature from your graveyard") {
+
+            test("casting a creature-targeting instant returns a creature card from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Forum Necroscribe") // 5/4
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInGraveyard(1, "Grizzly Bears") // creature card to reanimate
+                    .withCardOnBattlefield(2, "Glory Seeker") // a creature to target with Bolt
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gloryseeker = game.findPermanent("Glory Seeker")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = gloryseeker).error shouldBe null
+                game.resolveStack() // cast-trigger asks for a graveyard target
+
+                val bearsInGy = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+                game.selectTargets(listOf(bearsInGy)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is reanimated onto the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Grizzly Bears left the graveyard") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").isEmpty() shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four **Secrets of Strixhaven** (SOS) "cast an instant or sorcery" trigger-shape cards, adds the one engine capability they share, and extends the mtgish auto-gen emitter + bridge so the whole family auto-generates.

## Cards (all SOS-canonical, scenario-tested)
- **Aberrant Manawurm** — Trample; whenever you cast an instant or sorcery, it gets **+X/+0** until end of turn, where X is the mana spent on that spell.
- **Expressive Firedancer** — whenever you cast an instant or sorcery, **+1/+1** until end of turn; **double strike** until end of turn if 5+ mana was spent on that spell.
- **Forum Necroscribe** — **Ward—Discard a card**; whenever you cast an instant or sorcery that targets a creature, **reanimate** a creature card from your graveyard.
- **Lecturing Scornmage** — whenever you cast an instant or sorcery that targets a creature, **+1/+1 counter** on it.

All four pass `SosTriggerShapeCardsScenarioTest` (6 tests, including the edge case that a spell targeting a *player* does not fire Repartee, and the 5-mana double-strike threshold both ways).

## Engine — the shared new capability
- New `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`: total mana spent on the **triggering** spell, distinct from `DynamicAmount.TotalManaSpent` (the resolving object's own cast). Wired through `TriggerContext` → `EffectContext` → `TriggeredAbilityOnStackComponent` / `TriggeredAbilityContinuation` → `DynamicAmountEvaluator` + `ConditionEvaluator`, mirroring the existing `MODES_CHOSEN_ON_TRIGGERING_SPELL` plumbing. Drives Manawurm's `+X` and Firedancer's 5-mana gate.
- New `GameObjectFilter.targetsMatching(subfilter)` helper over the existing `CardPredicate.TargetsMatching` — "a spell that targets a creature" (Repartee).

## mtgish emitter / bridge (fix the emitter, never the generated cards)
- `dynamicAmountExpr`: `AmountOfManaSpentToCastSpell(Trigger_ThatSpell)` → `ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL)`.
- `spellCastCategory` + `castTriggerDsl`: render `And(<I/S>, TargetsAPermanent(<perm>))` as `youCastSpell(spellFilter = base.targetsMatching(<filter>))`; declines unless **both** halves render exactly.
- `on("If")`: `SpellPassesFilter(Trigger_ThatSpell, AnAmountOfManaWasSpentToCastIt >= N)` → `ConditionalEffect(Compare(ContextProperty(...), GTE, Fixed(N)))`.
- **Ward—<cost>** keyword ability now renders all SDK-expressible cost shapes (mana / discard-a-card / pay-N-life / sacrifice-a-`<filter>`); compound/dynamic ward costs still decline → SCAFFOLD. Added a `supported("Ward", …)` bridge entry so the probe scores Ward cards as covered.

## Verification
- All four cards emit at **fidelity tier AUTO**.
- `coverage-verify SOS`: **43/43** gameplay-tree match, **0 mismatch**, 0 capability gap (the four cards included).
- `coverage-verify POR`: **158/158**, **0 mismatch** (regression net clean).
- `EmitterGoldenTest` (POR + EOE) byte-identical; full `:mtgish-tooling` suite green.
- `CardLintTest` + `CardDefinitionSnapshotTest` (SOS re-blessed, **additive only**) pass; rules-engine scenario/trigger sweep passes.
- `docs/card-sdk-language-reference.md` updated for the new context key + filter helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)