### PR TITLE
SOS: conditional-effect cards + mtgish emitter support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2044,7 +2044,16 @@ staticAbility {
 - `target: SpellCostTarget` — `SelfCast`, `YouCast(filter)`, `AnyCaster(filter)`,
   `OpponentsCastTargeting(GroupFilter)`, `FaceDownYouCast`, `MorphActivation`.
 - `modification: CostModification` — `ReduceGeneric(amount)`, `ReduceGenericBy(source)`,
-  `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`, `IncreaseGeneric(amount)`,
+  `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`,
+  `ReduceColoredIfAnyTargetMatches(symbols, filter)` (target-gated **colored** reduction — the
+  colored analogue of the `FixedIfAnyTargetMatches` reduction source, which only reduces generic;
+  removes the given colored pips if the spell targets a matching object. Brush Off's "costs
+  {1}{U} less if it targets an instant or sorcery spell" pairs `ReduceColoredIfAnyTargetMatches("{U}",
+  InstantOrSorcery)` for the `{U}` with `ReduceGenericBy(FixedIfAnyTargetMatches(1, InstantOrSorcery))`
+  for the `{1}`, both gated on the same filter so they apply together. Like the generic gated
+  reduction, affordability enumeration only optimistically discounts when a matching *battlefield*
+  permanent exists; a stack-spell target reduction shows at full cost during enumeration and locks
+  in once targets are announced), `IncreaseGeneric(amount)`,
   `IncreaseColored(symbols)` (colored tax — adds colored pips, e.g. the Invasion Leeches'
   "White spells you cast cost {W} more"), `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
   `IncreaseGenericIfAnyTargetMatches(amount, filter)` (target-gated tax — "{N} more if it targets

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -50,6 +50,8 @@ data class ModifySpellCost(
             is CostModification.ReduceColored -> "cost ${modification.symbols} less to cast"
             is CostModification.ReduceColoredPerUnit ->
                 "cost ${modification.symbols} less to cast for each ${modification.countSource.description}"
+            is CostModification.ReduceColoredIfAnyTargetMatches ->
+                "cost ${modification.symbols} less to cast if it targets ${modification.filter.description}"
             is CostModification.IncreaseGeneric -> "cost {${modification.amount}} more"
             is CostModification.IncreaseColored -> "cost ${modification.symbols} more to cast"
             is CostModification.IncreaseGenericPerOtherSpellThisTurn ->
@@ -209,6 +211,33 @@ sealed interface CostModification {
         val symbols: String,
         val countSource: CostReductionSource,
     ) : CostModification
+
+    /**
+     * Remove specific colored mana [symbols] from the cost if the spell targets any object
+     * matching [filter]. The colored analogue of
+     * [CostReductionSource.FixedIfAnyTargetMatches] (which only reduces generic), and the
+     * reduction counterpart of [IncreaseGenericIfAnyTargetMatches].
+     *
+     * Used for cards like Brush Off ("This spell costs {1}{U} less to cast if it targets an
+     * instant or sorcery spell") — pair this `{U}` reduction with a
+     * `ReduceGenericBy(FixedIfAnyTargetMatches(1, filter))` for the `{1}` so both halves apply
+     * together once a matching target is chosen.
+     *
+     * At cast resolution, the reduction applies if any of the spell's chosen targets match.
+     * Like [CostReductionSource.FixedIfAnyTargetMatches], excess that cannot match is silently
+     * dropped (does NOT overflow to generic).
+     */
+    @SerialName("ReduceColoredIfAnyTargetMatches")
+    @Serializable
+    data class ReduceColoredIfAnyTargetMatches(
+        val symbols: String,
+        val filter: GameObjectFilter,
+    ) : CostModification {
+        override fun applyTextReplacement(replacer: TextReplacer): CostModification {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
 
     /** Increase generic mana by a fixed amount (tax effect). */
     @SerialName("IncreaseGeneric")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BrushOff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BrushOff.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Brush Off
+ * {2}{U}{U}
+ * Instant
+ * This spell costs {1}{U} less to cast if it targets an instant or sorcery spell.
+ * Counter target spell.
+ *
+ * The cost reduction is split into its generic and colored halves, each gated on the same
+ * "targets an instant or sorcery spell" filter so they apply together:
+ *  - {1} via [CostReductionSource.FixedIfAnyTargetMatches] on [CostModification.ReduceGenericBy].
+ *  - {U} via [CostModification.ReduceColoredIfAnyTargetMatches].
+ *
+ * The reduction filter matches an instant or sorcery *spell on the stack* (the chosen target),
+ * resolved at cast time once targets are announced (CR 601.2f).
+ */
+val BrushOff = card("Brush Off") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1}{U} less to cast if it targets an instant or sorcery spell.\n" +
+        "Counter target spell."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 1,
+                    filter = GameObjectFilter.InstantOrSorcery,
+                ),
+            ),
+        )
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceColoredIfAnyTargetMatches(
+                symbols = "{U}",
+                filter = GameObjectFilter.InstantOrSorcery,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Genel Jumalon"
+        flavorText = "\"You're the one who brought a priceless scroll to a duel!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/151eab82-d20f-433b-b3bb-1d44e2871d5c.jpg?1775937183"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BurrogBarrage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BurrogBarrage.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Burrog Barrage
+ * {1}{G}
+ * Instant
+ * Target creature you control gets +1/+0 until end of turn if you've cast another instant or
+ * sorcery spell this turn. Then it deals damage equal to its power to up to one target creature
+ * an opponent controls.
+ *
+ * "Cast another instant or sorcery this turn" — Burrog Barrage is itself an instant and is already
+ * recorded in the spells-cast tracker when it resolves, so the intervening-if is "two or more
+ * instant/sorcery spells cast this turn" ([Conditions.YouCastSpellsThisTurn] with atLeast = 2).
+ *
+ * The +1/+0 is applied before the power is read, so the damage (equal to the buffed creature's
+ * power) includes the bonus. The second creature is "up to one target", an optional target.
+ */
+val BurrogBarrage = card("Burrog Barrage") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +1/+0 until end of turn if you've cast another " +
+        "instant or sorcery spell this turn. Then it deals damage equal to its power to up to one " +
+        "target creature an opponent controls."
+
+    spell {
+        val own = target("target creature you control", Targets.CreatureYouControl)
+        val foe = target(
+            "up to one target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls, optional = true),
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.YouCastSpellsThisTurn(2, GameObjectFilter.InstantOrSorcery),
+            effect = Effects.ModifyStats(1, 0, own),
+        ) then Effects.DealDamage(
+            DynamicAmounts.targetPower(0),
+            foe,
+            damageSource = own,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Christina Kraus"
+        flavorText = "\"I had to leave Doradur to attend Strixhaven, so I brought a piece of home with me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95d5b0a8-2b66-418e-9e5e-ecf7b304c31e.jpg?1775937957"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/CostOfBrilliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/CostOfBrilliance.kt
@@ -29,7 +29,7 @@ val CostOfBrilliance = card("Cost of Brilliance") {
     oracleText = "Target player draws two cards and loses 2 life. Put a +1/+1 counter on up to one target creature."
     spell {
         val t1 = target("t1", TargetPlayer())
-        val t2 = target("t2", TargetCreature(filter = TargetFilter.Creature))
+        val t2 = target("t2", TargetCreature(filter = TargetFilter.Creature, optional = true))
         effect = Effects.Composite(
             DrawCardsEffect(2, t1),
             LoseLifeEffect(2, t1),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/DuelTactics.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/DuelTactics.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Duel Tactics
+ * {R}
+ * Sorcery
+ * Duel Tactics deals 1 damage to target creature. It can't block this turn.
+ * Flashback {1}{R}
+ *
+ * The damaged creature is also prevented from blocking for the rest of the turn
+ * ([Effects.CantBlock] with [Duration.EndOfTurn]). Flashback lets the spell be recast from the
+ * graveyard for {1}{R}, then exiles it.
+ */
+val DuelTactics = card("Duel Tactics") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Duel Tactics deals 1 damage to target creature. It can't block this turn.\n" +
+        "Flashback {1}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    keywordAbility(KeywordAbility.flashback("{1}{R}"))
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(1, creature) then
+            Effects.CantBlock(creature, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Craig J Spearing"
+        flavorText = "\"My trick? Hit their casting hand and they lose their advantage. So far, I'm undefeated.\"" +
+            "\n—Alessia, Lorehold duelist"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f3a1675-0cc7-4dfd-a12e-4740a2cf81e8.jpg?1775937718"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FoolishFate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FoolishFate.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Foolish Fate
+ * {2}{B}
+ * Instant
+ * Destroy target creature.
+ * Infusion — If you gained life this turn, that creature's controller loses 3 life.
+ *
+ * Infusion is an ability word (no rules meaning); it flavors the intervening-if clause.
+ * "That creature's controller" refers to the controller of the targeted creature, captured
+ * via [EffectTarget.TargetController] so the drain still resolves against the right player
+ * even though the creature itself has left the battlefield.
+ */
+val FoolishFate = card("Foolish Fate") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature.\n" +
+        "Infusion — If you gained life this turn, that creature's controller loses 3 life."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Destroy(creature) then ConditionalEffect(
+            condition = Conditions.YouGainedLifeThisTurn,
+            effect = Effects.LoseLife(3, EffectTarget.TargetController),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Danny Schwartz"
+        flavorText = "\"There are some lessons so simple that I thought they needn't be taught. " +
+            "I suppose I was wrong.\"\n—Moseo, dean of the vein"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d278f4c9-d20b-4a76-8c5c-4d3e985948b9.jpg?1775937489"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -88,6 +88,59 @@
     ]
 }
 
+// Brush Off
+{
+    "name": "Brush Off",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1}{U} less to cast if it targets an instant or sorcery spell.\nCounter target spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 1,
+                        "filter": "instant|sorcery"
+                    }
+                }
+            },
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceColoredIfAnyTargetMatches",
+                    "symbols": "{U}",
+                    "filter": "instant|sorcery"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Genel Jumalon",
+        "flavorText": "\"You're the one who brought a priceless scroll to a duel!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/151eab82-d20f-433b-b3bb-1d44e2871d5c.jpg?1775937183"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Burrog Banemaker
 {
     "name": "Burrog Banemaker",
@@ -135,6 +188,89 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Burrog Barrage
+{
+    "name": "Burrog Barrage",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gets +1/+0 until end of turn if you've cast another instant or sorcery spell this turn. Then it deals damage equal to its power to up to one target creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "PlayerCastSpellsThisTurn",
+                            "filter": "instant|sorcery",
+                            "atLeast": 2
+                        }
+                    },
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature an opponent controls"
+                    },
+                    "damageSource": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "up to one target creature an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Christina Kraus",
+        "flavorText": "\"I had to leave Doradur to attend Strixhaven, so I brought a piece of home with me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95d5b0a8-2b66-418e-9e5e-ecf7b304c31e.jpg?1775937957"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -293,6 +429,7 @@
             },
             {
                 "type": "TargetObject",
+                "optional": true,
                 "filter": {
                     "baseFilter": "creature"
                 },
@@ -462,6 +599,67 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Duel Tactics
+{
+    "name": "Duel Tactics",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Duel Tactics deals 1 damage to target creature. It can't block this turn.\nFlashback {1}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"My trick? Hit their casting hand and they lose their advantage. So far, I'm undefeated.\"\n—Alessia, Lorehold duelist",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f3a1675-0cc7-4dfd-a12e-4740a2cf81e8.jpg?1775937718"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -760,6 +958,76 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Foolish Fate
+{
+    "name": "Foolish Fate",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature.\nInfusion — If you gained life this turn, that creature's controller loses 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "LIFE_GAINED"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "TargetController"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Danny Schwartz",
+        "flavorText": "\"There are some lessons so simple that I thought they needn't be taught. I suppose I was wrong.\"\n—Moseo, dean of the vein",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d278f4c9-d20b-4a76-8c5c-4d3e985948b9.jpg?1775937489"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -20,7 +20,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("FromHand", "envelope: activated ability used from hand (activateFromZone = Zone.HAND)")
     envelope("FromGraveyard", "envelope: activated ability used from graveyard (activateFromZone = Zone.GRAVEYARD)")
     envelope("And", "envelope: cost/action conjunction")
-    envelope("If", "conditional envelope")
+    // A resolution-time intervening-if (`If[cond, [then]]` inside a spell/ability ActionList) realises as
+    // a `ConditionalEffect` -> `GatedEffect(gate = WhenCondition)` (SerialName "Gated") in our trees, the
+    // same compiled shape as a "you may" gate; so the conditional envelope composes the Gated capability
+    // (Foolish Fate's "if you gained life this turn …", Burrog Barrage's "+1/+0 if you've cast …").
+    envelope("If", "conditional envelope", composes = listOf("Gated"))
 
     // The "you may / unless / if you do" gate cluster (Lesson 1). A "you may [effect]" realises as a
     // `GatedEffect(gate = MayDecide)` (SerialName "Gated") in our trees, so the gate envelope composes it.
@@ -69,7 +73,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("CreateEachPermanentRuleEffectUntil", "envelope: continuous rule, each")
     envelope("CreatePlayerEffectUntil", "envelope: player-scoped continuous effect")
     envelope("CreatePermanentLayerEffect", UNIVERSAL)
-    envelope("CreatePermanentRuleEffectUntil", UNIVERSAL)
+    // A continuous rule until end of turn. The nested `_PermanentRule` is the real capability: CantBlock /
+    // CantAttack render to `CantBlockEffect` (SerialName "CantBlockTargetCreatures") / `CantAttackEffect`
+    // (Duel Tactics' "it can't block this turn"), and the can't-be-blocked rules to keyword grants.
+    envelope("CreatePermanentRuleEffectUntil", UNIVERSAL,
+        composes = listOf("CantBlockTargetCreatures", "CantAttack"))
 
     // Cross-set "may" / choice / branch envelopes surfaced by calibration on later sets.
     envelopes("PlayerMayAction", "PlayerMayCost", note = UNIVERSAL, composes = listOf("May"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2,6 +2,8 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.Assign
 import com.wingedsheep.tooling.coverage.Block
+import com.wingedsheep.tooling.coverage.Arg
+import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Eval
 import com.wingedsheep.tooling.coverage.Lit
@@ -92,8 +94,14 @@ private fun EmitCtx.multiTargetLocals(targets: List<JsonObject>, actions: List<J
     val stmts = mutableListOf<Stmt>()
     val vars = mutableListOf<String>()
     val refsByKind = mutableMapOf<String, MutableList<String>>()
+    // The mtgish IR sometimes drops the "up to one/N target" optionality on a multi-target spell's later
+    // target (Burrog Barrage's "up to one target creature an opponent controls" arrives as a plain
+    // mandatory TargetPermanent). The oracle text is authoritative, so recover per-target optionality
+    // from the ordered "target …" clauses there and inject `optional = true` when the IR omitted it.
+    val optionalByOrdinal = oracleOptionalTargetOrdinals(targets.size)
     targets.forEachIndexed { i, t ->
-        val node = targetExpr(t, actions) ?: run { reasons.add("target:${t.strField("_Target")}"); return null }
+        var node = targetExpr(t, actions) ?: run { reasons.add("target:${t.strField("_Target")}"); return null }
+        if (optionalByOrdinal.getOrNull(i) == true) node = node.withOptionalArg()
         val varName = "t${i + 1}"
         stmts.add(targetLocalNamed(varName, varName, node))
         vars.add(varName)
@@ -103,6 +111,31 @@ private fun EmitCtx.multiTargetLocals(targets: List<JsonObject>, actions: List<J
         if (refVars.size == 1) ref to refVars.single() else null
     }.toMap()
     return MultiTargetLocals(stmts, vars, refVars, refsByKind.mapValues { it.value.toList() })
+}
+
+/**
+ * For a spell whose IR declares [targetCount] targets in oracle order, returns a per-ordinal flag of
+ * which are "up to one/N target …" (optional). Reads the oracle text — the IR occasionally drops the
+ * "up to" qualifier on a later target (Burrog Barrage). Each ordered "(up to one|up to N )?target …"
+ * mention maps to one declared target in order; only the explicit "up to" ones are optional. If the
+ * count of "target" mentions doesn't line up with [targetCount], returns all-false (no over-claiming
+ * optionality — better a mandatory mismatch caught by the gate than a silently wrong optional flag).
+ */
+/** Add `optional = true` to a `Target…(…)` Call (idempotent). Non-Call nodes (or ones already carrying
+ *  the flag) are returned unchanged — recovering optionality only ever ADDS the flag, never overrides. */
+private fun Dsl.withOptionalArg(): Dsl = when {
+    this is Call && this.args.none { it.name == "optional" } ->
+        this.copy(args = this.args + Arg(Lit("true"), "optional"))
+    else -> this
+}
+
+private fun EmitCtx.oracleOptionalTargetOrdinals(targetCount: Int): List<Boolean> {
+    val text = oracleText?.lowercase() ?: return List(targetCount) { false }
+    // Match each "target" mention, capturing an immediately-preceding "up to <word/number> " qualifier.
+    val mentions = Regex("""(up to (?:one|two|three|four|\d+)\s+)?target\b""")
+        .findAll(text).map { it.groupValues[1].isNotBlank() }.toList()
+    if (mentions.size != targetCount) return List(targetCount) { false }
+    return mentions
 }
 
 private fun refKindForTarget(target: JsonObject): String? = when (target.strField("_Target")) {
@@ -125,6 +158,7 @@ internal fun EmitCtx.castEffectHandled(rule: JsonObject): Boolean {
         "CantBeCastUnless" -> castRestrictionLines(listOf(rule)) != null
         "AdditionalCastingCost" -> additionalCostLine(rule) != null
         "ReduceCastingCostIf" -> costReductionStaticLines(rule) != null
+        "ReduceCastingCostIfItTargetsASpell" -> targetSpellCostReductionLines(rule) != null
         else -> false
     }
 }
@@ -137,9 +171,72 @@ internal fun EmitCtx.cardLevelCastEffectLines(card: JsonObject): List<String>? {
         if (line != null) { lines.add(line); continue }
         val reduction = costReductionStaticLines(rule)
         if (reduction != null) { lines.addAll(reduction); continue }
+        val targetReduction = targetSpellCostReductionLines(rule)
+        if (targetReduction != null) { lines.addAll(targetReduction); continue }
         if (!castEffectHandled(rule)) return null
     }
     return lines
+}
+
+/**
+ * `CastEffect(ReduceCastingCostIfItTargetsASpell([<cost symbols>], <spell filter>))` -> one
+ * `staticAbility { ability = ModifySpellCost(SelfCast, …) }` per cost symbol, each gated on the spell
+ * targeting an object matching the filter. Brush Off ("This spell costs {1}{U} less to cast if it
+ * targets an instant or sorcery spell"):
+ *  - `{1}` -> `ReduceGenericBy(FixedIfAnyTargetMatches(1, <filter>))`.
+ *  - `{U}` -> `ReduceColoredIfAnyTargetMatches("{U}", <filter>)`.
+ *
+ * Only the instant-or-sorcery spell filter renders today (the only target-gated colored reduction in
+ * the corpus); any other spell filter, or a cost symbol we don't model (generic-per-unit, life, …),
+ * declines -> SCAFFOLD rather than emit a wrong gate.
+ */
+private fun EmitCtx.targetSpellCostReductionLines(rule: JsonObject): List<String>? {
+    val node = rule["args"] as? JsonObject ?: return null
+    if (node.strField("_CastEffect") != "ReduceCastingCostIfItTargetsASpell") return null
+    val args = node["args"].asArr ?: return null
+    val symbols = (args.getOrNull(0) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (symbols.isEmpty()) return null
+    val spellFilter = args.getOrNull(1) as? JsonObject ?: return null
+    // Only the "instant or sorcery spell" filter (Or(IsCardtype Instant, IsCardtype Sorcery)) is modeled.
+    val filterDsl = if (spellFilter.strField("_Spells") == "Or") {
+        val blob = compact(spellFilter)
+        if (blob.contains("\"Instant\"") && blob.contains("\"Sorcery\"") && "IsCreatureType" !in blob) {
+            "GameObjectFilter.InstantOrSorcery"
+        } else return null
+    } else return null
+
+    val abilities = symbols.map { sym ->
+        when (sym.strField("_CostReductionSymbol")) {
+            "CostReduceGeneric" -> {
+                val amount = sym["args"].asInt() ?: return null
+                call(
+                    "ModifySpellCost",
+                    arg("target", Lit("SpellCostTarget.SelfCast")),
+                    arg("modification", call(
+                        "CostModification.ReduceGenericBy",
+                        arg(call(
+                            "CostReductionSource.FixedIfAnyTargetMatches",
+                            arg("amount", "$amount"), arg("filter", Lit(filterDsl)),
+                        )),
+                    )),
+                )
+            }
+            // A single colored pip (CostReduceW/U/B/R/G) -> the colored target-gated reduction.
+            "CostReduceW", "CostReduceU", "CostReduceB", "CostReduceR", "CostReduceG" -> {
+                val pip = sym.strField("_CostReductionSymbol")!!.removePrefix("CostReduce")
+                call(
+                    "ModifySpellCost",
+                    arg("target", Lit("SpellCostTarget.SelfCast")),
+                    arg("modification", call(
+                        "CostModification.ReduceColoredIfAnyTargetMatches",
+                        arg("symbols", Lit("\"{$pip}\"")), arg("filter", Lit(filterDsl)),
+                    )),
+                )
+            }
+            else -> return null
+        }
+    }
+    return abilities.flatMap { renderBlock(Block("staticAbility", listOf(Assign("ability", it))), "    ") }
 }
 
 /**
@@ -698,7 +795,7 @@ private fun EmitCtx.liftInterveningIfAction(actions: List<JsonObject>): Pair<Str
  *  - `PlayerPassesFilter(You, ControlsA(<filter>))` ("you control a <filter>") ->
  *    `Conditions.YouControl(<filter>)` (Beastbond Outcaster's "a creature with power 4 or greater").
  */
-private fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
+internal fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
     if (cond == null) return null
     // Top-level And -> Conditions.All(arm, arm, ...); every arm must render or the whole declines.
     if (cond.strField("_Condition") == "And") {
@@ -738,12 +835,47 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
             filter.field("args").asStr() == "Creature"
         return if (bareCreature) "Conditions.CreatureDiedThisTurn" else null
     }
+    // "if you gained life this turn" — PlayerPassesFilter(You, GainedLifeThisTurn) (Foolish Fate's
+    // Infusion clause). No count/amount sub-clause, so the bare "you gained life this turn" maps to
+    // Conditions.YouGainedLifeThisTurn.
+    if (cond.strField("_Condition") == "PlayerPassesFilter" &&
+        jsonContains(cond, "_Player", "You") &&
+        jsonContains(cond, "_Players", "GainedLifeThisTurn")
+    ) {
+        return "Conditions.YouGainedLifeThisTurn"
+    }
+    // "if you've cast another instant or sorcery spell this turn" — PlayerPassesFilter(You,
+    // CastASpellThisTurn(And(Other(ThisSpell), Or(IsCardtype Instant, IsCardtype Sorcery)))) (Burrog
+    // Barrage). The Other(ThisSpell) self-exclusion means "another", and this spell is itself an
+    // instant/sorcery, so "another instant or sorcery" = "two or more instant/sorcery spells this turn"
+    // -> Conditions.YouCastSpellsThisTurn(2, GameObjectFilter.InstantOrSorcery). Only the exact
+    // Other(ThisSpell) + instant-or-sorcery shape renders; anything else declines -> SCAFFOLD.
+    youCastAnotherInstantOrSorceryDsl(cond)?.let { return it }
     // "you control another outlaw" — ControlsA over And(Other(ThatEnteringPermanent), IsAnOutlaw). The
     // entering permanent is itself an outlaw, so this is exactly "two or more outlaws you control".
     youControlAnotherOutlawDsl(cond)?.let { return it }
     // "you control a <filter>" — reuse the static-gate renderer (PlayerPassesFilter(You, ControlsA(filter))).
     youControlConditionDsl(cond)?.let { return it }
     return null
+}
+
+/** `PlayerPassesFilter(You, CastASpellThisTurn(And(Other(ThisSpell), Or(IsCardtype Instant, IsCardtype
+ *  Sorcery))))` ("you've cast another instant or sorcery spell this turn") ->
+ *  `Conditions.YouCastSpellsThisTurn(2, GameObjectFilter.InstantOrSorcery)`, else null. The
+ *  Other(ThisSpell) self-exclusion plus this spell itself being an instant/sorcery is what makes
+ *  "another instant or sorcery" equal "two or more instant/sorcery spells cast this turn" — the spell
+ *  on the stack is already counted in the cast tracker when it resolves (Burrog Barrage). */
+private fun EmitCtx.youCastAnotherInstantOrSorceryDsl(cond: JsonObject): String? {
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val cast = args.getOrNull(1) as? JsonObject ?: return null
+    if (cast.strField("_Players") != "CastASpellThisTurn") return null
+    val blob = compact(cast)
+    // Must be the "another" (Other ThisSpell) self-exclusion over an instant-or-sorcery filter.
+    if ("\"Other\"" !in blob || "ThisSpell" !in blob) return null
+    if (!(blob.contains("\"Instant\"") && blob.contains("\"Sorcery\""))) return null
+    return "Conditions.YouCastSpellsThisTurn(2, GameObjectFilter.InstantOrSorcery)"
 }
 
 /** The "<counter> counter" name for a `HasNoCountersOfType(<CounterType>)` node, mapped to the engine's

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.put
 /** Direct effects on life totals, damage, and the player's own cards (draw / discard / look). */
 internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers {
 
-    on("SpellDealsDamage", "PermanentDealsDamage") { _, args, tvar ->
+    on("SpellDealsDamage", "PermanentDealsDamage") { node, args, tvar ->
         val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
         if (jsonContains(args, "_DamageRecipient", "EachPermanent")) {  // mass: deal N to each creature
             val filter = groupFilterExpr(args) ?: return@on null
@@ -41,6 +41,22 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
             return@on eachPermanent
         }
         val tgt = damageRecipientTarget(args, tvar) ?: return@on null
+        // For `PermanentDealsDamage`, the acting permanent (the first arg's `_Permanent` ref) is the
+        // damage source — when it's a bound target ("target creature you control … deals damage equal to
+        // its power", Burrog Barrage), thread it through `damageSource = …` so the damage is attributed
+        // correctly. `SpellDealsDamage` (the spell itself is the source) needs no source attribution.
+        if (node.strField("_Action") == "PermanentDealsDamage") {
+            val srcRef = (args.asArr?.firstOrNull() as? JsonObject)?.strField("_Permanent")
+            val src = if (srcRef != null) refTargetFromRef(srcRef, tvar) else null
+            // Only thread an EXPLICIT damage source — a BOUND TARGET other than the recipient (Burrog
+            // Barrage's "target creature you control … deals damage equal to its power"). The implicit
+            // `EffectTarget.Self` source (the acting permanent is `ThisPermanent`, the common Fire
+            // Imp / Fire Dragon shape) is the engine default and must NOT be emitted, or it diverges
+            // from golden trees that omit it.
+            if (src != null && src != tgt && src != "EffectTarget.Self") {
+                return@on call("DealDamageEffect", arg(amt), arg(Lit(tgt)), arg("damageSource", Lit(src)))
+            }
+        }
         call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
     }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -212,8 +212,13 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // permanent subject declines (-> scaffold) rather than misattribute the stat.
         "ToughnessOfPermanent" ->
             return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourceToughness") else null
-        "PowerOfPermanent" ->
-            return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourcePower") else null
+        "PowerOfPermanent" -> {
+            if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) return call("DynamicAmounts.sourcePower")
+            // "equal to its power" where "it" is a bound target (Burrog Barrage's "deals damage equal to
+            // its power" — the buffed target creature). Resolve the ref to its declaration-order index.
+            val idx = targetFlatIndexForRef(findRef(node["args"]))
+            return if (idx != null) call("DynamicAmounts.targetPower", arg("$idx")) else null
+        }
         // "the greatest power among creatures you control" (Tumbleweed Rising's X/X token). The args are a
         // permanent filter — only the exact "creatures you control" (And(IsCardtype Creature,
         // ControlledByAPlayer You)) shape maps to the battlefield MAX-power facade; any other filter (a
@@ -368,12 +373,23 @@ internal fun EmitCtx.refTarget(args: JsonElement?, tvar: String?): String? {
     return refTargetFromRef(ref, tvar)
 }
 
+/** The flat declaration-order index of a bound-target ref (its position in [targetVars]) — the index
+ *  `DynamicAmounts.targetPower(n)` / `EffectTarget.ContextTarget(n)` use. Returns null for a ref that
+ *  isn't a bound target (-> the caller scaffolds). In a single-target spell the only target is index 0. */
+internal fun EmitCtx.targetFlatIndexForRef(ref: String?): Int? {
+    if (ref == null) return null
+    val resolved = refTargetFromRef(ref, targetVars.firstOrNull()) ?: return null
+    if (targetVars.isEmpty()) return 0  // single-target spell: the lone bound target is index 0
+    val idx = targetVars.indexOf(resolved)
+    return if (idx >= 0) idx else null
+}
+
 /** Resolve the ref under a marked subtree, such as `_DamageRecipient`, to an EffectTarget DSL. */
 internal fun EmitCtx.refTargetIn(args: JsonElement?, markerKey: String, tvar: String?): String? {
     return refTargetFromRef(findRefIn(args, markerKey), tvar)
 }
 
-private fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
+internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     // A suffixed multi-target ref (Ref_TargetPermanent1 / Ref_TargetPermanent2 / …) indexes the
     // per-KIND ordered list of target locals (1-based). The IR ordinal counts only targets of that
     // kind, so it must not index the flat target list — that would skew when an earlier slot is a
@@ -386,7 +402,12 @@ private fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
         }
     }
     if (ref in setOf("Ref_TargetPermanent", "Ref_TargetPlayer", "Ref_TargetGraveyardCard")) {
-        return if (targetVars.isNotEmpty()) targetRefVars[ref] else tvar
+        if (targetVars.isEmpty()) return tvar
+        // Multi-target spell: an unsuffixed ref resolves to the single target of its kind. When the IR
+        // mixes an unsuffixed ref with suffixed siblings of the SAME kind (Burrog Barrage's +1/+0 on
+        // `Ref_TargetPermanent` alongside the damage's `Ref_TargetPermanent1`/`2`), the unsuffixed ref
+        // means the first target of that kind. A genuinely ambiguous case (no first-of-kind) declines.
+        return targetRefVars[ref] ?: targetRefVarsByKind[ref]?.firstOrNull()
     }
     if (ref in SELF_REFS) return "EffectTarget.Self"
     // "that player" in a trigger ("the player ~ dealt combat damage to") -> the triggering player.
@@ -422,13 +443,20 @@ internal fun EmitCtx.keywordOf(node: JsonElement?): String? {
  */
 internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
     if (cond == null) return null
-    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
-    val args = cond["args"].asArr ?: return null
-    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
-    val controls = args.getOrNull(1) as? JsonObject ?: return null
-    if (controls.strField("_Players") != "ControlsA") return null
-    val filter = gameObjectFilterDsl(controls["args"]) ?: return null
-    return render(call("Conditions.YouControl", arg(Lit(filter))))
+    if (cond.strField("_Condition") == "PlayerPassesFilter") {
+        val args = cond["args"].asArr
+        if (args != null && (args.getOrNull(0) as? JsonObject)?.strField("_Player") == "You") {
+            val controls = args.getOrNull(1) as? JsonObject
+            if (controls?.strField("_Players") == "ControlsA") {
+                val filter = gameObjectFilterDsl(controls["args"])
+                if (filter != null) return render(call("Conditions.YouControl", arg(Lit(filter))))
+            }
+        }
+    }
+    // Other resolution-time intervening-if shapes ("if you gained life this turn", "if you've cast
+    // another instant or sorcery this turn", …) reuse the shared condition renderer; declining beats
+    // widening. These power the resolution-time `on("If")` action handler.
+    return interveningIfDsl(cond)
 }
 
 /** The nested _Action node inside an envelope action (PlayerAction / MayAction). */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -145,6 +145,15 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): Dsl? {
         val spec = createTokens?.get("args").asArr?.firstOrNull() as? JsonObject ?: return null
         return createTokenDsl(spec, controller = "EffectTarget.TargetController")
     }
+    // "that creature's controller loses N life" — ControllerOfPermanent(Ref_TargetPermanent) + LoseLife
+    // (Foolish Fate's Infusion drain). Like the controller-creates-tokens shape above, the destroyed
+    // permanent's controller resolves at resolution time via EffectTarget.TargetController. Only a fixed
+    // life amount renders; a derived/X amount declines -> SCAFFOLD.
+    if (jsonContains(node, "_Player", "ControllerOfPermanent") && jsonContains(node, "_Action", "LoseLife")) {
+        val loseLife = (args as? JsonArray)?.firstOrNull { it is JsonObject && it.containsKey("_Action") } as? JsonObject
+        val amt = amount(loseLife?.get("args")) ?: return null
+        return call("LoseLifeEffect", arg(Lit(amt)), arg("EffectTarget.TargetController"))
+    }
     val inner = innerAction(node) ?: return null
     val ptv = refTarget(args, tvar)  // the player the action applies to
     when (inner.strField("_Action")) {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -44,17 +44,27 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         val tgt = refTarget(args, tvar) ?: return@on null
         call("Effects.RemoveFromCombat", arg(Lit(tgt)), arg("unblockSoleBlockedAttackers", "true"))
     }
-    on("CreatePermanentRuleEffectUntil") { node, args, tvar ->
-        // "[permanent] can't block / can't attack this turn" (Ydwen Efreet's "it can't block this
-        // turn"). Only the bare CantBlock/CantAttack rule until end of turn maps to the matching
-        // Effects facade; any other rule or a non-EOT duration scaffolds rather than guess.
-        if (firstExpiration(node) !in setOf(null, "UntilEndOfTurn")) return@on null
-        val tgt = refTarget(args, tvar) ?: return@on null
-        when {
-            jsonContains(node, "_PermanentRule", "CantBlock") -> call("Effects.CantBlock", arg(Lit(tgt)))
-            jsonContains(node, "_PermanentRule", "CantAttack") -> call("Effects.CantAttack", arg(Lit(tgt)))
-            else -> null
-        }
+    on("If") { node, args, tvar ->
+        // Resolution-time intervening-if inside a spell/ability ActionList:
+        //   If[<condition>, [<then actions>]]  ->  ConditionalEffect(condition = …, effect = …)
+        // (Foolish Fate's "if you gained life this turn, …", Burrog Barrage's "+1/+0 if you've cast
+        // another instant or sorcery this turn"). An `If` with an else-branch (args[2]) declines —
+        // a resolution ConditionalEffect can carry an else, but no calibrated card needs it yet and a
+        // wrong else is worse than a scaffold. The condition must render exactly via actionConditionDsl
+        // and the then-branch via the normal effect-list path; either declining scaffolds the card.
+        val arr = args.asArr ?: return@on null
+        val cond = arr.getOrNull(0) as? JsonObject ?: return@on null
+        if (arr.getOrNull(2) != null) return@on null
+        val thenActions = (arr.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+            ?: return@on null
+        if (thenActions.isEmpty()) return@on null
+        val condDsl = actionConditionDsl(cond) ?: return@on null
+        val thenEffect = renderEffectList(thenActions, tvar) ?: return@on null
+        call(
+            "ConditionalEffect",
+            arg("condition", Lit(condDsl)),
+            arg("effect", thenEffect),
+        )
     }
     on("RegeneratePermanent") { _, args, _ ->
         // Self-regeneration ("{cost}: Regenerate this") renders faithfully. A chosen target's
@@ -119,16 +129,19 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
 
     on("CreatePermanentRuleEffectUntil") { node, _, tvar ->
-        // "target <permanent> can't be blocked this turn" (Crafty Pathmage) renders as a CANT_BE_BLOCKED
-        // ability-flag grant; "<permanent> can't be blocked except by creatures with <X> this turn"
-        // (Resilient Roadrunner) renders as a floating GrantCantBeBlockedExceptBy. Only the single rule at
-        // end-of-turn renders; anything else scaffolds.
+        // A permanent rule-effect until end of turn. Several single-rule shapes render to a matching
+        // Effects facade; anything else (multi-rule, non-EOT duration, an unmodeled rule) scaffolds:
+        //  - CantBlock / CantAttack ("it can't block this turn", Duel Tactics / Ydwen Efreet).
+        //  - CantBeBlocked ("can't be blocked this turn", Crafty Pathmage) -> CANT_BE_BLOCKED flag.
+        //  - CantBeBlockedExceptByDefenders ("except by creatures with <X>", Resilient Roadrunner).
         val args = node["args"].asArr ?: return@on null
         val tgt = refTarget(args, tvar) ?: return@on null
         if (!jsonContains(node, "_Expiration", "UntilEndOfTurn")) return@on null
         val rules = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
         if (rules.size != 1) return@on null
         when (rules[0].strField("_PermanentRule")) {
+            "CantBlock" -> call("Effects.CantBlock", arg(Lit(tgt)))
+            "CantAttack" -> call("Effects.CantAttack", arg(Lit(tgt)))
             "CantBeBlocked" -> call("GrantKeywordEffect", arg("AbilityFlag.CANT_BE_BLOCKED.name"), arg(Lit(tgt)))
             "CantBeBlockedExceptByDefenders" -> {
                 val bf = cantBeBlockedExceptByFilter(rules[0]) ?: return@on null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -314,6 +314,15 @@ class CostCalculator(
                     .filterIsInstance<ManaSymbol.Colored>()
                 repeat(units) { coloredSymbols.forEach(addColoredReductionWithOverflow) }
             }
+            is CostModification.ReduceColoredIfAnyTargetMatches -> {
+                if (chosenTargets.isNotEmpty() &&
+                    anyTargetMatchesFilter(state, casterId, chosenTargets, modification.filter)
+                ) {
+                    ManaCost.parse(modification.symbols).symbols
+                        .filterIsInstance<ManaSymbol.Colored>()
+                        .forEach(addColoredReduction)
+                }
+            }
             is CostModification.IncreaseGeneric -> addGenericIncrease(modification.amount)
             is CostModification.IncreaseColored -> {
                 ManaCost.parse(modification.symbols).symbols

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mana/ReduceColoredIfAnyTargetMatchesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mana/ReduceColoredIfAnyTargetMatchesTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.mana
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exercises [com.wingedsheep.sdk.scripting.CostModification.ReduceColoredIfAnyTargetMatches] — the
+ * target-gated colored cost reduction added for Brush Off ("This spell costs {1}{U} less to cast if
+ * it targets an instant or sorcery spell. Counter target spell.").
+ *
+ * Brush Off pairs the new colored `{U}` reduction with a generic `ReduceGenericBy(
+ * FixedIfAnyTargetMatches(1, InstantOrSorcery))` for the `{1}`, both gated on the same filter, so
+ * the combined reduction is exactly `{1}{U}` once a matching target is chosen.
+ */
+class ReduceColoredIfAnyTargetMatchesTest : FunSpec({
+
+    val casterId = EntityId.generate()
+
+    // Real registered Brush Off, so this test pins the card's own static abilities.
+    val registry = CardRegistry().apply { register(TestCards.all) }
+    val brushOff: CardDefinition = registry.getCard("Brush Off")
+        ?: error("Brush Off not registered")
+    val calculator = CostCalculator(registry, PredicateEvaluator())
+
+    fun stackSpell(type: CardType, name: String): Pair<EntityId, ComponentContainer> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = name,
+                name = name,
+                manaCost = ManaCost.parse("{1}"),
+                typeLine = TypeLine(cardTypes = setOf(type)),
+                oracleText = "",
+                colors = setOf(Color.BLUE),
+                ownerId = casterId,
+                spellEffect = null,
+            ),
+            OwnerComponent(casterId),
+        )
+        return id to container
+    }
+
+    fun baseState(spellId: EntityId, container: ComponentContainer): GameState =
+        GameState()
+            .withEntity(casterId, ComponentContainer.EMPTY)
+            .withEntity(spellId, container)
+            .addToZone(ZoneKey(casterId, Zone.STACK), spellId)
+            .copy(turnOrder = listOf(casterId))
+
+    test("Brush Off base cost is {2}{U}{U} with no chosen target") {
+        val (spellId, container) = stackSpell(CardType.INSTANT, "Some Instant")
+        val state = baseState(spellId, container)
+        val cost = calculator.calculateEffectiveCost(state, brushOff, casterId, chosenTargets = emptyList())
+        cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+    }
+
+    test("targeting an instant spell reduces Brush Off by {1}{U} to {1}{U}") {
+        val (spellId, container) = stackSpell(CardType.INSTANT, "Some Instant")
+        val state = baseState(spellId, container)
+        val cost = calculator.calculateEffectiveCost(state, brushOff, casterId, chosenTargets = listOf(spellId))
+        cost.toString() shouldBe ManaCost.parse("{1}{U}").toString()
+    }
+
+    test("targeting a sorcery spell also reduces Brush Off by {1}{U}") {
+        val (spellId, container) = stackSpell(CardType.SORCERY, "Some Sorcery")
+        val state = baseState(spellId, container)
+        val cost = calculator.calculateEffectiveCost(state, brushOff, casterId, chosenTargets = listOf(spellId))
+        cost.toString() shouldBe ManaCost.parse("{1}{U}").toString()
+    }
+
+    test("targeting a non-instant/sorcery spell (creature) leaves Brush Off at full cost") {
+        val (spellId, container) = stackSpell(CardType.CREATURE, "Some Creature")
+        val state = baseState(spellId, container)
+        val cost = calculator.calculateEffectiveCost(state, brushOff, casterId, chosenTargets = listOf(spellId))
+        cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosConditionalCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosConditionalCardsScenarioTest.kt
@@ -1,0 +1,209 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Secrets of Strixhaven (SOS) conditional-effect cards:
+ *
+ *  - Foolish Fate: destroy + intervening-if drain ("if you gained life this turn").
+ *  - Burrog Barrage: intervening-if pump ("if you've cast another instant or sorcery") +
+ *    deal-damage-equal-to-power to an optional second target.
+ *  - Duel Tactics: deal damage + can't-block-this-turn, with flashback recast from graveyard.
+ */
+class SosConditionalCardsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Foolish Fate") {
+
+            test("with no life gained this turn: only destroys, no life loss") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Foolish Fate")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Foolish Fate", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("creature is destroyed") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("no life lost — no life was gained this turn") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("after gaining life this turn: destroys AND the controller loses 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Foolish Fate")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Record that the caster gained life this turn so the intervening-if is satisfied.
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(3))
+                }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Foolish Fate", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("creature is destroyed") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("the destroyed creature's controller loses 3 life") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+        }
+
+        context("Burrog Barrage") {
+
+            test("no other instant/sorcery cast: no +1/+0, deals power-2 damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Burrog Barrage")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2 attacker
+                    .withCardOnBattlefield(2, "Grizzly Bears")     // 2/2 target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val own = game.findPermanents("Grizzly Bears").first { game.state.projectedState.getController(it) == game.player1Id }
+                val foe = game.findPermanents("Grizzly Bears").first { game.state.projectedState.getController(it) == game.player2Id }
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Burrog Barrage"
+                }
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(own), ChosenTarget.Permanent(foe)),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("no pump (power stays 2)") {
+                    game.state.projectedState.getPower(own) shouldBe 2
+                }
+                withClue("target took 2 damage and dies (2/2)") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("after casting another instant this turn: +1/+0 makes it deal 3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Burrog Barrage")
+                    .withCardInHand(1, "Shock")                    // another instant
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")        // 3/3 target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast another instant first to satisfy "cast another instant or sorcery this turn".
+                val giant = game.findPermanent("Hill Giant")!!
+                game.castSpell(1, "Shock", targetId = giant).error shouldBe null
+                game.resolveStack()
+
+                val own = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Burrog Barrage"
+                }
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(own), ChosenTarget.Permanent(giant)),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("pump applied: power is 3") {
+                    game.state.projectedState.getPower(own) shouldBe 3
+                }
+                withClue("Hill Giant (3/3) took 2 from Shock + 3 from Burrog Barrage = dead") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+        }
+
+        context("Duel Tactics") {
+
+            test("deals 1 damage to target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Duel Tactics")
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders") // 1/1 dies to 1 damage
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goblin = game.findPermanent("Mons's Goblin Raiders")!!
+                game.castSpell(1, "Duel Tactics", targetId = goblin).error shouldBe null
+                game.resolveStack()
+
+                withClue("1/1 took 1 damage and died") {
+                    game.isInGraveyard(2, "Mons's Goblin Raiders") shouldBe true
+                }
+            }
+
+            test("flashback recast from graveyard deals damage, then exiles the card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Duel Tactics")
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goblin = game.findPermanent("Mons's Goblin Raiders")!!
+                val cardId = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Duel Tactics"
+                }
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(goblin)),
+                        useAlternativeCost = true,
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 1/1 took 1 damage and died") {
+                    game.isInGraveyard(2, "Mons's Goblin Raiders") shouldBe true
+                }
+                withClue("flashback exiles the card after it resolves (not back to graveyard)") {
+                    game.isInGraveyard(1, "Duel Tactics") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Secrets of Strixhaven (SOS) cards built around resolution-time intervening-ifs and target-gated cost reduction, plus the mtgish auto-gen emitter/bridge work that promotes the whole family from SCAFFOLD to AUTOGEN.

## Cards (scenario-tested in `rules-engine`)
- **Foolish Fate** `{2}{B}` — Destroy target creature. Infusion — if you gained life this turn, that creature's controller loses 3 life. (`ConditionalEffect` + `EffectTarget.TargetController`)
- **Burrog Barrage** `{1}{G}` — Target creature you control gets +1/+0 until end of turn if you've cast another instant or sorcery spell this turn; then it deals damage equal to its power to up to one target creature an opponent controls. (multi-target, optional 2nd target, `DynamicAmounts.targetPower` with `damageSource`)
- **Duel Tactics** `{R}` — 1 damage to target creature; it can't block this turn; Flashback `{1}{R}`.
- **Brush Off** `{2}{U}{U}` — costs `{1}{U}` less if it targets an instant or sorcery spell; counter target spell.

## SDK feature
- New `CostModification.ReduceColoredIfAnyTargetMatches(symbols, filter)` — the **colored** analogue of `CostReductionSource.FixedIfAnyTargetMatches` (which only reduces generic). Wired into `CostCalculator.applyToSpellCast`; documented in `docs/card-sdk-language-reference.md`. Brush Off's `{1}{U}` pairs this `{U}` reduction with the existing generic gated reduction for the `{1}`. Unit-tested in `ReduceColoredIfAnyTargetMatchesTest`.

## mtgish emitter / bridge changes
- Resolution-time `on("If")` action handler → `ConditionalEffect`; condition renderer gains "you gained life this turn" and "you've cast another instant or sorcery this turn".
- `ControllerOfPermanent` + `LoseLife` → `LoseLifeEffect(n, EffectTarget.TargetController)`.
- `PowerOfPermanent` on a bound target → `DynamicAmounts.targetPower(idx)`; `PermanentDealsDamage` threads an explicit `damageSource` only for a bound-target source (`Self` stays implicit, so POR golden is untouched).
- Unsuffixed multi-target ref resolves to the first target of its kind.
- Recover "up to one / N target" optionality from oracle text when the IR drops it.
- Merged the shadowed `CreatePermanentRuleEffectUntil` handlers so `CantBlock`/`CantAttack` render alongside the `CantBeBlocked` rules.
- `ReduceCastingCostIfItTargetsASpell` CastEffect → generic + colored target-gated `ModifySpellCost` blocks.
- Bridge: `If` envelope composes `Gated`; `CreatePermanentRuleEffectUntil` composes `CantBlockTargetCreatures`/`CantAttack`.

Also fixes a latent bug the optional-target recovery surfaced: **Cost of Brilliance** (an mtgish-generated SOS card) was missing `optional = true` on its "up to one target creature".

## Verification
- `just coverage-verify SOS` → **GATE PASS, 43/43, 0 gameplay-tree mismatch**.
- `just coverage-verify POR` → **GATE PASS, 158/158, 0 mismatch** (no regression).
- `EmitterGoldenTest` (EOE + POR) → PASS.
- SOS fidelity: **43 AUTO / 0 SCAFFOLD / 0 MISS**, 100% recall; all four cards emit `// fidelity tier: AUTO`.
- Full `mtg-sdk`, `mtg-sets`, `rules-engine`, `mtgish-tooling` suites green; SOS card snapshot re-blessed (adds the 4 cards + the Cost of Brilliance optional fix).

Note: `coverage-gaps --list AUTOGEN` lists only *unimplemented* cards, so the now-implemented four don't appear there; the authoritative AUTOGEN proof is the `coverage-verify SOS` gate (emitted == golden, gameplay-tree-equivalent) plus the AUTO tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)