### PR TITLE
SOS: Silverquill cards (Honorbound Page, Conciliator's Duelist, Snooping Page) + mtgish autogen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ConciliatorsDuelist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ConciliatorsDuelist.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Conciliator's Duelist
+ * {W}{W}{B}{B}
+ * Creature — Kor Warlock
+ * 4/3
+ * When this creature enters, draw a card. Each player loses 1 life.
+ * Repartee — Whenever you cast an instant or sorcery spell that targets a creature, exile up to
+ * one target creature. Return that card to the battlefield under its owner's control at the
+ * beginning of the next end step.
+ *
+ * "Repartee" is an ability word (flavor only). The Repartee trigger is the standard
+ * `youCastSpell(InstantOrSorcery)` narrowed by `targetsMatching(Creature)` shared with the other
+ * SOS Repartee cards. The exile/return-at-next-end-step body is the Salvation Swan shape: exile
+ * up to one target creature, then a `CreateDelayedTriggerEffect(Step.END, ...)` returns that card
+ * to the battlefield (under its owner's control, the default for a `Move` to battlefield).
+ */
+val ConciliatorsDuelist = card("Conciliator's Duelist") {
+    manaCost = "{W}{W}{B}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Kor Warlock"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, draw a card. Each player loses 1 life.\n" +
+        "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, exile " +
+        "up to one target creature. Return that card to the battlefield under its owner's control " +
+        "at the beginning of the next end step."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                Effects.DrawCards(1, EffectTarget.Controller),
+                Effects.LoseLife(1, EffectTarget.PlayerRef(Player.Each)),
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)
+        )
+
+        val creature = target(
+            "target creature",
+            TargetCreature(optional = true, filter = TargetFilter.Creature),
+        )
+
+        effect = Effects.Composite(
+            listOf(
+                Effects.Move(creature, Zone.EXILE),
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = Effects.Move(creature, Zone.BATTLEFIELD),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "182"
+        artist = "Andrew Mar"
+        flavorText = "\"By all means, let's debate.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e225929b-6197-4550-969e-3c4a97206a68.jpg?1775938257"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SnoopingPage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SnoopingPage.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snooping Page
+ * {1}{W}{B}
+ * Creature — Human Cleric
+ * 2/3
+ * Repartee — Whenever you cast an instant or sorcery spell that targets a creature, this creature
+ * can't be blocked this turn.
+ * Whenever this creature deals combat damage to a player, you draw a card and lose 1 life.
+ *
+ * "Repartee" is an ability word (flavor only). The first trigger is the standard
+ * `youCastSpell(InstantOrSorcery)` narrowed by `targetsMatching(Creature)` shared with the other
+ * SOS Repartee cards; it grants SELF the floating `CANT_BE_BLOCKED` flag for the turn. The second
+ * is a plain combat-damage-to-player trigger that draws and self-pays 1 life.
+ */
+val SnoopingPage = card("Snooping Page") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "Repartee — Whenever you cast an instant or sorcery spell that targets a " +
+        "creature, this creature can't be blocked this turn.\n" +
+        "Whenever this creature deals combat damage to a player, you draw a card and lose 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)
+        )
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self, Duration.EndOfTurn)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            listOf(
+                Effects.DrawCards(1, EffectTarget.Controller),
+                Effects.LoseLife(1, EffectTarget.Controller),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Alexandre Honoré"
+        flavorText = "Eavesdropping is not a misdeed in the Forum, but a fact of life."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73d06987-8686-461b-b260-9a4fee6a3b32.jpg?1775938584"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -438,6 +438,122 @@
     ]
 }
 
+// Conciliator's Duelist
+{
+    "name": "Conciliator's Duelist",
+    "manaCost": "{W}{W}{B}{B}",
+    "typeLine": "Creature — Kor Warlock",
+    "oracleText": "When this creature enters, draw a card. Each player loses 1 life.\nRepartee — Whenever you cast an instant or sorcery spell that targets a creature, exile up to one target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "Each"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "TargetsMatching",
+                                "subfilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "RARE",
+        "artist": "Andrew Mar",
+        "flavorText": "\"By all means, let's debate.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e225929b-6197-4550-969e-3c4a97206a68.jpg?1775938257"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Cost of Brilliance
 {
     "name": "Cost of Brilliance",
@@ -2770,6 +2886,92 @@
         "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b4c120e-abe9-4f11-a7e4-bc3f723da4b2.jpg"
     },
     "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Snooping Page
+{
+    "name": "Snooping Page",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, this creature can't be blocked this turn.\nWhenever this creature deals combat damage to a player, you draw a card and lose 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "TargetsMatching",
+                                "subfilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Alexandre Honoré",
+        "flavorText": "Eavesdropping is not a misdeed in the Forum, but a fact of life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73d06987-8686-461b-b260-9a4fee6a3b32.jpg?1775938584"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLACK"
     ]
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -43,6 +43,9 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("LookAtTheTopNumberCardsOfPlayersLibrary", "look pipeline on opponent library -> MoveCollection", composes = listOf("MoveCollection"))
 
     composed("ExilePermanent", UNIVERSAL, composes = listOf("MoveToZone"))
+    // "Return the exiled card to the battlefield" — the delayed return half of exile-then-return
+    // (Conciliator's Duelist). A plain MoveToZone back to the battlefield under its owner's control.
+    composed("PutExiledCardOntoBattlefield", UNIVERSAL, composes = listOf("MoveToZone"))
     composed("ExileEachPermanent", UNIVERSAL, composes = listOf("MoveCollection", "MoveToZone"))
     composed("MillNumberCards", UNIVERSAL, composes = listOf("MoveCollection"))
     composed("MillCards", UNIVERSAL, composes = listOf("MoveCollection"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -263,6 +263,14 @@ internal fun EmitCtx.renderEachPlayer(node: JsonObject): Dsl? {
         val amt = findInteger(inner["args"]) as? Int ?: return null
         return call("Effects.LoseLife", arg("$amt"), arg("EffectTarget.PlayerRef(Player.EachOpponent)"))
     }
+    // "each player loses N life" (Conciliator's Duelist). Like the opponent shape above but scoped to
+    // every player (controller included) via EffectTarget.PlayerRef(Player.Each); a derived/X amount scaffolds.
+    if (jsonContains(node, "_Players", "AnyPlayer") && jsonContains(node, "_Action", "LoseLife")) {
+        val inner = node["args"].asArr?.filterIsInstance<JsonObject>()
+            ?.firstOrNull { it.strField("_Action") == "LoseLife" } ?: return null
+        val amt = findInteger(inner["args"]) as? Int ?: return null
+        return call("Effects.LoseLife", arg("$amt"), arg("EffectTarget.PlayerRef(Player.Each)"))
+    }
     if (jsonContains(node, "_Action", "DrawNumberCards") || jsonContains(node, "_GameNumber", "ValueX"))
         return call("Patterns.Hand.eachPlayerDrawsX", arg("includeController", "true"), arg("includeOpponents", "true"))
     return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -60,6 +60,33 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         call("Effects.Exile", arg(Lit(tgt)))
     }
 
+    // "Return the exiled card to the battlefield under its owner's control" (the second half of the
+    // exile-then-return idiom — Conciliator's Duelist, Parting Gust). `TheCardExiledThisWay` refers to
+    // the same bound target that was exiled earlier in the ability, so it resolves to the ability's
+    // bound `tvar`; a plain Move to the battlefield returns it under its owner's control (the default).
+    // Only the under-owner's-control form renders; an under-your-control / no-bound-target form declines.
+    on("PutExiledCardOntoBattlefield") { node, _, tvar ->
+        if (tvar == null) return@on null
+        if (!jsonContains(node, "_CardInExile", "TheCardExiledThisWay")) return@on null
+        val flagBlob = compact(node)
+        if ("EntersUnderPlayersControl" in flagBlob || "EntersUnderYourControl" in flagBlob) return@on null
+        call("Effects.Move", arg(Lit(tvar)), arg("Zone.BATTLEFIELD"))
+    }
+
+    // "...at the beginning of the next end step" delayed trigger (the return half of exile-then-return).
+    // Renders only the next-end-step timing as a `CreateDelayedTriggerEffect(step = Step.END, …)`; the
+    // body is the normal action-list renderer sharing the ability's bound `tvar` so the exiled target
+    // returns. Any other future-trigger timing, or a body the renderer can't express, declines -> SCAFFOLD.
+    on("CreateFutureTrigger") { _, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val timing = a.getOrNull(0) as? JsonObject ?: return@on null
+        if (timing.strField("_FutureTrigger") != "AtTheBeginningOfTheNextEndStep") return@on null
+        val actionsNode = a.getOrNull(1) as? JsonObject ?: return@on null
+        val inner = actionsNode["args"].asArr?.filterIsInstance<JsonObject>() ?: return@on null
+        val body = renderEffectList(inner, tvar) ?: return@on null
+        call("CreateDelayedTriggerEffect", arg("step", "Step.END"), arg("effect", body))
+    }
+
     on("PutPermanentIntoItsOwnersHand") { _, args, tvar ->  // bounce
         val tgt = refTarget(args, tvar) ?: return@on null
         call("Effects.Move", arg(Lit(tgt)), arg("Zone.HAND"))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosTriggerShapeCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosTriggerShapeCardsScenarioTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
@@ -186,6 +187,153 @@ class SosTriggerShapeCardsScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Grizzly Bears left the graveyard") {
                     game.findCardsInGraveyard(1, "Grizzly Bears").isEmpty() shouldBe true
+                }
+            }
+        }
+
+        context("Snooping Page — Repartee makes it unblockable; combat damage draws and self-pays 1 life") {
+
+            test("casting a creature-targeting instant grants the Page CANT_BE_BLOCKED until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Snooping Page") // 2/3
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val page = game.findPermanent("Snooping Page")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Page can be blocked before Repartee fires") {
+                    projector.project(game.state).hasKeyword(page, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+                }
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Repartee fires: the Page can't be blocked this turn") {
+                    projector.project(game.state).hasKeyword(page, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+            }
+
+            test("casting an instant targeting a player does NOT make the Page unblockable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Snooping Page") // 2/3
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val page = game.findPermanent("Snooping Page")!!
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", targetPlayerNumber = 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Spell targeted a player, not a creature → Repartee does not fire") {
+                    projector.project(game.state).hasKeyword(page, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+                }
+            }
+
+            test("dealing combat damage to a player draws a card and the controller loses 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Snooping Page", tapped = false, summoningSickness = false) // 2/3
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.declareAttackers(mapOf("Snooping Page" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("Defending player took 2 combat damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Controller drew a card from the combat-damage trigger") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("Controller lost 1 life from the combat-damage trigger") {
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+        }
+
+        context("Conciliator's Duelist — ETB draws + each player loses 1; Repartee exiles up to one creature, returns at next end step") {
+
+            test("entering draws a card and makes each player lose 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Conciliator's Duelist") // {W}{W}{B}{B}
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Conciliator's Duelist").error shouldBe null
+                game.resolveStack() // resolve the creature, then its ETB trigger
+
+                withClue("Conciliator's Duelist is on the battlefield") {
+                    game.isOnBattlefield("Conciliator's Duelist") shouldBe true
+                }
+                // Hand: -1 for casting the Duelist, +1 from the ETB draw → net unchanged.
+                withClue("ETB drew a card (net: cast one creature, drew one)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("Each player loses 1 life") {
+                    game.getLifeTotal(1) shouldBe 19
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+
+            test("Repartee exiles a creature and returns it at the beginning of the next end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Conciliator's Duelist") // 4/3
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Cast Lightning Bolt at the Bears (also the Repartee creature target).
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack() // Repartee trigger asks for its "up to one target creature"
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("The targeted creature has been exiled by Repartee") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+
+                // Advance to the next end step; the delayed trigger returns it.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Grizzly Bears returns to the battlefield at the next end step") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
                 }
             }
         }


### PR DESCRIPTION
Implements two of the three requested Secrets of Strixhaven (SOS) Silverquill (W/B) cards and teaches the mtgish auto-generation tooling to render their shapes. The third (Honorbound Page) is declined with justification below.

## Cards

### Snooping Page — `{1}{W}{B}`, 2/3 Human Cleric (uncommon, #227)
- **Repartee** — Whenever you cast an instant or sorcery spell that targets a creature, this creature can't be blocked this turn. Uses the shared `Triggers.youCastSpell(InstantOrSorcery.targetsMatching(Creature))` Repartee trigger (same as Forum Necroscribe / Lecturing Scornmage) and grants SELF the `CANT_BE_BLOCKED` flag until end of turn.
- Whenever this creature deals combat damage to a player, you draw a card and lose 1 life.
- **mtgish tier: AUTOGEN** (the emitter already rendered both triggers whole; no emitter change needed for this card).

### Conciliator's Duelist — `{W}{W}{B}{B}`, 4/3 Kor Warlock (rare, #182)
- ETB: draw a card; **each player** loses 1 life.
- **Repartee** — exile up to one target creature; return it under its owner's control at the beginning of the next end step (the Salvation Swan / Parting Gust idiom: `Move -> EXILE` + `CreateDelayedTriggerEffect(Step.END, Move -> BATTLEFIELD)`).
- **mtgish tier: AUTOGEN** (after the emitter additions below — was SCAFFOLD on `EachPlayerAction` + the delayed-return shape).

Both cards use only existing SDK primitives (no new SDK types), so the SDK reference needs no update.

## mtgish tooling changes (faithful — render correctly or decline)
- `PlayerContinuousHandlers.renderEachPlayer`: render **"each player loses N life"** (`EachPlayerAction` `_Players=AnyPlayer` + `LoseLife` Integer) → `Effects.LoseLife(N, Player.Each)` — the sibling of the existing each-opponent branch. Derived/X amounts still decline → SCAFFOLD.
- `ZoneHandlers`: render the **exile-then-return-at-next-end-step** idiom:
  - `PutExiledCardOntoBattlefield(TheCardExiledThisWay, EntersUnderOwnersControl)` → `Effects.Move(<bound target>, Zone.BATTLEFIELD)` (under owner's control = the default). Under-your-control / no-bound-target decline.
  - `CreateFutureTrigger(AtTheBeginningOfTheNextEndStep)` → `CreateDelayedTriggerEffect(step = Step.END, effect = <body>)`. Any other future-trigger timing, or a body the renderer can't express, declines → SCAFFOLD.
- Bridge: added `PutExiledCardOntoBattlefield → MoveToZone` capability so the probe scores the shape as coverable.

One bridge + emitter entry unlocks the shape across every set, not just this card.

## Honorbound Page — declined (not in this PR)
Honorbound Page is a SOS **"prepare"-layout** card (`Honorbound Page // Forum's Favor`) whose **Prepared** keyword has **no engine support anywhere in the codebase**. Per the Scryfall rulings, "enters prepared" means: the controller creates a *copy of the card's spell face in exile*, which remains while the permanent stays on the battlefield and prepared; the controller may cast that copy from exile (paying its mana cost — not an alternative cost), and doing so unprepares the creature; losing prepared status makes the exiled copy cease to exist. Implementing this faithfully is an `add-feature`-scale effort: a new `CardLayout.PREPARE`, a prepared-status component, a "cast a copy of the linked spell face from exile" permission + unprepare-on-cast flow, cleanup when the permanent leaves / becomes unprepared, and client UI. That is out of scope for a card-implementation PR, and the guiding principle is "a card that looks right but resolves wrong is worse than an unimplemented one", so it is declined rather than faked. Its mtgish tier is **SCAFFOLD** (unrecovered `AsPermanentEnters` — the Prepared mechanic).

## Verification
- `:rules-engine:test --tests "*SosTriggerShapeCardsScenarioTest*"` — all green (added 5 tests across the two cards).
- `:mtg-sets:test` (full, incl. `CardDefinitionSnapshotTest` + `CardLintTest`) — green; SOS golden re-blessed, diff adds only the two new cards.
- `:mtgish-tooling:test` (incl. `EmitterGoldenTest`) — green; no existing card's render changed.
- `just coverage-verify POR` — **GATE PASS, 158/158, 0 mismatch** (the required gate; my changes do not regress POR).

### Pre-existing issue (NOT introduced here)
`just coverage-verify SOS` reports a GATE FAIL on three SOS modal "Charm" cards (Lorehold / Prismari / Silverquill Charm — modal-spell golden drift, e.g. `counterType "+1/+1"` vs `"+1+1"`). I verified these mismatches are present on the branch baseline **with my emitter edits reverted**, so they are pre-existing and unrelated to this change (those cards don't use any of the tags I added). Per the repo's hard rules I did not modify other agents' cards; flagging it here instead. My change actually improves SOS (47 → 48 auto-emitted & verified by promoting Conciliator's Duelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)