### PR TITLE
SOS: Lorehold/Witherbloom cards (Adventurous Eater, Owlin Historian, Landscape Painter) + mtgish autogen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -89,8 +89,16 @@ section; do not let SDK additions land without a corresponding doc update.
   face from hand (front via primary characteristics, back via `CastSpell.faceIndex = 0`), never both. Unlike
   ADVENTURE there is no exile-then-recast linkage — a spell back resolves as an ordinary spell (graveyard, or exile
   when its script sets `selfExileOnResolve` via `spell { selfExile() }`). DSL: `card { modalBack("Name") { spell { … } } }`.
+- `PREPARE` — primary characteristics are the creature face, `cardFaces[0]` is the **prepare spell** (an
+  instant/sorcery) (Secrets of Strixhaven). The card is only ever cast as the creature; the prepare spell is never
+  cast from hand. The creature carries `Keyword.PREPARED` ("This creature enters prepared"). When it enters
+  (becomes prepared), the engine creates a **copy of the prepare spell in exile** that the controller may cast for
+  the face's cost — surfaced by the cast-from-exile enumerator as `CastSpell(..., faceIndex = 0)` from `EXILE`.
+  Casting the copy unprepares the creature; the copy ceases to exist on resolution. The exile copy persists in
+  exile (exempt from the 707.10a phantom-copy SBA) until the source leaves the battlefield or stops being prepared,
+  at which point it is cleaned up. DSL: `card { prepare("Name") { spell { … } } }`.
 
-**`CardFace` (SPLIT / ADVENTURE / OMEN / MODAL_DFC)**
+**`CardFace` (SPLIT / ADVENTURE / OMEN / MODAL_DFC / PREPARE)**
 
 - `name` — face name.
 - `manaCost` — face mana cost.
@@ -3497,6 +3505,18 @@ Card authors rarely reference these directly; they are created/updated by the ma
   `CastSpell.faceIndex = 0`); reuses the Adventure cast/enumeration path (`enumerateSecondaryFace`) but with no
   exile-then-recast linkage at resolution. `StackResolver` reads the cast face's `selfExileOnResolve`, and the back
   art rides on `CardFace.imageUri` → `CardComponent.backFaceImageUri`. First user: Flamescroll Celebrant.
+- **Prepare / Prepared (Secrets of Strixhaven)** — `layout = PREPARE` + `cardFaces[0]` prepare spell + the creature
+  carries `Keyword.PREPARED` ("This creature enters prepared"); DSL: `card { prepare("Name") { spell { … } } }`.
+  The creature is only cast as itself. When it enters (`StackResolver.enterPermanentOnBattlefield` → `makePrepared`),
+  the engine creates a stack-style copy of the prepare spell in the controller's exile carrying
+  `PreparedSpellCopyComponent(sourceId)`, stamps `PreparedComponent(exileCopyId)` on the creature, and grants a
+  permanent `MayPlayPermission` for the copy. `CastFromZoneEnumerator` recognizes the copy and offers it as
+  `CastSpell(..., faceIndex = 0)` from `EXILE` using the prepare face's cost/targets. Casting the copy
+  (`StackResolver.castSpell`) strips the source's `PreparedComponent` and consumes the permission; the copy resolves
+  via the face script and ceases to exist (`CopyOfComponent`). The exiled copy is exempt from the 707.10a
+  phantom-copy SBA (`PhantomCardCopiesCheck`) while linked, and that same check removes it once the source leaves
+  the battlefield or stops being prepared. First users: Adventurous Eater // Have a Bite, Landscape Painter //
+  Vibrant Idea.
 - **Hideaway N** — `KeywordAbility.hideaway(n)` (display, "Hideaway N") + `MoveCollectionEffect(faceDown = true,
   linkToSource = true)` + `CardSource.FromLinkedExile()`; no special engine plumbing needed.
 - **Ascend / City's Blessing** — `Keyword.ASCEND` + `Effects.GainCitysBlessing()` + `Conditions.YouHaveCitysBlessing` /

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -301,7 +301,17 @@ enum class Keyword(val displayName: String) {
      * tutor up other Spider-related cards. Per CR 207.2c, ability words have no rules
      * meaning; the prefix is metadata only and does not modify resolution.
      */
-    FATEFUL_BITE("Fateful Bite");
+    FATEFUL_BITE("Fateful Bite"),
+
+    /**
+     * Prepared (Secrets of Strixhaven).
+     * Display keyword on a preparation card ([com.wingedsheep.sdk.model.CardLayout.PREPARE]):
+     * "This creature enters prepared." Display-only on the keyword — the behavior is driven by
+     * the PREPARE layout. When the creature becomes prepared (e.g. as it enters), its controller
+     * creates a copy of the card's prepare spell (`cardFaces[0]`) in exile that they may cast
+     * (paying that spell's cost); casting the copy unprepares the creature.
+     */
+    PREPARED("Prepared");
 
     companion object {
         fun fromString(value: String): Keyword? =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -642,6 +642,23 @@ class CardBuilder(private val name: String) {
         face(name, init)
     }
 
+    /**
+     * Declare the prepare spell of a preparation card (Secrets of Strixhaven). Sets [layout]
+     * to [CardLayout.PREPARE] and registers the named face. Inside the block, declare the
+     * prepare spell's `manaCost`, `typeLine` (e.g. `"Sorcery"`), `oracleText`, and a
+     * `spell { … }` block for its effect / targets.
+     *
+     * The creature face is described by the surrounding [CardBuilder]'s top-level fields
+     * (`manaCost`, `typeLine`, `power`, `toughness`, plus the [com.wingedsheep.sdk.core.Keyword.PREPARED]
+     * keyword and any creature-side abilities). The creature enters prepared, which creates a
+     * copy of this prepare spell in exile that its controller may cast (paying this face's cost);
+     * casting that copy unprepares the creature.
+     */
+    fun prepare(name: String, init: CardFaceBuilder.() -> Unit) {
+        layout = CardLayout.PREPARE
+        face(name, init)
+    }
+
     // =========================================================================
     // Metadata
     // =========================================================================
@@ -709,6 +726,19 @@ class CardBuilder(private val name: String) {
         if (layout == CardLayout.MODAL_DFC) {
             require(cardFaceList.size == 1) {
                 "MODAL_DFC layout requires exactly one back face: $name"
+            }
+        }
+
+        // PREPARE layout (Secrets of Strixhaven): the surrounding CardBuilder fields describe the
+        // creature face; cardFaces[0] is the prepare spell. A copy of that spell is created in
+        // exile when the creature enters prepared.
+        if (layout == CardLayout.PREPARE) {
+            require(cardFaceList.size == 1) {
+                "PREPARE layout requires exactly one face (the prepare spell): $name"
+            }
+            val prepareFace = cardFaceList.first()
+            require(prepareFace.script.spellEffect != null) {
+                "Prepare spell '${prepareFace.name}' must declare a spell { } effect"
             }
         }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -109,6 +109,25 @@ enum class CardLayout {
      * ([CardFace.imageUri]).
      */
     MODAL_DFC,
+
+    /**
+     * Preparation card (Secrets of Strixhaven). The primary characteristics in [CardDefinition]
+     * describe the creature face; [CardDefinition.cardFaces] holds the single "prepare spell"
+     * face — an instant or sorcery with its own name, mana cost, type line, oracle text, target
+     * requirements, and spell effect.
+     *
+     * Unlike [ADVENTURE], a preparation card is only ever cast with its **creature**
+     * characteristics (its prepare spell is never cast from hand). It enters with the
+     * [com.wingedsheep.sdk.core.Keyword.PREPARED] keyword, which says "This creature enters
+     * prepared."
+     *
+     * Becoming prepared (per the official rulings): the controller creates a copy of the prepare
+     * spell (`cardFaces[0]`) in exile. That copy persists in exile while the permanent is on the
+     * battlefield and prepared, and the controller may cast that copy from exile (paying its
+     * mana cost). Casting the copy makes the creature stop being prepared. If the permanent
+     * leaves the battlefield or otherwise stops being prepared, the exiled copy ceases to exist.
+     */
+    PREPARE,
 }
 
 /**
@@ -285,6 +304,7 @@ data class CardDefinition(
     val isSplit: Boolean get() = layout == CardLayout.SPLIT
     val isAdventure: Boolean get() = layout == CardLayout.ADVENTURE
     val isOmen: Boolean get() = layout == CardLayout.OMEN
+    val isPreparation: Boolean get() = layout == CardLayout.PREPARE
 
     /**
      * True if this card is a Room (CR 709.5 + 205.3h). A Room is a split-layout enchantment whose

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AdventurousEater.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AdventurousEater.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adventurous Eater // Have a Bite — Secrets of Strixhaven #72
+ * {2}{B} · Creature — Human Warlock · 3/2
+ *
+ * This creature enters prepared. (While it's prepared, you may cast a copy of its spell.
+ * Doing so unprepares it.)
+ * //
+ * Have a Bite — {B}, Sorcery: Put a +1/+1 counter on target creature. You gain 1 life.
+ *
+ * Prepare (Secrets of Strixhaven): the creature enters with the PREPARED keyword. Becoming
+ * prepared creates a copy of its prepare spell ("Have a Bite") in exile that its controller may
+ * cast for {B}; casting that copy unprepares the creature. Modeled via [CardLayout.PREPARE] +
+ * the `prepare(name) { }` DSL.
+ */
+val AdventurousEater = card("Adventurous Eater") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    keywords(Keyword.PREPARED)
+
+    // Have a Bite — the prepare spell. Put a +1/+1 counter on target creature; you gain 1 life.
+    prepare("Have a Bite") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        oracleText = "Put a +1/+1 counter on target creature. You gain 1 life."
+        spell {
+            target = Targets.Creature
+            effect = Effects.Composite(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)),
+                Effects.GainLife(1)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d40cc7da-c731-418e-8547-7033d1939450.jpg?1775937412"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LandscapePainter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LandscapePainter.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Landscape Painter // Vibrant Idea — Secrets of Strixhaven #56
+ * {1}{U} · Creature — Merfolk Wizard · 2/1
+ *
+ * This creature enters prepared. (While it's prepared, you may cast a copy of its spell.
+ * Doing so unprepares it.)
+ * //
+ * Vibrant Idea — {4}{U}, Sorcery: Draw two cards.
+ *
+ * Prepare (Secrets of Strixhaven): the creature enters with the PREPARED keyword. Becoming
+ * prepared creates a copy of its prepare spell ("Vibrant Idea") in exile that its controller may
+ * cast for {4}{U}; casting that copy unprepares the creature. Modeled via [CardLayout.PREPARE] +
+ * the `prepare(name) { }` DSL.
+ */
+val LandscapePainter = card("Landscape Painter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    keywords(Keyword.PREPARED)
+
+    // Vibrant Idea — the prepare spell. Draw two cards.
+    prepare("Vibrant Idea") {
+        manaCost = "{4}{U}"
+        typeLine = "Sorcery"
+        oracleText = "Draw two cards."
+        spell {
+            effect = Effects.DrawCards(2)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Vincent Christiaens"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0bd30c4-3cdf-4eda-8be5-0fb5e5ddddbf.jpg?1778165077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/OwlinHistorian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/OwlinHistorian.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Owlin Historian — Secrets of Strixhaven #24
+ * {2}{W} · Creature — Bird Cleric · 2/3
+ *
+ * Flying
+ * When this creature enters, surveil 1. (Look at the top card of your library. You may put
+ * it into your graveyard.)
+ * Whenever one or more cards leave your graveyard, this creature gets +1/+1 until end of turn.
+ *
+ * The leave-graveyard trigger batches per event, so it grows the Historian once per batch of
+ * cards that leave the graveyard (CR 603.3 — one trigger per simultaneous batch).
+ */
+val OwlinHistorian = card("Owlin Historian") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n" +
+        "Whenever one or more cards leave your graveyard, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.surveil(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Matheus Graef"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fe99be0-e1ec-485e-82f8-02eba7b82441.jpg?1775937078"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -57,6 +57,69 @@
     ]
 }
 
+// Adventurous Eater
+{
+    "name": "Adventurous Eater",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "PREPARED"
+    ],
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d40cc7da-c731-418e-8547-7033d1939450.jpg?1775937412"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Have a Bite",
+            "manaCost": "{B}",
+            "typeLine": "Sorcery",
+            "oracleText": "Put a +1/+1 counter on target creature. You gain 1 life.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Banishing Betrayal
 {
     "name": "Banishing Betrayal",
@@ -1610,6 +1673,47 @@
     ]
 }
 
+// Landscape Painter
+{
+    "name": "Landscape Painter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PREPARED"
+    ],
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Vincent Christiaens",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0bd30c4-3cdf-4eda-8be5-0fb5e5ddddbf.jpg?1778165077"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Vibrant Idea",
+            "manaCost": "{4}{U}",
+            "typeLine": "Sorcery",
+            "oracleText": "Draw two cards.",
+            "script": {
+                "spellEffect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        }
+    ]
+}
+
 // Lecturing Scornmage
 {
     "name": "Lecturing Scornmage",
@@ -2038,6 +2142,106 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Owlin Historian
+{
+    "name": "Owlin Historian",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird Cleric",
+    "oracleText": "Flying\nWhen this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nWhenever one or more cards leave your graveyard, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CardsLeftYourGraveyardEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Matheus Graef",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fe99be0-e1ec-485e-82f8-02eba7b82441.jpg?1775937078"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -18,6 +18,9 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenAPermanentBecomesTheTargetOfASpellOrAbility", "trigger: becomes target (Triggers.BecomesTargetByOpponent / BecomesTarget / CreatureYouControlBecomesTargetByOpponent)")
     // OTJ crime (CR 700.10) — "Whenever you commit a crime, …" (Triggers.YouCommitCrime, Marauding Sphinx).
     supported("WhenAPlayerCommitsACrime", "trigger: you commit a crime (Triggers.YouCommitCrime)")
+    // "Whenever one or more cards leave your graveyard, …" — batching leave-graveyard trigger
+    // (Triggers.CardsLeaveYourGraveyard — Owlin Historian, Attuned Hunter). You-scoped + unfiltered only.
+    supported("WhenAnyNumberOfGraveyardCardsLeave", "trigger: one or more cards leave your graveyard (Triggers.CardsLeaveYourGraveyard)")
 
     // Intervening-if conditions (CR 603.4) gating a TriggerI, plus the Mount "while saddled" gate. The
     // emitter renders the recognised shapes to `triggerCondition = Conditions.*`; an unrenderable

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1176,6 +1176,22 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     if (jsonContains(trig, "_Trigger", "WhenAPlayerCommitsACrime") && jsonContains(trig, "_Player", "You"))
         return "Triggers.YouCommitCrime"
 
+    // "Whenever one or more cards leave your graveyard" — WhenAnyNumberOfGraveyardCardsLeave over
+    // InAPlayersGraveyard(SinglePlayer(You)). The batching leave-graveyard trigger fires once per
+    // event batch. Only the You scope maps to Triggers.CardsLeaveYourGraveyard(); any other graveyard
+    // owner has no matching Triggers.* constant yet, so it declines -> SCAFFOLD. The unfiltered shape
+    // (no `_Cards`/`IsCardtype` constraint) renders the filterless any-card form (Owlin Historian,
+    // Attuned Hunter). A constrained leave-graveyard (a typed card) declines rather than widening.
+    if (jsonContains(trig, "_Trigger", "WhenAnyNumberOfGraveyardCardsLeave") &&
+        jsonContains(trig, "_Player", "You")
+    ) {
+        val blob = compact(trig)
+        val unfiltered = "IsCardtype" !in blob && "IsCreatureType" !in blob &&
+            "_Color" !in blob && "IsCardname" !in blob
+        if (unfiltered) return "Triggers.CardsLeaveYourGraveyard()"
+        return null
+    }
+
     return null
 }
 
@@ -1423,6 +1439,27 @@ internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<Stmt>? {
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))
     return listOf(Sub(Block("triggeredAbility", stmts)))
+}
+
+/**
+ * Preparation card (Secrets of Strixhaven). The IR shapes a preparation card as `_OracleCard:
+ * "Preparer"` with a single top-level `AsPermanentEnters[EntersPrepared]` rule and a sibling
+ * `Prepared` object holding the prepare spell (its own Name / Typeline / ManaCost / SpellActions).
+ * Render the `prepare("<spell name>") { manaCost; typeLine; spell { … } }` block by running the
+ * generic spell-action renderer ([spellBlock]) over the nested prepare card. Returns null ->
+ * SCAFFOLD when the nested prepare spell's effect can't be rendered exactly (so we never emit a
+ * preparation creature whose prepare spell silently differs from oracle).
+ */
+internal fun EmitCtx.prepareBlock(card: JsonObject): List<Stmt>? {
+    val prepared = card["Prepared"] as? JsonObject ?: run { reasons.add("Prepared"); return null }
+    val faceName = prepared["Name"].asStr() ?: run { reasons.add("Prepared"); return null }
+    val spellStmts = spellBlock(prepared) ?: run { reasons.add("Prepared"); return null }
+    val faceBody = mutableListOf<Stmt>(
+        RawLine("        manaCost = \"${renderMana(prepared["ManaCost"])}\""),
+        RawLine("        typeLine = \"${renderTypeline(prepared["Typeline"])}\""),
+    )
+    faceBody.addAll(spellStmts)
+    return listOf(Sub(Block("prepare(\"${ktStr(faceName)}\")", faceBody)))
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -96,6 +96,23 @@ object Emitter {
         val plainKw = kw.filterNot { it == "PROWESS" }
         if (plainKw.isNotEmpty()) body.add(RawLine("    keywords(${plainKw.joinToString(", ") { "Keyword.$it" }})"))
         if ("PROWESS" in kw) body.add(RawLine("    prowess()"))
+
+        // Preparation card (Secrets of Strixhaven): `_OracleCard: "Preparer"` with a single
+        // AsPermanentEnters[EntersPrepared] rule and a sibling `Prepared` prepare spell. Emit the
+        // PREPARED keyword + a prepare("…") { spell { … } } block from the nested prepare card, and
+        // skip the AsPermanentEnters rule (the PREPARE layout already encodes "enters prepared").
+        // The whole card scaffolds if the prepare spell can't be rendered exactly.
+        val isPreparer = card.strField("_OracleCard") == "Preparer" && card["Prepared"] != null
+        if (isPreparer) {
+            body.add(RawLine("    keywords(Keyword.PREPARED)"))
+            val prepStmts = ctx.prepareBlock(card)
+            if (prepStmts == null) gap("Prepared")?.let { return it }
+            else body.addAll(prepStmts)
+            (card["Rules"].asArr ?: JsonArray(emptyList())).forEach { r ->
+                if ((r as? JsonObject)?.strField("_Rule") == "AsPermanentEnters") skipRules.add(r)
+            }
+            parts++
+        }
         val cardLevelLines = ctx.cardLevelCastEffectLines(card)
         if (cardLevelLines == null) gap("CastEffect")?.let { return it }
         else body.addAll(cardLevelLines.map { RawLine(it) })

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -378,6 +378,8 @@ val engineSerializersModule = SerializersModule {
         subclass(SaddledComponent::class)
         subclass(CrewSaddleContributorsComponent::class)
         subclass(CastForImpendingComponent::class)
+        subclass(PreparedComponent::class)
+        subclass(PreparedSpellCopyComponent::class)
         subclass(SuspendedComponent::class)
         subclass(CastRecordComponent::class)
         subclass(CastChoicesComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -383,12 +383,25 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         )
                     )
                 } else {
-                    val isInstant = cardComponent.typeLine.isInstant
-                    val hasCorrectTiming = isInstant || context.canPlaySorcerySpeed
                     val cardDef = context.cardRegistry.getCard(cardComponent.name)
-                    val castRestrictions = cardDef?.script?.castRestrictions ?: emptyList()
+                    // Prepare-spell copy (Secrets of Strixhaven): this exiled copy is cast as the
+                    // card's prepare spell — face index 0. Read the face's script for timing,
+                    // restrictions, cost, and targets, and thread faceIndex onto the CastSpell so
+                    // the handler/resolver use the prepare spell's characteristics.
+                    val prepareCopyFaceIndex: Int? =
+                        if (container.has<com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent>() &&
+                            cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.PREPARE
+                        ) 0 else null
+                    val prepareFace = prepareCopyFaceIndex?.let { cardDef?.cardFaces?.getOrNull(it) }
+                    val effectiveScript = prepareFace?.script ?: cardDef?.script
+                    val effectiveTypeLine = prepareFace?.typeLine ?: cardComponent.typeLine
+                    val isInstant = effectiveTypeLine.isInstant
+                    val hasCorrectTiming = isInstant || context.canPlaySorcerySpeed
+                    val castRestrictions = effectiveScript?.castRestrictions ?: emptyList()
                     val meetsRestrictions = context.castPermissionUtils.checkCastRestrictions(state, playerId, castRestrictions)
-                    val baseEffectiveCost = if (cardDef != null) {
+                    val baseEffectiveCost = if (cardDef != null && prepareFace != null) {
+                        context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, prepareFace.manaCost, playerId)
+                    } else if (cardDef != null) {
                         context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
                     } else {
                         cardComponent.manaCost
@@ -425,7 +438,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     // (e.g. Cinder Strike granted via Sanar's "you may cast" permission). If the
                     // card has a payable blight path, emit a second legal action with
                     // costType = "Blight" so the client surfaces both the pay and blight options.
-                    val printedBlightOrPay = cardDef?.script?.additionalCosts
+                    val printedBlightOrPay = effectiveScript?.additionalCosts
                         ?.flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
                         ?.filterIsInstance<AdditionalCost.BlightOrPay>()
                         ?.firstOrNull()
@@ -440,8 +453,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
                     if (hasCorrectTiming && meetsRestrictions && canAfford && canPayAdditionalCost) {
                         val targetReqs = buildList {
-                            addAll(cardDef?.script?.targetRequirements ?: emptyList())
-                            cardDef?.script?.auraTarget?.let { add(it) }
+                            addAll(effectiveScript?.targetRequirements ?: emptyList())
+                            effectiveScript?.auraTarget?.let { add(it) }
                         }
 
                         if (targetReqs.isNotEmpty()) {
@@ -455,7 +468,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                     LegalAction(
                                         actionType = "CastSpell",
                                         description = "Cast ${cardComponent.name}",
-                                        action = CastSpell(playerId, cardId),
+                                        action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex),
                                         validTargets = firstInfo.validTargets,
                                         requiresTargets = true,
                                         targetCount = firstReq.count,
@@ -478,7 +491,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                         LegalAction(
                                             actionType = "CastSpell",
                                             description = "Cast ${cardComponent.name} (Blight ${printedBlightOrPay.blightAmount})",
-                                            action = CastSpell(playerId, cardId),
+                                            action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex),
                                             validTargets = firstInfo.validTargets,
                                             requiresTargets = true,
                                             targetCount = firstReq.count,
@@ -504,7 +517,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 LegalAction(
                                     actionType = "CastSpell",
                                     description = "Cast ${cardComponent.name}",
-                                    action = CastSpell(playerId, cardId),
+                                    action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex),
                                     manaCostString = costString,
                                     hasXCost = hasXCost,
                                     maxAffordableX = maxAffordableX,
@@ -517,7 +530,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                     LegalAction(
                                         actionType = "CastSpell",
                                         description = "Cast ${cardComponent.name} (Blight ${printedBlightOrPay.blightAmount})",
-                                        action = CastSpell(playerId, cardId),
+                                        action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex),
                                         manaCostString = costString,
                                         hasXCost = hasXCost,
                                         maxAffordableX = maxAffordableX,
@@ -538,7 +551,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                             LegalAction(
                                 actionType = "CastSpell",
                                 description = "Cast ${cardComponent.name}",
-                                action = CastSpell(playerId, cardId),
+                                action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex),
                                 affordable = false,
                                 manaCostString = costString,
                                 hasXCost = hasXCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/PhantomCardCopiesCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/PhantomCardCopiesCheck.kt
@@ -25,6 +25,12 @@ import com.wingedsheep.sdk.model.EntityId
  * null. Clone-style copies (Mockingbird, "becomes a copy of") snapshot the pre-copy component
  * and live on the battlefield as real permanents, so they are out of scope. Tokens are left to
  * the dedicated [TokensInWrongZonesCheck] (Rule 704.5s).
+ *
+ * Prepare-spell copies (Secrets of Strixhaven, carrying
+ * [com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent]) are also
+ * exempt: per the official rulings those copies deliberately persist in exile for as long as the
+ * prepared permanent is on the battlefield. They are cleaned up when the source leaves the
+ * battlefield or stops being prepared, not by this check.
  */
 class PhantomCardCopiesCheck : StateBasedActionCheck {
     override val name = "707.10a Phantom Card Copies"
@@ -40,6 +46,21 @@ class PhantomCardCopiesCheck : StateBasedActionCheck {
                 for (entityId in state.getZone(zoneKey)) {
                     val container = state.getEntity(entityId) ?: continue
                     if (container.has<TokenComponent>()) continue
+                    // Prepare-spell copies (Secrets of Strixhaven) persist in exile by design for as
+                    // long as their source creature is on the battlefield and prepared. Remove the
+                    // copy only when that link is broken — the source left the battlefield, stopped
+                    // being prepared, or the prepared link now points at a different copy.
+                    val prepareCopy = container.get<com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent>()
+                    if (prepareCopy != null) {
+                        val sourcePrepared = state.getEntity(prepareCopy.sourceId)
+                            ?.get<com.wingedsheep.engine.state.components.battlefield.PreparedComponent>()
+                        val stillLinked = sourcePrepared?.exileCopyId == entityId &&
+                            prepareCopy.sourceId in state.getBattlefield()
+                        if (!stillLinked) {
+                            copiesToRemove.add(entityId to zoneKey)
+                        }
+                        continue
+                    }
                     val copyOf = container.get<CopyOfComponent>() ?: continue
                     if (copyOf.originalCardComponent == null) {
                         copiesToRemove.add(entityId to zoneKey)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -270,6 +270,20 @@ class StackResolver(
             }
         )
 
+        // Prepared (Secrets of Strixhaven): casting the prepare-spell copy unprepares its source
+        // creature. Strip the source's PreparedComponent and consume the (permanent) cast-from-exile
+        // permission for this copy so it can't be cast again — the copy itself is on the stack and
+        // ceases to exist on resolution (CopyOfComponent), or the source's leave-battlefield cleanup
+        // removes it if it never resolves.
+        val prepareCopyComp = state.getEntity(cardId)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent>()
+        if (prepareCopyComp != null) {
+            newState = newState.updateEntity(prepareCopyComp.sourceId) { c ->
+                c.without<com.wingedsheep.engine.state.components.battlefield.PreparedComponent>()
+            }
+            newState = newState.removeMayPlayPermissionsForCard(cardId)
+        }
+
         // For face-down creatures, use a generic name in the event
         val eventName = if (castFaceDown) "Face-down creature" else cardComponent.name
 
@@ -1331,7 +1345,78 @@ class StackResolver(
             newState = newState.addDelayedTrigger(delayedTrigger)
         }
 
+        // Prepared (Secrets of Strixhaven): a preparation creature enters prepared. Becoming
+        // prepared creates a copy of the card's prepare spell in exile that its controller may
+        // cast (paying that spell's cost); casting it unprepares the creature.
+        if (cardDef != null && cardDef.layout == com.wingedsheep.sdk.model.CardLayout.PREPARE &&
+            !spellComponent.castFaceDown
+        ) {
+            newState = makePrepared(newState, spellId, cardDef, controllerId)
+        }
+
         return newState to counterEvents
+    }
+
+    /**
+     * Make the permanent [permanentId] prepared (Secrets of Strixhaven): create a copy of the
+     * card's prepare spell (`cardFaces[0]`) in [controllerId]'s exile, grant a permanent
+     * cast-from-exile permission for it, and link the two via [PreparedComponent] /
+     * [PreparedSpellCopyComponent]. The copy carries a [CopyOfComponent] (stack-style copy) so it
+     * ceases to exist on resolution, and a [PreparedSpellCopyComponent] so the cast-from-exile
+     * enumerator casts it as face 0 and the phantom-copy state-based action leaves it in exile.
+     */
+    private fun makePrepared(
+        state: GameState,
+        permanentId: EntityId,
+        cardDef: com.wingedsheep.sdk.model.CardDefinition,
+        controllerId: EntityId,
+    ): GameState {
+        val sourceCard = state.getEntity(permanentId)?.get<CardComponent>() ?: return state
+        val prepareFace = cardDef.cardFaces.firstOrNull() ?: return state
+
+        var newState = state
+        val (copyId, stateWithCopy) = newState.newEntity()
+        newState = stateWithCopy
+        newState = newState.updateEntity(copyId) { c ->
+            c.with(
+                CardComponent(
+                    cardDefinitionId = sourceCard.cardDefinitionId,
+                    name = sourceCard.name,
+                    manaCost = prepareFace.manaCost,
+                    typeLine = prepareFace.typeLine,
+                    oracleText = prepareFace.oracleText,
+                    colors = prepareFace.manaCost.colors,
+                    ownerId = controllerId,
+                    spellEffect = prepareFace.script.spellEffect,
+                    imageUri = sourceCard.imageUri,
+                )
+            ).with(
+                com.wingedsheep.engine.state.components.identity.CopyOfComponent(
+                    originalCardDefinitionId = sourceCard.cardDefinitionId,
+                    copiedCardDefinitionId = sourceCard.cardDefinitionId,
+                )
+            ).with(
+                com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent(sourceId = permanentId)
+            )
+        }
+        newState = newState.addToZone(ZoneKey(controllerId, Zone.EXILE), copyId)
+
+        val (permId, stateWithPerm) = newState.newEntity()
+        newState = stateWithPerm.addMayPlayPermission(
+            com.wingedsheep.engine.state.permissions.MayPlayPermission(
+                id = permId,
+                cardIds = setOf(copyId),
+                controllerId = controllerId,
+                sourceId = permanentId,
+                permanent = true,
+                timestamp = newState.timestamp,
+            )
+        )
+
+        newState = newState.updateEntity(permanentId) { c ->
+            c.with(com.wingedsheep.engine.state.components.battlefield.PreparedComponent(exileCopyId = copyId))
+        }
+        return newState
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -129,6 +129,40 @@ data class CrewSaddleContributorsComponent(
 data object CastForImpendingComponent : Component
 
 /**
+ * Marks a creature permanent as prepared (Secrets of Strixhaven, [com.wingedsheep.sdk.model.CardLayout.PREPARE]).
+ *
+ * A creature with a prepare spell becomes prepared as it enters (per the "This creature enters
+ * prepared" keyword). When it becomes prepared, its controller creates a copy of the card's
+ * prepare spell ([com.wingedsheep.sdk.model.CardDefinition.cardFaces] index 0) in exile and may
+ * cast that copy (paying its cost). [exileCopyId] links to that exiled copy so it can be removed
+ * if the permanent stops being prepared or leaves the battlefield, and casting the copy removes
+ * this component (the creature stops being prepared).
+ *
+ * Transient engine state, not a copiable value (a copy of a prepared creature is not prepared).
+ * Naturally gone when the permanent leaves the battlefield (a fresh entity has no battlefield
+ * components); the linked exile copy is cleaned up by [com.wingedsheep.engine.core.StateBasedActionChecker]-adjacent
+ * cleanup when the source leaves.
+ */
+@Serializable
+data class PreparedComponent(
+    val exileCopyId: EntityId
+) : Component
+
+/**
+ * Marks an exiled card as the prepare-spell copy of a prepared permanent (Secrets of Strixhaven).
+ *
+ * [sourceId] is the prepared permanent on the battlefield. This copy is cast as the card's prepare
+ * spell — face index 0 of [com.wingedsheep.sdk.model.CardDefinition.cardFaces] — so the cast-from-exile
+ * enumerator emits the cast with `faceIndex = 0` and the prepare spell's cost/targets. Per the
+ * rulings, this copy persists in exile (it is not removed by the "copies in non-stack zones cease to
+ * exist" state-based action) for as long as the source is on the battlefield and prepared.
+ */
+@Serializable
+data class PreparedSpellCopyComponent(
+    val sourceId: EntityId
+) : Component
+
+/**
  * Marks an exiled card as suspended (CR 702.62). The marker — not the card's printed
  * abilities — is what the engine keys on, so an arbitrary card with no printed suspend can
  * be suspended (e.g. Taigam, Master Opportunist exiles the spell you cast and grants it

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OwlinHistorianScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OwlinHistorianScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Owlin Historian (SOS #24).
+ *
+ * "{2}{W} Creature — Bird Cleric 2/3. Flying.
+ *  When this creature enters, surveil 1.
+ *  Whenever one or more cards leave your graveyard, this creature gets +1/+1 until end of turn."
+ *
+ * Verifies the static keyword (flying), the enters-the-battlefield surveil trigger, and the
+ * leave-graveyard pump (returning a creature card from the graveyard to hand via Raise Dead
+ * counts as a card leaving the graveyard, so the Historian grows +1/+1).
+ */
+class OwlinHistorianScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Owlin Historian") {
+
+            test("has flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Owlin Historian", summoningSickness = false)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val owlin = game.findPermanent("Owlin Historian")!!
+                game.state.projectedState.hasKeyword(owlin, Keyword.FLYING) shouldBe true
+            }
+
+            test("returning a creature card from graveyard pumps it +1/+1 until end of turn") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Owlin Historian", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Raise Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val owlin = game.findPermanent("Owlin Historian")!!
+                withClue("Base power before the trigger") {
+                    game.state.projectedState.getPower(owlin) shouldBe 2
+                }
+
+                // Raise Dead: return the creature card from the graveyard to hand.
+                game.castSpellTargetingGraveyardCard(1, "Raise Dead", 1, "Grizzly Bears")
+                game.resolveStack()
+
+                withClue("Grizzly Bears left the graveyard, so the Historian gets +1/+1") {
+                    game.state.projectedState.getPower(owlin) shouldBe 3
+                    game.state.projectedState.getToughness(owlin) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrepareMechanicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrepareMechanicScenarioTest.kt
@@ -1,0 +1,196 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Prepare / Prepared mechanic (Secrets of Strixhaven), covering
+ * Adventurous Eater // Have a Bite and Landscape Painter // Vibrant Idea.
+ *
+ * A preparation creature enters prepared: its controller gets a copy of the card's prepare spell
+ * in exile and may cast that copy (paying its mana cost). Casting the copy unprepares the creature
+ * and resolves the prepare spell; the copy ceases to exist. If the creature leaves the battlefield
+ * the exiled copy is cleaned up.
+ */
+class PrepareMechanicScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.findExileCopy(playerNumber: Int, name: String): com.wingedsheep.sdk.model.EntityId? {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).firstOrNull { id ->
+            val e = state.getEntity(id)
+            e?.get<CardComponent>()?.name == name && e.get<PreparedSpellCopyComponent>() != null
+        }
+    }
+
+    init {
+        context("Adventurous Eater — Have a Bite") {
+
+            test("entering creates an exiled prepare-spell copy and marks the creature prepared") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Adventurous Eater")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpell(1, "Adventurous Eater")
+                game.resolveStack()
+
+                val eater = game.findPermanent("Adventurous Eater")!!
+                val prepared = game.state.getEntity(eater)?.get<PreparedComponent>()
+                withClue("Adventurous Eater should be prepared on ETB") {
+                    prepared shouldNotBe null
+                }
+                val copyId = game.findExileCopy(1, "Adventurous Eater")
+                withClue("A prepare-spell copy should exist in exile") {
+                    copyId shouldNotBe null
+                }
+                prepared!!.exileCopyId shouldBe copyId
+            }
+
+            test("casting the prepare-spell copy adds a +1/+1 counter, gains life, and unprepares the creature") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Adventurous Eater")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpell(1, "Adventurous Eater")
+                game.resolveStack()
+
+                val eater = game.findPermanent("Adventurous Eater")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val copyId = game.findExileCopy(1, "Adventurous Eater")!!
+
+                // The cast-from-exile enumerator should surface the prepare-spell copy as a {B}
+                // cast of face 0 from exile.
+                val prepareAction = game.getLegalActions(1).firstOrNull { la ->
+                    val a = la.action
+                    a is CastSpell && a.cardId == copyId
+                }
+                withClue("The prepare-spell copy should be offered as a legal cast from exile") {
+                    prepareAction shouldNotBe null
+                }
+                withClue("It should be cast as face 0 (the prepare spell) for {B}") {
+                    (prepareAction!!.action as CastSpell).faceIndex shouldBe 0
+                    prepareAction.sourceZone shouldBe "EXILE"
+                    prepareAction.manaCostString shouldBe "{B}"
+                }
+
+                // Cast the prepare-spell copy (face 0) targeting Grizzly Bears.
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        copyId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        faceIndex = 0
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Grizzly Bears should have a +1/+1 counter from Have a Bite") {
+                    val counters = game.state.getEntity(bears)?.get<CountersComponent>()
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+                withClue("Controller should have gained 1 life") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+                withClue("Adventurous Eater should no longer be prepared") {
+                    game.state.getEntity(eater)?.get<PreparedComponent>() shouldBe null
+                }
+                withClue("The prepare-spell copy should be gone from exile") {
+                    game.findExileCopy(1, "Adventurous Eater") shouldBe null
+                }
+            }
+        }
+
+        context("Landscape Painter — Vibrant Idea") {
+
+            test("casting the prepare-spell copy draws two cards and unprepares the creature") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Landscape Painter")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(6) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(6) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpell(1, "Landscape Painter")
+                game.resolveStack()
+
+                val painter = game.findPermanent("Landscape Painter")!!
+                val handBefore = game.handSize(1)
+                val copyId = game.findExileCopy(1, "Landscape Painter")!!
+
+                game.execute(CastSpell(game.player1Id, copyId, faceIndex = 0))
+                game.resolveStack()
+
+                withClue("Vibrant Idea draws two cards") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+                withClue("Landscape Painter should no longer be prepared") {
+                    game.state.getEntity(painter)?.get<PreparedComponent>() shouldBe null
+                }
+                withClue("The prepare-spell copy should be gone from exile") {
+                    game.findExileCopy(1, "Landscape Painter") shouldBe null
+                }
+            }
+        }
+
+        context("Prepared cleanup") {
+
+            test("the exiled copy is removed when the prepared creature leaves the battlefield") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Landscape Painter")
+                    .withCardInHand(1, "Murder")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpell(1, "Landscape Painter")
+                game.resolveStack()
+
+                val painter = game.findPermanent("Landscape Painter")!!
+                game.findExileCopy(1, "Landscape Painter") shouldNotBe null
+
+                // Destroy the prepared creature (Murder targets the painter).
+                game.castSpell(1, "Murder", painter)
+                game.resolveStack()
+
+                withClue("Landscape Painter should be gone from the battlefield") {
+                    game.findPermanent("Landscape Painter") shouldBe null
+                }
+                withClue("The prepare-spell copy should be cleaned up once the source leaves the battlefield") {
+                    game.findExileCopy(1, "Landscape Painter") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Secrets of Strixhaven (SOS) cards and the new **Prepare / Prepared** mechanic the two preparation cards require, and teaches the mtgish generator to draft all three to **AUTOGEN**.

## Cards

- **Owlin Historian** — `{2}{W}` Creature — Bird Cleric 2/3. Flying; "When this creature enters, surveil 1"; "Whenever one or more cards leave your graveyard, this creature gets +1/+1 until end of turn." Composed from existing primitives (`Triggers.EntersBattlefield` + `Patterns.Library.surveil`, `Triggers.CardsLeaveYourGraveyard()` + `Effects.ModifyStats`).
  - mtgish tier: **AUTOGEN** (emitter renders it whole, matching the hand-authored card).
- **Adventurous Eater // Have a Bite** — `{2}{B}` Creature — Human Warlock 3/2. Prepare card; prepare spell "Have a Bite" ({B} Sorcery): put a +1/+1 counter on target creature, gain 1 life.
  - mtgish tier: **AUTOGEN**.
- **Landscape Painter // Vibrant Idea** — `{1}{U}` Creature — Merfolk Wizard 2/1. Prepare card; prepare spell "Vibrant Idea" ({4}{U} Sorcery): draw two cards.
  - mtgish tier: **AUTOGEN**.

## New mechanic: Prepare / Prepared (Secrets of Strixhaven)

Modeled CR-faithfully per the official SOS rulings (the creature is only ever cast as itself; becoming prepared creates a **persistent copy of the prepare spell in exile** that the controller may cast for its cost; casting it unprepares the creature):

- **SDK:** `CardLayout.PREPARE` + `prepare("Name") { spell { … } }` DSL builder + `Keyword.PREPARED` ("This creature enters prepared").
- **Engine:** `StackResolver.makePrepared` (ETB) creates a stack-style copy in the controller's exile (`PreparedSpellCopyComponent`), stamps `PreparedComponent(exileCopyId)` on the creature, and grants a permanent cast-from-exile `MayPlayPermission`. `CastFromZoneEnumerator` surfaces the copy as `CastSpell(faceIndex = 0)` from EXILE using the prepare face's cost/targets. Casting it (`StackResolver.castSpell`) strips `PreparedComponent` and consumes the permission; the copy ceases to exist on resolution (`CopyOfComponent`).
- **SBA:** `PhantomCardCopiesCheck` (CR 707.10a) exempts the prepare copy while linked and removes it once the source leaves the battlefield or stops being prepared.
- New components `PreparedComponent` / `PreparedSpellCopyComponent` registered for serialization.

## mtgish autogen

- Added trigger spec `WhenAnyNumberOfGraveyardCardsLeave` (You, unfiltered → `Triggers.CardsLeaveYourGraveyard()`) + bridge entry (unlocks Owlin Historian and Attuned-Hunter-shaped cards corpus-wide).
- Taught the emitter the `Preparer` / nested `Prepared` IR shape (`prepareBlock` renders `prepare("…") { spell { … } }` over the nested prepare card; emits `keywords(Keyword.PREPARED)` and skips the redundant `AsPermanentEnters[EntersPrepared]` rule). Declines → SCAFFOLD if the prepare spell can't render exactly.

## Verification

- New scenario tests pass: `OwlinHistorianScenarioTest`, `PrepareMechanicScenarioTest` (ETB-creates-exile-copy, cast-unprepares + resolves, leave-battlefield cleanup, legal-action enumeration).
- Full `:rules-engine` suite green; `CardLintTest` + `CardDefinitionSnapshotTest` green (SOS golden reblessed — only the 3 new cards added).
- `EmitterGoldenTest` (POR, EOE) green; **`coverage-verify POR` is GATE PASS (158/158, 0-mismatch)** — no regression. SOS is an `incomplete` set with pre-existing emitter gaps (Lorehold/Prismari/Silverquill Charm, Expressive Firedancer) not touched here; the 3 new cards emit gameplay-equivalent output (listed only under "emitted outside golden").
- `docs/card-sdk-language-reference.md` updated for `CardLayout.PREPARE` + `Keyword.PREPARED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>