### PR TITLE
SOS: Prismari/Quandrix cards (Quick Study, Hydro-Channeler, Fractal Tender) + mtgish autogen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2344,6 +2344,14 @@ composite abilities).
   with [ManaExpiry](#manaexpiry).`END_OF_COMBAT` and discarded by `CombatManager.endCombat`. It is a normal
   triggered ability (not a mana ability): it uses the stack and can be responded to. `n` may be any fixed value;
   "firebending X (X = its power)" is not yet expressible by this helper (the keyword carries only a fixed Int).
+- `Increment` — "Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power
+  or toughness, put a +1/+1 counter on this creature." (Secrets of Strixhaven). Display-only; wire the behavior with
+  the `card { increment() }` builder helper, which adds the `KeywordAbility.Increment` display marker (surfacing
+  `Keyword.INCREMENT`) plus a `Triggers.YouCastSpell` triggered `AddCounters(+1/+1, 1, Self)` gated by an
+  intervening-if (CR 603.4) that compares the triggering spell's mana spent (`EntityProperty(Triggering,
+  ManaSpent)`) against the source's power *or* toughness — modelled as an `AnyCondition` of two `Compare(GT)`
+  arms, so it fires when the mana exceeds the smaller characteristic. No parameter (mirrors `firebending()` /
+  `decayed()`).
 - `Decayed` — "This creature can't block, and when it attacks, sacrifice it at end of combat" (CR 702.147,
   Innistrad: Midnight Hunt). Display-only; wire the behavior with the `card { decayed() }` builder helper, which adds
   the keyword plus a `CantBlock(GroupFilter.source())` static ability and a "whenever this attacks" triggered
@@ -2634,6 +2642,11 @@ that works in both resolution and static-ability (projection) contexts.
 - `SourceIsModified` — has counters, attached Equipment, or controller-owned Aura
   attached (CR 700.4). Kept as a dedicated condition because the controller-of-Aura
   match isn't expressible via the generic `EntityMatches` filter machinery.
+- `SourceReceivedCounterThisTurn` — "if you put a counter on this creature this turn." True while the source
+  carries the per-turn `ReceivedCountersThisTurnComponent` marker (stamped by the counter-placement path, cleared
+  at cleanup). Distinct from `SourceHasCounter` (which checks current counters): this fires even if the counter was
+  later removed, and stays false if the source merely entered with counters from a *prior* turn. Used as the
+  end-step intervening-if of Secrets of Strixhaven's Fractal Tender.
 - `SourceHasSubtype(subtype)` — `SourceMatches(GameObjectFilter.Any.withSubtype(...))`;
   Changeling is honored.
 - `SourceHasKeyword(keyword)` — `SourceMatches(GameObjectFilter.Any.withKeyword(...))`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -311,7 +311,16 @@ enum class Keyword(val displayName: String) {
      * creates a copy of the card's prepare spell (`cardFaces[0]`) in exile that they may cast
      * (paying that spell's cost); casting the copy unprepares the creature.
      */
-    PREPARED("Prepared");
+    PREPARED("Prepared"),
+
+    /**
+     * Increment (Secrets of Strixhaven).
+     * "Whenever you cast a spell, if the amount of mana you spent is greater than this
+     * creature's power or toughness, put a +1/+1 counter on this creature."
+     * Wired via the `increment()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder],
+     * which attaches this display-only keyword plus the cast-spell triggered ability.
+     */
+    INCREMENT("Increment");
 
     companion object {
         fun fromString(value: String): Keyword? =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -70,6 +70,14 @@ object Conditions {
      */
     val YouChoseOtherCreatureAsRingBearer: ConditionInterface = YouChoseOtherCreatureAsRingBearerCondition
 
+    /**
+     * If you put a counter on this creature this turn (Secrets of Strixhaven — Fractal
+     * Tender). True while the source permanent carries the per-turn "received counters"
+     * marker, which the counter-placement path stamps and cleanup clears each turn.
+     */
+    val SourceReceivedCounterThisTurn: ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.SourceReceivedCounterThisTurn
+
     // =========================================================================
     // Battlefield Conditions (via Exists / Compare)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/IncrementDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/IncrementDsl.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.conditions.AnyCondition
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Add Increment (Secrets of Strixhaven).
+ *
+ * "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than
+ * this creature's power or toughness, put a +1/+1 counter on this creature.)"
+ *
+ * Wires the full keyword from one call:
+ *  - the display-only [KeywordAbility.Increment] (prints the keyword + surfaces
+ *    [com.wingedsheep.sdk.core.Keyword.INCREMENT] in the base keyword set), and
+ *  - a "whenever you cast a spell" triggered ability whose intervening-if compares the
+ *    mana spent on that spell ([EntityNumericProperty.ManaSpent] read off the triggering
+ *    spell on the stack) against this creature's power *or* toughness (CR 603.4 — the
+ *    condition is checked both when the ability would trigger and again on resolution).
+ *
+ * "greater than this creature's power or toughness" is true when the mana spent exceeds
+ * *either* characteristic, i.e. greater than the smaller of the two — modelled here as an
+ * OR over the two `>` comparisons rather than a single `min`, so each side reads the live
+ * projected value independently.
+ */
+fun CardBuilder.increment() {
+    keywordAbilityList.add(KeywordAbility.Increment)
+
+    val manaSpent = DynamicAmount.EntityProperty(
+        EntityReference.Triggering,
+        EntityNumericProperty.ManaSpent
+    )
+    val incrementCondition = AnyCondition(
+        listOf(
+            Compare(manaSpent, ComparisonOperator.GT, DynamicAmounts.sourcePower()),
+            Compare(manaSpent, ComparisonOperator.GT, DynamicAmounts.sourceToughness())
+        )
+    )
+
+    triggeredAbilities.add(
+        TriggeredAbility.create(
+            trigger = Triggers.YouCastSpell.event,
+            binding = Triggers.YouCastSpell.binding,
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            triggerCondition = incrementCondition,
+            descriptionOverride = "Increment (Whenever you cast a spell, if the amount of mana " +
+                "you spent is greater than this creature's power or toughness, put a +1/+1 " +
+                "counter on this creature.)"
+        )
+    )
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -584,6 +584,27 @@ sealed interface KeywordAbility {
     }
 
     // =========================================================================
+    // Increment
+    // =========================================================================
+
+    /**
+     * Increment (Secrets of Strixhaven).
+     * "Whenever you cast a spell, if the amount of mana you spent is greater than this
+     * creature's power or toughness, put a +1/+1 counter on this creature."
+     *
+     * This [KeywordAbility] entry is display-only (it prints the keyword + reminder text
+     * and surfaces [Keyword.INCREMENT] in the base keyword set). The mechanical wiring —
+     * the "whenever you cast a spell" triggered ability gated on the mana-spent intervening-if —
+     * is composed by the `increment()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder].
+     */
+    @SerialName("Increment")
+    @Serializable
+    data object Increment : KeywordAbility {
+        override val keyword: Keyword = Keyword.INCREMENT
+        override val description: String = "Increment"
+    }
+
+    // =========================================================================
     // Companion Methods
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
@@ -118,6 +118,22 @@ data object SourceIsModified : Condition {
 }
 
 /**
+ * Condition: "if you put a counter on this creature this turn".
+ *
+ * True iff one or more counters have been placed on the source permanent during the
+ * current turn — tracked by the per-permanent `ReceivedCountersThisTurnComponent`, which
+ * the counter-placement path stamps and the cleanup step clears each turn. Used by
+ * Secrets of Strixhaven's Fractal Tender end-step trigger ("if you put a counter on this
+ * creature this turn, …"), and reusable by any "if a counter was put on this permanent
+ * this turn" intervening-if.
+ */
+@SerialName("SourceReceivedCounterThisTurn")
+@Serializable
+data object SourceReceivedCounterThisTurn : Condition {
+    override val description: String = "you put a counter on this creature this turn"
+}
+
+/**
  * Condition: "If you cast this spell from your hand"
  * Used for Phage the Untouchable's ETB trigger condition.
  * Checks whether the source permanent was cast from the hand (as opposed to

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/QuickStudyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/QuickStudyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quick Study reprint in Foundations. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Wilds of Eldraine `cards/`
+ * package; this file contributes only presentation data.
+ */
+val QuickStudyReprint = Printing(
+    oracleId = "7bff8d4a-1c7d-48b8-b3e3-737dd6f01823",
+    name = "Quick Study",
+    setCode = "FDN",
+    collectorNumber = "513",
+    scryfallId = "098c86fd-5a38-41fd-be44-ab963448f2a2",
+    artist = "Iris Compiet",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/098c86fd-5a38-41fd-be44-ab963448f2a2.jpg?1730490549",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FractalTender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FractalTender.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.increment
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fractal Tender
+ * {3}{G}{U}
+ * Creature — Elf Wizard
+ * 3/3
+ *
+ * Ward {2}
+ * Increment (Whenever you cast a spell, if the amount of mana you spent is greater than
+ * this creature's power or toughness, put a +1/+1 counter on this creature.)
+ * At the beginning of each end step, if you put a counter on this creature this turn,
+ * create a 0/0 green and blue Fractal creature token and put three +1/+1 counters on it.
+ */
+val FractalTender = card("Fractal Tender") {
+    manaCost = "{3}{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Creature — Elf Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Ward {2}\n" +
+        "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than " +
+        "this creature's power or toughness, put a +1/+1 counter on this creature.)\n" +
+        "At the beginning of each end step, if you put a counter on this creature this turn, " +
+        "create a 0/0 green and blue Fractal creature token and put three +1/+1 counters on it."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+    increment()
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        triggerCondition = Conditions.SourceReceivedCounterThisTurn
+        // Create the 0/0 Fractal (publishing it to the CREATED_TOKENS pipeline collection), then put
+        // three +1/+1 counters on that just-created token via PipelineTarget(CREATED_TOKENS, 0).
+        effect = Effects.Composite(
+            listOf(
+                Effects.CreateToken(
+                    power = 0,
+                    toughness = 0,
+                    colors = setOf(Color.GREEN, Color.BLUE),
+                    creatureTypes = setOf("Fractal"),
+                    imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                ),
+                Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    3,
+                    EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+                )
+            )
+        )
+        description = "At the beginning of each end step, if you put a counter on this creature " +
+            "this turn, create a 0/0 green and blue Fractal creature token and put three +1/+1 " +
+            "counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Elizabeth Peiró"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea7f5262-4ddb-410a-be72-4bac6af9b4ec.jpg?1775938318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/HydroChanneler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/HydroChanneler.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Hydro-Channeler
+ * {1}{U}
+ * Creature — Merfolk Wizard
+ * 1/3
+ *
+ * {T}: Add {U}. Spend this mana only to cast an instant or sorcery spell.
+ * {1}, {T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.
+ */
+val HydroChanneler = card("Hydro-Channeler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "{T}: Add {U}. Spend this mana only to cast an instant or sorcery spell.\n" +
+        "{1}, {T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.BLUE, 1, ManaRestriction.InstantOrSorceryOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(listOf(Costs.Mana("{1}"), AbilityCost.Tap))
+        effect = Effects.AddManaOfChoice(restriction = ManaRestriction.InstantOrSorceryOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Mila Pesic"
+        flavorText = "Only when they can defy the laws of nature can a Quandrix student claim to have mastered a spell."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/099f8400-d70a-48ef-8ff6-645eae97e072.jpg?1775937286"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuickStudyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuickStudyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quick Study reprint in Secrets of Strixhaven. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Wilds of Eldraine `cards/`
+ * package; this file contributes only presentation data.
+ */
+val QuickStudyReprint = Printing(
+    oracleId = "7bff8d4a-1c7d-48b8-b3e3-737dd6f01823",
+    name = "Quick Study",
+    setCode = "SOS",
+    collectorNumber = "65",
+    scryfallId = "2d4f0bc7-da7c-4749-a24c-b01f3eb5860c",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d4f0bc7-da7c-4749-a24c-b01f3eb5860c.jpg?1775937363",
+    releaseDate = "2026-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/QuickStudy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/QuickStudy.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quick Study
+ * {2}{U}
+ * Instant
+ *
+ * Draw two cards.
+ */
+val QuickStudy = card("Quick Study") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw two cards."
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Iris Compiet"
+        flavorText = "At first, Johann was annoyed that the library had decided to reorganize itself. But he had to admit that storing the cookbooks in the cauldron made a certain kind of sense."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg?1692937231"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1539,6 +1539,129 @@
     ]
 }
 
+// Fractal Tender
+{
+    "name": "Fractal Tender",
+    "manaCost": "{3}{G}{U}",
+    "typeLine": "Creature — Elf Wizard",
+    "oracleText": "Ward {2}\nIncrement (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)\nAt the beginning of each end step, if you put a counter on this creature this turn, create a 0/0 green and blue Fractal creature token and put three +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "WARD",
+        "INCREMENT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        },
+        "Increment"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "GREEN",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Fractal"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": "SourceReceivedCounterThisTurn",
+                "descriptionOverride": "At the beginning of each end step, if you put a counter on this creature this turn, create a 0/0 green and blue Fractal creature token and put three +1/+1 counters on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Elizabeth Peiró",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea7f5262-4ddb-410a-be72-4bac6af9b4ec.jpg?1775938318"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Grapple with Death
 {
     "name": "Grapple with Death",
@@ -1645,6 +1768,64 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Hydro-Channeler
+{
+    "name": "Hydro-Channeler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{T}: Add {U}. Spend this mana only to cast an instant or sorcery spell.\n{1}, {T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE",
+                    "restriction": "InstantOrSorceryOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": "InstantOrSorceryOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Mila Pesic",
+        "flavorText": "Only when they can defy the laws of nature can a Quandrix student claim to have mastered a spell.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/099f8400-d70a-48ef-8ff6-645eae97e072.jpg?1775937286"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1,3 +1,29 @@
+// Quick Study
+{
+    "name": "Quick Study",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Iris Compiet",
+        "flavorText": "At first, Johann was annoyed that the library had decided to reorganize itself. But he had to admit that storing the cookbooks in the cauldron made a certain kind of sense.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg?1692937231"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sleep-Cursed Faerie
 {
     "name": "Sleep-Cursed Faerie",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Registry.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Registry.kt
@@ -29,7 +29,7 @@ object Registry {
 
     // --- import resolution: symbol -> package, from a live scan of the SDK source (anti-rot) -----
     private val DECL = Regex(
-        """^(?:public\s+|internal\s+)?(?:sealed\s+|abstract\s+|open\s+|data\s+|value\s+)?""" +
+        """^(?:public\s+|internal\s+)?(?:const\s+)?(?:sealed\s+|abstract\s+|open\s+|data\s+|value\s+)?""" +
             // The `(?:Receiver\.)*` segment skips an extension's receiver type so e.g.
             // `fun GameObjectFilter.namedFromVariable(...)` is indexed under `namedFromVariable`, not the
             // receiver `GameObjectFilter` — otherwise the receiver (which actually lives in another

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -29,6 +29,17 @@ internal fun BridgeBuilder.keywords() {
     // the integer case auto-renders, while "firebending X (X = its power)" carries an XValue node and
     // the emitter declines it (-> SCAFFOLD). This entry only marks the capability covered.
     supported("Firebending", "keyword ability: Firebending N -> keywordAbility(KeywordAbility.firebending(N)) (CR 702.189)")
+    // Increment (Secrets of Strixhaven) — a keyword whose whole mechanic is composed by the
+    // `increment()` CardBuilder helper: the display keyword plus a "whenever you cast a spell, if the
+    // mana you spent exceeds this creature's power or toughness, put a +1/+1 counter on it" triggered
+    // ability (intervening-if on EntityNumericProperty.ManaSpent). `composed`, not a bare keyword: a
+    // plain Keyword.INCREMENT stamp would drop the cast-spell trigger. The emitter's `rname ==
+    // "Increment"` branch renders the no-arg `increment()` builder call (the rule carries no args).
+    composed(
+        "Increment",
+        "keyword: increment() -> Keyword.INCREMENT + 'whenever you cast a spell, if mana spent > power or toughness, +1/+1 counter' trigger",
+        composes = listOf("AddCounters"),
+    )
     // Ward (CR 702.21) — a PARAMETERIZED keyword ability: the cost rides in the rule's args
     // (`Ward—Discard a card`, `Ward {2}`, `Ward—Pay N life`, `Ward—Sacrifice <filter>`). Like Saddle,
     // it must be `supported`, not `keyword`: a bare `keywords(Keyword.WARD)` would drop the cost. The

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -8,6 +8,11 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // scorer can't see the symbol arg, so name the whole mana family the action can lower to.
     composed("AddMana", UNIVERSAL, composes = listOf("AddMana", "AddColorlessMana", "AddManaOfChoice"))
     composed("AddManaRepeated", UNIVERSAL, composes = listOf("AddMana", "AddColorlessMana", "AddManaOfChoice"))
+    // "Add {U}/{C}/any color. Spend this mana only to cast an instant or sorcery spell."
+    // (Hydro-Channeler, Vodalian Arcanist): same mana family as AddMana, carrying a
+    // ManaRestriction.InstantOrSorceryOnly — the emitter renders only that one CanOnlySpendOnSpells
+    // shape and scaffolds any other modifier.
+    composed("AddManaWithModifiers", UNIVERSAL, composes = listOf("AddMana", "AddColorlessMana", "AddManaOfChoice"))
     effect("AddColorlessMana", "AddColorlessMana", UNIVERSAL)
 
     // CreateTokens lowers to either the generic CreateToken (creature tokens) or a predefined-token

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -935,6 +935,19 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
             filter.field("args").asStr() == "Creature"
         return if (bareCreature) "Conditions.CreatureDiedThisTurn" else null
     }
+    // "if you put a counter on this creature this turn" — PlayerPassesFilter(You,
+    // HasPutACounterOnAPermanentThisTurn(SinglePermanent(ThisPermanent))) (Fractal Tender's end-step
+    // gate). Only the exact ThisPermanent subject maps to Conditions.SourceReceivedCounterThisTurn;
+    // a wider permanent filter (any permanent, a group) declines -> SCAFFOLD rather than over-fire.
+    if (cond.strField("_Condition") == "PlayerPassesFilter" &&
+        jsonContains(cond, "_Player", "You") &&
+        jsonContains(cond, "_Players", "HasPutACounterOnAPermanentThisTurn")
+    ) {
+        val perms = ((cond["args"].asArr?.getOrNull(1)) as? JsonObject)?.get("args") as? JsonObject
+        val isThisPermanent = perms?.strField("_Permanents") == "SinglePermanent" &&
+            perms.field("args").strField("_Permanent") == "ThisPermanent"
+        return if (isThisPermanent) "Conditions.SourceReceivedCounterThisTurn" else null
+    }
     // "if you gained life this turn" — PlayerPassesFilter(You, GainedLifeThisTurn) (Foolish Fate's
     // Infusion clause). No count/amount sub-clause, so the bare "you gained life this turn" maps to
     // Conditions.YouGainedLifeThisTurn.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -436,6 +436,11 @@ internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
         return targetRefVars[ref] ?: targetRefVarsByKind[ref]?.firstOrNull()
     }
     if (ref in SELF_REFS) return "EffectTarget.Self"
+    // "the created token" — the token a preceding CreateTokens action in this same action list just
+    // made (Fractal Tender: "create a 0/0 Fractal … and put three +1/+1 counters on it"). The token
+    // executor publishes its ids under the CREATED_TOKENS pipeline collection, so the follow-up effect
+    // addresses it via PipelineTarget(CREATED_TOKENS, 0).
+    if (ref == "TheCreatedToken") return "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"
     // "that player" in a trigger ("the player ~ dealt combat damage to") -> the triggering player.
     if (ref == "Trigger_ThatPlayer") return "EffectTarget.PlayerRef(Player.TriggeringPlayer)"
     // A plain player reference (no target) — the controller / "you" or an opponent. The pain-land idiom

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -212,6 +212,12 @@ object Emitter {
                 rname == "Affinity" -> block = ctx.affinityBlock(rule)
                 // Station keyword ability (CR 702.184a) — fully fixed, renders the no-arg builder.
                 rname == "Station" -> block = listOf(Eval(call("station")))
+                // Increment (Secrets of Strixhaven) — a keyword whose whole mechanic ("whenever you cast
+                // a spell, if the mana you spent exceeds this creature's power or toughness, +1/+1
+                // counter") is composed by the `increment()` CardBuilder helper. Like `station()` /
+                // `firebending(n)`, render the builder call directly rather than a bare keywordAbility
+                // (which would print the keyword but drop the cast-spell trigger). The rule carries no args.
+                rname == "Increment" -> block = listOf(Eval(call("increment")))
                 // {N+} station symbol that animates into a creature (CR 721.2b). Non-animating
                 // `StationCharged` (gating an activated/triggered ability) is left to the default
                 // branch → scaffold, since its payload is arbitrary.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -18,6 +18,17 @@ import kotlinx.serialization.json.JsonObject
  */
 internal val manaHandlers: Map<String, ActionHandler> = actionHandlers {
     on("AddMana") { _, args, _ -> manaProduceDsl(args) }
+    on("AddManaWithModifiers") { _, args, _ ->
+        // "{T}: Add {U}. Spend this mana only to cast an instant or sorcery spell." (Hydro-Channeler,
+        // Vodalian Arcanist): a produced mana plus a use-restriction modifier. args = [<ManaProduce>,
+        // <ManaUseModifier>…]. Render only the one restriction we can express exactly —
+        // CanOnlySpendOnSpells over an Or of {Instant, Sorcery} -> ManaRestriction.InstantOrSorceryOnly;
+        // any other modifier scaffolds (return null) rather than drop the restriction silently.
+        val arr = args.asArr ?: return@on null
+        val produce = arr.getOrNull(0) as? JsonObject ?: return@on null
+        val restriction = manaUseModifierRestriction(arr.drop(1)) ?: return@on null
+        manaProduceWithRestrictionDsl(produce, restriction)
+    }
     on("AddManaRepeated") { _, args, _ ->
         // "Add {R} for each Goblin on the battlefield" (Brightstone Ritual): a single mana symbol produced
         // a dynamic number of times -> Effects.AddMana(color, <count>). Only one colour/colourless symbol
@@ -46,6 +57,39 @@ internal fun manaProduceDsl(node: JsonElement?): Dsl? =
         else -> MANA_PRODUCE_COLOR[produce]?.let { call("Effects.AddMana", arg(it)) }
     }
 
+/**
+ * Recover the single use-restriction we can render exactly from the `_ManaUseModifier` list of an
+ * `AddManaWithModifiers` action. Returns the Argentum `ManaRestriction.*` token, or null to scaffold
+ * for any modifier we don't render (so a restriction is never silently dropped). Today only
+ * `CanOnlySpendOnSpells` over an `Or` of `{Instant, Sorcery}` maps cleanly.
+ */
+private fun manaUseModifierRestriction(modifiers: List<JsonElement>): String? {
+    val modifier = modifiers.singleOrNull() as? JsonObject ?: return null
+    if (modifier.strField("_ManaUseModifier") != "CanOnlySpendOnSpells") return null
+    val spells = modifier["args"] as? JsonObject ?: return null
+    if (spells.strField("_Spells") != "Or") return null
+    val branches = spells["args"] as? JsonArray ?: return null
+    val cardtypes = branches.mapNotNull { b ->
+        (b as? JsonObject)?.takeIf { it.strField("_Spells") == "IsCardtype" }?.get("args")
+    }.mapNotNull { (it as? kotlinx.serialization.json.JsonPrimitive)?.content }.toSet()
+    return if (cardtypes == setOf("Instant", "Sorcery")) "ManaRestriction.InstantOrSorceryOnly" else null
+}
+
+/**
+ * `{_ManaProduce}` + a recovered restriction token -> the matching restricted mana Effect. Mirrors
+ * [manaProduceDsl] but threads the `restriction = …` named argument; declines (null) for produce shapes
+ * the restricted facades don't cover (And pools, etc.).
+ */
+private fun manaProduceWithRestrictionDsl(node: JsonObject, restriction: String): Dsl? =
+    when (val produce = node.strField("_ManaProduce")) {
+        null -> null
+        "ManaProduceC" -> call("Effects.AddColorlessMana", arg("1"), arg("restriction", restriction))
+        "AnyManaColor" -> call("Effects.AddManaOfChoice", arg("restriction", restriction))
+        else -> MANA_PRODUCE_COLOR[produce]?.let {
+            call("Effects.AddMana", arg(it), arg("1"), arg("restriction", restriction))
+        }
+    }
+
 /** `And[<produce>…]` -> one `Effects.Add*Mana(color, count)` per distinct mana, composited (inline) when
  *  the pool mixes colors. Null (-> SCAFFOLD) if any child is itself a non-leaf produce (nested And /
  *  choice), so we never emit a partial pool. */
@@ -66,4 +110,6 @@ private fun manaAndDsl(node: JsonObject): Dsl? {
 
 /** True when this ability is a mana ability: no target, and at least one action adds mana. */
 internal fun isManaAbility(tvar: String?, actions: List<JsonObject>): Boolean =
-    tvar == null && actions.any { it.strField("_Action") in setOf("AddMana", "AddManaRepeated") }
+    tvar == null && actions.any {
+        it.strField("_Action") in setOf("AddMana", "AddManaRepeated", "AddManaWithModifiers")
+    }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
@@ -148,6 +148,10 @@ internal fun keywordLines(card: JsonObject, keywords: Set<String>): Set<String> 
         // Protection always carries a "from X" scope, so it renders as a scoped `keywordAbility(...)`
         // (see Emitter.protectionScopeDsl), never a bare `keywords(Keyword.PROTECTION)`.
         if (rname == "Protection") continue
+        // Increment's whole mechanic is composed by the `increment()` builder (Emitter `rname ==
+        // "Increment"`), which itself surfaces Keyword.INCREMENT. A bare `keywords(Keyword.INCREMENT)`
+        // here would both duplicate the keyword and drop the cast-spell trigger, so skip it.
+        if (rname == "Increment") continue
         val entry = Bridge.entry("_Rule", rname)
         val auto = pascalToUpperSnake(rname)
         if (entry is MappingEntry.Keyword) out.add(entry.tag)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -65,6 +65,7 @@ import com.wingedsheep.sdk.scripting.conditions.OpponentSpellOnStack
 import com.wingedsheep.sdk.scripting.conditions.ControllerTurnsTakenAtMost
 import com.wingedsheep.sdk.scripting.conditions.SourceCastForImpending
 import com.wingedsheep.sdk.scripting.conditions.SourceIsModified
+import com.wingedsheep.sdk.scripting.conditions.SourceReceivedCounterThisTurn
 import com.wingedsheep.sdk.scripting.conditions.SourceChosenModeIs
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceMade
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceIs
@@ -198,6 +199,13 @@ class ConditionEvaluator(
             is SourceCastForImpending -> {
                 val sourceId = ctx.sourceId
                 sourceId != null && state.getEntity(sourceId)?.has<CastForImpendingComponent>() == true
+            }
+
+            is SourceReceivedCounterThisTurn -> {
+                val sourceId = ctx.sourceId
+                sourceId != null &&
+                    state.getEntity(sourceId)
+                        ?.has<com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent>() == true
             }
 
             // The unified "an entity matches a filter" primitive. Dispatches on the entity role:

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FractalTenderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FractalTenderScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Fractal Tender (Secrets of Strixhaven #190).
+ *
+ * Fractal Tender ({3}{G}{U}, 3/3, Elf Wizard):
+ *   Ward {2}
+ *   Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this
+ *     creature's power or toughness, put a +1/+1 counter on this creature.)
+ *   At the beginning of each end step, if you put a counter on this creature this turn, create a
+ *     0/0 green and blue Fractal creature token and put three +1/+1 counters on it.
+ *
+ * Exercises the new Increment keyword (cast-spell intervening-if on mana spent vs power/toughness)
+ * and the SourceReceivedCounterThisTurn end-step condition.
+ */
+class FractalTenderScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Fractal Tender — Increment + end-step Fractal token") {
+
+            test("casting a spell with mana spent > P/T increments, then end step makes a Fractal") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Fractal Tender")
+                    .withCardInHand(1, "Stoke the Flames") // {2}{R}{R} = 4 mana spent
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tender = game.findPermanent("Fractal Tender")!!
+
+                // Cast Stoke the Flames paying 4 mana (no convoke), targeting the opponent.
+                val cast = game.castSpellTargetingPlayer(1, "Stoke the Flames", 2)
+                withClue("Casting Stoke the Flames should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Increment trigger resolves: 4 > 3 -> +1/+1 counter
+                game.resolveStack() // Stoke the Flames resolves
+
+                withClue("Increment should have placed one +1/+1 counter (4 mana > 3 toughness)") {
+                    plusOneCounters(game, tender) shouldBe 1
+                }
+
+                // Advance to the end step; the intervening-if (counter placed this turn) is true.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                val fractal = game.findPermanent("Fractal Token")
+                withClue("A Fractal token should have been created at the end step") {
+                    (fractal != null) shouldBe true
+                }
+                withClue("The Fractal token enters with three +1/+1 counters (0/0 base)") {
+                    plusOneCounters(game, fractal!!) shouldBe 3
+                }
+            }
+
+            test("casting a spell with mana spent not greater than P/T does not increment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Fractal Tender")
+                    .withCardInHand(1, "Lightning Bolt") // {R} = 1 mana spent
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tender = game.findPermanent("Fractal Tender")!!
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                withClue("1 mana is not greater than power 3 or toughness 3 — no counter") {
+                    plusOneCounters(game, tender) shouldBe 0
+                }
+
+                // No counter placed this turn -> no Fractal token at end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                withClue("No Fractal token without a counter placed this turn") {
+                    (game.findPermanent("Fractal Token") == null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroChannelerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroChannelerScenarioTest.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.HydroChanneler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hydro-Channeler — {1}{U} 1/3 Creature — Merfolk Wizard
+ *
+ * {T}: Add {U}. Spend this mana only to cast an instant or sorcery spell.
+ * {1}, {T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.
+ */
+class HydroChannelerScenarioTest : FunSpec({
+
+    val blueAbilityId = HydroChanneler.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HydroChanneler)
+        return driver
+    }
+
+    test("{T}: Add {U} produces blue mana restricted to instants/sorceries") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val channeler = driver.putCreatureOnBattlefield(player, "Hydro-Channeler")
+        driver.removeSummoningSickness(channeler)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = player, sourceId = channeler, abilityId = blueAbilityId)
+        )
+        result.error shouldBe null
+        driver.isTapped(channeler) shouldBe true
+
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>()!!
+        // The mana is restricted, so it lands in the restricted pool, not the plain blue count.
+        pool.blue shouldBe 0
+        pool.restrictedMana.size shouldBe 1
+        val entry = pool.restrictedMana.single()
+        entry.color shouldBe Color.BLUE
+        entry.restriction shouldBe ManaRestriction.InstantOrSorceryOnly
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickStudyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickStudyScenarioTest.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.QuickStudy
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Quick Study — {2}{U} Instant — "Draw two cards."
+ */
+class QuickStudyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(QuickStudy)
+        return driver
+    }
+
+    test("draws two cards on resolution") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val handBefore = driver.getHandSize(player)
+        val quickStudy = driver.putCardInHand(player, "Quick Study")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2)
+        driver.castSpell(player, quickStudy)
+        driver.bothPass() // resolve Quick Study
+
+        // +1 (the card put in hand) is cast (-1), then draw 2 => net +2 over baseline.
+        driver.getHandSize(player) shouldBe handBefore + 2
+    }
+})


### PR DESCRIPTION
Implements three Secrets of Strixhaven (SOS) Prismari/Quandrix cards and extends the mtgish auto-gen tooling so each renders at the AUTOGEN tier.

## Cards

| Card | Notes | mtgish tier |
|------|-------|-------------|
| **Quick Study** — `{2}{U}` Instant, "Draw two cards." | Reprint. Canonical `CardDefinition` placed in its earliest real printing (**Wilds of Eldraine**); SOS and Foundations each get a `Printing` row. Uses only `Effects.DrawCards(2)`. | **AUTO** (renders whole) |
| **Hydro-Channeler** — `{1}{U}` 1/3 Merfolk Wizard | Two mana abilities adding instant/sorcery-restricted mana via the existing `ManaRestriction.InstantOrSorceryOnly` (`{T}: Add {U}` and `{1},{T}: Add one mana of any color`). New card; canonical lives in SOS. | **AUTO** |
| **Fractal Tender** — `{3}{G}{U}` 3/3 Elf Wizard | Ward {2}; the new **Increment** keyword; and an end-step trigger that creates a 0/0 G/U Fractal token with three +1/+1 counters when a counter was placed on it this turn. New card; canonical lives in SOS. | **AUTO** |

## New SDK building blocks (Increment — a shared ~10-card SOS keyword)

- `Keyword.INCREMENT` + `KeywordAbility.Increment` + the `increment()` `CardBuilder` helper. The helper composes the display keyword plus a `Triggers.YouCastSpell` triggered `AddCounters(+1/+1, Self)` gated by an intervening-if (CR 603.4) comparing the triggering spell's mana spent (`EntityProperty(Triggering, ManaSpent)`) against the source's power **or** toughness (an `AnyCondition` of two `Compare(GT)` arms). Mirrors the `impending()` / `firebending()` / `decayed()` builder pattern.
- `Conditions.SourceReceivedCounterThisTurn` — reads the existing per-permanent `ReceivedCountersThisTurnComponent` marker (stamped by the counter-placement path, cleared at cleanup); wired into `ConditionEvaluator`.
- `docs/card-sdk-language-reference.md` updated for both (§11 Keywords, §12 Conditions).

## mtgish autogen (`:mtgish-tooling`)

All three cards emit at **AUTO** (`just coverage-fidelity --emit` confirms the tier). Emitter/bridge changes:

- **`AddManaWithModifiers`** — renders the produced mana plus the one restriction we can express exactly (`CanOnlySpendOnSpells` over an Or of `{Instant, Sorcery}` → `ManaRestriction.InstantOrSorceryOnly`); any other modifier declines → SCAFFOLD. Bridge + mana-ability recognition updated.
- **`Increment`** rule → the `increment()` builder call (bridge `composed` entry; `keywordLines` skips it so it isn't double-stamped as a bare keyword).
- **`TheCreatedToken`** ref → `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)` (so "create a token … put N counters on it" renders as the atomic `Composite(CreateToken, AddCounters)` idiom).
- **`HasPutACounterOnAPermanentThisTurn(ThisPermanent)`** intervening-if → `Conditions.SourceReceivedCounterThisTurn`.
- `Registry` import auto-derivation now indexes top-level `const val`s (so `CREATED_TOKENS` auto-imports).

No lossy widening: every new emitter path declines (→ SCAFFOLD) for shapes it can't render exactly.

## Verification

- Scenario tests pass: `QuickStudyScenarioTest`, `HydroChannelerScenarioTest`, `FractalTenderScenarioTest`.
- Full `:rules-engine` suite, `CardLintTest`, and `CardDefinitionSnapshotTest` (re-blessed WOE + SOS goldens — diff adds only the three cards/token) all green.
- `:mtgish-tooling` suite green (incl. `EmitterGoldenTest` for POR/EOE).
- **`just coverage-verify POR` → GATE PASS, 158/158 (0 mismatch)** — no regression to the calibrated set.
- `just coverage-verify SOS`: my cards match the golden; the 3 reported mismatches (Lorehold/Prismari/Silverquill Charm) are **pre-existing and untouched** by this PR (SOS is `incomplete`, not a calibrated 0-mismatch set). Quick Study appears under "emitted outside golden" because its golden tree lives in WOE (reprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)