### PR TITLE
Add Opus ability-word builder (Secrets of Strixhaven)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2352,6 +2352,19 @@ composite abilities).
   ManaSpent)`) against the source's power *or* toughness — modelled as an `AnyCondition` of two `Compare(GT)`
   arms, so it fires when the mana exceeds the smaller characteristic. No parameter (mirrors `firebending()` /
   `decayed()`).
+- `Opus` — "Opus — Whenever you cast an instant or sorcery spell, [base]. If five or more mana was spent to cast
+  that spell, [bonus] [instead]." (Secrets of Strixhaven). **Opus is an ability word** (CR 207.2c — flavor only),
+  so it adds *no keyword*; the whole mechanic is one `Triggers.YouCastInstantOrSorcery` triggered ability wired by
+  the `card { opus { … } }` builder helper. The 5+ mana tier is a `Compare` of
+  `ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5` (the mana spent on the *triggering* spell, not the
+  resolving object's own cast). Author the base effect as `effect = …` and pick exactly one bonus setter:
+  `insteadIfFiveOrMore = …` lowers to `ConditionalEffect(5+ → bonus, otherwise → base)` and renders "… [bonus]
+  instead" (Deluge Virtuoso, Exhibition Tidecaller, Tackle Artist); `alsoIfFiveOrMore = …` lowers to
+  `base then ConditionalEffect(5+ → bonus)` and runs the bonus *in addition* (Expressive Firedancer, Colorstorm
+  Stallion). Declare a `target(name, requirement)` inside the block and reference the returned handle from both
+  `effect` and the bonus so the single chosen target carries across both tiers (Exhibition Tidecaller's "target
+  player mills three … mills ten instead"). The rendered ability text is auto-composed from the base/bonus effect
+  descriptions unless `description` overrides the whole string.
 - `Decayed` — "This creature can't block, and when it attacks, sacrifice it at end of combat" (CR 702.147,
   Innistrad: Midnight Hunt). Display-only; wire the behavior with the `card { decayed() }` builder helper, which adds
   the keyword plus a `CantBlock(GroupFilter.source())` static ability and a "whenever this attacks" triggered

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/OpusDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/OpusDsl.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.targets.withId
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** "Opus" pays off at five or more mana spent on the triggering spell. */
+private const val OPUS_THRESHOLD = 5
+
+/**
+ * Add Opus (Secrets of Strixhaven).
+ *
+ * "Opus — Whenever you cast an instant or sorcery spell, <base>. If five or more mana was spent to
+ * cast that spell, <bonus> [instead]."
+ *
+ * **Opus is an ability word** — flavor only, no rules meaning of its own (CR 207.2c), so it adds no
+ * keyword. The whole mechanic is one spell-cast triggered ability whose 5+ mana tier is gated by a
+ * [Compare] of [ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL] `>= 5` — the mana spent on the
+ * *triggering* spell (distinct from [DynamicAmount.TotalManaSpent], which reads the resolving
+ * object's own cast).
+ *
+ * The set's Opus cards come in two shapes; pick exactly one bonus setter:
+ *  - [insteadIfFiveOrMore] — the bonus **replaces** [effect] when 5+ mana was spent ("… mills three
+ *    cards. If five or more mana was spent to cast that spell, that player mills ten cards instead.").
+ *    Lowers to `ConditionalEffect(5+ → bonus, otherwise → base)`.
+ *  - [alsoIfFiveOrMore] — the bonus runs **in addition** to [effect] ("… gets +1/+1 until end of
+ *    turn. If five or more mana was spent to cast that spell, this creature also gains double
+ *    strike …"). Lowers to `base then ConditionalEffect(5+ → bonus)`.
+ *
+ * Declare a [target] inside the block (like `triggeredAbility { }`) and reference the returned
+ * handle from *both* the base and bonus effects so the single chosen target carries across the tier
+ * (Exhibition Tidecaller's "target player mills three … mills ten instead").
+ */
+fun CardBuilder.opus(init: OpusBuilder.() -> Unit) {
+    triggeredAbilities.add(OpusBuilder().apply(init).build())
+}
+
+@CardDsl
+class OpusBuilder {
+    /** The base effect — happens whenever you cast an instant or sorcery spell. */
+    var effect: Effect? = null
+
+    /** Bonus that **replaces** [effect] when 5+ mana was spent (rendered "… <bonus> instead"). */
+    var insteadIfFiveOrMore: Effect? = null
+
+    /** Bonus that runs **in addition** to [effect] when 5+ mana was spent. */
+    var alsoIfFiveOrMore: Effect? = null
+
+    /**
+     * Optional full override of the rendered ability text (the entire "Opus — Whenever you cast …"
+     * string). Leave null to auto-compose it from the base/bonus effect descriptions.
+     */
+    var description: String? = null
+
+    private val namedTargets = mutableListOf<Pair<String, TargetRequirement>>()
+
+    /**
+     * Declare a target for this Opus ability and get a handle to reference from the base and bonus
+     * effects (so both tiers act on the same chosen object). Mirrors `triggeredAbility { target() }`.
+     */
+    fun target(name: String, requirement: TargetRequirement): EffectTarget.BoundVariable {
+        namedTargets.add(name to requirement.withId(name))
+        return EffectTarget.BoundVariable(name)
+    }
+
+    internal fun build(): TriggeredAbility {
+        val base = requireNotNull(effect) { "opus { } requires a base `effect`" }
+        val instead = insteadIfFiveOrMore
+        val also = alsoIfFiveOrMore
+        require((instead == null) != (also == null)) {
+            "opus { } needs exactly one of `insteadIfFiveOrMore` or `alsoIfFiveOrMore`"
+        }
+        val bonus = instead ?: also!!
+        val replaces = instead != null
+
+        val fiveOrMoreManaSpent = Compare(
+            left = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(OPUS_THRESHOLD),
+        )
+        val combined = if (replaces) {
+            ConditionalEffect(condition = fiveOrMoreManaSpent, effect = bonus, elseEffect = base)
+        } else {
+            base then ConditionalEffect(condition = fiveOrMoreManaSpent, effect = bonus)
+        }
+
+        val targets = namedTargets.map { it.second }
+        val trigger = Triggers.YouCastInstantOrSorcery
+        return TriggeredAbility.create(
+            trigger = trigger.event,
+            binding = trigger.binding,
+            effect = combined,
+            targetRequirement = targets.firstOrNull(),
+            additionalTargetRequirements = if (targets.size > 1) targets.drop(1) else emptyList(),
+            descriptionOverride = description ?: renderText(base, bonus, replaces),
+        )
+    }
+
+    private fun renderText(base: Effect, bonus: Effect, replaces: Boolean): String {
+        val insteadSuffix = if (replaces) " instead" else ""
+        return "Opus — Whenever you cast an instant or sorcery spell, ${clause(base)}. " +
+            "If five or more mana was spent to cast that spell, ${clause(bonus)}$insteadSuffix."
+    }
+
+    /** Lowercase the leading char and drop a trailing period so effect text reads inline. */
+    private fun clause(effect: Effect): String =
+        effect.description.trimEnd().trimEnd('.').replaceFirstChar { it.lowercase() }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ExpressiveFiredancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ExpressiveFiredancer.kt
@@ -2,15 +2,10 @@ package com.wingedsheep.mtg.sets.definitions.sos.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.conditions.Compare
-import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
-import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Expressive Firedancer
@@ -21,9 +16,9 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * turn. If five or more mana was spent to cast that spell, this creature also gains double
  * strike until end of turn.
  *
- * "Opus" is an ability word (flavor only). The +1/+1 is unconditional; the double strike is
- * gated by a `Compare` of `ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5` — the mana
- * spent on the *triggering* spell.
+ * "Opus" is an ability word (flavor only). The `opus { }` builder wires the spell-cast trigger and
+ * the 5+ mana tier (`ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5`). The double strike is
+ * `alsoIfFiveOrMore`, so it runs in addition to the unconditional +1/+1.
  */
 val ExpressiveFiredancer = card("Expressive Firedancer") {
     manaCost = "{1}{R}"
@@ -35,17 +30,9 @@ val ExpressiveFiredancer = card("Expressive Firedancer") {
         "+1/+1 until end of turn. If five or more mana was spent to cast that spell, this " +
         "creature also gains double strike until end of turn."
 
-    triggeredAbility {
-        trigger = Triggers.YouCastInstantOrSorcery
-        effect = Effects.ModifyStats(1, 1, EffectTarget.Self) then
-            ConditionalEffect(
-                condition = Compare(
-                    left = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
-                    operator = ComparisonOperator.GTE,
-                    right = DynamicAmount.Fixed(5),
-                ),
-                effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self),
-            )
+    opus {
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        alsoIfFiveOrMore = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self)
     }
 
     metadata {

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1157,7 +1157,8 @@
                             }
                         }
                     ]
-                }
+                },
+                "descriptionOverride": "Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn. If five or more mana was spent to cast that spell, this creature gains double strike until end of turn."
             }
         ]
     },

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OpusMechanicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OpusMechanicScenarioTest.kt
@@ -1,0 +1,191 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the `opus { }` ability-word builder (Secrets of Strixhaven). Opus is an
+ * ability word, so the mechanic is a single spell-cast triggered ability whose 5+ mana tier reads
+ * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL] (the mana
+ * spent on the *triggering* spell).
+ *
+ * Expressive Firedancer (a real `alsoIfFiveOrMore` card) is exercised in
+ * [SosTriggerShapeCardsScenarioTest]; this file pins the parts that card doesn't reach: the
+ * `insteadIfFiveOrMore` "bonus replaces base" semantics, the exact 5-mana boundary, and a targeted
+ * Opus whose single chosen target carries across both tiers.
+ */
+class OpusMechanicScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        // +1/+1 normally; +2/+2 *instead* when 5+ mana was spent (the bonus replaces the base).
+        cardRegistry.register(
+            card("Opus Instead Tester") {
+                manaCost = "{1}{R}"
+                colorIdentity = "R"
+                typeLine = "Creature — Human Wizard"
+                power = 2
+                toughness = 2
+                opus {
+                    effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+                    insteadIfFiveOrMore = Effects.ModifyStats(2, 2, EffectTarget.Self)
+                }
+            }
+        )
+
+        // Targeted Opus: the chosen creature gets +1/+1, or +2/+2 instead at 5+ mana.
+        cardRegistry.register(
+            card("Opus Targeted Tester") {
+                manaCost = "{1}{U}"
+                colorIdentity = "U"
+                typeLine = "Creature — Djinn Wizard"
+                power = 1
+                toughness = 3
+                opus {
+                    val pick = target("creature", Targets.Creature)
+                    effect = Effects.ModifyStats(1, 1, pick)
+                    insteadIfFiveOrMore = Effects.ModifyStats(2, 2, pick)
+                }
+            }
+        )
+
+        context("Opus — insteadIfFiveOrMore replaces the base effect") {
+
+            test("a 1-mana spell applies the base +1/+1 (5+ tier not reached)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Opus Instead Tester") // 2/2
+                    .withCardInHand(1, "Lightning Bolt") // {R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tester = game.findPermanent("Opus Instead Tester")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("1 mana spent → base +1/+1 only → 3/3") {
+                    projector.getProjectedPower(game.state, tester) shouldBe 3
+                    projector.getProjectedToughness(game.state, tester) shouldBe 3
+                }
+            }
+
+            test("a 4-mana spell still applies only the base (boundary: 4 < 5)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Opus Instead Tester") // 2/2
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tester = game.findPermanent("Opus Instead Tester")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Blaze X=3 → {3}{R} → 4 mana spent.
+                game.castXSpell(1, "Blaze", xValue = 3, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("4 mana spent → base +1/+1 only → 3/3") {
+                    projector.getProjectedPower(game.state, tester) shouldBe 3
+                    projector.getProjectedToughness(game.state, tester) shouldBe 3
+                }
+            }
+
+            test("a 5-mana spell applies +2/+2 INSTEAD (not stacked with the base)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Opus Instead Tester") // 2/2
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tester = game.findPermanent("Opus Instead Tester")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Blaze X=4 → {4}{R} → 5 mana spent (boundary).
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("5 mana spent → +2/+2 instead → 4/4 (NOT 5/5, base is replaced)") {
+                    projector.getProjectedPower(game.state, tester) shouldBe 4
+                    projector.getProjectedToughness(game.state, tester) shouldBe 4
+                }
+            }
+        }
+
+        context("Opus — a single chosen target carries across both tiers") {
+
+            test("at 1 mana the targeted creature gets +1/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Opus Targeted Tester") // 1/3
+                    .withCardOnBattlefield(1, "Grizzly Bears") // the creature to buff
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Glory Seeker") // a creature for Bolt to target
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val gloryseeker = game.findPermanent("Glory Seeker")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = gloryseeker).error shouldBe null
+                game.resolveStack() // Opus trigger asks for its target creature
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("1 mana spent → targeted Bears gets +1/+1 → 3/3") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 3
+                    projector.getProjectedToughness(game.state, bears) shouldBe 3
+                }
+            }
+
+            test("at 5 mana the SAME targeted creature gets +2/+2 instead") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Opus Targeted Tester") // 1/3
+                    .withCardOnBattlefield(1, "Grizzly Bears") // the creature to buff
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val gloryseeker = game.findPermanent("Glory Seeker")!!
+
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = gloryseeker).error shouldBe null
+                game.resolveStack() // Opus trigger asks for its target creature
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("5 mana spent → targeted Bears gets +2/+2 instead → 4/4") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 4
+                    projector.getProjectedToughness(game.state, bears) shouldBe 4
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds the **Opus** ability-word builder to the card SDK, the third Tier-1 mechanic from `backlog/sos-engine-gaps.md` (§3).

> *Opus — Whenever you cast an instant or sorcery spell, **\<base\>**. If five or more mana was spent to cast that spell, **\<bonus\>** [instead].*

**Opus is an ability word** (CR 207.2c — italic prefix, no rules meaning of its own), so it adds **no keyword**. The whole mechanic is one `Triggers.YouCastInstantOrSorcery` triggered ability whose 5+ mana tier is a `Compare` of `ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5` — the mana spent on the *triggering* spell.

## Key finding: the load-bearing primitive already existed

The backlog scoped §8 (the triggering-spell mana-spent context value) as a gap, but it is already wired end-to-end — `SpellCastEvent.totalManaSpent` → `TriggerContext` → `TriggeredAbilityOnStackComponent` → `EffectContext` → `DynamicAmountEvaluator`, via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL` (used today by Aberrant Manawurm and Expressive Firedancer). So **no engine wiring was needed** — the gap was authoring ergonomics. Each of the set's 10 Opus cards otherwise hand-rolls the same `ConditionalEffect(Compare(...))` boilerplate.

## The builder

`card { opus { … } }` (mirrors `flurry { }` / `increment()`):

| Field | Meaning | Lowers to |
|---|---|---|
| `effect = …` | base — always runs | — |
| `insteadIfFiveOrMore = …` | bonus **replaces** base at 5+ mana ("… \<bonus\> instead") | `ConditionalEffect(5+ → bonus, otherwise → base)` |
| `alsoIfFiveOrMore = …` | bonus runs **in addition** | `base then ConditionalEffect(5+ → bonus)` |
| `target(name, req)` | one target referenced by both tiers | shared `BoundVariable` |

This covers 9/10 SOS Opus cards directly (the two shapes + the targeted Exhibition Tidecaller). Muse Seeker's inverted "… discard a card *unless* 5+" wording stays a plain `triggeredAbility` — correctly outside the builder.

## Changes

- **`mtg-sdk/.../dsl/mechanics/OpusDsl.kt`** — new `opus { }` builder + `OpusBuilder` (no keyword; ability word).
- **Expressive Firedancer** refactored onto the builder (`alsoIfFiveOrMore`). Effect tree is byte-identical; the snapshot only gains the auto-composed `descriptionOverride`.
- **`OpusMechanicScenarioTest`** (rules-engine) — pins the `instead` replace semantics, the exact 5-mana boundary (4 → base only, 5 → bonus), and a targeted Opus carrying its single chosen target across both tiers. (Expressive Firedancer's `also` path stays covered by `SosTriggerShapeCardsScenarioTest`.)
- **`card-sdk-language-reference.md`** — Opus entry alongside Flurry/Increment.
- **SOS snapshot** re-blessed (single-line `descriptionOverride` addition).

## Cross-layer trace

Pure SDK-authoring feature on top of an existing primitive: no new `GameEvent`, no new client-visible state, no new keyword/decision/legal action → **no server-DTO or client changes**. Trigger detection, `ConditionalEffect`/`Compare`/`ContextProperty` evaluation, `ModifyStats`/`GrantKeyword` projection, and target-carrying continuations are all pre-existing and covered by the scenario tests.

## mtgish

N/A — Opus is an ability word with no IR tag in the mtgish corpus; these cards model as raw spell-cast triggers, so there's no bridge/emitter mapping to add.

## Follow-up (not in this PR)

The remaining 9 Opus cards (Deluge Virtuoso, Exhibition Tidecaller, Colorstorm Stallion, Elemental Mascot, Molten-Core Maestro, Muse Seeker, Spectacular Skywhale, Tackle Artist, Thunderdrum Soloist) are now trivial `add-card` work.

## Tests

`./gradlew :mtg-sdk:test :mtg-sets:test` green; `:rules-engine` `OpusMechanicScenarioTest` + `SosTriggerShapeCardsScenarioTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)