### PR TITLE
Add Paradigm mechanic (Secrets of Strixhaven) to the engine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2396,6 +2396,20 @@ composite abilities).
     off the stack with a zone-move); a printed `suspend N—[cost]` exiles from hand as its cast cost.
   - **Taigam, Master Opportunist** is the first user: `Composite(CopyTargetSpell(TriggeringEntity),
     CounterEffect(TriggeringEntity → Exile), Suspend(TriggeringEntity, 4))`.
+- `Paradigm` (Secrets of Strixhaven) — `spell { effect = …; paradigm() }` on a Lesson spell. An **exile-zone
+  recurrence** mechanic, modelled exactly like Suspend (a marker the engine reads off an exiled card), differing
+  only in that it casts a **copy** rather than the card itself, so the original recurs forever. Oracle: "[effect]
+  Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile
+  without paying its mana cost at the beginning of each of your first main phases." `paradigm()` implies
+  `selfExile()`: the spell exiles itself on resolution (reusing the `selfExileOnResolve` → `StackResolver` exile
+  path) and is tagged with the `ParadigmComponent` marker as it lands in exile; the `Keyword.PARADIGM` display
+  keyword is added automatically. The engine then grants `Paradigm.recastAbility` — a synthesized
+  `activeZone = EXILE`, `StepEvent(PRECOMBAT_MAIN, You)` trigger whose `MayEffect` copies the card via
+  `CopyCardIntoCollectionEffect(Self)` and casts it with `CastFromCollectionWithoutPayingCostEffect` — to **any**
+  exiled card carrying the marker (the marker is the gate: a Lesson exiled by some other path never recurs). The
+  original stays in exile; each cast copy is a phantom that ceases to exist (CR 707.10a / 112.3b), so there is no
+  exponential growth. The `Lesson` spell subtype (`Subtype.LESSON`) is a plain, non-functional subtype (no Learn
+  mechanic in the set), but the type line must parse it.
 - `Craft(filter, cost)` — `card { craft(filter, cost) }` builder helper (CR 702.167, The Lost Caverns of
   Ixalan). On the front face of a transforming DFC: "Craft with [filter] [cost] ([cost], Exile this permanent,
   Exile [filter] you control and/or [filter] cards from your graveyard: Return this card to the battlefield

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -311,7 +311,18 @@ enum class Keyword(val displayName: String) {
      * creates a copy of the card's prepare spell (`cardFaces[0]`) in exile that they may cast
      * (paying that spell's cost); casting the copy unprepares the creature.
      */
-    PREPARED("Prepared");
+    PREPARED("Prepared"),
+
+    /**
+     * Paradigm (Secrets of Strixhaven).
+     * Appears on Lesson spells. "Then exile this spell. After you first resolve a spell with this
+     * name, you may cast a copy of it from exile without paying its mana cost at the beginning of
+     * each of your first main phases." Display-only on the keyword — the behavior is driven by the
+     * spell's `paradigm` flag, which routes the spell to exile on resolution and tags it with the
+     * paradigm marker so the engine synthesizes the recurring free-recast ability
+     * ([com.wingedsheep.sdk.scripting.Paradigm.recastAbility]).
+     */
+    PARADIGM("Paradigm");
 
     companion object {
         fun fromString(value: String): Keyword? =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
@@ -186,6 +186,9 @@ value class Subtype(val value: String) {
         val ROOM = Subtype("Room")
         val SAGA = Subtype("Saga")
 
+        // Spell (instant/sorcery) subtypes
+        val LESSON = Subtype("Lesson")
+
         // Artifact subtypes
         val EQUIPMENT = Subtype("Equipment")
         val FOOD = Subtype("Food")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -785,6 +785,7 @@ class CardBuilder(private val name: String) {
             classLevels = classLevelsList.toList(),
             sagaChapters = sagaChaptersList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
+            paradigm = spellBuilder?.isParadigm ?: false,
             selfAlternativeCost = selfAlternativeCost,
             xManaRestriction = spellBuilder?.xManaRestriction ?: emptySet(),
             mayStartOnBattlefield = mayStartOnBattlefield,
@@ -807,7 +808,9 @@ class CardBuilder(private val name: String) {
 
         // Derive simple keywords from parameterized keyword abilities
         val derivedKeywords = finalKeywordAbilities.mapNotNull { it.keyword }.toSet()
-        val finalKeywords = keywordSet + derivedKeywords
+        // Paradigm is a display keyword whose behavior is driven by the spell's `paradigm` flag.
+        val paradigmKeyword = if (spellBuilder?.isParadigm == true) setOf(Keyword.PARADIGM) else emptySet()
+        val finalKeywords = keywordSet + derivedKeywords + paradigmKeyword
 
         val parsedColorIdentity: Set<Color>? = colorIdentity?.let { raw ->
             raw.mapNotNullTo(mutableSetOf()) { Color.fromSymbol(it.uppercaseChar()) }
@@ -880,6 +883,23 @@ class SpellBuilder {
     }
 
     internal val exilesOnResolve: Boolean get() = selfExileOnResolve
+
+    private var paradigm: Boolean = false
+
+    /**
+     * Paradigm (Secrets of Strixhaven). The spell exiles itself on resolution and is tagged with
+     * the paradigm marker, so the engine synthesizes the recurring "at the beginning of each of
+     * your first main phases, you may cast a copy of this card from exile without paying its mana
+     * cost" ability ([com.wingedsheep.sdk.scripting.Paradigm.recastAbility]). Implies
+     * [selfExile]; the [com.wingedsheep.sdk.core.Keyword.PARADIGM] display keyword is added
+     * automatically.
+     */
+    fun paradigm() {
+        paradigm = true
+        selfExileOnResolve = true
+    }
+
+    internal val isParadigm: Boolean get() = paradigm
 
     /**
      * Alternate effect used when kicker is paid. When set along with [kickerTarget],
@@ -1548,6 +1568,7 @@ class CardFaceBuilder(private val name: String) {
             staticAbilities = staticAbilities.toList(),
             additionalCosts = additionalCostsList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
+            paradigm = spellBuilder?.isParadigm ?: false,
         )
         return CardFace(
             name = name,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -216,6 +216,16 @@ data class CardScript(
     val selfExileOnResolve: Boolean = false,
 
     /**
+     * Paradigm (Secrets of Strixhaven). When true, this spell exiles itself on resolution
+     * (implies [selfExileOnResolve]) and is tagged with the paradigm marker as it lands in
+     * exile, so the engine synthesizes the recurring free-recast triggered ability
+     * ([com.wingedsheep.sdk.scripting.Paradigm.recastAbility]): "At the beginning of each of
+     * your first main phases, you may cast a copy of this card from exile without paying its
+     * mana cost." The original stays in exile; each recast is a phantom copy (CR 707.10a).
+     */
+    val paradigm: Boolean = false,
+
+    /**
      * An alternative cost that the caster may pay instead of the spell's mana cost.
      * Used for cards like Zahid, Djinn of the Lamp: "You may pay {3}{U} and tap an
      * untapped artifact you control rather than pay this spell's mana cost."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Paradigm.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Paradigm.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CopyCardIntoCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Paradigm (Secrets of Strixhaven) as a composable, content-agnostic primitive.
+ *
+ * Paradigm is an **exile-zone** recurrence mechanic on Lesson spells. The printed text reads:
+ * "[main effect] Then exile this spell. After you first resolve a spell with this name, you may
+ * cast a copy of it from exile without paying its mana cost at the beginning of each of your first
+ * main phases."
+ *
+ * Like Suspend (CR 702.62), it lives entirely off a **marker component** rather than a printed
+ * ability, so the very same machinery would work for any card a future effect "grants paradigm" to.
+ * Two halves make up the mechanic:
+ *  - **Entering exile** — a Paradigm spell carries `CardScript.paradigm`. When it resolves it is
+ *    routed to exile instead of the graveyard (reusing the existing self-exile-on-resolve path) and
+ *    tagged with the paradigm marker as it lands. The marker is what the engine keys on.
+ *  - **Recurring free recast** — [recastAbility] below, the single triggered ability the engine
+ *    synthesizes for every exiled card carrying the paradigm marker. It fires at the beginning of
+ *    the owner's precombat (first) main phase — the trigger detector already scans exile for
+ *    `activeZone == EXILE` triggers and treats exiled cards as owner-controlled — and lets the owner
+ *    cast a **copy** of the exiled card for free through the ordinary
+ *    [CopyCardIntoCollectionEffect] → [CastFromCollectionWithoutPayingCostEffect] pipeline (which
+ *    handles target / X selection). The original never leaves exile, so the trigger recurs every
+ *    turn; each cast copy is a phantom (CR 707.10a) that ceases to exist when it leaves the stack.
+ *
+ * Because it casts a *copy* — not the card itself — Paradigm differs from Suspend (which plays the
+ * exiled card directly and so consumes it). That single difference is the [CopyCardIntoCollectionEffect]
+ * step; everything else mirrors the proven Suspend wiring.
+ */
+object Paradigm {
+
+    /** Pipeline collection key the recast uses to hand the fresh copy to the free-cast step. */
+    const val COPY_COLLECTION: String = "paradigm_copy"
+
+    /**
+     * The synthesized triggered ability granted (by the engine) to any exiled card that carries
+     * the paradigm marker. Functions only in exile (`activeZone == EXILE`), so it is inert anywhere
+     * else and harmless to return universally.
+     */
+    val recastAbility: TriggeredAbility = TriggeredAbility(
+        id = AbilityId("paradigm_recast"),
+        // "your first main phase" = the precombat main phase (CR 505 — the first main phase).
+        trigger = EventPattern.StepEvent(Step.PRECOMBAT_MAIN, Player.You),
+        binding = TriggerBinding.SELF,
+        activeZone = Zone.EXILE,
+        effect = MayEffect(
+            CompositeEffect(
+                listOf(
+                    CopyCardIntoCollectionEffect(source = EffectTarget.Self, storeAs = COPY_COLLECTION),
+                    CastFromCollectionWithoutPayingCostEffect(from = COPY_COLLECTION),
+                )
+            ),
+            descriptionOverride = "cast a copy of it without paying its mana cost",
+        ),
+        descriptionOverride = "At the beginning of each of your first main phases, you may cast a " +
+            "copy of this card from exile without paying its mana cost.",
+    )
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -381,6 +381,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PreparedComponent::class)
         subclass(PreparedSpellCopyComponent::class)
         subclass(SuspendedComponent::class)
+        subclass(ParadigmComponent::class)
         subclass(CastRecordComponent::class)
         subclass(CastChoicesComponent::class)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SuppressesWardForGroupComponent
+import com.wingedsheep.engine.state.components.battlefield.ParadigmComponent
 import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -81,9 +82,10 @@ class TriggerAbilityResolver(
         // while it carries the marker. Component-driven, so it works for an arbitrary card
         // with no printed suspend (e.g. a spell exiled by Taigam, Master Opportunist).
         val suspendAbilities = getSuspendTriggeredAbilities(entityId, state)
+        val paradigmAbilities = getParadigmTriggeredAbilities(entityId, state)
 
         val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            wardAbilities + ringBearerAbilities + suspendAbilities
+            wardAbilities + ringBearerAbilities + suspendAbilities + paradigmAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         // Apply text replacement if the entity has one
@@ -103,6 +105,18 @@ class TriggerAbilityResolver(
     private fun getSuspendTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
         if (state.getEntity(entityId)?.has<SuspendedComponent>() == true) {
             listOf(com.wingedsheep.sdk.scripting.Suspend.countdownAbility)
+        } else {
+            emptyList()
+        }
+
+    /**
+     * Grant [com.wingedsheep.sdk.scripting.Paradigm.recastAbility] to any card carrying the
+     * [ParadigmComponent] marker. The ability functions only in exile (`activeZone == EXILE`), so
+     * it is inert anywhere else and harmless to return universally.
+     */
+    private fun getParadigmTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
+        if (state.getEntity(entityId)?.has<ParadigmComponent>() == true) {
+            listOf(com.wingedsheep.sdk.scripting.Paradigm.recastAbility)
         } else {
             emptyList()
         }
@@ -215,9 +229,10 @@ class TriggerAbilityResolver(
         val ringBearerAbilities = getRingBearerAbilities(entityId, state)
 
         val suspendAbilities = getSuspendTriggeredAbilities(entityId, state)
+        val paradigmAbilities = getParadigmTriggeredAbilities(entityId, state)
 
         val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            wardAbilities + ringBearerAbilities + suspendAbilities
+            wardAbilities + ringBearerAbilities + suspendAbilities + paradigmAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -287,6 +287,7 @@ object ZoneMovementUtils {
             .without<com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.CastForImpendingComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
+            .without<com.wingedsheep.engine.state.components.battlefield.ParadigmComponent>()
             // Note: CastRecordComponent is NOT stripped here — it needs to persist
             // for intervening-if checks on mana-spent-gated triggers that may still
             // be on the stack when the permanent leaves the battlefield (e.g., evoke).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -250,6 +250,15 @@ object ZoneTransitionService {
                     c.without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
                 }
             }
+            // Likewise a Paradigm card that leaves exile by any non-cast path stops recurring —
+            // the marker is what the engine keys on, so drop it.
+            if (entityContainer != null &&
+                entityContainer.has<com.wingedsheep.engine.state.components.battlefield.ParadigmComponent>()
+            ) {
+                newState = newState.updateEntity(entityId) { c ->
+                    c.without<com.wingedsheep.engine.state.components.battlefield.ParadigmComponent>()
+                }
+            }
         }
 
         // 6. Remove from current zone

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1549,6 +1549,13 @@ class StackResolver(
                 }
                 pausedState = pausedState.addToZone(pausedDestZoneKey, spellId)
 
+                // Paradigm: tag the just-exiled spell even when its effect paused mid-resolution.
+                if (pausedDestZone == Zone.EXILE && pausedResolvedScript?.paradigm == true) {
+                    pausedState = pausedState.updateEntity(spellId) { c ->
+                        c.with(com.wingedsheep.engine.state.components.battlefield.ParadigmComponent)
+                    }
+                }
+
                 // CR 715.3d — Adventure exiled by its own resolution: re-grant cast-from-exile.
                 if (pausedAdventureFaceExile && pausedDestZone == Zone.EXILE) {
                     val (permId, stateWithPerm) = pausedState.newEntity()
@@ -1658,6 +1665,15 @@ class StackResolver(
         }
         newState = newState.removeMayPlayPermissionsForCard(spellId)
         newState = newState.addToZone(destZoneKey, spellId)
+
+        // Paradigm (Secrets of Strixhaven): tag the just-exiled spell so the engine synthesizes its
+        // recurring precombat-main free-recast ability (Paradigm.recastAbility). The marker is the
+        // gate — a Lesson exiled by any other path carries no marker and so never recurs.
+        if (destinationZone == Zone.EXILE && resolvedScript?.paradigm == true) {
+            newState = newState.updateEntity(spellId) { c ->
+                c.with(com.wingedsheep.engine.state.components.battlefield.ParadigmComponent)
+            }
+        }
 
         // CR 715.3d — an Adventure card exiled by its own resolution may be cast as the creature
         // by the spell's controller while it remains in exile. Re-add the permission after

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -176,6 +176,19 @@ data class PreparedSpellCopyComponent(
 data object SuspendedComponent : Component
 
 /**
+ * Marks an exiled card as a Paradigm spell (Secrets of Strixhaven). Attached as a Paradigm spell
+ * lands in exile on its own resolution. While present on an exiled card,
+ * [com.wingedsheep.engine.event.TriggerAbilityResolver] grants it
+ * [com.wingedsheep.sdk.scripting.Paradigm.recastAbility] — the precombat-main trigger that lets the
+ * owner cast a free *copy* of the card each turn. The marker's presence is the gate: a Lesson exiled
+ * by some other effect (graveyard hate, opponent removal) carries no marker and so never recurs.
+ *
+ * Stripped when the card leaves exile by a non-cast path and when it leaves the battlefield.
+ */
+@Serializable
+data object ParadigmComponent : Component
+
+/**
  * Records the mana colors spent to cast this permanent.
  * Used by mana-spent-gated trigger conditions (e.g., "if {W}{W} was spent to cast it").
  * Stripped when the permanent leaves the battlefield.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParadigmMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParadigmMechanicTest.kt
@@ -1,0 +1,219 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.ParadigmComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mechanic-level tests for Paradigm (Secrets of Strixhaven), driven by the [ParadigmComponent]
+ * marker the engine attaches as a Paradigm spell lands in exile on its own resolution. Each of the
+ * owner's precombat (first) main phases, the engine synthesizes a triggered ability
+ * ([com.wingedsheep.sdk.scripting.Paradigm.recastAbility]) that lets the owner cast a **copy** of
+ * the exiled card for free. The original never leaves exile (the recurrence) and each copy is a
+ * phantom that ceases to exist (CR 707.10a / 112.3b).
+ *
+ * The test Lesson gains 2 life so every cast/recast is observable on the life total.
+ */
+class ParadigmMechanicTest : FunSpec({
+
+    // "Research Seminar" — Sorcery — Lesson: gain 2 life, then exile + recur via Paradigm.
+    val researchSeminar = card("Research Seminar") {
+        manaCost = "{1}{U}"
+        typeLine = "Sorcery — Lesson"
+        spell {
+            effect = Effects.GainLife(2)
+            paradigm()
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(researchSeminar))
+        return driver
+    }
+
+    /** Cast Research Seminar from hand on the owner's current precombat main and resolve it. */
+    fun castSeminar(driver: GameTestDriver, player: EntityId): EntityId {
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.BLUE, 2) // pays {1}{U} from pool
+        val cardId = driver.putCardInHand(player, "Research Seminar")
+        driver.castSpell(player, cardId) // FromPool — pool has mana
+        driver.bothPass() // resolve the spell
+        return cardId
+    }
+
+    /**
+     * Advance to the owner's *next* precombat main phase, passing through any intervening turns,
+     * and stop the instant it begins — with the Paradigm recast trigger already on the stack but
+     * not yet resolved. Steps off the current precombat main (via postcombat main) first so
+     * consecutive calls keep moving forward.
+     */
+    fun advanceToNextOwnerPrecombatMain(driver: GameTestDriver, owner: EntityId) {
+        do {
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        } while (driver.activePlayer != owner)
+    }
+
+    fun seminarsInExile(driver: GameTestDriver, player: EntityId): Int =
+        driver.getExile(player).count { driver.getCardName(it) == "Research Seminar" }
+
+    test("the card definition carries the Lesson subtype and the Paradigm keyword") {
+        researchSeminar.typeLine.hasSubtype(Subtype.LESSON).shouldBeTrue()
+        researchSeminar.keywords.contains(Keyword.PARADIGM).shouldBeTrue()
+        researchSeminar.script.paradigm.shouldBeTrue()
+        // Paradigm implies self-exile-on-resolve.
+        researchSeminar.script.selfExileOnResolve.shouldBeTrue()
+    }
+
+    test("casting a Paradigm spell does its effect, exiles itself, and gets the marker") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        val lifeBefore = driver.getLifeTotal(player)
+        val cardId = castSeminar(driver, player)
+
+        driver.getLifeTotal(player) shouldBe lifeBefore + 2
+        // Exiled, NOT in the graveyard.
+        driver.getExile(player).contains(cardId).shouldBeTrue()
+        driver.getGraveyard(player).contains(cardId).shouldBeFalse()
+        driver.state.getEntity(cardId)?.has<ParadigmComponent>().shouldBe(true)
+    }
+
+    test("it does NOT recast on the turn it was cast (the precombat-main trigger already passed)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        val lifeBefore = driver.getLifeTotal(player)
+        castSeminar(driver, player)
+        // Move through the rest of this turn; no recast trigger should fire again this turn.
+        driver.passPriorityUntil(Step.END)
+        driver.getLifeTotal(player) shouldBe lifeBefore + 2 // only the original cast
+    }
+
+    test("at the owner's next precombat main, the recast offers a free copy that gains life again") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        val cardId = castSeminar(driver, player)
+        val lifeAfterCast = driver.getLifeTotal(player)
+
+        advanceToNextOwnerPrecombatMain(driver, player)
+        driver.bothPass()                 // resolve the recast trigger -> "may cast a copy?"
+        driver.submitYesNo(player, true)  // yes
+        driver.bothPass()                 // resolve the copy -> +2 life
+
+        driver.getLifeTotal(player) shouldBe lifeAfterCast + 2
+        // The original stays in exile, still marked, and there is exactly ONE copy of it in exile
+        // (the phantom copy ceased to exist — no exponential growth).
+        driver.getExile(player).contains(cardId).shouldBeTrue()
+        driver.state.getEntity(cardId)?.has<ParadigmComponent>().shouldBe(true)
+        seminarsInExile(driver, player) shouldBe 1
+        // The copy did not fall into the graveyard either.
+        driver.getGraveyard(player).any { driver.getCardName(it) == "Research Seminar" }.shouldBeFalse()
+    }
+
+    test("declining the recast leaves no copy and keeps the original recurring") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        val cardId = castSeminar(driver, player)
+        val lifeAfterCast = driver.getLifeTotal(player)
+
+        advanceToNextOwnerPrecombatMain(driver, player)
+        driver.bothPass()                  // resolve the recast trigger
+        driver.submitYesNo(player, false)  // decline
+
+        driver.getLifeTotal(player) shouldBe lifeAfterCast // no extra life
+        // No leftover phantom copy in exile — only the original remains.
+        seminarsInExile(driver, player) shouldBe 1
+        driver.getExile(player).contains(cardId).shouldBeTrue()
+        driver.state.getEntity(cardId)?.has<ParadigmComponent>().shouldBe(true)
+    }
+
+    test("the recast recurs every one of the owner's turns") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        val cardId = castSeminar(driver, player)
+        var life = driver.getLifeTotal(player)
+
+        repeat(2) {
+            advanceToNextOwnerPrecombatMain(driver, player)
+            driver.bothPass()
+            driver.submitYesNo(player, true)
+            driver.bothPass()
+            life += 2
+            driver.getLifeTotal(player) shouldBe life
+        }
+        // Still exactly one original in exile after multiple recasts.
+        seminarsInExile(driver, player) shouldBe 1
+        driver.state.getEntity(cardId)?.has<ParadigmComponent>().shouldBe(true)
+    }
+
+    test("the recast does NOT fire on an opponent's precombat main (Player.You = owner)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        castSeminar(driver, player)
+        val lifeBefore = driver.getLifeTotal(player)
+
+        // Advance to the opponent's precombat main — the owner's recast must not trigger.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe opponent
+
+        driver.getTopOfStack().shouldBe(null) // no recast trigger on the stack
+        driver.state.pendingDecision.shouldBe(null)
+        driver.getLifeTotal(player) shouldBe lifeBefore
+    }
+
+    test("a Lesson exiled without the Paradigm marker never recurs") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val player = driver.activePlayer!!
+
+        // Put Research Seminar into exile by a non-Paradigm path (no marker attached).
+        val cardId = driver.putCardInGraveyard(player, "Research Seminar")
+        driver.replaceState(
+            driver.state
+                .removeFromZone(ZoneKey(player, Zone.GRAVEYARD), cardId)
+                .addToZone(ZoneKey(player, Zone.EXILE), cardId)
+        )
+        driver.state.getEntity(cardId)?.has<ParadigmComponent>().shouldBe(false)
+
+        val lifeBefore = driver.getLifeTotal(player)
+        advanceToNextOwnerPrecombatMain(driver, player)
+
+        // No trigger fired: nothing on the stack, no decision, life unchanged.
+        driver.getTopOfStack().shouldBe(null)
+        driver.state.pendingDecision.shouldBe(null)
+        driver.getLifeTotal(player) shouldBe lifeBefore
+    }
+})


### PR DESCRIPTION
## Summary

Adds the **Paradigm** mechanic (Secrets of Strixhaven, backlog `sos-engine-gaps.md` §6) — an exile-zone recurrence mechanic on Lesson spells:

> *"[effect] Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases."*

The key design insight is that this is **Suspend-shaped**: a card sits in exile carrying a marker, and the engine synthesizes a from-exile triggered ability off that marker (the trigger detector already scans exile for `activeZone == EXILE` step triggers). Paradigm differs from Suspend only in that it casts a **copy** (a CR 707.10a phantom that ceases to exist) rather than the card itself — so the original never leaves exile and the trigger recurs every turn.

Because of that framing, there is **no new effect executor, trigger detector, continuation, or projection layer**. It composes the existing self-exile-on-resolve path, `CopyCardIntoCollectionEffect`, and `CastFromCollectionWithoutPayingCostEffect`.

## What changed

**SDK (`mtg-sdk`)**
- `Subtype.LESSON` — plain non-functional spell subtype (no Learn mechanic in the set), but the type line must parse it.
- `Keyword.PARADIGM` — display keyword, added automatically by the builder.
- `CardScript.paradigm` flag + `spell { paradigm() }` DSL (implies `selfExile()`).
- `Paradigm.recastAbility` — the synthesized `activeZone = EXILE`, `StepEvent(PRECOMBAT_MAIN, You)` trigger: `MayEffect(copy Self → cast the copy for free)`. Mirrors `Suspend.countdownAbility`.

**Engine (`rules-engine`)**
- `ParadigmComponent` marker (registered for serialization; stripped on zone change, like `SuspendedComponent`).
- `StackResolver` tags the spell with the marker as it self-exiles on resolution — both the normal and paused-resolution exile paths.
- `TriggerAbilityResolver` grants `Paradigm.recastAbility` to any exiled card carrying the marker. **The marker is the gate**: a Lesson exiled by some other path (graveyard hate, opponent removal) carries no marker and never recurs.

## Cross-layer trace
- **SDK / Engine / TriggerDetector** ✅ — reuses the exile-zone step-trigger detection unchanged.
- **StateProjector** — N/A (no continuous effect).
- **Continuations** ✅ — reuses the `MayEffect` + cast-from-collection continuations; the paused-resolution exile path also tags the marker.
- **Cleanup** ✅ — marker stripped when the card leaves exile by a non-cast path.
- **Server DTO / ClientEvent** ✅ — no new `GameEvent`; the exiled card already renders, the recast surfaces as a normal triggered ability + yes/no + cast decisions.
- **Frontend** ✅ — the `PARADIGM` keyword is display-only; the client `Keyword` enum is a curated subset (it omits `SUSPEND`/`PREPARED` too), so no client change is needed and none of the recast flow introduces a new decision component.

## Tests
`ParadigmMechanicTest` — 8 scenario tests against the live `ActionProcessor` covering the full rule matrix:
- casting does its effect, exiles itself (not graveyard), and gets the marker;
- no same-turn recast (the precombat-main trigger already passed);
- a free copy each of the owner's precombat mains, gaining life again;
- declining the may leaves no phantom copy;
- recurs across multiple owner turns;
- does **not** fire on an opponent's precombat main (`Player.You` = owner);
- an unmarked exiled Lesson never recurs;
- no exponential growth — exactly one original stays in exile, the copy ceases to exist.

Snapshot + lint nets pass (no corpus churn — `paradigm` defaults `false`); `:mtg-sets`, `:game-server`, `:ai`, `:gym` all compile.

## Notes
- **mtgish generator (skill Step 8b):** Paradigm is a fictional SOS keyword with no corresponding mtgish IR tag (the mtgish corpus is real MTG cards), so there is nothing to bridge or emit. `Subtype.LESSON` exists in real MTG (STX) but the `Paradigm` keyword does not.
- No real SOS card is added here — the set is being built by other agents. The feature is proven with an inline test Lesson (`Research Seminar`), per the add-feature skill's guidance for cards that don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)