### PR TITLE
Fire batched "creatures you control die" trigger when the source dies in the same batch (CR 603.10)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -174,7 +174,28 @@ the narrower "cast, but for free" sense. Tests: `FreestriderCommandoScenarioTest
   batch "Satoru and/or one or more other nontoken creatures enter" once-per-turn trigger before it's
   buildable.
 
-### 6b. "Whenever one or more creatures you control die" batch trigger (once per batch)
+### 6b. "Whenever one or more creatures you control die" batch trigger (once per batch) — ✅ DONE
+
+**Implemented:** `EventPattern.CreaturesYouControlDiedEvent(filter, excludeSelf)` +
+`Triggers.OneOrMoreCreaturesYouControlDie(...)` facade, detected by
+`TriggerDetector.detectCreaturesDiedBatchTriggers` (a new `TriggerCategory.CREATURES_DIED_BATCH`):
+it groups battlefield→graveyard zone-change events by each dying creature's **last-known**
+controller (so dead tokens survive the 704.5s cleanup) and fires **once per controller per batch**
+— a board wipe that kills several of your creatures fires it once, not once per creature.
+`excludeSelf = true` models the "*other* creatures" wording. Per-event matching declines the event
+in `TriggerMatcher` (batch-handled separately). The detector also honours CR 603.10 "look back in
+time": a source that itself dies in the **same** batch as another qualifying creature still sees
+that death and fires (recovered from its last-known card definition), so a *non-self* payoff
+(draw / token / gain life) survives a board wipe that also kills the source — a per-self payoff like
+Vengeful Townsfolk's own +1/+1 is just a harmless no-op once it is in the graveyard. Tests:
+`VengefulTownsfolkScenarioTest` (board-wipe = one counter; single death; opponent's deaths; +
+source-dies-in-batch look-back, fires & does-not-fire-alone). Docs: card-sdk-language-reference §8.
+
+→ **Vengeful Townsfolk** built. Also the right home for other "one or more … die" payoffs (cf.
+  Scavenger's Talent / Spiteful Banditry, which lean on the `oncePerTurn` approximation because
+  their printed text *does* say "only once each turn").
+
+<details><summary>Original gap description</summary>
 
 The engine has per-creature dies triggers (`Triggers.YourCreatureDies`, ANY/OTHER binding, fires once
 **per dying creature**) and a once-per-*turn* gate (`oncePerTurn = true`), plus batch detectors for
@@ -196,6 +217,8 @@ with an OTHER-binding variant for "another creature(s)." Mirrors the existing
   on this creature"). Also the right home for other "one or more … die" payoffs (cf. Scavenger's
   Talent / Spiteful Banditry, which currently lean on the `oncePerTurn` approximation because their
   printed text *does* say "only once each turn").
+
+</details>
 
 ### 6. `CARDS_DRAWN` turn-tracker + characteristic-defining P/T from it
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1451,6 +1451,12 @@ for any other (filter, binding, to/excludeTo) combination.
   die, …" (Vengeful Townsfolk) — a per-creature `YourCreatureDies` would over-count on mass removal.
   Set `excludeSelf = true` for the "*other* creatures" wording (the source's own death is excluded).
   Detected specially by `TriggerDetector` (grouped by each dying creature's last-known controller).
+  Rule 603.10 "look back in time": if the source itself dies in the *same* batch as another
+  qualifying creature, it still sees that death and fires (recovered from its last-known card
+  definition, since it has already left the battlefield). For `excludeSelf = true` payoffs that
+  target the source (Vengeful Townsfolk's own +1/+1) this is a harmless no-op, but a *non-self*
+  payoff — draw a card, make a token, gain life — correctly still resolves on a board wipe that
+  also kills the source.
 - `PutIntoGraveyardFromBattlefield` — SELF, same event shape as `Dies`; rename
   clarifies non-creature intent (artifact / enchantment going to yard).
 - `leavesBattlefield(filter, to?, excludeTo?, binding)` — factory. `to = GRAVEYARD`

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1730,6 +1730,11 @@ class TriggerDetector(
         }
     }
 
+    private data class CreatureDeathInfo(
+        val entityId: EntityId,
+        val typeLine: com.wingedsheep.sdk.core.TypeLine?
+    )
+
     /**
      * Detect "whenever one or more [other] creatures you control die" batching triggers
      * (e.g., Vengeful Townsfolk).
@@ -1744,6 +1749,11 @@ class TriggerDetector(
      * since the creature has already left the battlefield. The creature's type line comes from
      * [ZoneChangeEvent.lastKnownTypeLine] so it survives the 704.5s token cleanup that can remove
      * a dead token from the graveyard in the same pass.
+     *
+     * Two source populations are considered: permanents that survived the batch (taken from the
+     * post-batch battlefield index) and — for Rule 603.10 "look back in time" — a source that
+     * itself died in this same batch, recovered from its last-known card definition since it is no
+     * longer on the battlefield (mirrors [DeathAndLeaveTriggerDetector.detectSimultaneousDeathTriggers]).
      */
     private fun detectCreaturesDiedBatchTriggers(
         state: GameState,
@@ -1751,11 +1761,8 @@ class TriggerDetector(
         triggers: MutableList<PendingTrigger>,
         index: TriggerIndex
     ) {
-        if (index.getEntitiesForCategory(TriggerCategory.CREATURES_DIED_BATCH).isEmpty()) return
-
         // Collect creature deaths (battlefield → graveyard), grouped by last-known controller.
-        data class DeathInfo(val entityId: EntityId, val typeLine: com.wingedsheep.sdk.core.TypeLine?)
-        val deathsByController = mutableMapOf<EntityId, MutableList<DeathInfo>>()
+        val deathsByController = mutableMapOf<EntityId, MutableList<CreatureDeathInfo>>()
         for (event in events) {
             if (event !is ZoneChangeEvent) continue
             if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) continue
@@ -1764,51 +1771,105 @@ class TriggerDetector(
             if (typeLine?.isCreature != true) continue
             val controllerId = event.lastKnownController ?: event.ownerId
             deathsByController.getOrPut(controllerId) { mutableListOf() }
-                .add(DeathInfo(event.entityId, typeLine))
+                .add(CreatureDeathInfo(event.entityId, typeLine))
         }
         if (deathsByController.isEmpty()) return
 
+        // (1) Sources that survived the batch — taken from the (post-batch) battlefield index.
         for (entry in index.getEntitiesForCategory(TriggerCategory.CREATURES_DIED_BATCH)) {
             for (ability in entry.abilities) {
-                val trigger = ability.trigger
-                if (trigger !is EventPattern.CreaturesYouControlDiedEvent) continue
+                fireCreaturesDiedBatchTrigger(
+                    ability = ability,
+                    sourceId = entry.entityId,
+                    sourceName = entry.cardComponent.name,
+                    controllerId = entry.controllerId,
+                    deathsByController = deathsByController,
+                    triggers = triggers
+                )
+            }
+        }
 
-                val controllerId = entry.controllerId
-                val controllerDeaths = deathsByController[controllerId] ?: continue
+        // (2) Rule 603.10 "look back in time": a source that itself died in this same batch must
+        // still see the *other* creatures that died alongside it. The index is built from the
+        // current (post-batch) battlefield, so such a source is absent from it — recover its
+        // abilities from its last-known card definition, exactly as detectSimultaneousDeathTriggers
+        // does for the per-creature path. (For Vengeful Townsfolk the on-self +1/+1 is a harmless
+        // no-op once it is in the graveyard, but a non-self payoff — draw a card, make a token,
+        // deal damage — would otherwise be silently dropped on a board wipe that also kills it.)
+        for (event in events) {
+            if (event !is ZoneChangeEvent) continue
+            if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) continue
+            // Still on the battlefield → already covered by the index path above.
+            if (event.entityId in state.getBattlefield()) continue
+            val container = state.getEntity(event.entityId)
+            // Face-down permanents have no abilities (Rule 708.2).
+            if (container?.has<FaceDownComponent>() == true) continue
+            val cardDefId = container?.get<CardComponent>()?.cardDefinitionId
+                ?: event.lastKnownCardDefinitionId ?: continue
+            val controllerId = event.lastKnownController ?: event.ownerId
+            val sourceName = container?.get<CardComponent>()?.name ?: event.entityName
+            for (ability in abilityResolver.getTriggeredAbilities(event.entityId, cardDefId, state)) {
+                if (ability.trigger !is EventPattern.CreaturesYouControlDiedEvent) continue
+                fireCreaturesDiedBatchTrigger(
+                    ability = ability,
+                    sourceId = event.entityId,
+                    sourceName = sourceName,
+                    controllerId = controllerId,
+                    deathsByController = deathsByController,
+                    triggers = triggers
+                )
+            }
+        }
+    }
 
-                // "one or more *other* creatures you control die" excludes the source's own death.
-                val relevantDeaths = if (trigger.excludeSelf) {
-                    controllerDeaths.filter { it.entityId != entry.entityId }
-                } else {
-                    controllerDeaths
-                }
-                if (relevantDeaths.isEmpty()) continue
+    /**
+     * Evaluate a single "whenever one or more [filtered] creatures you control die" ability
+     * against the batch of deaths grouped by controller, firing it at most once. Shared by the
+     * surviving-source (battlefield index) and dead-source (Rule 603.10 look-back) paths.
+     */
+    private fun fireCreaturesDiedBatchTrigger(
+        ability: TriggeredAbility,
+        sourceId: EntityId,
+        sourceName: String,
+        controllerId: EntityId,
+        deathsByController: Map<EntityId, List<CreatureDeathInfo>>,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        val trigger = ability.trigger
+        if (trigger !is EventPattern.CreaturesYouControlDiedEvent) return
 
-                val hasMatch = relevantDeaths.any { info ->
-                    trigger.filter.cardPredicates.all { predicate ->
-                        when (predicate) {
-                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
-                                info.typeLine?.isCreature == true
-                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
-                                info.typeLine?.hasSubtype(predicate.subtype) == true
-                            else -> true
-                        }
-                    }
-                }
+        val controllerDeaths = deathsByController[controllerId] ?: return
 
-                if (hasMatch) {
-                    triggers.add(
-                        PendingTrigger(
-                            ability = ability,
-                            sourceId = entry.entityId,
-                            sourceName = entry.cardComponent.name,
-                            controllerId = controllerId,
-                            triggerContext = TriggerContext()
-                        )
-                    )
+        // "one or more *other* creatures you control die" excludes the source's own death.
+        val relevantDeaths = if (trigger.excludeSelf) {
+            controllerDeaths.filter { it.entityId != sourceId }
+        } else {
+            controllerDeaths
+        }
+        if (relevantDeaths.isEmpty()) return
+
+        val hasMatch = relevantDeaths.any { info ->
+            trigger.filter.cardPredicates.all { predicate ->
+                when (predicate) {
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
+                        info.typeLine?.isCreature == true
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
+                        info.typeLine?.hasSubtype(predicate.subtype) == true
+                    else -> true
                 }
             }
         }
+        if (!hasMatch) return
+
+        triggers.add(
+            PendingTrigger(
+                ability = ability,
+                sourceId = sourceId,
+                sourceName = sourceName,
+                controllerId = controllerId,
+                triggerContext = TriggerContext()
+            )
+        )
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTownsfolkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTownsfolkScenarioTest.kt
@@ -3,8 +3,16 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
@@ -27,7 +35,32 @@ class VengefulTownsfolkScenarioTest : ScenarioTestBase() {
             ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
     }
 
+    /**
+     * A {1}{B} 2/2 with the same once-per-batch trigger as Vengeful Townsfolk, but a *non-self*
+     * payoff — "Whenever one or more other creatures you control die, you gain 2 life." It dies to
+     * Pyroclasm itself, so it exercises the Rule 603.10 "look back in time" path: a trigger source
+     * that dies in the same batch as another qualifying creature must still see that creature dying.
+     * (Vengeful Townsfolk's own +1/+1 is a no-op once it is in the graveyard, so it cannot prove this.)
+     */
+    private val grievingSentinel = CardDefinition.creature(
+        name = "Grieving Sentinel",
+        manaCost = ManaCost.parse("{1}{B}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Soldier")),
+        power = 2,
+        toughness = 2,
+        oracleText = "Whenever one or more other creatures you control die, you gain 2 life.",
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = EventPattern.CreaturesYouControlDiedEvent(excludeSelf = true),
+                binding = TriggerBinding.ANY,
+                effect = GainLifeEffect(2)
+            )
+        )
+    )
+
     init {
+        cardRegistry.register(grievingSentinel)
+
         context("Vengeful Townsfolk") {
             test("board wipe killing two of your creatures adds exactly one +1/+1 counter") {
                 val game = scenario()
@@ -100,6 +133,62 @@ class VengefulTownsfolkScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Only creatures the opponent controls died → no counter on your Vengeful Townsfolk") {
                     plusOneCounters(game) shouldBe 0
+                }
+            }
+        }
+
+        context("OneOrMoreCreaturesYouControlDie — source dies in the same batch (CR 603.10)") {
+            test("a source that dies alongside another creature still sees that death (non-self payoff fires)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grieving Sentinel") // 2/2, dies to Pyroclasm
+                    .withCardOnBattlefield(1, "Glory Seeker")       // 2/2, dies to Pyroclasm
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                val cast = game.castSpell(1, "Pyroclasm")
+                withClue("Casting Pyroclasm should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both 2/2s should have died to 2 damage in one batch") {
+                    (game.findPermanent("Grieving Sentinel") == null) shouldBe true
+                    game.findPermanents("Glory Seeker").size shouldBe 0
+                }
+                withClue(
+                    "Grieving Sentinel died in the same batch as Glory Seeker; its 'one or more " +
+                        "other creatures you control die' trigger must still fire (look-back), gaining 2 life"
+                ) {
+                    game.getLifeTotal(1) shouldBe (lifeBefore + 2)
+                }
+            }
+
+            test("a source dying alone with no other creatures does not fire its 'other creatures die' trigger") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grieving Sentinel") // only creature in play
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Pyroclasm")
+                game.resolveStack()
+
+                withClue("Grieving Sentinel should have died") {
+                    (game.findPermanent("Grieving Sentinel") == null) shouldBe true
+                }
+                withClue("No *other* creature died, so the excludeSelf trigger must not fire — no life gained") {
+                    game.getLifeTotal(1) shouldBe lifeBefore
                 }
             }
         }


### PR DESCRIPTION
## Summary

Backlog item **OTJ 6b** ("Whenever one or more creatures you control die" batch trigger) was already implemented on `main` (commit `1d8270345`, Vengeful Townsfolk) — the SDK event/trigger, the `detectCreaturesDiedBatchTriggers` detector, the `CREATURES_DIED_BATCH` index category, the card, a scenario test, and the mtgish decline all exist. The backlog file just hadn't been marked done.

While verifying that implementation, I found one **latent, dormant correctness gap** in the primitive and fixed it.

## The bug (CR 603.10 "look back in time")

`detectCreaturesDiedBatchTriggers` built its source population from the **post-batch battlefield index**, so it only considered trigger sources that *survived* the batch. When the trigger's own source died in the **same batch** as another qualifying creature (a board wipe killing it alongside others), the trigger silently failed to fire.

The per-creature death path already handles this via `detectSimultaneousDeathTriggers`, but the batch path had no equivalent — `TriggerMatcher` declines `CreaturesYouControlDiedEvent` in its per-event path, so the simultaneous-death pass doesn't cover it either.

For **Vengeful Townsfolk specifically the bug is dormant**: putting a +1/+1 counter on a creature already in the graveyard is a no-op. But any *non-self* payoff on this primitive — draw a card, make a token, gain life, deal damage — would have been dropped on a board wipe that also kills the source.

## The fix

`detectCreaturesDiedBatchTriggers` now also scans the batch's battlefield→graveyard deaths for a source that has left the battlefield, recovers its triggered abilities from its **last-known card definition** (face-down skipped per CR 708.2), and runs the same once-per-batch evaluation. The per-trigger evaluation is extracted into a shared `fireCreaturesDiedBatchTrigger` helper used by both the surviving-source and dead-source paths; the early-return guard is dropped (dead sources are never in the index).

## Tests

`VengefulTownsfolkScenarioTest` gains a **CR 603.10** context with a non-self test card ("Grieving Sentinel", gains 2 life when other creatures die):
- ✅ fires when it dies beside another creature in a Pyroclasm wipe (look-back)
- ✅ does **not** fire when it dies alone (excludeSelf with no other deaths)

The 3 pre-existing Vengeful Townsfolk cases and the **full `:rules-engine` suite** pass.

## Docs
- `docs/card-sdk-language-reference.md` §8 — documents the look-back behavior of `OneOrMoreCreaturesYouControlDie`.
- `backlog/otj-engine-gaps.md` — 6b marked ✅ DONE (matching the #2–#5 convention), original gap text preserved in a `<details>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)