### PR TITLE
Add Converge (colors of mana spent) support to the engine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -308,7 +308,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   library was empty) → `RevealCollection("drawn", revealToSelf = false)` →
   `FilterCollection(MatchesFilter(Land), storeNonMatching = "notLand")` →
   `MoveCollection("notLand" → graveyard, moveType = Discard)`.
-- `Discard(count, target)` — controller-of-target chooses; mandatory.
+- `Discard(count, target)` — controller-of-target chooses; mandatory. `count` is an `Int` or a
+  `DynamicAmount` ("discard X cards, where X is …" — e.g. Converge's Arcane Omens with
+  `DynamicAmounts.colorsOfManaSpent()`).
 - `EachOpponentDiscards(count)` — each opponent discards N.
 - `EachPlayerReturnPermanentToHand()` — each player bounces a permanent.
 - `EachPlayerDrawsForDamageDealtToSource()` — each player draws equal to damage source took this turn.
@@ -361,6 +363,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `ReturnToHand(target)` — bounce to hand.
 - `PutOnTopOfLibrary(target)` — place target on top of its owner's library.
+- `PutOnBottomOfLibrary(target)` — place target on the bottom of its owner's library (forced, no choice).
 - `PutOnTopOrBottomOfLibrary(target)` — player chooses top or bottom.
 - `PutSecondFromTopOrBottomOfLibrary(target)` — second-from-top or bottom.
 - `ShuffleIntoLibrary(target)` — shuffle target into owner's library.
@@ -1303,6 +1306,11 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `CastRecordComponent` snapshot once it has resolved onto the battlefield (0 if it was never cast).
   Used by Edge of Eternities warp payoffs like Astelli Reclaimer ("…mana value X or less…, where X is the
   amount of mana spent to cast this creature") — X is 5 for `{3}{W}{W}`, 3 for warp `{2}{W}`, 0 for free.
+- `.manaValueAtMostColorsSpent(ref)` — mana value ≤ the number of distinct **colors** of mana spent to
+  cast a referenced entity (0–5). Sibling of `.manaValueAtMostEntityManaSpent`, but compares against the
+  color *count* rather than total mana (colorless is not a color). The **Converge** exile-by-color-count
+  gate — Sundering Archaic ("exile target nonland permanent an opponent controls with mana value less than
+  or equal to the number of colors of mana spent to cast this creature"), with `EntityReference.Source`.
 - `.manaValueIsOdd()` / `.manaValueIsEven()` — mana-value parity (zero is even). Pair with modal
   spells whose modes ask the caster to choose a parity (e.g. *Mutinous Massacre*).
 - `.toughnessAtMost(n)` / `.toughnessAtLeast(n)` — toughness comparator.
@@ -2267,13 +2275,22 @@ activatedAbility {
 
 > **Where set-mechanic helpers live.** The `card { … }` keyword helpers below for *set-specific*
 > mechanics — `leyline()`, `flurry { }`, `mobilize(…)`, `firebending(n)`, `sneak(cost)`, `decayed()`,
-> `vividEtb { }` / `vividCostReduction()`, `impending(time, cost)`, `renew(cost) { }`,
+> `vividEtb { }` / `vividCostReduction()`, `convergeEntersWithCounters(counterType?)`,
+> `impending(time, cost)`, `renew(cost) { }`,
 > `craft(filter, cost)`, `station()` — are `CardBuilder` **extension functions** in
 > `mtg-sdk/.../dsl/mechanics/` (one file per mechanic), not methods on the core `CardBuilder`. They
 > stay in package `com.wingedsheep.sdk.dsl`, so the call syntax is unchanged, but a card file that
 > uses one needs the matching import (e.g. `import com.wingedsheep.sdk.dsl.station`). Evergreen /
 > multi-set parameterized keywords (`prowess()`, `rampage(n)`, `keywordAbility(…)`) remain on the core
 > builder. New set mechanics get an extension file in `dsl/mechanics/`.
+
+> **Converge** (ability word, CR 207.2c — flavor only, no keyword, like Opus/Vivid). Scales an effect
+> by the number of distinct colors of mana spent to cast the spell. Three shapes:
+> (1) *enters with counters* — `convergeEntersWithCounters(counterType = PlusOnePlusOne)` (the SOS
+> "Archaic" cycle; lowers to `EntersWithDynamicCounters(DynamicAmount.DistinctColorsManaSpent)`);
+> (2) *spell whose effect scales* — read `DynamicAmounts.colorsOfManaSpent()` directly (Arcane Omens
+> "discard X"); (3) *exile-by-color-count* — the `manaValueAtMostColorsSpent(EntityReference.Source)`
+> target predicate (Sundering Archaic). Author the printed "Converge — …" text into `oracleText`.
 
 **`Keyword` enum (display-level)**
 
@@ -2844,6 +2861,14 @@ Numbers computed at resolution time.
   down by color. Used by payoffs that scale with how much of a color went into X — Soul Burn ("you gain
   life equal to the amount of black mana spent on X"). Pair with `xManaRestriction` (see below) so the X
   can only be paid with the relevant colors.
+- `DistinctColorsManaSpent` — the number of distinct *colors* of mana spent to cast the source spell
+  (0–5), counting how many of the W/U/B/R/G payment buckets are non-zero. Colorless is not a color
+  (CR 105.1) and never counts; mana spent on `{X}` and on generic costs still has its color counted.
+  Backs the **Converge** ability word and the classic **Sunburst** rule. Resolves off the source
+  entity's recorded payment (live `SpellOnStackComponent` while on the stack, the resolved permanent's
+  `CastRecordComponent` afterward), so it reads correctly both at resolution and as the permanent enters
+  (the common use: feeding `EntersWithDynamicCounters`). Facade: `DynamicAmounts.colorsOfManaSpent()`.
+  A permanent put onto the battlefield without being cast spent no mana, so this is 0 for it.
 - `Add(a, b)` — `a + b`.
 - `Subtract(a, b)` — `a − b`.
 - `Multiply(a, b)` — `a × b`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -116,6 +116,13 @@ object DynamicAmounts {
     ): DynamicAmount =
         DynamicAmount.AggregateBattlefield(player, filter, Aggregation.DISTINCT_COLORS)
 
+    /**
+     * The number of distinct colors of mana spent to cast the source spell (0–5).
+     * Backs the Converge ability word and the Sunburst counter rule. Colorless is not a
+     * color, so it never contributes.
+     */
+    fun colorsOfManaSpent(): DynamicAmount = DynamicAmount.DistinctColorsManaSpent
+
     fun creaturesYouControl(): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Creature).count()
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -350,6 +350,14 @@ object Effects {
         HandPatterns.discardCards(count, target)
 
     /**
+     * Target player discards a [DynamicAmount] of cards (controller chooses, mandatory) — e.g.
+     * "discard X cards, where X is the number of colors of mana spent" (Converge). Delegates to
+     * the same Gather → Select → Move pipeline as the fixed-count overload.
+     */
+    fun Discard(count: DynamicAmount, target: EffectTarget = EffectTarget.Controller): Effect =
+        HandPatterns.discardCards(count, target)
+
+    /**
      * Connive (CR 702.166): draw a card, then discard a card. If the discarded card
      * is a nonland, put a +1/+1 counter on [target].
      *
@@ -623,6 +631,14 @@ object Effects {
      */
     fun PutOnTopOfLibrary(target: EffectTarget): Effect =
         MoveToZoneEffect(target, Zone.LIBRARY, ZonePlacement.Top)
+
+    /**
+     * Put on the bottom of its owner's library (forced — no player choice). Mirror of
+     * [PutOnTopOfLibrary]; used by graveyard-hate abilities like Sundering Archaic's
+     * "{2}: Put target card from a graveyard on the bottom of its owner's library."
+     */
+    fun PutOnBottomOfLibrary(target: EffectTarget): Effect =
+        MoveToZoneEffect(target, Zone.LIBRARY, ZonePlacement.Bottom)
 
     /**
      * Owner chooses to put target on top or bottom of their library.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -87,7 +87,24 @@ object HandPatterns {
         )
     }
 
-    fun discardCards(count: Int, target: EffectTarget = EffectTarget.Controller): CompositeEffect {
+    fun discardCards(count: Int, target: EffectTarget = EffectTarget.Controller): CompositeEffect =
+        discardCards(
+            DynamicAmount.Fixed(count),
+            target,
+            prompt = "Choose $count card${if (count != 1) "s" else ""} to discard",
+        )
+
+    /**
+     * Discard a [DynamicAmount] of cards (e.g. "discard X cards, where X is the number of colors
+     * of mana spent to cast this spell" — SOS Converge's Arcane Omens). Same Gather → Select →
+     * Move pipeline as the fixed-count overload; the count is resolved at the SelectFromCollection
+     * step.
+     */
+    fun discardCards(
+        count: DynamicAmount,
+        target: EffectTarget = EffectTarget.Controller,
+        prompt: String = "Choose cards to discard",
+    ): CompositeEffect {
         val player = effectTargetToPlayer(target)
         val chooser = effectTargetToChooser(target)
         return CompositeEffect(
@@ -98,10 +115,10 @@ object HandPatterns {
                 ),
                 SelectFromCollectionEffect(
                     from = "hand",
-                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(count)),
+                    selection = SelectionMode.ChooseExactly(count),
                     chooser = chooser,
                     storeSelected = "discarded",
-                    prompt = "Choose $count card${if (count != 1) "s" else ""} to discard"
+                    prompt = prompt
                 ),
                 MoveCollectionEffect(
                     from = "discarded",

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/ConvergeDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/ConvergeDsl.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Converge (Oath of the Gatewatch; reused in Secrets of Strixhaven).
+ *
+ * **Converge is an ability word** — flavor only, no rules meaning of its own (CR 207.2c), so it
+ * adds no keyword (mirrors how [opus] models its SOS sibling). Each Converge card scales some
+ * effect by the number of distinct colors of mana spent to cast it; that count is
+ * [DynamicAmount.DistinctColorsManaSpent] ([DynamicAmounts.colorsOfManaSpent]).
+ *
+ * The set's Converge cards come in three shapes:
+ *  - **Enters with counters** (the "Archaic" cycle) — use [convergeEntersWithCounters].
+ *  - **A spell whose effect scales** — read [DynamicAmounts.colorsOfManaSpent] directly in the
+ *    spell's effect (e.g. a dynamic amount fed to draw/damage/token effects).
+ *  - **Exile-by-color-count** — use the `manaValueAtMostColorsSpent(EntityReference.Source)`
+ *    target/group predicate.
+ *
+ * In every case author the printed "Converge — …" reminder into the card's `oracleText`; the
+ * mechanic carries no keyword tag.
+ */
+
+/**
+ * Converge — "This creature enters with a [counterType] counter for each color of mana spent to
+ * cast it." Composes an [EntersWithDynamicCounters] replacement effect fed by
+ * [DynamicAmount.DistinctColorsManaSpent]. This is the dominant Converge shape (the SOS "Archaic"
+ * cycle); defaults to +1/+1 counters.
+ */
+fun CardBuilder.convergeEntersWithCounters(
+    counterType: CounterTypeFilter = CounterTypeFilter.PlusOnePlusOne,
+) {
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = counterType,
+            count = DynamicAmount.DistinctColorsManaSpent,
+        ),
+    )
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -273,6 +273,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostEntityManaSpent(reference)
     )
 
+    /** Mana value at most the number of colors of mana spent to cast a referenced entity (Converge). */
+    fun manaValueAtMostColorsSpent(reference: EntityReference) = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostColorsSpent(reference)
+    )
+
     /** Mana value is even (zero is even). */
     fun manaValueIsEven() = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueIsEven

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -356,6 +356,21 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
             "with mana value less than or equal to the mana spent to cast ${reference.description}"
     }
 
+    /**
+     * Mana value at most the number of distinct *colors* of mana spent to cast a referenced
+     * entity (0–5). Sibling of [ManaValueAtMostEntityManaSpent], but compares against the
+     * color *count* rather than the total mana — the **Converge** exile-by-color-count variant
+     * ("… mana value less than or equal to the number of colors of mana spent to cast this
+     * creature"). Resolves the reference and reads its recorded payment (live spell buckets or
+     * the resolved permanent's cast record); colorless is not a color and never contributes.
+     */
+    @SerialName("ManaValueAtMostColorsSpent")
+    @Serializable
+    data class ManaValueAtMostColorsSpent(val reference: EntityReference) : CardPredicate {
+        override val description: String =
+            "with mana value less than or equal to the number of colors of mana spent to cast ${reference.description}"
+    }
+
     @SerialName("ManaValueIsEven")
     @Serializable
     data object ManaValueIsEven : CardPredicate {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -351,6 +351,26 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The number of distinct *colors* of mana spent to cast the source spell (0–5).
+     *
+     * Backs the **Converge** ability word — "Converge — … for each color of mana spent to
+     * cast it" — and the classic **Sunburst** counter rule. Counts how many of the five
+     * colored buckets (W/U/B/R/G) recorded on the spell's stack object are non-zero; colorless
+     * is not a color (CR 105.1) and never contributes. As with [TotalManaSpent], mana spent on
+     * the `{X}` portion is already folded into those buckets, so it counts here too.
+     *
+     * Evaluated against the source entity's recorded payment, so it resolves correctly whether
+     * read while the spell is still on the stack or as the permanent enters (the dominant use:
+     * feeding `ReplacementEffect.EntersWithDynamicCounters`). A permanent put onto the
+     * battlefield without being cast spent no mana, so this is 0 for it.
+     */
+    @SerialName("DistinctColorsManaSpent")
+    @Serializable
+    data object DistinctColorsManaSpent : DynamicAmount {
+        override val description: String = "the number of colors of mana spent to cast this spell"
+    }
+
+    /**
      * Reference to a stored variable by name.
      * Used for effects that need to reference a previously computed/stored value.
      * Example: Scapeshift stores "sacrificedCount" and SearchLibrary reads it.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ArcaneOmens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ArcaneOmens.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Arcane Omens
+ * {4}{B}
+ * Sorcery
+ *
+ * Converge — Target player discards X cards, where X is the number of colors of mana spent to
+ * cast this spell.
+ *
+ * X is resolved while the spell is still on the stack, so it reads the live per-colour payment
+ * buckets via [DynamicAmounts.colorsOfManaSpent] (`DynamicAmount.DistinctColorsManaSpent`).
+ */
+val ArcaneOmens = card("Arcane Omens") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Converge — Target player discards X cards, where X is the number of colors of " +
+        "mana spent to cast this spell."
+
+    spell {
+        val player = target("target player", TargetPlayer())
+        effect = Effects.Discard(DynamicAmounts.colorsOfManaSpent(), player)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d357d997-9d4e-4ade-81f2-37629853f13a.jpg?1775937419"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RancorousArchaic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RancorousArchaic.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.convergeEntersWithCounters
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rancorous Archaic
+ * {5}
+ * Creature — Avatar
+ * 2/2
+ *
+ * Trample, reach
+ * Converge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.
+ *
+ * The mana cost is all generic, so the colour count is entirely up to how you pay it: cast for five
+ * colourless and it enters with no counters; pay the {5} with mana of five different colours and it
+ * enters 7/7. Modelled via [convergeEntersWithCounters], i.e.
+ * `EntersWithDynamicCounters(DynamicAmount.DistinctColorsManaSpent)`.
+ */
+val RancorousArchaic = card("Rancorous Archaic") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Creature — Avatar"
+    power = 2
+    toughness = 2
+    oracleText = "Trample, reach\n" +
+        "Converge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it."
+
+    keywords(Keyword.TRAMPLE, Keyword.REACH)
+
+    convergeEntersWithCounters()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/2565e16a-ed31-4867-adb8-f1633d580397.jpg?1775936927"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SunderingArchaic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SunderingArchaic.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Sundering Archaic
+ * {6}
+ * Creature — Avatar
+ * 3/3
+ *
+ * Converge — When this creature enters, exile target nonland permanent an opponent controls with
+ * mana value less than or equal to the number of colors of mana spent to cast this creature.
+ * {2}: Put target card from a graveyard on the bottom of its owner's library.
+ *
+ * The colour-count gate on the exile target is the
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostColorsSpent] predicate
+ * (`manaValueAtMostColorsSpent`), reading this creature's `CastRecordComponent` snapshot — sibling
+ * of Astelli Reclaimer's total-mana-spent predicate, but comparing against the colour *count*.
+ */
+val SunderingArchaic = card("Sundering Archaic") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Creature — Avatar"
+    power = 3
+    toughness = 3
+    oracleText = "Converge — When this creature enters, exile target nonland permanent an opponent " +
+        "controls with mana value less than or equal to the number of colors of mana spent to cast " +
+        "this creature.\n" +
+        "{2}: Put target card from a graveyard on the bottom of its owner's library."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "nonland permanent an opponent controls with mana value less than or equal to the " +
+                "number of colors of mana spent to cast this creature",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent
+                        .opponentControls()
+                        .manaValueAtMostColorsSpent(EntityReference.Source)
+                )
+            )
+        )
+        effect = Effects.Exile(permanent)
+        description = "Converge — When this creature enters, exile target nonland permanent an " +
+            "opponent controls with mana value less than or equal to the number of colors of mana " +
+            "spent to cast this creature."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val graveyardCard = target(
+            "target card from a graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any, zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.PutOnBottomOfLibrary(graveyardCard)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Quintin Gleim"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c35b57e4-2358-46c0-8f09-cd27c10eaf2d.jpg?1775936933"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -120,6 +120,72 @@
     ]
 }
 
+// Arcane Omens
+{
+    "name": "Arcane Omens",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Converge — Target player discards X cards, where X is the number of colors of mana spent to cast this spell.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "hand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "hand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": "DistinctColorsManaSpent"
+                    },
+                    "chooser": "TargetPlayer",
+                    "storeSelected": "discarded",
+                    "prompt": "Choose cards to discard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "discarded",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d357d997-9d4e-4ade-81f2-37629853f13a.jpg?1775937419"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Banishing Betrayal
 {
     "name": "Banishing Betrayal",
@@ -2729,6 +2795,36 @@
     ]
 }
 
+// Rancorous Archaic
+{
+    "name": "Rancorous Archaic",
+    "manaCost": "{5}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Trample, reach\nConverge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "REACH"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "DistinctColorsManaSpent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/2565e16a-ed31-4867-adb8-f1633d580397.jpg?1775936927"
+    },
+    "colorIdentityOverride": []
+}
+
 // Rapturous Moment
 {
     "name": "Rapturous Moment",
@@ -3450,6 +3546,93 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Sundering Archaic
+{
+    "name": "Sundering Archaic",
+    "manaCost": "{6}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Converge — When this creature enters, exile target nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature.\n{2}: Put target card from a graveyard on the bottom of its owner's library.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsNonland",
+                                "IsPermanent",
+                                {
+                                    "type": "ManaValueAtMostColorsSpent",
+                                    "reference": "Source"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByOpponent"
+                        }
+                    },
+                    "id": "nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature"
+                },
+                "descriptionOverride": "Converge — When this creature enters, exile target nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card from a graveyard"
+                    },
+                    "destination": "Library",
+                    "placement": "Bottom"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card from a graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Quintin Gleim",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c35b57e4-2358-46c0-8f09-cd27c10eaf2d.jpg?1775936933"
+    },
+    "colorIdentityOverride": []
 }
 
 // Titan's Grave

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -111,6 +111,13 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.TotalManaSpent -> context.totalManaSpent
 
+            // Distinct colors of mana spent to cast the source (Converge / Sunburst). Read off
+            // the source entity's recorded payment via the shared reader so it resolves at ETB
+            // (EntersWithDynamicCounters) as well as mid-resolution; falls through to the context
+            // total being irrelevant — color breakdown only lives on the entity's components.
+            is DynamicAmount.DistinctColorsManaSpent ->
+                context.sourceId?.let { ManaSpentReader.distinctColorsSpent(state, it) } ?: 0
+
             is DynamicAmount.ManaSpentOnX -> context.manaSpentOnXByColor[amount.color] ?: 0
 
             is DynamicAmount.YourLifeTotal -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ManaSpentReader.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ManaSpentReader.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.handlers
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Single source of truth for reading the mana actually spent to cast an entity.
+ *
+ * Reads the live [SpellOnStackComponent] buckets while the entity is still a spell on the
+ * stack, otherwise the [CastRecordComponent] snapshot stamped when it resolved onto the
+ * battlefield. Both record the full payment broken down by color — for `{X}` spells the X
+ * portion is already folded into the per-color buckets by the mana solver, so these counts
+ * include mana spent on X. All-zero when neither component is present (the entity was put
+ * onto the battlefield without being cast, or is a copy created on the stack — no mana was
+ * spent in either case), which is CR-faithful for "the mana spent to cast it" payoffs.
+ *
+ * Shared by [PredicateEvaluator] (mana-value-vs-mana-spent predicates) and
+ * [DynamicAmountEvaluator] (Converge / total-mana-spent amounts) so the read path can never
+ * drift between the two.
+ */
+object ManaSpentReader {
+
+    /** The five colored buckets (W, U, B, R, G) spent to cast [entityId]; colorless excluded. */
+    private fun coloredBuckets(state: GameState, entityId: EntityId): IntArray {
+        val container = state.getEntity(entityId) ?: return IntArray(5)
+        container.get<SpellOnStackComponent>()?.let {
+            return intArrayOf(it.manaSpentWhite, it.manaSpentBlue, it.manaSpentBlack, it.manaSpentRed, it.manaSpentGreen)
+        }
+        container.get<CastRecordComponent>()?.let {
+            return intArrayOf(it.whiteSpent, it.blueSpent, it.blackSpent, it.redSpent, it.greenSpent)
+        }
+        return IntArray(5)
+    }
+
+    /** Total mana (all colors plus colorless) spent to cast [entityId]; 0 if it wasn't cast. */
+    fun totalSpent(state: GameState, entityId: EntityId): Int {
+        val container = state.getEntity(entityId) ?: return 0
+        container.get<SpellOnStackComponent>()?.let {
+            return it.manaSpentWhite + it.manaSpentBlue + it.manaSpentBlack +
+                it.manaSpentRed + it.manaSpentGreen + it.manaSpentColorless
+        }
+        container.get<CastRecordComponent>()?.let {
+            return it.whiteSpent + it.blueSpent + it.blackSpent +
+                it.redSpent + it.greenSpent + it.colorlessSpent
+        }
+        return 0
+    }
+
+    /**
+     * The number of distinct *colors* of mana spent to cast [entityId] (0–5). Colorless is not
+     * a color (CR 105.1), so it never contributes. Backs the Converge ability word and Sunburst.
+     */
+    fun distinctColorsSpent(state: GameState, entityId: EntityId): Int =
+        coloredBuckets(state, entityId).count { it > 0 }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -21,7 +21,6 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
-import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
 import com.wingedsheep.engine.state.components.identity.TokenComponent
@@ -290,9 +289,15 @@ class PredicateEvaluator {
             }
             is CardPredicate.ManaValueAtMostEntityManaSpent -> {
                 val refEntityId = resolveEntityReference(predicate.reference, context) ?: return false
-                val manaSpent = manaSpentToCast(state, refEntityId)
+                val manaSpent = ManaSpentReader.totalSpent(state, refEntityId)
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= manaSpent
+            }
+            is CardPredicate.ManaValueAtMostColorsSpent -> {
+                val refEntityId = resolveEntityReference(predicate.reference, context) ?: return false
+                val colorsSpent = ManaSpentReader.distinctColorsSpent(state, refEntityId)
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc <= colorsSpent
             }
             CardPredicate.ManaValueIsEven -> {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
@@ -614,26 +619,6 @@ class PredicateEvaluator {
     /**
      * Resolve an EntityReference to an EntityId using the predicate context.
      */
-    /**
-     * Total mana actually spent to cast an entity. Reads the live [SpellOnStackComponent]
-     * buckets while the entity is still a spell on the stack, otherwise the
-     * [CastRecordComponent] snapshot stamped when it resolved onto the battlefield. Returns 0
-     * when neither is present (entity was put onto the battlefield without being cast, or is
-     * a copy created on the stack — no mana was spent in either case).
-     */
-    private fun manaSpentToCast(state: GameState, entityId: EntityId): Int {
-        val container = state.getEntity(entityId) ?: return 0
-        container.get<SpellOnStackComponent>()?.let { spell ->
-            return spell.manaSpentWhite + spell.manaSpentBlue + spell.manaSpentBlack +
-                spell.manaSpentRed + spell.manaSpentGreen + spell.manaSpentColorless
-        }
-        container.get<CastRecordComponent>()?.let { record ->
-            return record.whiteSpent + record.blueSpent + record.blackSpent +
-                record.redSpent + record.greenSpent + record.colorlessSpent
-        }
-        return 0
-    }
-
     private fun resolveEntityReference(ref: EntityReference, context: PredicateContext?): EntityId? {
         return when (ref) {
             is EntityReference.Source -> context?.sourceId
@@ -924,6 +909,7 @@ class PredicateEvaluator {
             // Entity-relative — no entity context for cast records
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+            is CardPredicate.ManaValueAtMostColorsSpent -> false
             CardPredicate.ManaValueIsEven -> record.manaValue % 2 == 0
             CardPredicate.ManaValueIsOdd -> record.manaValue % 2 != 0
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -525,6 +525,7 @@ internal class AffectsFilterResolver {
         // Entity-relative — layer-projection has no trigger/source context for filter purposes here.
         is CardPredicate.ManaValueAtMostEntity -> false
         is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+        is CardPredicate.ManaValueAtMostColorsSpent -> false
         is CardPredicate.PowerGreaterThanEntity -> false
         is CardPredicate.PowerAtMostEntity -> false
         CardPredicate.ManaValueIsEven -> card.manaValue % 2 == 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -906,6 +906,7 @@ class CostCalculator(
             // CostCalculator has no entity context; predicate has no static answer here.
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+            is CardPredicate.ManaValueAtMostColorsSpent -> false
             is CardPredicate.PowerGreaterThanEntity -> false
             is CardPredicate.PowerAtMostEntity -> false
             CardPredicate.ManaValueIsEven -> cardDef.manaCost.cmc % 2 == 0

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvergeMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvergeMechanicTest.kt
@@ -1,0 +1,206 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ArcaneOmens
+import com.wingedsheep.mtg.sets.definitions.sos.cards.RancorousArchaic
+import com.wingedsheep.mtg.sets.definitions.sos.cards.SunderingArchaic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Converge (ability word, CR 207.2c) — scales an effect by the number of distinct *colors* of
+ * mana spent to cast the spell. Exercises the two new SDK primitives end-to-end:
+ *  - [com.wingedsheep.sdk.scripting.values.DynamicAmount.DistinctColorsManaSpent] — counter / spell
+ *    payoff (Rancorous Archaic enters-with-counters; Arcane Omens "discard X").
+ *  - [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostColorsSpent] — the
+ *    exile-by-colour-count target gate (Sundering Archaic).
+ *
+ * The CR clauses pinned here: colours are counted, not pips (5 mana of 2 colours → 2); colourless
+ * is not a colour (CR 105.1) and never counts; mana paid on generic costs still has its colour
+ * counted; a permanent put onto the battlefield without being cast spent 0 mana → 0 colours.
+ */
+class ConvergeMechanicTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(RancorousArchaic, ArcaneOmens, SunderingArchaic))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver) {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // ── DistinctColorsManaSpent via EntersWithDynamicCounters (Rancorous Archaic {5}) ──
+
+    test("Rancorous Archaic: all colorless mana spent → 0 colors → no counters (2/2)") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Rancorous Archaic")
+        driver.giveColorlessMana(p, 5)
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        plusCounters(driver, spell) shouldBe 0
+    }
+
+    test("Rancorous Archaic: one color among the generic payment → 1 counter") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Rancorous Archaic")
+        driver.giveColorlessMana(p, 4)
+        driver.giveMana(p, Color.RED, 1)
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        plusCounters(driver, spell) shouldBe 1
+    }
+
+    test("Rancorous Archaic: counts colors, not pips — 3 white + 2 blue (5 mana, 2 colors) → 2 counters") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Rancorous Archaic")
+        driver.giveMana(p, Color.WHITE, 3)
+        driver.giveMana(p, Color.BLUE, 2)
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Five mana spent, but only two distinct colors → two counters (a 4/4), not five.
+        plusCounters(driver, spell) shouldBe 2
+    }
+
+    test("Rancorous Archaic: five different colors → 5 counters (7/7)") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Rancorous Archaic")
+        driver.giveMana(p, Color.WHITE, 1)
+        driver.giveMana(p, Color.BLUE, 1)
+        driver.giveMana(p, Color.BLACK, 1)
+        driver.giveMana(p, Color.RED, 1)
+        driver.giveMana(p, Color.GREEN, 1)
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        plusCounters(driver, spell) shouldBe 5
+    }
+
+    // ── DistinctColorsManaSpent in a resolution effect (Arcane Omens {4}{B} "discard X") ──
+
+    test("Arcane Omens: one color spent → target player discards exactly 1") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val opp = driver.getOpponent(p)
+        repeat(3) { driver.putCardInHand(opp, "Savannah Lions") }
+
+        val spell = driver.putCardInHand(p, "Arcane Omens")
+        driver.giveMana(p, Color.BLACK, 5) // {4}{B} all black → 1 color
+
+        driver.castSpell(p, spell, targets = listOf(opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val discard = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        discard.minSelections shouldBe 1
+        discard.maxSelections shouldBe 1
+    }
+
+    test("Arcane Omens: five colors spent → target player discards exactly 5") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val opp = driver.getOpponent(p)
+        repeat(6) { driver.putCardInHand(opp, "Savannah Lions") }
+
+        val spell = driver.putCardInHand(p, "Arcane Omens")
+        // {4}{B}: B pays {B}; W/U/R/G pay the {4} generic → five distinct colors.
+        driver.giveMana(p, Color.WHITE, 1)
+        driver.giveMana(p, Color.BLUE, 1)
+        driver.giveMana(p, Color.RED, 1)
+        driver.giveMana(p, Color.GREEN, 1)
+        driver.giveMana(p, Color.BLACK, 1)
+
+        driver.castSpell(p, spell, targets = listOf(opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val discard = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        discard.minSelections shouldBe 5
+        discard.maxSelections shouldBe 5
+    }
+
+    // ── ManaValueAtMostColorsSpent predicate (Sundering Archaic exile gate) ──
+
+    test("Sundering Archaic: exile target gated by colors spent — MV ≤ colors is legal, MV > colors is not") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val opp = driver.getOpponent(p)
+        val mv1 = driver.putCreatureOnBattlefield(opp, "Goblin Guide")      // {R} → mana value 1
+        val mv3 = driver.putCreatureOnBattlefield(opp, "Centaur Courser")   // {2}{G} → mana value 3
+
+        val spell = driver.putCardInHand(p, "Sundering Archaic")
+        driver.giveColorlessMana(p, 4)
+        driver.giveMana(p, Color.RED, 1)
+        driver.giveMana(p, Color.BLUE, 1) // {6} paid with 4 colorless + R + U → 2 colors
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass() // creature resolves; CastRecordComponent stamped (2 colors)
+
+        val predicateEvaluator = PredicateEvaluator()
+        val filter = GameObjectFilter.NonlandPermanent
+            .opponentControls()
+            .manaValueAtMostColorsSpent(EntityReference.Source)
+        val context = PredicateContext(controllerId = p, sourceId = spell)
+
+        // 2 colors of mana spent: MV1 is a legal target, MV3 is not.
+        predicateEvaluator.matches(driver.state, driver.state.projectedState, mv1, filter, context) shouldBe true
+        predicateEvaluator.matches(driver.state, driver.state.projectedState, mv3, filter, context) shouldBe false
+    }
+
+    test("Sundering Archaic: all-colorless cast → 0 colors → even a mana-value-1 permanent is illegal") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val opp = driver.getOpponent(p)
+        val mv1 = driver.putCreatureOnBattlefield(opp, "Goblin Guide") // mana value 1
+
+        val spell = driver.putCardInHand(p, "Sundering Archaic")
+        driver.giveColorlessMana(p, 6) // 0 colors spent
+
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        val predicateEvaluator = PredicateEvaluator()
+        val filter = GameObjectFilter.NonlandPermanent
+            .opponentControls()
+            .manaValueAtMostColorsSpent(EntityReference.Source)
+        val context = PredicateContext(controllerId = p, sourceId = spell)
+
+        // 0 colors → 1 > 0 → not a legal target (colorless is not a color).
+        predicateEvaluator.matches(driver.state, driver.state.projectedState, mv1, filter, context) shouldBe false
+    }
+})


### PR DESCRIPTION
Implements **Converge** from `backlog/sos-engine-gaps.md` §4 / Tier 2 §9.

Converge is an ability word (CR 207.2c — flavor only, no rules meaning of its own) that scales an effect by the **number of distinct colors of mana spent** to cast the spell. Like its SOS sibling **Opus** (PR #686), it adds **no keyword**.

## New SDK primitives (parameterized for reuse)
- **`DynamicAmount.DistinctColorsManaSpent`** — distinct colors (0–5) among the W/U/B/R/G payment buckets. Colorless is not a color (CR 105.1) and never counts; mana spent on `{X}` and generic costs still has its color counted. Read off the source entity's recorded payment (live `SpellOnStackComponent`, else the resolved permanent's `CastRecordComponent`), so it resolves correctly both mid-resolution and as the permanent enters — the dominant use, feeding `EntersWithDynamicCounters`. Facade `DynamicAmounts.colorsOfManaSpent()`.
- **`CardPredicate.ManaValueAtMostColorsSpent`** — mana value ≤ that color count; the exile-by-color-count target gate (sibling of `ManaValueAtMostEntityManaSpent`, counting colors not total mana).

Both reads go through a new shared **`ManaSpentReader`** (SpellOnStack → CastRecord fallback), which also absorbs `PredicateEvaluator`'s private `manaSpentToCast` so the read path can't drift between the two evaluators.

## DSL / facades
- `convergeEntersWithCounters(counterType = PlusOnePlusOne)` — composes the dominant "enters with a counter for each color of mana spent" shape.
- `Effects.Discard(DynamicAmount, target)` overload (for "discard X cards") and `Effects.PutOnBottomOfLibrary(target)` facade.

## Cards (SOS) — one per code path
- **Rancorous Archaic** `{5}` — `convergeEntersWithCounters()` (ETB-counter path).
- **Arcane Omens** `{4}{B}` — `DistinctColorsManaSpent` in a resolution effect (dynamic discard).
- **Sundering Archaic** `{6}` — the `manaValueAtMostColorsSpent` exile predicate + a graveyard-bottom activated ability.

The remaining Converge cards need *other* unbuilt primitives and are deliberately out of scope: Magmablood/Wildgrowth Archaic (triggering-spell color count), Archaic's Agony (excess-damage impulse), Snarl Song (Fractal tokens).

## Tests
`rules-engine` `ConvergeMechanicTest` pins the CR clauses through real casts: colors not pips (5 mana of 2 colors → 2), colorless excluded, generic/`{X}` color counted, not-cast → 0, and the predicate's MV ≤ colors gate. SDK round-trip is covered by the card snapshot net (SOS golden re-blessed). `card-sdk-language-reference.md` updated.

**Gates:** `:mtg-sets:test` (snapshot + lint + facade-boundary) ✅ · full `:rules-engine:test` ✅

**mtgish:** N/A — Converge is an ability word with no IR tag and its color-count amount is X-carrying, so there's no bridge/emitter mapping to add (same call as Opus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)