### PR TITLE
Add Longhorn Sharpshooter, Irascible Wolverine, Bounding Felidar (OTJ) + mtgish auto-gen support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoundingFelidar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoundingFelidar.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bounding Felidar
+ * {5}{W}
+ * Creature — Cat Beast Mount
+ * 4/7
+ * Whenever this creature attacks while saddled, put a +1/+1 counter on each other creature you
+ * control. You gain 1 life for each of those creatures.
+ * Saddle 2 (Tap any number of other creatures you control with total power 2 or more:
+ * This Mount becomes saddled until end of turn. Saddle only as a sorcery.)
+ */
+val BoundingFelidar = card("Bounding Felidar") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Beast Mount"
+    power = 4
+    toughness = 7
+    oracleText = "Whenever this creature attacks while saddled, put a +1/+1 counter on each other " +
+        "creature you control. You gain 1 life for each of those creatures.\n" +
+        "Saddle 2 (Tap any number of other creatures you control with total power 2 or more: " +
+        "This Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.saddle(2))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        effect = Effects.Composite(
+            listOf(
+                Effects.ForEachInGroup(
+                    filter = GroupFilter(
+                        baseFilter = GameObjectFilter.Creature.youControl(),
+                        excludeSelf = true
+                    ),
+                    effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                ),
+                // "You gain 1 life for each of those creatures" — the other creatures you control,
+                // whether or not counters could be placed (CR ruling 2024-04-12).
+                Effects.GainLife(
+                    DynamicAmount.AggregateBattlefield(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature,
+                        aggregation = Aggregation.COUNT,
+                        excludeSelf = true
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg"
+
+        ruling("2024-04-12", "In the rare case where +1/+1 counters can't be put on one or more creatures you control, you still gain 1 life for each creature you control when Bounding Felidar's first ability resolves.")
+        ruling("2024-04-12", "An ability that triggers when a creature \"attacks while saddled\" will trigger only if that creature was saddled when it was declared as an attacker.")
+        ruling("2024-04-12", "\"Saddled\" isn't an ability that a creature has. It's just something true about that creature. It won't stop being saddled until the turn ends or it leaves the battlefield.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IrascibleWolverine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IrascibleWolverine.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Irascible Wolverine
+ * {2}{R}
+ * Creature — Wolverine
+ * 3/2
+ * When this creature enters, exile the top card of your library. Until end of turn, you may play that card.
+ * Plot {2}{R}
+ */
+val IrascibleWolverine = card("Irascible Wolverine") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wolverine"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, exile the top card of your library. Until end of turn, you may play that card.\n" +
+        "Plot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.plot("{2}{R}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "exiledCard",
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                ),
+                GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.EndOfTurn),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg"
+
+        ruling("2024-04-12", "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\"")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LonghornSharpshooter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LonghornSharpshooter.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Longhorn Sharpshooter
+ * {2}{R}
+ * Creature — Minotaur Rogue
+ * 3/3
+ * Reach
+ * When this card becomes plotted, it deals 2 damage to any target.
+ * Plot {3}{R}
+ */
+val LonghornSharpshooter = card("Longhorn Sharpshooter") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Rogue"
+    power = 3
+    toughness = 3
+    oracleText = "Reach\n" +
+        "When this card becomes plotted, it deals 2 damage to any target.\n" +
+        "Plot {3}{R} (You may pay {3}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywords(Keyword.REACH)
+    keywordAbility(KeywordAbility.plot("{3}{R}"))
+
+    triggeredAbility {
+        trigger = Triggers.BecomesPlotted
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "132"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg"
+
+        ruling("2024-04-12", "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\"")
+        ruling("2024-04-12", "Longhorn Sharpshooter's triggered ability triggers when it becomes plotted, not when you cast it from exile. You choose the target as the ability is put onto the stack.")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -552,6 +552,98 @@
     ]
 }
 
+// Bounding Felidar
+{
+    "name": "Bounding Felidar",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Cat Beast Mount",
+    "oracleText": "Whenever this creature attacks while saddled, put a +1/+1 counter on each other creature you control. You gain 1 life for each of those creatures.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 7
+    },
+    "keywords": [
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "In the rare case where +1/+1 counters can't be put on one or more creatures you control, you still gain 1 life for each creature you control when Bounding Felidar's first ability resolves."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "An ability that triggers when a creature \"attacks while saddled\" will trigger only if that creature was saddled when it was declared as an attacker."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "\"Saddled\" isn't an ability that a creature has. It's just something true about that creature. It won't stop being saddled until the turn ends or it leaves the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Bovine Intervention
 {
     "name": "Bovine Intervention",
@@ -3377,6 +3469,84 @@
     ]
 }
 
+// Irascible Wolverine
+{
+    "name": "Irascible Wolverine",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Wolverine",
+    "oracleText": "When this creature enters, exile the top card of your library. Until end of turn, you may play that card.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiledCard"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\""
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Jagged Barrens
 {
     "name": "Jagged Barrens",
@@ -3742,6 +3912,74 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Longhorn Sharpshooter
+{
+    "name": "Longhorn Sharpshooter",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Rogue",
+    "oracleText": "Reach\nWhen this card becomes plotted, it deals 2 damage to any target.\nPlot {3}{R} (You may pay {3}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH",
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{3}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesPlottedEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "rarity": "UNCOMMON",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\""
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Longhorn Sharpshooter's triggered ability triggers when it becomes plotted, not when you cast it from exile. You choose the target as the ability is put onto the stack."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -8,6 +8,9 @@ internal fun BridgeBuilder.damageLifeAndCards() {
         // deal N damage to <recipient>" (Skirk Commando, Snapping Thragg, Aether Charge) — both realise as
         // a DealDamageEffect, so they carry the same DealDamage capability as the plain spell/permanent forms.
         "SpellDealsDamageCantBePrevented", "HavePermanentDealDamage",
+        // "it deals N damage to <recipient>" where "it" is a card face up in exile (Longhorn
+        // Sharpshooter's plot trigger) — same DealDamageEffect, attributed to the ability source.
+        "ExiledCardDealsDamage",
         tag = "DealDamage",
     )
     effect("SpellDealsDistributedDamage", "DividedDamage")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -23,6 +23,10 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // layer effect collapse to one BecomeCreatureTypeEffect (Mistform cycle, Imagecrafter).
     effect("AddCreatureTypeVariable", "BecomeCreatureType", UNIVERSAL)
     effects("PutACounterOfTypeOnPermanent", "PutNumberCountersOfTypeOnPermanent", tag = "AddCounters", note = UNIVERSAL)
+    // "Put a counter on each <filter>" — the mass form, rendered as ForEachInGroup(AddCounters) over the
+    // recovered group filter (Bounding Felidar's "each other creature you control").
+    composed("PutACounterOfTypeOnEachPermanent", "ForEachInGroup(AddCounters) over a group filter",
+        composes = listOf("AddCounters"))
 
     // Earthbend N (TLA keyword action): target land becomes a 0/0 creature-land with haste, gets N
     // +1/+1 counters, and gains "when it dies or is exiled, return it to the battlefield tapped".

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -43,6 +43,9 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("LookAtTheTopNumberCardsOfPlayersLibrary", "look pipeline on opponent library -> MoveCollection", composes = listOf("MoveCollection"))
 
     composed("ExilePermanent", UNIVERSAL, composes = listOf("MoveToZone"))
+    // "Exile the top card of your library" — the impulse-draw exile half (Irascible Wolverine, Alania's
+    // Pathmaker). Gather(top of library) + MoveCollection -> exile; paired with a MayPlayExiledCard grant.
+    composed("ExileTopCardOfLibrary", "Gather(top of library) + MoveCollection -> exile (impulse)", composes = listOf("MoveCollection"))
     // "Return the exiled card to the battlefield" — the delayed return half of exile-then-return
     // (Conciliator's Duelist). A plain MoveToZone back to the battlefield under its owner's control.
     composed("PutExiledCardOntoBattlefield", UNIVERSAL, composes = listOf("MoveToZone"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -78,6 +78,17 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
     }
 
+    on("ExiledCardDealsDamage") { _, args, tvar ->
+        // "it deals N damage to <recipient>" where "it" is the card sitting face up in exile (Longhorn
+        // Sharpshooter's "When this card becomes plotted, it deals 2 damage to any target"). The damage
+        // source is the plotted card; the engine attributes it via the ability source (the default), so —
+        // like HavePermanentDealDamage — the golden carries no damageSource. IR args are
+        // [<CardInExile>, N, <recipient>]. Render only a fixed amount + an exactly-resolvable recipient.
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
+        val tgt = refTargetIn(args, "_DamageRecipient", tvar) ?: return@on null
+        call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
+    }
+
     on("SpellDealsDistributedDamage") { _, args, _ ->
         val total = findInteger(args)
         if (total !is Int) return@on null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -322,6 +322,11 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         //   a tapped/untapped LAND — only "tapped creature" is recovered, via the oracle text (Theft of
         //     Dreams, correctly); "tapped land" (Mana Geyser) would silently drop the restriction.
         val countBlob = compact(node)
+        // "for each of those creatures" — a `HadCountersPutOnItThisWay` permanent set scopes to the
+        // creatures THIS resolution just put counters on (Bounding Felidar's "gain 1 life for each of
+        // those creatures"), not a current battlefield tally. The land/type search filter can't express
+        // it and would silently widen to GameObjectFilter.Any (every permanent). Decline -> SCAFFOLD.
+        if ("HadCountersPutOnItThisWay" in countBlob) return null
         if ("IsArtifactType" in countBlob) return null
         if (("IsTapped" in countBlob && "tapped creature" !in oracle) || "IsUntapped" in countBlob) return null
         //   IsNamed — "the number of creatures named ~ on the battlefield" (Plague Rats): the search

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -87,23 +87,23 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         // counter"). Only the bare ±1/±1 PTCounter and the keyword counters we name render; any other
         // counter kind scaffolds rather than guess. The subject ref is self or the bound target.
         val arr = args.asArr ?: return@on null
-        val counterNode = arr.getOrNull(0) as? JsonObject ?: return@on null
-        val counter = when (counterNode.strField("_CounterType")) {
-            "PTCounter" -> {
-                val pt = counterNode["args"].asArr ?: return@on null
-                when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
-                    Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
-                    Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
-                    else -> return@on null
-                }
-            }
-            // Keyword counters (CR 122.1c) that grant their keyword via the engine's keyword-counter
-            // projection. Only the ones we can name render; anything else scaffolds.
-            "FlyingCounter" -> "Counters.FLYING"
-            else -> return@on null
-        }
+        val counter = counterTypeDsl(arr.getOrNull(0)) ?: return@on null
         val tgt = refTarget(arr.getOrNull(1), tvar) ?: return@on null
         call("AddCountersEffect", arg("counterType", counter), arg("count", "1"), arg("target", tgt))
+    }
+
+    on("PutACounterOfTypeOnEachPermanent") { _, args, _ ->
+        // "Put a +1/+1 counter on each <filter>." — the mass form of PutACounterOfTypeOnPermanent
+        // (Bounding Felidar's "each other creature you control"). IR args are [<CounterType>, <filter>].
+        // Render as ForEachInGroup(AddCountersEffect(..., Self)) over the recovered group filter; the
+        // same named-counter restriction applies, and an unrenderable filter declines (-> SCAFFOLD).
+        val arr = args.asArr ?: return@on null
+        val counter = counterTypeDsl(arr.getOrNull(0)) ?: return@on null
+        val filter = groupFilterExpr(arr.getOrNull(1)) ?: return@on null
+        call(
+            "Effects.ForEachInGroup", arg(filter),
+            arg(call("AddCountersEffect", arg(Lit(counter)), arg("1"), arg("EffectTarget.Self"))),
+        )
     }
 
     on("PutNumberCountersOfTypeOnPermanent") { _, args, tvar ->
@@ -113,19 +113,7 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         // other counter kind or a derived count scaffolds rather than guess.
         val arr = args.asArr ?: return@on null
         val count = findInteger(arr.getOrNull(0)) as? Int ?: return@on null
-        val counterNode = arr.getOrNull(1) as? JsonObject ?: return@on null
-        val counter = when (counterNode.strField("_CounterType")) {
-            "PTCounter" -> {
-                val pt = counterNode["args"].asArr ?: return@on null
-                when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
-                    Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
-                    Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
-                    else -> return@on null
-                }
-            }
-            "FlyingCounter" -> "Counters.FLYING"
-            else -> return@on null
-        }
+        val counter = counterTypeDsl(arr.getOrNull(1)) ?: return@on null
         val tgt = refTarget(arr.getOrNull(2), tvar) ?: return@on null
         call("AddCountersEffect", arg("counterType", counter), arg("count", "$count"), arg("target", tgt))
     }
@@ -178,8 +166,25 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     on("CreatePlayerEffectUntil") { node, _, _ ->  // Summer Bloom: may play N additional lands
         val n = findInteger(node)
         if (jsonContains(node, "_PlayerEffect", "MayPlayAdditionalLands") && n is Int) {
-            call("PlayAdditionalLandsEffect", arg("$n"))
-        } else null
+            return@on call("PlayAdditionalLandsEffect", arg("$n"))
+        }
+        // "Until end of turn / end of your next turn, you may play that card." — the second half of the
+        // impulse-draw idiom (Irascible Wolverine, Alania's Pathmaker). The grant reads the card the paired
+        // `ExileTopCardOfLibrary` action stashed under "exiledCard". Only the controller-scoped grant on the
+        // card-exiled-this-way renders, and only for the two expirations the MayPlayExpiry facade names;
+        // any other player scope or expiration declines (-> SCAFFOLD) rather than emit a wrong window.
+        if (jsonContains(node, "_PlayerEffect", "MayPlayExiledCard") &&
+            jsonContains(node, "_CardInExile", "TheCardExiledThisWay") &&
+            jsonContains(node, "_Player", "You")
+        ) {
+            val expiry = when (firstExpiration(node)) {
+                "UntilEndOfTurn" -> "MayPlayExpiry.EndOfTurn"
+                "UntilEndOfNextTurn" -> "MayPlayExpiry.UntilEndOfNextTurn"
+                else -> return@on null
+            }
+            return@on call("GrantMayPlayFromExileEffect", arg("\"exiledCard\""), arg(Lit(expiry)))
+        }
+        null
     }
 
     on("EachPermanentDoesntUntapDuringControllersNextUntap") { _, _, tvar ->
@@ -187,6 +192,28 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
     on("SkipAllCombatPhasesTheirNextTurn") { _, _, tvar ->
         if (tvar != null) call("SkipCombatPhasesEffect", arg(Lit(tvar))) else call("SkipCombatPhasesEffect")
+    }
+}
+
+/** A mtgish `_CounterType` node -> the `Counters.*` constant the AddCountersEffect facade takes, or null
+ *  for a counter kind we can't name (-> the caller scaffolds rather than guess). Shared by every "put a
+ *  counter" handler (single / N / each). Only the bare ±1/±1 PTCounter and the keyword counters whose
+ *  engine keyword-counter projection we model render. */
+internal fun counterTypeDsl(counterNode: JsonElement?): String? {
+    val node = counterNode as? JsonObject ?: return null
+    return when (node.strField("_CounterType")) {
+        "PTCounter" -> {
+            val pt = node["args"].asArr ?: return null
+            when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
+                Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
+                Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
+                else -> null
+            }
+        }
+        // Keyword counters (CR 122.1c) that grant their keyword via the engine's keyword-counter
+        // projection. Only the ones we can name render; anything else scaffolds.
+        "FlyingCounter" -> "Counters.FLYING"
+        else -> null
     }
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -60,6 +60,18 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         call("Effects.Exile", arg(Lit(tgt)))
     }
 
+    // "Exile the top card of your library." (the first half of the impulse-draw idiom — Irascible
+    // Wolverine, Alania's Pathmaker). The exiled card is stored under the shared "exiledCard" key that
+    // the paired `CreatePlayerEffectUntil{MayPlayExiledCard(TheCardExiledThisWay)}` action reads to grant
+    // the may-play window (see TapLayerStateHandlers' CreatePlayerEffectUntil branch). The exile itself is
+    // the gather + move-to-exile atomic pair.
+    on("ExileTopCardOfLibrary") { _, _, _ ->
+        Composite(listOf(
+            Lit("GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = \"exiledCard\")"),
+            Lit("MoveCollectionEffect(from = \"exiledCard\", destination = CardDestination.ToZone(Zone.EXILE))"),
+        ))
+    }
+
     // "Return the exiled card to the battlefield under its owner's control" (the second half of the
     // exile-then-return idiom — Conciliator's Duelist, Parting Gust). `TheCardExiledThisWay` refers to
     // the same bound target that was exiled earlier in the ability, so it resolves to the ability's

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoundingFelidarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoundingFelidarScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bounding Felidar (OTJ #5) — {5}{W} Cat Beast Mount, 4/7, Saddle 2.
+ *
+ *   "Whenever this creature attacks while saddled, put a +1/+1 counter on each other creature you
+ *    control. You gain 1 life for each of those creatures."
+ *
+ * Verifies the saddle-gated attack trigger: each OTHER creature you control gets a +1/+1 counter
+ * (the Felidar itself does not), and the controller gains 1 life per other creature.
+ */
+class BoundingFelidarScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("attacking while saddled pumps each other creature and gains life per creature") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val felidar = driver.putCreatureOnBattlefield(player, "Bounding Felidar")
+        val bear1 = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2, power 2 → saddles
+        val bear2 = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2
+        driver.removeSummoningSickness(felidar)
+
+        val lifeBefore = driver.getLifeTotal(player)
+        driver.state.projectedState.getPower(bear1) shouldBe 2
+        driver.state.projectedState.getPower(bear2) shouldBe 2
+
+        // Saddle with bear1 (power 2 pays Saddle 2). bear2 stays untapped to receive a counter.
+        driver.submitSuccess(SaddleMount(player, felidar, listOf(bear1)))
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(felidar), driver.player2)
+        driver.bothPass() // resolve the attack trigger
+
+        // Both bears get a +1/+1 counter (now 3/3); the Felidar itself does not.
+        driver.state.projectedState.getPower(bear1) shouldBe 3
+        driver.state.projectedState.getPower(bear2) shouldBe 3
+        driver.state.projectedState.getPower(felidar) shouldBe 4
+
+        // Gain 1 life for each of the 2 other creatures you control.
+        driver.getLifeTotal(player) shouldBe lifeBefore + 2
+    }
+
+    test("attacking while NOT saddled does nothing") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val felidar = driver.putCreatureOnBattlefield(player, "Bounding Felidar")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.removeSummoningSickness(felidar)
+
+        val lifeBefore = driver.getLifeTotal(player)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(felidar), driver.player2)
+        driver.bothPass()
+
+        driver.state.projectedState.getPower(bear) shouldBe 2
+        driver.getLifeTotal(player) shouldBe lifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrascibleWolverineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrascibleWolverineScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Irascible Wolverine (OTJ #130) — {2}{R} Wolverine, 3/2, Plot {2}{R}.
+ *
+ *   "When this creature enters, exile the top card of your library. Until end of turn, you may
+ *    play that card."
+ *
+ * Exercises the impulse-draw ETB (GatherCards → MoveCollection(EXILE) →
+ * GrantMayPlayFromExile with [MayPlayExpiry.EndOfTurn]). Unlike Alania's Pathmaker (until end of
+ * NEXT turn), this permission must expire at the cleanup step of the same turn.
+ */
+class IrascibleWolverineScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        return driver
+    }
+
+    test("ETB exiles the top card and grants permission to play it this turn") {
+        val driver = createDriver()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(p1, "Mountain")
+        val wolverine = driver.putCardInHand(p1, "Irascible Wolverine")
+        driver.giveMana(p1, Color.RED, 3) // {2}{R}
+
+        driver.castSpell(p1, wolverine).isSuccess shouldBe true
+        driver.bothPass() // resolve the spell (Wolverine enters)
+        if (driver.stackSize > 0) driver.bothPass() // resolve the ETB trigger
+
+        // The Mountain is exiled and flagged playable.
+        driver.getExileCardNames(p1) shouldBe listOf("Mountain")
+        val exiled = driver.getExile(p1).single()
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+
+        // And it can actually be played from exile this turn.
+        driver.playLand(p1, exiled).isSuccess shouldBe true
+        driver.getExile(p1).contains(exiled) shouldBe false
+    }
+
+    test("the play permission expires at end of turn") {
+        val driver = createDriver()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(p1, "Mountain")
+        val wolverine = driver.putCardInHand(p1, "Irascible Wolverine")
+        driver.giveMana(p1, Color.RED, 3)
+
+        driver.castSpell(p1, wolverine).isSuccess shouldBe true
+        driver.bothPass()
+        if (driver.stackSize > 0) driver.bothPass()
+
+        val exiled = driver.getExile(p1).single()
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+
+        // Advance into the opponent's turn — the until-end-of-turn window is now closed.
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+        driver.state.activePlayerId shouldBe p2
+
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LonghornSharpshooterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LonghornSharpshooterScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlotCard
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Longhorn Sharpshooter (OTJ #132) — {2}{R} Minotaur Rogue, 3/3, Reach, Plot {3}{R}.
+ *
+ *   "When this card becomes plotted, it deals 2 damage to any target."
+ *
+ * Exercises the SELF-bound [com.wingedsheep.sdk.dsl.Triggers.BecomesPlotted] trigger paired with
+ * an "any target" damage effect whose source is the card sitting face up in exile (never on the
+ * battlefield). Paying the plot cost (CR 718) fires the trigger.
+ */
+class LonghornSharpshooterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("plotting Longhorn Sharpshooter fires its trigger and burns the chosen creature") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val target = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+        val sharpshooter = driver.putCardInHand(player, "Longhorn Sharpshooter")
+        driver.giveMana(player, Color.RED, 4) // plot cost {3}{R}
+
+        // Plotting pauses for the "becomes plotted" trigger's target choice.
+        driver.submit(PlotCard(player, sharpshooter)).isPaused shouldBe true
+        driver.submitTargetSelection(player, listOf(target))
+        driver.bothPass() // resolve the trigger
+
+        // Sharpshooter is now plotted in exile, not on the battlefield.
+        driver.getExile(player).contains(sharpshooter) shouldBe true
+        driver.getCreatures(player).contains(sharpshooter) shouldBe false
+
+        // 2/2 takes 2 damage and dies.
+        driver.getCreatures(opponent).contains(target) shouldBe false
+    }
+
+    test("the trigger can deal 2 damage to a player") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val sharpshooter = driver.putCardInHand(player, "Longhorn Sharpshooter")
+        driver.giveMana(player, Color.RED, 4)
+
+        driver.submit(PlotCard(player, sharpshooter)).isPaused shouldBe true
+        driver.submitTargetSelection(player, listOf(opponent))
+        driver.bothPass()
+
+        driver.getLifeTotal(opponent) shouldBe 18
+    }
+})


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards (via the `add-card` skill) and extends the mtgish auto-gen tooling so two of them now draft whole.

## Cards added

| Card | Cost / P-T | Text | Built from |
|------|-----------|------|-----------|
| **Longhorn Sharpshooter** | {2}{R} 3/3 | Reach; *When this card becomes plotted, it deals 2 damage to any target.* Plot {3}{R} | `Triggers.BecomesPlotted` + `Effects.DealDamage(2, any target)` |
| **Irascible Wolverine** | {2}{R} 3/2 | *When this creature enters, exile the top card of your library. Until end of turn, you may play that card.* Plot {2}{R} | impulse-draw composite: `GatherCards(top of library)` → `MoveCollection(EXILE)` → `GrantMayPlayFromExile(MayPlayExpiry.EndOfTurn)` |
| **Bounding Felidar** | {5}{W} 4/7 Mount | *Whenever this creature attacks while saddled, put a +1/+1 counter on each other creature you control. You gain 1 life for each of those creatures.* Saddle 2 | `Triggers.Attacks` + `Conditions.SourceIsSaddled` → `ForEachInGroup(AddCounters)` + `GainLife(AggregateBattlefield count, excludeSelf)` |

All three compose existing SDK primitives — **no new SDK surface**, so no `card-sdk-language-reference.md` change. Each has a rules-engine scenario test; the OTJ card-definition snapshot is re-blessed (only these 3 cards added).

## mtgish auto-gen tooling

Longhorn Sharpshooter and Irascible Wolverine now render **whole (AUTO tier)** and match the hand-authored cards. Emitter handlers + bridge entries added for:
- `ExiledCardDealsDamage` — plot "it deals N damage to <recipient>" → `DealDamageEffect` (source attributed to the ability, like `HavePermanentDealDamage`).
- `ExileTopCardOfLibrary` — impulse exile, stored under a shared `"exiledCard"` key.
- `CreatePlayerEffectUntil{MayPlayExiledCard(TheCardExiledThisWay)}` — → `GrantMayPlayFromExileEffect("exiledCard", expiry)`, mapping `UntilEndOfTurn`/`UntilEndOfNextTurn` to the two `MayPlayExpiry` facade values.
- `PutACounterOfTypeOnEachPermanent` — `ForEachInGroup(AddCounters)` over a recovered group filter (shared `counterTypeDsl` helper extracted from the single/N counter handlers).

### Bounding Felidar deliberately stays SCAFFOLD
Its "gain 1 life for each of those creatures" reads a **resolution-scoped** `HadCountersPutOnItThisWay` count — the creatures this resolution just put counters on, *not* a current battlefield tally. The battlefield-aggregate path would silently widen that to `GameObjectFilter.Any` (every permanent). Per "decline → SCAFFOLD, don't widen", I added a decline guard for that count shape rather than mis-render it. The counter half now renders, but the card stays SCAFFOLD on the life-gain — the correct, safe outcome.

## Verification
- 3 scenario tests + `CardDefinitionSnapshotTest` + `CardLintTest` — green.
- `mtgish-tooling` unit tests (incl. EmitterGoldenTest, TargetRecovery) — green.
- **POR coverage-verify gate: GATE PASS, 158/158, 0-mismatch** — no emitter regression.
- OTJ AUTOGEN compile gate: 113/276 whole-card drafts all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)