### PR TITLE
mtgish: fix 4 OTJ emitter/fidelity target-recovery mismatches

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -367,18 +367,30 @@ object Fidelity {
             }
         }
         collect(root)
-        if (labels.isEmpty()) return root
-        val mapping: Map<String, String> =
-            if (labels.size == 1) mapOf(labels.first() to "target")
-            else labels.withIndex().associate { (i, l) -> l to "§T$i§" }
+        val mapping: Map<String, String> = when {
+            labels.isEmpty() -> emptyMap()
+            labels.size == 1 -> mapOf(labels.first() to "target")
+            else -> labels.withIndex().associate { (i, l) -> l to "§T$i§" }
+        }
+        // A target-requirement node carries an `id` (the binding key) and a target `type`. Its id is
+        // gameplay-relevant ONLY when some BoundVariable references it by name (handled via `mapping`);
+        // a requirement referenced positionally (`ContextTarget`/`ContextPlayer` index) leaves its id a
+        // pure decoration the golden author still names descriptively ("target player"). Collapse such an
+        // unreferenced id to "target" so [normalizeForFidelity] then drops it, matching the emitter's
+        // generic "target" (Desperate Bloodseeker). Never touches a referenced (`mapping`) id, so the
+        // multi-target binding-reorder check is preserved.
+        fun isTargetRequirementId(node: JsonObject): Boolean =
+            node.containsKey("id") && node["type"].asStr()?.contains("Target") == true
         fun rewrite(node: JsonElement): JsonElement = when (node) {
             is JsonArray -> JsonArray(node.map { rewrite(it) })
             is JsonObject -> {
                 val isBound = node["type"].asStr() == "BoundVariable"
+                val isReqNode = isTargetRequirementId(node)
                 JsonObject(node.entries.associate { (k, v) ->
                     when {
                         isBound && k == "name" -> k to (mapping[v.asStr()]?.let { JsonPrimitive(it) } ?: rewrite(v))
                         k == "id" && v.asStr() in mapping -> k to JsonPrimitive(mapping.getValue(v.asStr()!!))
+                        k == "id" && isReqNode -> k to JsonPrimitive("target")  // unreferenced binding key
                         else -> k to rewrite(v)
                     }
                 })

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -796,7 +796,11 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     // through to the normal action path (where `on("If")` handles the static gates or declines).
     val lifted = if (effTriggerCondition == null) liftInterveningIfAction(effectActions) else null
     val condFromIf = lifted?.first
-    val edsl = renderEffectList(lifted?.second ?: effectActions, tvar) ?: return null
+    // A spell-cast trigger's triggering entity is the spell, so "that player" in the body is the caster
+    // (ControllerOfTriggeringEntity), not the triggering player — see [EmitCtx.triggeringEntityIsSpell].
+    val prevTriggeringSpell = triggeringEntityIsSpell
+    triggeringEntityIsSpell = jsonContains(effRule["args"].asArr?.firstOrNull(), "_Trigger", "WhenAPlayerCastsASpell")
+    val edsl = renderEffectList(lifted?.second ?: effectActions, tvar).also { triggeringEntityIsSpell = prevTriggeringSpell } ?: return null
 
     val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
     val triggerCond = effTriggerCondition ?: condFromIf

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -96,6 +96,17 @@ class EmitCtx(val keywords: Set<String>, val oracleText: String? = null) {
      * maps to `[t2, t3]`, so `Ref_TargetPermanent1` is `t2` and `Ref_TargetPermanent2` is `t3`.
      */
     var targetRefVarsByKind: Map<String, List<String>> = emptyMap()
+
+    /**
+     * True while rendering the effect of a trigger whose triggering entity is a *spell* (a
+     * `WhenAPlayerCastsASpell` cast trigger). In that context the IR's "that player"
+     * (`Trigger_ThatPlayer`) is the spell's controller — the caster — so a damage recipient resolves
+     * to `EffectTarget.ControllerOfTriggeringEntity` (Magebane Lizard). For every other trigger
+     * ("~ deals combat damage to a player", …) "that player" is the triggering player itself, so the
+     * flag stays false and [refTargetFromRef] keeps emitting `PlayerRef(Player.TriggeringPlayer)`.
+     * Set/cleared only by [triggerBlock]; default false on every other path.
+     */
+    var triggeringEntityIsSpell: Boolean = false
 }
 
 internal val SELF_REFS = setOf(
@@ -446,8 +457,12 @@ internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     // executor publishes its ids under the CREATED_TOKENS pipeline collection, so the follow-up effect
     // addresses it via PipelineTarget(CREATED_TOKENS, 0).
     if (ref == "TheCreatedToken") return "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"
-    // "that player" in a trigger ("the player ~ dealt combat damage to") -> the triggering player.
-    if (ref == "Trigger_ThatPlayer") return "EffectTarget.PlayerRef(Player.TriggeringPlayer)"
+    // "that player" in a trigger. In a spell-cast trigger the triggering entity is the spell, so "that
+    // player" is its controller — the caster — modeled as ControllerOfTriggeringEntity (Magebane Lizard).
+    // In every other trigger ("the player ~ dealt combat damage to") it's the triggering player itself.
+    if (ref == "Trigger_ThatPlayer") return if (triggeringEntityIsSpell)
+        "EffectTarget.ControllerOfTriggeringEntity"
+    else "EffectTarget.PlayerRef(Player.TriggeringPlayer)"
     // A plain player reference (no target) — the controller / "you" or an opponent. The pain-land idiom
     // "{T}: Add {C}. This land deals N damage to you" carries a `_DamageRecipient: Player{You}` recipient
     // that is the controller, not a chosen target (Adarkar Wastes, Caldera Lake, Ancient Tomb).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -165,6 +165,26 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         )
         if (unrenderableAlongside.any { it in blob }) return null
     }
+    // "non-outlaw creature" (Shoot the Sheriff): IsNonOutlaw excludes the five outlaw creature types
+    // (Assassin, Mercenary, Pirate, Rogue, Warlock) at once. Render the exact filter
+    // Targets.NonOutlawCreature compiles to — Creature.notAnyOfSubtypes(Subtype.OUTLAW_TYPES). Only the
+    // bare shape (optionally a You/Opponent controller) is modeled; any other predicate alongside it
+    // would be silently dropped, so decline rather than widen.
+    if ("IsNonOutlaw" in blob) {
+        val otherPredicates = listOf(
+            "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "PowerIs", "ToughnessIs", "ManaValueIs",
+            "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken", "IsCreatureType",
+            "IsNonCreatureType", "IsNonCardtype", "Other", "HasACounterOfType", "WasDealtDamageThisTurn",
+        )
+        if (otherPredicates.any { it in blob }) return null
+        var g: Dsl = Lit("GameObjectFilter.Creature").dot("notAnyOfSubtypes", arg("Subtype.OUTLAW_TYPES"))
+        when {
+            "\"You\"" in blob -> g = g.dot("youControl")
+            "\"Opponent\"" in blob -> g = g.dot("opponentControls")
+            "ControlledByAPlayer" in blob || "ControlledByPlayer" in blob -> return null
+        }
+        return Call("TargetFilter", listOf(arg(g)))
+    }
     // "non-Mount creature" / "non-<creature-type> creature" (Sterling Keykeeper): a negated creature
     // subtype (IsNonCreatureType). TargetFilter has no `.notSubtype` passthrough, so render the
     // GameObjectFilter form wrapped in TargetFilter. Only the bare negated subtype (optionally a
@@ -220,8 +240,15 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     // ControlledByAPlayer clause. Preserve it as a `.youControl()` / `.opponentControls()` suffix; never
     // drop it (an unrestricted target would let the spell hit any creature). Only the plain-creature
     // path below can compose it, so the special shapes scaffold when a controller clause is present.
+    // `ControlledByAPlayer` is the generic "you / an opponent" controller clause; `ControlledByPlayer`
+    // names a specific player ref (e.g. the attack trigger's defending player). Either is a controller
+    // restriction that must be preserved or the card declines — never silently widened.
+    val hasController = "ControlledByAPlayer" in blob || "ControlledByPlayer" in blob
     val controller: Link? = when {
-        "ControlledByAPlayer" !in blob -> null
+        !hasController -> null
+        // "target creature defending player controls" in an attack trigger (Spring Splasher): the
+        // defending player is by definition an opponent of the attacking source's controller.
+        "\"Trigger_DefendingPlayer\"" in blob -> Link("opponentControls")
         "\"Opponent\"" in blob -> Link("opponentControls")
         "\"You\"" in blob -> Link("youControl")
         // "a creature that player controls" in a combat-damage trigger: the player ~ dealt damage to is an
@@ -229,7 +256,6 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         "\"Trigger_ThatPlayer\"" in blob -> Link("opponentControls")
         else -> return null
     }
-    val hasController = "ControlledByAPlayer" in blob
     // Whole-creature shapes whose helpers live on GameObjectFilter (not TargetFilter), or are a named
     // TargetFilter constant. ONS targets use these in isolation, so render them as the whole filter.
     if ("IsAttacking" in blob && "IsBlocking" in blob) {

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -237,6 +237,30 @@ class TargetRecoveryTest : StringSpec({
         ctx.creatureFilterDsl(dealtDamageGoblin).shouldBeNull()
     }
 
+    "creatureFilterDsl renders a non-outlaw creature via notAnyOfSubtypes (Shoot the Sheriff)" {
+        // "destroy target non-outlaw creature" — IsNonOutlaw excludes the five outlaw creature types at
+        // once; it must render the exact filter Targets.NonOutlawCreature compiles to, not drop to "creature".
+        val nonOutlaw = obj(
+            """{"_Permanents":"And","args":[""" +
+                """{"_Permanents":"IsNonOutlaw"},""" +
+                """{"_Permanents":"IsCardtype","args":"Creature"}]}""",
+        )
+        ctx.creatureFilterDsl(nonOutlaw) shouldBe
+            "TargetFilter(GameObjectFilter.Creature.notAnyOfSubtypes(Subtype.OUTLAW_TYPES))"
+    }
+
+    "creatureFilterDsl renders 'defending player controls' as opponentControls (Spring Splasher)" {
+        // "target creature defending player controls" in an attack trigger — a ControlledByPlayer clause
+        // bound to Trigger_DefendingPlayer (an opponent of the attacking source); must preserve the
+        // controller restriction rather than widen to any creature.
+        val defendingPlayer = obj(
+            """{"_Permanents":"And","args":[""" +
+                """{"_Permanents":"IsCardtype","args":"Creature"},""" +
+                """{"_Permanents":"ControlledByPlayer","args":{"_Player":"Trigger_DefendingPlayer"}}]}""",
+        )
+        ctx.creatureFilterDsl(defendingPlayer) shouldBe "TargetFilter.Creature.opponentControls()"
+    }
+
     "gameObjectFilterDsl renders an outlaw filter via withAnyOfSubtypes (Vial Smasher)" {
         // "another outlaw you control" — IsAnOutlaw must render the outlaw creature group, not widen to
         // any permanent.


### PR DESCRIPTION
## Summary

`just coverage-verify OTJ` reported 4 gameplay-tree mismatches. None were in the recent OTJ batch (flashback / conditional-flash / impulse shapes) — they were pre-existing emitter target/filter-recovery drift surfaced by live analysis (OTJ has no committed emitter-golden fixture). Each is fixed at the right layer — **render correctly or canonicalize**, never silently emit a lossy approximation — with **POR staying 0-mismatch** and the **EmitterGoldenTest unchanged** (no committed fixture card uses these shapes).

OTJ gate now **PASS** (93/120 auto-emitted & verified, was 89).

## The four mismatches

| Card | Was | Fix |
|------|-----|-----|
| **Shoot the Sheriff** | dropped the non-outlaw constraint → `creature` | render `Creature.notAnyOfSubtypes(Subtype.OUTLAW_TYPES)` — the exact filter `Targets.NonOutlawCreature` compiles to; decline if any other predicate is present |
| **Spring Splasher** | dropped "defending player controls" → `creature` | recover `ControlledByPlayer{Trigger_DefendingPlayer}` as `.opponentControls()`; `ControlledByPlayer` now counts as a controller clause so unknown refs decline rather than widen |
| **Magebane Lizard** | `PlayerRef(TriggeringPlayer)` | in a `WhenAPlayerCastsASpell` trigger the triggering entity is the *spell*, so the "that player" damage recipient is the caster → `EffectTarget.ControllerOfTriggeringEntity`; threaded via a per-render `triggeringEntityIsSpell` flag (every other trigger unchanged) |
| **Desperate Bloodseeker** | n/a — emitter was already correct | the diff was a target-requirement `id` the fidelity normalizer didn't canonicalize, because the effect references the target *positionally* (`ContextPlayer`), not by `BoundVariable` name. `canonicalizeTargetRefs` now collapses an unreferenced requirement id to `"target"`; referenced (binding-reorder) ids are untouched |

`Archmage's Newt` remains correctly on the emitter's NOT-EMITTED list (runtime flashback grant declined, not approximated).

## Tests
- New `TargetRecoveryTest` cases: non-outlaw creature, defending-player controller.
- `just coverage-verify OTJ` → GATE PASS (0 mismatch).
- `just coverage-verify-all` → EmitterGoldenTest pass + POR GATE PASS (158/158, 0 mismatch).
- `:mtgish-tooling:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)