### PR TITLE
Model "any combination of colors" as a true per-mana split; fix cost-trigger ordering for multi-pause mana abilities

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -462,14 +462,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `CombatManager.endCombat`. See [ManaExpiry](#manaexpiry).
 - `AddColorlessMana(amount, restriction?)` — add colorless.
 - `AddManaOfChoice(colorSet, amount?, restriction?, riders?)` — **unified primitive.** Add N mana of one color the controller picks from a resolved [ManaColorSet](#manacolorset). All "any-color from a constrained pool" cards (any color, commander identity, among permanents, lands could produce, source-chosen color) are expressed as this effect plus a different `ManaColorSet`. `riders` is a `Set<ManaSpellRider>` consumed when the mana pays for a spell (e.g. Path of Ancestry tags its mana with `ScryOnSharedTypeWithCommander`); when riders are set without a `restriction`, the engine stores the entries under `ManaRestriction.AnySpend` to preserve the rider through the pool.
-- `AddAnyColorMana(amount?, restriction?)` — sugar for `AddManaOfChoice(ManaColorSet.AnyColor, amount)`.
+- `AddAnyColorMana(amount?, restriction?)` — sugar for `AddManaOfChoice(ManaColorSet.AnyColor, amount)`. "Add N mana of any **one** color" (Gilded Lotus): one chosen color, N of it. For "any **combination** of colors" use `AddManaInAnyCombination`.
 - `AddManaOfChosenColor(amount?)` — sugar for `AddManaOfChoice(ManaColorSet.SourceChosenColor, amount)`.
 - `AddManaOfColorAmong(filter)` — sugar for `AddManaOfChoice(ManaColorSet.AmongPermanents(filter))`.
 - `AddManaOfColorLandsCouldProduce(scope)` — sugar for `AddManaOfChoice(ManaColorSet.LandsCouldProduce(scope))`. Fellwar Stone / Exotic Orchard / Reflecting Pool shape.
 - `AddManaOfColorInCommanderColorIdentity()` — sugar for `AddManaOfChoice(ManaColorSet.CommanderIdentity)`. Arcane Signet / Command Tower shape.
 - `AddAnyColorManaSpendOnChosenType(typeName)` — mana that can only pay for a specific card type (kept separate because it derives a runtime [ManaRestriction] from the source's chosen subtype).
 - `AddDynamicMana(amount, allowedColors, restriction?)` — split X across a fixed color set, distinct from `AddManaOfChoice` because it distributes the full X total across multiple colors rather than producing X copies of one chosen color.
-- `AddManaInAnyCombination(colors, amount)` — split N across colors (alias for `AddDynamicMana`).
+- `AddManaInAnyCombination(amount, allowedColors?, restriction?)` — "Add N mana in any combination of colors" (Wizard's Rockets, Thornvault Forager, Interdimensional Web Watch). Sugar for `AddDynamicMana`; `allowedColors` defaults to all five. The controller colors **each** pip independently at resolution (3+ colors → pip-by-pip color choice; 2 colors → one "how much of the first" prompt; ≤0 → no mana, no prompt), so the result can mix colors — distinct from `AddAnyColorMana`, where all N share one color.
 - `AddOneManaOfEachColorAmong(filter)` — one mana of *each* color found among matching permanents (Bloom Tender shape).
 - `PayDynamicMana(amount, payer?)` — pay a dynamically-computed amount of **generic** mana at resolution; the
   dynamic, payer-parametric twin of the flat `PayManaCostEffect`. `amount` is a [DynamicAmount](#dynamicamount)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1122,7 +1122,11 @@ object Effects {
         restriction: ManaRestriction? = null,
     ): Effect = AddManaOfChoiceEffect(colorSet, amount, restriction)
 
-    /** Add one mana of any color — the original "any-color" shape, kept for readability. */
+    /**
+     * Add N mana of any *one* color ("Add three mana of any one color" — Gilded Lotus):
+     * the player picks a single color and gets [amount] of it. For "any **combination** of
+     * colors" (each mana independently colored), use [AddManaInAnyCombination] instead.
+     */
     fun AddAnyColorMana(amount: Int = 1, restriction: ManaRestriction? = null): Effect =
         AddManaOfChoiceEffect(ManaColorSet.AnyColor, DynamicAmount.Fixed(amount), restriction)
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ThornvaultForager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ThornvaultForager.kt
@@ -38,7 +38,7 @@ val ThornvaultForager = card("Thornvault Forager") {
     // {T}, Forage: Add two mana in any combination of colors
     activatedAbility {
         cost = Costs.Composite(Costs.Tap, Costs.Forage())
-        effect = Effects.AddAnyColorMana(2)
+        effect = Effects.AddManaInAnyCombination(2)
         manaAbility = true
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/Flamebraider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/Flamebraider.kt
@@ -25,7 +25,7 @@ val Flamebraider = card("Flamebraider") {
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddAnyColorMana(
+        effect = Effects.AddManaInAnyCombination(
             amount = 2,
             restriction = ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Elemental")
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WizardsRockets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WizardsRockets.kt
@@ -31,7 +31,7 @@ val WizardsRockets = card("Wizard's Rockets") {
     // {X}, {T}, Sacrifice this artifact: Add X mana in any combination of colors.
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap, Costs.SacrificeSelf)
-        effect = Effects.AddAnyColorMana(DynamicAmount.XValue)
+        effect = Effects.AddManaInAnyCombination(DynamicAmount.XValue)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -20004,11 +20004,18 @@
                     ]
                 },
                 "effect": {
-                    "type": "AddManaOfChoice",
-                    "amount": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
                         "type": "Fixed",
                         "amount": 2
-                    }
+                    },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ]
                 },
                 "isManaAbility": true
             },

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -7135,11 +7135,18 @@
                 "id": "ability_1",
                 "cost": "CostTap",
                 "effect": {
-                    "type": "AddManaOfChoice",
-                    "amount": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
                         "type": "Fixed",
                         "amount": 2
                     },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ],
                     "restriction": {
                         "type": "SubtypeSpellsOrAbilitiesOnly",
                         "subtype": "Elemental"

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -14678,8 +14678,15 @@
                     ]
                 },
                 "effect": {
-                    "type": "AddManaOfChoice",
-                    "amount": "XValue"
+                    "type": "AddDynamicMana",
+                    "amountSource": "XValue",
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ]
                 },
                 "timing": "ManaAbility",
                 "isManaAbility": true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -835,12 +835,12 @@ class ActivateAbilityHandler(
                         decisionId = "mana-ability-cost-triggers-${java.util.UUID.randomUUID()}",
                         remainingTriggers = deferred
                     )
-                    val stack = effectResult.state.continuationStack
-                    val newStack = if (stack.isNotEmpty()) {
-                        stack.dropLast(1) + pending + stack.last()
-                    } else {
-                        listOf(pending)
-                    }
+                    // Insert at the BOTTOM of the continuation stack so the cost trigger is put on
+                    // the stack only after the whole mana ability finishes resolving — including a
+                    // multi-step "any combination of colors" effect that pauses once per mana. The
+                    // stack here holds only frames pushed by this activation's effect, so bottom
+                    // insertion can't jump ahead of unrelated work.
+                    val newStack = listOf(pending) + effectResult.state.continuationStack
                     return ExecutionResult.paused(
                         effectResult.state.copy(continuationStack = newStack),
                         effectResult.pendingDecision!!,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsRocketsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsRocketsScenarioTest.kt
@@ -81,7 +81,7 @@ class WizardsRocketsScenarioTest : ScenarioTestBase() {
                 }
             }
 
-            test("paying X=2 adds two mana and still draws a card") {
+            test("paying X=2 lets each mana be colored independently (true combination)") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardOnBattlefield(1, "Wizard's Rockets", tapped = false, summoningSickness = false)
@@ -105,20 +105,56 @@ class WizardsRocketsScenarioTest : ScenarioTestBase() {
                     activation.error shouldBe null
                 }
 
-                // Choose the color for the X mana produced.
-                if (game.hasPendingDecision()) {
-                    game.submitDecision(ColorChosenResponse(game.getPendingDecision()!!.id, Color.RED))
+                // "Any combination of colors" prompts once per mana — colour the first RED and
+                // the second BLUE to prove they're chosen independently (not one colour ×2).
+                val colors = listOf(Color.RED, Color.BLUE)
+                var i = 0
+                while (game.hasPendingDecision()) {
+                    val color = colors.getOrElse(i++) { Color.RED }
+                    game.submitDecision(ColorChosenResponse(game.getPendingDecision()!!.id, color))
                 }
 
                 val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
-                withClue("Wizard's Rockets should add X=2 mana of the chosen color") {
-                    pool?.red shouldBe 2
+                withClue("X=2 should add one RED and one BLUE (a true colour combination)") {
+                    pool?.red shouldBe 1
+                    pool?.blue shouldBe 1
                 }
 
                 game.resolveStack()
 
                 withClue("The sacrifice's draw trigger still fires when X mana is produced") {
                     game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("X=2 may also be taken as two of the same colour") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wizard's Rockets", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rockets = game.findPermanent("Wizard's Rockets")!!
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rockets,
+                        abilityId = manaAbilityId,
+                        xValue = 2
+                    )
+                )
+                withClue("Activating with X=2 should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                while (game.hasPendingDecision()) {
+                    game.submitDecision(ColorChosenResponse(game.getPendingDecision()!!.id, Color.GREEN))
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Both mana coloured green → two green") {
+                    pool?.green shouldBe 2
                 }
             }
         }


### PR DESCRIPTION
## What

Two related fixes around mana abilities that produce mana in *any combination of colors*.

### 1. Card semantics: true per-mana color split
Thornvault Forager, Flamebraider, and Wizard's Rockets print **"add N mana in any combination of colors"**, but were modeled with `Effects.AddAnyColorMana(N)` — which produces N mana of a *single* chosen color. Routed them to `Effects.AddManaInAnyCombination(N)` so each pip is colored independently at resolution. (The primitive already existed; this just points the cards at it.)

### 2. Cost-trigger ordering for mana abilities that pause more than once
`ActivateAbilityHandler` deferred a mana ability's cost-triggered abilities (e.g. the dies trigger from `Costs.SacrificeSelf`) by inserting the pending-triggers frame second-from-top of the continuation stack:

```kotlin
stack.dropLast(1) + pending + stack.last()
```

That's correct only when the mana effect pauses **once**. "Any combination of colors" pauses **once per mana** (one color choice per pip), leaving multiple frames on the stack — so second-from-top insertion would put the dies trigger on the stack ahead of the remaining mana-production frames. Now the pending frame is inserted at the **bottom**, so the cost trigger only goes on the stack after the whole mana ability finishes resolving. Safe because the stack at this point holds only frames pushed by this activation's effect.

This is the follow-on to the cost-trigger work in #626 (Wizard's Rockets).

## Tests
- Rewrote `WizardsRocketsScenarioTest` to prove independent coloring (X=2 → one RED + one BLUE) and added a case for two-of-one-color.
- `CardDefinitionSnapshotTest` re-blessed for BLB / ECL / LTR; `CardLintTest` green.
- Updated `docs/card-sdk-language-reference.md` to distinguish `AddAnyColorMana` (one color ×N) from `AddManaInAnyCombination` (per-pip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)