### PR TITLE
Close remaining fail-open defaults: three-valued controller-predicate fold + real CollectionNonEmpty gating

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -684,9 +684,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     enforced corpus-wide by `SuccessCriterionValidationTest`) rejects an Auto criterion on any other
     action — non-zone-move actions (deal damage, gain life, …) must state `SuccessCriterion.Always`
     or `CollectionNonEmpty(name, min)` explicitly instead of silently inheriting a fail-open
-    "it happened". The executor pre-pushes a `GatedActionContinuation` so a paused action
-    auto-resumes and evaluates after its own continuations drain. Replaces `IfYouDoEffect` (see
-    "Sequencing & conditional" below).
+    "it happened". `CollectionNonEmpty` gates on the action's actual pipeline collection
+    (`storedCollections[name].size >= min` after the action runs) — the collections propagate onto
+    the gate frame via `exposeCollectionsToNextFrame`, in both the synchronous and the
+    paused/continuation-drain paths. The executor pre-pushes a `GatedActionContinuation` so a paused
+    action auto-resumes and evaluates after its own continuations drain. Replaces `IfYouDoEffect`
+    (see "Sequencing & conditional" below).
   - `Gate.MayPayX` — **not a yes/no, a number chooser.** "You may pay {X}. If you do, [then]." The
     decision-maker is prompted for a number 0..(most generic mana they can produce); paying X > 0
     succeeds → `then` runs with the chosen X bound into the context (read via `DynamicAmount.XValue`),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
@@ -131,10 +131,25 @@ sealed interface ControllerPredicate {
  * notions (live projected state, zone-change last-known-controller snapshots, grant-provider
  * fast paths). Each site supplies only its own leaf semantics and shares the combinator
  * logic through this fold, so a composed predicate behaves consistently everywhere.
+ *
+ * **Unsupported leaves.** A site that can't evaluate a leaf kind returns `null` ("unknown"),
+ * NOT `true` — unknowns propagate through the combinators with three-valued (Kleene) logic
+ * and only resolve to "don't constrain" (match) at the root. This keeps "the site ignores
+ * predicates it can't see" consistent under negation: with a boolean leaf fallback,
+ * `Not(unsupported)` would flip the fail-open into rejecting everything.
  */
-fun ControllerPredicate.evaluateWith(leaf: (ControllerPredicate) -> Boolean): Boolean = when (this) {
-    is ControllerPredicate.And -> predicates.all { it.evaluateWith(leaf) }
-    is ControllerPredicate.Or -> predicates.any { it.evaluateWith(leaf) }
-    is ControllerPredicate.Not -> !predicate.evaluateWith(leaf)
+fun ControllerPredicate.evaluateWith(leaf: (ControllerPredicate) -> Boolean?): Boolean =
+    evaluateOrUnknown(leaf) ?: true
+
+private fun ControllerPredicate.evaluateOrUnknown(leaf: (ControllerPredicate) -> Boolean?): Boolean? = when (this) {
+    is ControllerPredicate.And -> {
+        val branches = predicates.map { it.evaluateOrUnknown(leaf) }
+        if (false in branches) false else if (null in branches) null else true
+    }
+    is ControllerPredicate.Or -> {
+        val branches = predicates.map { it.evaluateOrUnknown(leaf) }
+        if (true in branches) true else if (null in branches) null else false
+    }
+    is ControllerPredicate.Not -> predicate.evaluateOrUnknown(leaf)?.let { !it }
     else -> leaf(this)
 }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/GameObjectFilterCompositionTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/GameObjectFilterCompositionTest.kt
@@ -77,6 +77,29 @@ class GameObjectFilterCompositionTest : DescribeSpec({
             ).evaluateWith(leaf) shouldBe true
         }
 
+        it("unsupported leaves (null) don't constrain — even under Not") {
+            // Leaf semantics of a site that only understands ControlledByYou (= true here).
+            val partial: (ControllerPredicate) -> Boolean? =
+                { if (it == ControllerPredicate.ControlledByYou) true else null }
+
+            // A bare unsupported leaf matches (don't constrain) …
+            ControllerPredicate.OwnedByYou.evaluateWith(partial) shouldBe true
+            // … and so does its negation: unknown propagates through Not instead of flipping
+            // "ignore this predicate" into "reject everything".
+            ControllerPredicate.Not(ControllerPredicate.OwnedByYou).evaluateWith(partial) shouldBe true
+
+            // Supported branches still constrain alongside unknowns.
+            ControllerPredicate.And(
+                listOf(ControllerPredicate.ControlledByYou, ControllerPredicate.OwnedByYou)
+            ).evaluateWith(partial) shouldBe true
+            ControllerPredicate.And(
+                listOf(ControllerPredicate.Not(ControllerPredicate.ControlledByYou), ControllerPredicate.OwnedByYou)
+            ).evaluateWith(partial) shouldBe false
+            ControllerPredicate.Or(
+                listOf(ControllerPredicate.Not(ControllerPredicate.ControlledByYou), ControllerPredicate.OwnedByYou)
+            ).evaluateWith(partial) shouldBe true
+        }
+
         it("survives a JSON round-trip inside a filter") {
             val filter = GameObjectFilter.Permanent.withControllerPredicate(
                 ControllerPredicate.And(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -155,7 +155,7 @@ class TriggerAbilityResolver(
                     when (leaf) {
                         is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
                         is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
-                        else -> true
+                        else -> null // leaf kinds this fast path can't evaluate don't constrain
                     }
                 } ?: true
                 if (controllerMatch) {
@@ -280,7 +280,7 @@ class TriggerAbilityResolver(
                     when (leaf) {
                         is ControllerPredicate.ControlledByYou -> targetControllerId == entry.sourceControllerId
                         is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != entry.sourceControllerId
-                        else -> true
+                        else -> null // leaf kinds this fast path can't evaluate don't constrain
                     }
                 } ?: true
                 if (controllerMatch) add(entry.grant.ability)
@@ -416,7 +416,7 @@ class TriggerAbilityResolver(
                     when (leaf) {
                         is ControllerPredicate.ControlledByYou -> targetControllerId == sourceControllerId
                         is ControllerPredicate.ControlledByOpponent -> targetControllerId != null && targetControllerId != sourceControllerId
-                        else -> true
+                        else -> null // leaf kinds this fast path can't evaluate don't constrain
                     }
                 } ?: true
                 if (!controllerMatch) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -677,7 +677,7 @@ class TriggerMatcher(
                         is ControllerPredicate.ControlledByOpponent -> effectiveController != controllerId
                         is ControllerPredicate.OwnedByYou -> event.ownerId == controllerId
                         is ControllerPredicate.OwnedByOpponent -> event.ownerId != controllerId
-                        else -> true
+                        else -> null // leaf kinds this LKI site can't evaluate don't constrain
                     }
                 }
                 if (!controllerMatches) return false
@@ -955,7 +955,7 @@ class TriggerMatcher(
                     when (leaf) {
                         is ControllerPredicate.ControlledByYou -> targetController == controllerId
                         is ControllerPredicate.ControlledByOpponent -> targetController != controllerId
-                        else -> true
+                        else -> null // leaf kinds this site can't evaluate don't constrain
                     }
                 }
                 if (!controllerMatches) return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
@@ -51,42 +51,10 @@ class AmassContinuationResumer(
         // The synchronous Amass paths thread `updatedCollections` (the AmassedArmy pipeline
         // slot) back through the composite executor. The multi-Army resume path runs after
         // the parent has already pushed its continuation, so we inject the slot into that
-        // pending frame directly — same pattern as LibraryAndZoneContinuationResumer.
-        // Both EffectContinuation (composite siblings, e.g. AmassedArmyReferenceScenarioTest)
-        // and ReflexiveTriggerTargetContinuation (`When you do, …` reflexive triggers like
-        // Foray of Orcs) carry an effectContext whose pipeline.storedCollections is read
-        // by the next effect's evaluator.
-        val stateWithArmyExposed = if (result.updatedCollections.isNotEmpty()) {
-            when (val nextFrame = result.state.peekContinuation()) {
-                is EffectContinuation -> {
-                    val (_, stateAfterPop) = result.state.popContinuation()
-                    stateAfterPop.pushContinuation(
-                        nextFrame.copy(
-                            effectContext = nextFrame.effectContext.copy(
-                                pipeline = nextFrame.effectContext.pipeline.copy(
-                                    storedCollections = nextFrame.effectContext.pipeline.storedCollections + result.updatedCollections
-                                )
-                            )
-                        )
-                    )
-                }
-                is ReflexiveTriggerTargetContinuation -> {
-                    val (_, stateAfterPop) = result.state.popContinuation()
-                    stateAfterPop.pushContinuation(
-                        nextFrame.copy(
-                            effectContext = nextFrame.effectContext.copy(
-                                pipeline = nextFrame.effectContext.pipeline.copy(
-                                    storedCollections = nextFrame.effectContext.pipeline.storedCollections + result.updatedCollections
-                                )
-                            )
-                        )
-                    )
-                }
-                else -> result.state
-            }
-        } else {
-            result.state
-        }
+        // pending frame directly via the shared propagation seam (composite siblings,
+        // `When you do, …` reflexive triggers like Foray of Orcs, and DoAction gates all
+        // read pipeline.storedCollections off their frame's effectContext).
+        val stateWithArmyExposed = exposeCollectionsToNextFrame(result.state, result.updatedCollections)
 
         return checkForMore(stateWithArmyExposed, result.events)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -111,7 +111,15 @@ class CoreAutoResumerModule(
             if (runResult.isPaused) {
                 return@autoResumer ExecutionResult.paused(runResult.state, runResult.pendingDecision!!, events + runResult.events)
             }
-            checkForMore(runResult.state, events + runResult.events)
+            // A drained composite hands its pipeline collections to the frame beneath —
+            // e.g. a DoAction gate scoring SuccessCriterion.CollectionNonEmpty. The full
+            // frame map (not just this drain's accumulation) is what propagates: keys
+            // injected into this frame by an earlier select-resume are part of it.
+            val stateWithCollections = exposeCollectionsToNextFrame(
+                runResult.state,
+                continuation.effectContext.pipeline.storedCollections + runResult.updatedCollections
+            )
+            checkForMore(stateWithCollections, events + runResult.events)
         },
 
         autoResumer(RepeatWhileContinuation::class, canResume = { it.phase == RepeatWhilePhase.AFTER_BODY }) { state, continuation, events, checkForMore ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -47,7 +47,15 @@ class EffectAndTriggerContinuationResumer(
     ): ExecutionResult {
         val effectResult = effectRunner.executeRemainingEffects(state, continuation.remainingEffects, continuation.effectContext)
         if (effectResult.isPaused) return effectResult.toExecutionResult()
-        return checkForMore(effectResult.state, effectResult.events.toList())
+        // A drained composite hands its pipeline collections to the frame beneath —
+        // e.g. a DoAction gate scoring SuccessCriterion.CollectionNonEmpty. The full
+        // frame map (not just this drain's accumulation) is what propagates: keys
+        // injected into this frame by an earlier select-resume are part of it.
+        val stateWithCollections = exposeCollectionsToNextFrame(
+            effectResult.state,
+            continuation.effectContext.pipeline.storedCollections + effectResult.updatedCollections
+        )
+        return checkForMore(stateWithCollections, effectResult.events.toList())
     }
 
     private fun resumeTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -485,16 +485,8 @@ class LibraryAndZoneContinuationResumer(
             updatedCollections[continuation.storeRemainder] = remainder
         }
 
-        // Inject updated collections into the next EffectContinuation on the stack (if present)
-        val nextFrame = state.peekContinuation()
-        val newState = if (nextFrame is EffectContinuation) {
-            val (_, stateAfterPop) = state.popContinuation()
-            stateAfterPop.pushContinuation(
-                nextFrame.copy(effectContext = nextFrame.effectContext.copy(pipeline = nextFrame.effectContext.pipeline.copy(storedCollections = updatedCollections)))
-            )
-        } else {
-            state
-        }
+        // Inject updated collections into the consumer frame beneath (if any)
+        val newState = exposeCollectionsToNextFrame(state, updatedCollections)
 
         return checkForMore(newState, emptyList())
     }
@@ -527,15 +519,7 @@ class LibraryAndZoneContinuationResumer(
         updatedCollections[continuation.storeChosenAs] = chosen
         updatedCollections[continuation.storeOtherAs] = other
 
-        val nextFrame = state.peekContinuation()
-        val newState = if (nextFrame is EffectContinuation) {
-            val (_, stateAfterPop) = state.popContinuation()
-            stateAfterPop.pushContinuation(
-                nextFrame.copy(effectContext = nextFrame.effectContext.copy(pipeline = nextFrame.effectContext.pipeline.copy(storedCollections = updatedCollections)))
-            )
-        } else {
-            state
-        }
+        val newState = exposeCollectionsToNextFrame(state, updatedCollections)
 
         return checkForMore(newState, emptyList())
     }
@@ -563,16 +547,8 @@ class LibraryAndZoneContinuationResumer(
         val updatedCollections = continuation.storedCollections.toMutableMap()
         updatedCollections[continuation.storeAs] = selectedTargetIds
 
-        // Inject updated collections into the next EffectContinuation on the stack (if present)
-        val nextFrame = state.peekContinuation()
-        val newState = if (nextFrame is EffectContinuation) {
-            val (_, stateAfterPop) = state.popContinuation()
-            stateAfterPop.pushContinuation(
-                nextFrame.copy(effectContext = nextFrame.effectContext.copy(pipeline = nextFrame.effectContext.pipeline.copy(storedCollections = updatedCollections)))
-            )
-        } else {
-            state
-        }
+        // Inject updated collections into the consumer frame beneath (if any)
+        val newState = exposeCollectionsToNextFrame(state, updatedCollections)
 
         return checkForMore(newState, emptyList())
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.EffectContinuation
+import com.wingedsheep.engine.core.GatedActionContinuation
+import com.wingedsheep.engine.core.ReflexiveTriggerTargetContinuation
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Merge pipeline [collections] produced by a resolved continuation into the next frame's
+ * effect context, so the consumer beneath sees what the drained step stored.
+ *
+ * Pipeline storage lives in [EffectContext], which is frozen into each continuation frame
+ * when it is pushed — a frame pushed *before* its action ran (the pre-push pattern) holds a
+ * pre-action context. This helper is the propagation seam: every resumer that finishes a
+ * collection-producing step routes its `updatedCollections` here, and the recognized
+ * consumer frames get a merged context:
+ *
+ * - [EffectContinuation] — remaining composite siblings read the collections
+ *   (the original LibraryAndZone inject pattern).
+ * - [ReflexiveTriggerTargetContinuation] — "When you do, …" reflexive effects
+ *   (the Amass multi-Army path).
+ * - [GatedActionContinuation] — a `Gate.DoAction` frame whose
+ *   [com.wingedsheep.sdk.scripting.effects.SuccessCriterion.CollectionNonEmpty] criterion
+ *   (and `then`/`otherwise` branches) must see the collections the action produced.
+ *
+ * Unknown frame types are left untouched (they don't read pipeline storage).
+ */
+fun exposeCollectionsToNextFrame(
+    state: GameState,
+    collections: Map<String, List<EntityId>>
+): GameState {
+    if (collections.isEmpty()) return state
+
+    fun EffectContext.withMergedCollections(): EffectContext =
+        copy(pipeline = pipeline.copy(storedCollections = pipeline.storedCollections + collections))
+
+    return when (val next = state.peekContinuation()) {
+        is EffectContinuation -> {
+            val (_, popped) = state.popContinuation()
+            popped.pushContinuation(next.copy(effectContext = next.effectContext.withMergedCollections()))
+        }
+        is ReflexiveTriggerTargetContinuation -> {
+            val (_, popped) = state.popContinuation()
+            popped.pushContinuation(next.copy(effectContext = next.effectContext.withMergedCollections()))
+        }
+        is GatedActionContinuation -> {
+            val (_, popped) = state.popContinuation()
+            popped.pushContinuation(next.copy(effectContext = next.effectContext.withMergedCollections()))
+        }
+        else -> state
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -545,7 +545,7 @@ object ZoneMovementUtils {
                     val controllerId = container.get<ControllerComponent>()?.playerId
                     controllerId != null && controllerId != sourceControllerId
                 }
-                else -> true
+                else -> null // leaf kinds this site can't evaluate don't constrain
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -393,15 +393,23 @@ class GatedEffectExecutor(
         }
 
         // Action ran synchronously (success or recoverable error). Pop our pre-pushed
-        // continuation and evaluate the outcome inline.
+        // continuation and evaluate the outcome inline. Collections the action produced
+        // are merged into the context so a CollectionNonEmpty criterion (and the chosen
+        // branch) can read them — the paused path gets the same data via
+        // exposeCollectionsToNextFrame updating the pre-pushed frame.
         val (_, stateWithoutCont) = result.state.popContinuation()
+        val contextWithCollections = if (result.updatedCollections.isEmpty()) context else context.copy(
+            pipeline = context.pipeline.copy(
+                storedCollections = context.pipeline.storedCollections + result.updatedCollections
+            )
+        )
         return evaluateAndDispatch(
             state = stateWithoutCont,
             then = effect.then,
             otherwise = effect.otherwise,
             criterion = gate.successCriterion,
             snapshot = snapshot,
-            effectContext = context,
+            effectContext = contextWithCollections,
             priorEvents = result.events,
             effectExecutor = effectExecutor
         )
@@ -482,7 +490,7 @@ class GatedEffectExecutor(
             priorEvents: List<GameEvent>,
             effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
         ): EffectResult {
-            val happened = evaluate(state, criterion, snapshot)
+            val happened = evaluate(state, criterion, snapshot, effectContext)
             val branch = if (happened) then else otherwise
                 ?: return EffectResult.success(state, priorEvents)
             val branchResult = effectExecutor(state, branch, effectContext)
@@ -491,19 +499,22 @@ class GatedEffectExecutor(
 
         /**
          * Did the action accomplish its work, given the snapshot taken before it ran?
+         *
+         * [effectContext] carries the action's pipeline collections: the synchronous path
+         * merges the action result's `updatedCollections` in before dispatch, and the paused
+         * path receives them via `exposeCollectionsToNextFrame` updating the pre-pushed
+         * [GatedActionContinuation] when the action's last collection-producing step resolves.
          */
         private fun evaluate(
             state: GameState,
             criterion: SuccessCriterion,
-            snapshot: GatedActionSnapshot
+            snapshot: GatedActionSnapshot,
+            effectContext: EffectContext
         ): Boolean = when (criterion) {
             is SuccessCriterion.Always -> true
             is SuccessCriterion.Auto -> evaluateAuto(state, snapshot)
             is SuccessCriterion.CollectionNonEmpty ->
-                // Pipeline storage doesn't propagate up to this level after resume — until that
-                // plumbing exists, fall back to Auto's zone-delta probe (set by captureSnapshot
-                // when the action's terminal move is recognized).
-                evaluateAuto(state, snapshot)
+                (effectContext.pipeline.storedCollections[criterion.name]?.size ?: 0) >= criterion.min
         }
 
         private fun evaluateAuto(state: GameState, snapshot: GatedActionSnapshot): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -280,7 +280,7 @@ internal class AffectsFilterResolver {
                         ControllerPredicate.ControlledByYou -> entityController == controller
                         ControllerPredicate.ControlledByOpponent -> entityController != controller
                         ControllerPredicate.ControlledByAny -> true
-                        else -> true // other predicates not applicable in static ability context
+                        else -> null // other predicates not applicable in static ability context
                     }
                 }
                 if (!controllerMatches) return@filter false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectionNonEmptyCriterionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectionNonEmptyCriterionScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.matchers.shouldBe
+
+/**
+ * [SuccessCriterion.CollectionNonEmpty] must gate a `Gate.DoAction` on the actual pipeline
+ * collection the action stored — both when the action drains through continuations (the
+ * select pauses for a decision) and on the declined path. Before the collection-propagation
+ * seam ([com.wingedsheep.engine.handlers.continuations.exposeCollectionsToNextFrame]) the
+ * criterion silently fell back to the Auto zone-probe's "it happened" default, so the
+ * declined path below would have (wrongly) drawn a card instead of losing life.
+ */
+class CollectionNonEmptyCriterionScenarioTest : ScenarioTestBase() {
+
+    // "Exile up to one card from your graveyard. If you do, draw a card.
+    //  Otherwise, you lose 1 life."
+    private val scavengersBargain = card("Scavenger's Bargain") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        oracleText = "Exile up to one card from your graveyard. If you do, draw a card. Otherwise, you lose 1 life."
+        spell {
+            effect = Effects.IfYouDo(
+                action = Effects.Composite(
+                    GatherCardsEffect(CardSource.FromZone(Zone.GRAVEYARD), storeAs = "gathered"),
+                    SelectFromCollectionEffect(
+                        from = "gathered",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                        storeSelected = "exiled",
+                    ),
+                    MoveCollectionEffect(from = "exiled", destination = CardDestination.ToZone(Zone.EXILE)),
+                ),
+                ifYouDo = Effects.DrawCards(1),
+                ifYouDont = LoseLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                successCriterion = SuccessCriterion.CollectionNonEmpty("exiled"),
+            )
+        }
+    }
+
+    init {
+        cardRegistry.register(scavengersBargain)
+
+        fun buildGame() = scenario()
+            .withPlayers("Scavenger", "Opponent")
+            .withCardInGraveyard(1, "Grizzly Bears")
+            .withCardInHand(1, "Scavenger's Bargain")
+            .withCardInLibrary(1, "Forest")
+            .withLandsOnBattlefield(1, "Swamp", 1)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        test("exiling a card satisfies CollectionNonEmpty — the payoff runs") {
+            val game = buildGame()
+            val bearsId = game.state.getGraveyard(game.player1Id).single()
+
+            game.castSpell(1, "Scavenger's Bargain")
+            game.resolveStack()
+            game.selectCards(listOf(bearsId))
+
+            game.state.getExile(game.player1Id).size shouldBe 1
+            game.state.getHand(game.player1Id).size shouldBe 1 // drew the Forest
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 20
+        }
+
+        test("declining leaves the collection empty — the otherwise branch runs") {
+            val game = buildGame()
+
+            game.castSpell(1, "Scavenger's Bargain")
+            game.resolveStack()
+            game.skipSelection()
+
+            game.state.getExile(game.player1Id).size shouldBe 0
+            game.state.getHand(game.player1Id).size shouldBe 0 // no draw
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 19
+        }
+    }
+}


### PR DESCRIPTION
## What

Review follow-up to #617 (fail-open defaults closed), closing the two remaining holes.

### 1. Three-valued (Kleene) controller-predicate evaluation
Fast-path sites (`TriggerMatcher`, `TriggerAbilityResolver`) that can't evaluate a `ControllerPredicate` leaf kind returned `true` ("don't constrain"). That fail-open is wrong under negation: `Not(unsupported)` flips `true` → `false` and rejects **everything**.

`ControllerPredicate.evaluateWith` now folds with three-valued logic — an unsupported leaf returns `null` (unknown), unknowns propagate through `And`/`Or`/`Not`, and only resolve to "don't constrain" (match) at the **root**. Each site's `else` branch changed from `-> true` to `-> null`, so "ignore predicates I can't see" stays consistent under negation.

### 2. `CollectionNonEmpty` gates on the real pipeline collection
The criterion previously fell back to `evaluateAuto`'s zone-delta probe with a literal *"until that plumbing exists"* TODO. It now checks `storedCollections[name].size >= min` against the action's actual pipeline collection.

New `PipelineCollectionPropagation.kt` is the single propagation seam — `exposeCollectionsToNextFrame` merges a resolved step's collections onto the consuming frame (`EffectContinuation`, `ReflexiveTriggerTargetContinuation`, `GatedActionContinuation`), covering both the synchronous and paused/continuation-drain paths. This also **removes** net duplication: `AmassContinuationResumer` and `LibraryAndZoneContinuationResumer` now route through the shared helper.

## Tests
- New `CollectionNonEmptyCriterionScenarioTest`.
- Added negation/composition cases to `GameObjectFilterCompositionTest`.
- `GatedEffect*` and `Amass*` regressions green.
- Updated `docs/card-sdk-language-reference.md` for the real `CollectionNonEmpty` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)