### PR TITLE
Add three OTJ cards: Blood Hustler, Brimstone Roundup, Hellspur Posse Boss

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BloodHustler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BloodHustler.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Blood Hustler
+ * {1}{B}
+ * Creature — Vampire Rogue
+ * 1/1
+ *
+ * Whenever you commit a crime, put a +1/+1 counter on this creature. This ability triggers only once
+ * each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)
+ * {3}{B}: Target opponent loses 1 life and you gain 1 life.
+ */
+val BloodHustler = card("Blood Hustler") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever you commit a crime, put a +1/+1 counter on this creature. " +
+        "This ability triggers only once each turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n" +
+        "{3}{B}: Target opponent loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = AddCountersEffect(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = EffectTarget.Self
+        )
+        description = "Whenever you commit a crime, put a +1/+1 counter on this creature. " +
+            "This ability triggers only once each turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}")
+        val t = target("target", TargetOpponent())
+        effect = Effects.Composite(
+            LoseLifeEffect(1, t),
+            GainLifeEffect(1, EffectTarget.Controller)
+        )
+        description = "{3}{B}: Target opponent loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Anna Pavleeva"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg?1712355556"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BrimstoneRoundup.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BrimstoneRoundup.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brimstone Roundup
+ * {1}{R}
+ * Enchantment
+ *
+ * Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with
+ * "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ * Plot {2}{R}
+ */
+val BrimstoneRoundup = card("Brimstone Roundup") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast your second spell each turn, create a 1/1 red Mercenary " +
+        "creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. " +
+        "Activate only as a sorcery.\"\n" +
+        "Plot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+        description = "Whenever you cast your second spell each turn, create a 1/1 red Mercenary " +
+            "creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. " +
+            "Activate only as a sorcery.\""
+    }
+
+    keywordAbility(KeywordAbility.plot("{2}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Milivoj Ćeran"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg?1712355715"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HellspurPosseBoss.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HellspurPosseBoss.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hellspur Posse Boss
+ * {2}{R}{R}
+ * Creature — Lizard Rogue
+ * 2/4
+ *
+ * Other outlaws you control have haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are
+ * outlaws.)
+ * When this creature enters, create two 1/1 red Mercenary creature tokens with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *
+ * "Outlaws" are creatures with any of the [Subtype.OUTLAW_TYPES] (Assassin / Mercenary / Pirate /
+ * Rogue / Warlock; per the 2024-04-12 ruling). The haste grant uses `excludeSelf` so the Boss
+ * (itself a Rogue) does not grant haste to itself.
+ */
+val HellspurPosseBoss = card("Hellspur Posse Boss") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Rogue"
+    power = 2
+    toughness = 4
+    oracleText = "Other outlaws you control have haste. (Assassins, Mercenaries, Pirates, Rogues, " +
+        "and Warlocks are outlaws.)\n" +
+        "When this creature enters, create two 1/1 red Mercenary creature tokens with \"{T}: " +
+        "Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.HASTE,
+            GroupFilter(
+                GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(2),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+        description = "When this creature enters, create two 1/1 red Mercenary creature tokens " +
+            "with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only " +
+            "as a sorcery.\""
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "128"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg?1712355772"
+
+        ruling("2024-04-12", "A card, spell, or permanent is an outlaw if it has the Assassin, " +
+            "Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more " +
+            "than one of those creature types; as long as it has at least one, it's an outlaw.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -501,6 +501,86 @@
     ]
 }
 
+// Blood Hustler
+{
+    "name": "Blood Hustler",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Rogue",
+    "oracleText": "Whenever you commit a crime, put a +1/+1 counter on this creature. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n{3}{B}: Target opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, put a +1/+1 counter on this creature. This ability triggers only once each turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{3}{B}: Target opponent loses 1 life and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Pavleeva",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg?1712355556"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blooming Marsh
 {
     "name": "Blooming Marsh",
@@ -852,6 +932,88 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Brimstone Roundup
+{
+    "name": "Brimstone Roundup",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "UNCOMMON",
+        "artist": "Milivoj Ćeran",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg?1712355715"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3456,6 +3618,116 @@
         "artist": "Caio Monteiro",
         "flavorText": "The last fool who called him \"cowboy\" earned a free ride to the bottom of Blacksnag Bog.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg?1712355767",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Hellspur Posse Boss
+{
+    "name": "Hellspur Posse Boss",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Lizard Rogue",
+    "oracleText": "Other outlaws you control have haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhen this creature enters, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Assassin",
+                                    "Mercenary",
+                                    "Pirate",
+                                    "Rogue",
+                                    "Warlock"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "RARE",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg?1712355772",
         "rulings": [
             {
                 "date": "2024-04-12",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodHustlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodHustlerScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BloodHustler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blood Hustler — {1}{B} 1/1 Creature — Vampire Rogue
+ *
+ * "Whenever you commit a crime, put a +1/+1 counter on this creature. This ability triggers only
+ * once each turn."
+ * "{3}{B}: Target opponent loses 1 life and you gain 1 life."
+ *
+ * Verifies: a crime adds a +1/+1 counter (1/1 -> 2/2); a second crime in the same turn does NOT add
+ * a second counter (once-per-turn gate); and the drain ability swings life by 1 each way.
+ */
+class BloodHustlerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BloodHustler)
+        return driver
+    }
+
+    test("committing a crime puts a +1/+1 counter, but only once per turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val hustler = driver.putCreatureOnBattlefield(me, "Blood Hustler")
+
+        driver.state.projectedState.getPower(hustler) shouldBe 1
+        driver.state.projectedState.getToughness(hustler) shouldBe 1
+
+        // Commit a crime: cast Lightning Bolt targeting the opponent.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> commit-crime -> counter trigger on stack
+        driver.bothPass() // resolve counter trigger
+
+        driver.state.projectedState.getPower(hustler) shouldBe 2
+        driver.state.projectedState.getToughness(hustler) shouldBe 2
+
+        // Commit a second crime this turn: it must NOT add another counter (once per turn).
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.state.projectedState.getPower(hustler) shouldBe 2
+        driver.state.projectedState.getToughness(hustler) shouldBe 2
+    }
+
+    test("activated ability drains 1 life from target opponent and gains 1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val hustler = driver.putCreatureOnBattlefield(me, "Blood Hustler")
+        val abilityId = BloodHustler.activatedAbilities.first().id
+
+        driver.giveMana(me, Color.BLACK, 4)
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = hustler,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, opp))
+            )
+        )
+        result.isSuccess shouldBe true
+        // Activating an ability that targets an opponent is itself a crime, so Blood Hustler's
+        // own counter trigger also goes on the stack above the drain ability. Resolve both.
+        driver.bothPass() // resolve the once-per-turn counter trigger
+        driver.bothPass() // resolve the drain ability
+
+        driver.getLifeTotal(opp) shouldBe 19
+        driver.getLifeTotal(me) shouldBe 21
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrimstoneRoundupScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrimstoneRoundupScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Brimstone Roundup (OTJ #115, {1}{R} Enchantment).
+ *
+ *   Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with
+ *   "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *   Plot {2}{R}
+ *
+ * The trigger reuses [com.wingedsheep.sdk.dsl.Triggers.NthSpellCast] (n = 2, You), and the token is
+ * the standard OTJ Mercenary (same shape as Form a Posse). Plot is the shared keyword and is covered
+ * by other plot scenario tests; here we exercise the unique second-spell trigger + token ability.
+ */
+class BrimstoneRoundupScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Brimstone Roundup") {
+
+            test("casting your second spell each turn creates one Mercenary token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brimstone Roundup")
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn — no trigger.
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                game.state.getBattlefield().count { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Mercenary Token"
+                } shouldBe 0
+
+                // Second spell — triggers the token creation.
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                withClue("The second spell created exactly one Mercenary token") {
+                    game.state.getBattlefield().count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Mercenary Token"
+                    } shouldBe 1
+                }
+            }
+
+            test("the Mercenary token's tap ability gives a creature you control +1/+0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brimstone Roundup")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 vanilla
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                val token = game.findPermanent("Mercenary Token")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // The token is a creature — its {T} ability is summoning-sick the turn it enters
+                // (CR 302.6). Clear it so we can exercise the ability itself.
+                game.state = game.state.withEntity(
+                    token, game.state.getEntity(token)!!.without<SummoningSicknessComponent>()
+                )
+
+                val abilityId = game.state.grantedActivatedAbilities.first { it.entityId == token }.ability.id
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = token,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating the token's tap ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +1/+0 (becomes 3/2)") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HellspurPosseBossScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HellspurPosseBossScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Hellspur Posse Boss (OTJ #128, {2}{R}{R} Creature — Lizard Rogue, 2/4).
+ *
+ *   Other outlaws you control have haste.
+ *   When this creature enters, create two 1/1 red Mercenary creature tokens with
+ *   "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *
+ * Reuses the OTJ outlaw subtype group ([com.wingedsheep.sdk.core.Subtype.OUTLAW_TYPES]) for the
+ * `excludeSelf` haste lord and the standard Mercenary token for the ETB trigger.
+ */
+class HellspurPosseBossScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hellspur Posse Boss") {
+
+            test("ETB creates two Mercenary tokens and they gain haste from the lord") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hellspur Posse Boss")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast the Boss; its ETB trigger creates the two Mercenary tokens on resolution.
+                game.castSpell(1, "Hellspur Posse Boss").error shouldBe null
+                game.resolveStack() // resolve the Boss spell -> ETB trigger goes on the stack
+                game.resolveStack() // resolve the ETB trigger
+
+                val tokens = game.state.getBattlefield().filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Mercenary Token"
+                }
+                withClue("ETB created exactly two Mercenary tokens") {
+                    tokens.size shouldBe 2
+                }
+
+                // Mercenary tokens are outlaws (Mercenary) controlled by you, so the lord grants
+                // them haste even though they just entered.
+                val projected = game.state.projectedState
+                withClue("Each Mercenary token has haste from the lord") {
+                    tokens.forEach { token ->
+                        projected.hasKeyword(token, Keyword.HASTE) shouldBe true
+                    }
+                }
+            }
+
+            test("the lord does not grant haste to itself (excludeSelf)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hellspur Posse Boss", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.resolveStack()
+
+                val boss = game.findPermanent("Hellspur Posse Boss")!!
+                withClue("The Boss (a Rogue) does not grant haste to itself") {
+                    game.state.projectedState.hasKeyword(boss, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("the lord does not grant haste to non-outlaw creatures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true) // Bear, not an outlaw
+                    .withCardOnBattlefield(1, "Hellspur Posse Boss", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("A non-outlaw creature you control does not gain haste") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements three Outlaws of Thunder Junction (OTJ) cards. All three are pure authoring over existing SDK primitives (AUTOGEN-tier) — no new engine/SDK capability was required.

### Cards

- **Blood Hustler** — `{1}{B}` 1/1 Vampire Rogue
  - *Whenever you commit a crime, put a +1/+1 counter on this creature. This ability triggers only once each turn.* → `Triggers.YouCommitCrime` + `oncePerTurn` + `AddCountersEffect`.
  - *`{3}{B}`: Target opponent loses 1 life and you gain 1 life.* → activated ability (`LoseLifeEffect` on target opponent + `GainLifeEffect` to controller).
- **Brimstone Roundup** — `{1}{R}` Enchantment
  - *Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."* → `Triggers.NthSpellCast(2, You)` + the standard OTJ Mercenary token (same shape as Form a Posse).
  - *Plot `{2}{R}`* → `KeywordAbility.plot`.
- **Hellspur Posse Boss** — `{2}{R}{R}` 2/4 Lizard Rogue
  - *Other outlaws you control have haste.* → `GrantKeyword(HASTE, GroupFilter(Creature.withAnyOfSubtypes(OUTLAW_TYPES).youControl(), excludeSelf = true))`.
  - *When this creature enters, create two 1/1 red Mercenary creature tokens with the sorcery-speed +1/+0 tap ability.* → `Triggers.EntersBattlefield` + `CreateTokenEffect`.

### Tests

New `rules-engine` scenario tests (all passing):
- `BloodHustlerScenarioTest` — crime adds a counter, the once-per-turn gate blocks a second counter, and the drain ability swings life 1 each way.
- `BrimstoneRoundupScenarioTest` — only the second spell each turn creates a token; the token's tap ability buffs a creature you control.
- `HellspurPosseBossScenarioTest` — ETB creates two Mercenary tokens that gain haste from the lord; the lord excludes itself and non-outlaws.

Reblessed the OTJ card-definition snapshot golden (additive — only these three card trees added; `CardDefinitionSnapshotTest` and `CardLintTest` pass).

### mtgish tooling

All three cards already render at **AUTO** tier and verify golden-equivalent under `just coverage-verify OTJ` (counted among the 97 GAMEPLAY TREE MATCH), so **no emitter/bridge change was needed**.

Note: `coverage-verify OTJ` currently reports a GATE FAIL from **4 pre-existing** mismatches (Desperate Bloodseeker, Magebane Lizard, Shoot the Sheriff, Spring Splasher) — all committed by earlier work and unrelated to this PR's cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)