### PR TITLE
Add OTJ cards: Wanted Griffin, Prosperity Tycoon, Razzle-Dazzler

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ProsperityTycoon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ProsperityTycoon.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Prosperity Tycoon
+ * {3}{W}
+ * Creature — Human Noble
+ * 4/2
+ *
+ * When this creature enters, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ * {2}, Sacrifice a token: This creature gains indestructible until end of turn. Tap it.
+ *
+ * The created token is the standard OTJ Mercenary token (same one made by Prickly Pair /
+ * Mourner's Surprise).
+ */
+val ProsperityTycoon = card("Prosperity Tycoon") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Noble"
+    power = 4
+    toughness = 2
+    oracleText = "When this creature enters, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n" +
+        "{2}, Sacrifice a token: This creature gains indestructible until end of turn. Tap it."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Sacrifice(GameObjectFilter.Token))
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self),
+            Effects.Tap(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "25"
+        artist = "Caio Monteiro"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg?1712355328"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RazzleDazzler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RazzleDazzler.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Razzle-Dazzler
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/2
+ *
+ * Whenever you cast your second spell each turn, put a +1/+1 counter on this creature.
+ * It can't be blocked this turn.
+ */
+val RazzleDazzler = card("Razzle-Dazzler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. " +
+        "It can't be blocked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Wayne Wu"
+        flavorText = "\"Now you see me, now you—\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg?1712355485"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/WantedGriffin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/WantedGriffin.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wanted Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 3/2
+ *
+ * Flying
+ * When this creature dies, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *
+ * The created token is the standard OTJ Mercenary token (same one made by Prickly Pair /
+ * Mourner's Surprise): a sorcery-speed [TimingRule.SorcerySpeed] tap ability that pumps a
+ * creature you control +1/+0.
+ */
+val WantedGriffin = card("Wanted Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\nWhen this creature dies, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Alexandre Honoré"
+        flavorText = "Many a would-be captor has gotten close enough to count its feathers, only to be " +
+            "left behind with nothing but regret and a dangling rope."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg?1712355379"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5679,6 +5679,118 @@
     ]
 }
 
+// Prosperity Tycoon
+{
+    "name": "Prosperity Tycoon",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Noble",
+    "oracleText": "When this creature enters, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{2}, Sacrifice a token: This creature gains indestructible until end of turn. Tap it.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "token"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg?1712355328"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Quick Draw
 {
     "name": "Quick Draw",
@@ -5913,6 +6025,56 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Razzle-Dazzler
+{
+    "name": "Razzle-Dazzler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. It can't be blocked this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "CANT_BE_BLOCKED",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Wayne Wu",
+        "flavorText": "\"Now you see me, now you—\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg?1712355485"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -8763,6 +8925,84 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wanted Griffin
+{
+    "name": "Wanted Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\nWhen this creature dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Alexandre Honoré",
+        "flavorText": "Many a would-be captor has gotten close enough to count its feathers, only to be left behind with nothing but regret and a dangling rope.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg?1712355379"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProsperityTycoonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProsperityTycoonScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Prosperity Tycoon (OTJ #25) — {3}{W} 4/2 Creature — Human Noble.
+ *
+ *   "When this creature enters, create a 1/1 red Mercenary creature token with
+ *    '{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.'
+ *    {2}, Sacrifice a token: This creature gains indestructible until end of turn. Tap it."
+ *
+ * Verifies (1) the ETB creates a 1/1 red Mercenary token, and (2) the {2}, Sacrifice a token
+ * ability grants the Tycoon indestructible and taps it.
+ */
+class ProsperityTycoonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Prosperity Tycoon") {
+
+            test("ETB creates a Mercenary token; sac-a-token ability grants indestructible and taps Tycoon") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Prosperity Tycoon")
+                    .withLandsOnBattlefield(1, "Plains", 6) // {3}{W} cast + {2} ability
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun ownedTokens() = game.state.getBattlefield().filter {
+                    val e = game.state.getEntity(it)
+                    e?.has<TokenComponent>() == true &&
+                        e.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+
+                game.castSpell(1, "Prosperity Tycoon").error shouldBe null
+                game.resolveStack() // resolve the creature, then the ETB trigger
+
+                val tokens = ownedTokens()
+                withClue("ETB creates exactly one token") { tokens.size shouldBe 1 }
+                val token = tokens.first()
+                val tokenCard = game.state.getEntity(token)!!.get<CardComponent>()!!
+                tokenCard.colors shouldBe setOf(Color.RED)
+                tokenCard.typeLine.subtypes.map { it.value }.contains("Mercenary") shouldBe true
+
+                val tycoon = game.findPermanent("Prosperity Tycoon")!!
+                withClue("Tycoon starts without indestructible") {
+                    game.state.projectedState.hasKeyword(tycoon, Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+
+                // Activate {2}, Sacrifice a token: gains indestructible, tap it.
+                val abilityId = cardRegistry.getCard("Prosperity Tycoon")!!
+                    .activatedAbilities.first().id
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tycoon,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(token))
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The token was sacrificed as a cost") {
+                    ownedTokens().contains(token) shouldBe false
+                }
+                withClue("Tycoon gains indestructible until end of turn") {
+                    game.state.projectedState.hasKeyword(tycoon, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+                withClue("Tycoon is tapped by the ability") {
+                    game.state.getEntity(tycoon)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RazzleDazzlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RazzleDazzlerScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Razzle-Dazzler (OTJ #63) — {1}{U} 1/2 Creature — Human Wizard.
+ *
+ *   "Whenever you cast your second spell each turn, put a +1/+1 counter on this creature.
+ *    It can't be blocked this turn."
+ *
+ * Verifies the trigger fires on the controller's *second* spell each turn (not the first),
+ * adding exactly one +1/+1 counter and granting CANT_BE_BLOCKED until end of turn.
+ */
+class RazzleDazzlerScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame): Int {
+        val id = game.findPermanent("Razzle-Dazzler") ?: return 0
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Razzle-Dazzler") {
+
+            test("second spell each turn adds a +1/+1 counter and grants can't-be-blocked; first does not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Razzle-Dazzler")
+                    .withCardInHand(1, "Grizzly Bears") // first spell, {1}{G}
+                    .withCardInHand(1, "Goblin Guide")  // second spell, {R}
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dazzler = game.findPermanent("Razzle-Dazzler")!!
+
+                // First spell: trigger must NOT fire.
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                withClue("First spell does not trigger Razzle-Dazzler") {
+                    plusOneCounters(game) shouldBe 0
+                    game.state.projectedState
+                        .hasKeyword(dazzler, "CANT_BE_BLOCKED") shouldBe false
+                }
+
+                // Second spell: trigger fires once.
+                game.castSpell(1, "Goblin Guide").error shouldBe null
+                game.resolveStack()
+                withClue("Second spell adds exactly one +1/+1 counter") {
+                    plusOneCounters(game) shouldBe 1
+                }
+                withClue("Second spell grants CANT_BE_BLOCKED this turn") {
+                    game.state.projectedState
+                        .hasKeyword(dazzler, "CANT_BE_BLOCKED") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WantedGriffinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WantedGriffinScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wanted Griffin (OTJ #38) — {3}{W} 3/2 Creature — Griffin.
+ *
+ *   "Flying
+ *    When this creature dies, create a 1/1 red Mercenary creature token with
+ *    '{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.'"
+ *
+ * Verifies the Griffin has flying and that when it dies it makes a single 1/1 red Mercenary token.
+ */
+class WantedGriffinScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Wanted Griffin") {
+
+            test("has flying; dying creates a 1/1 red Mercenary token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wanted Griffin")
+                    .withCardInHand(1, "Pyroclasm") // 2 damage to all creatures — lethal to the 3/2
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val griffin = game.findPermanent("Wanted Griffin")!!
+                withClue("Wanted Griffin has flying") {
+                    projector.getProjectedKeywords(game.state, griffin).contains(Keyword.FLYING) shouldBe true
+                }
+
+                fun ownedTokens() = game.state.getBattlefield().filter {
+                    val e = game.state.getEntity(it)
+                    e?.has<TokenComponent>() == true &&
+                        e.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                ownedTokens().size shouldBe 0
+
+                game.castSpell(1, "Pyroclasm").error shouldBe null
+                game.resolveStack() // Pyroclasm kills the Griffin, then the dies trigger resolves
+
+                withClue("The Griffin died") {
+                    (game.findPermanent("Wanted Griffin") == null) shouldBe true
+                }
+
+                val tokens = ownedTokens()
+                withClue("Dies trigger creates exactly one Mercenary token") { tokens.size shouldBe 1 }
+                val token = tokens.first()
+                projector.getProjectedPower(game.state, token) shouldBe 1
+                projector.getProjectedToughness(game.state, token) shouldBe 1
+                val tokenCard = game.state.getEntity(token)!!.get<CardComponent>()!!
+                tokenCard.colors shouldBe setOf(Color.RED)
+                tokenCard.typeLine.subtypes.map { it.value }.contains("Mercenary") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction (OTJ) cards. All three are pure authoring over existing SDK primitives — no engine/SDK surface changed.

## Cards

- **Wanted Griffin** ({3}{W} 3/2 Griffin, common #38) — Flying. "When this creature dies, create a 1/1 red Mercenary creature token with '{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.'" Uses the standard OTJ Mercenary token (same shape as Prickly Pair / Mourner's Surprise).
- **Prosperity Tycoon** ({3}{W} 4/2 Human Noble, uncommon #25) — ETB creates the same Mercenary token. "{2}, Sacrifice a token: This creature gains indestructible until end of turn. Tap it." (`Costs.Sacrifice(GameObjectFilter.Token)` + composite grant-indestructible / tap-self).
- **Razzle-Dazzler** ({1}{U} 1/2 Human Wizard, common #63) — "Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. It can't be blocked this turn." (`Triggers.NthSpellCast(2, Player.You)` → `AddCounters` + `GrantKeyword(CANT_BE_BLOCKED)` for the turn).

## Tests

- New rules-engine scenario test per card (token creation, dies/ETB triggers, sacrifice-a-token ability granting indestructible + tap, second-spell trigger with counter + can't-be-blocked, flying). All pass.
- Reblessed the OTJ `CardDefinitionSnapshot` golden — diff adds only the three new cards.
- `CardLintTest` passes.

## mtgish-tooling

All three cards already emit at **AUTO** tier and their generated gameplay trees match the hand-authored golden — `just coverage-verify OTJ` is **GATE PASS** (101/129 matched, 0 mismatch, 0 capability mismatch). No emitter or bridge change was required. Merged latest main to pick up the already-landed emitter target-recovery fix (PR #695) so the gate runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)