### PR TITLE
SOS card-draw batch C: Daydream, Procrastinate, Wild Hypothesis, Muse Seeker

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Daydream.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Daydream.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Daydream
+ * {W}
+ * Sorcery
+ *
+ * Exile target creature you control, then return that card to the battlefield under its
+ * owner's control with a +1/+1 counter on it.
+ * Flashback {2}{W}
+ *
+ * The blink is the standard `Move(EXILE) then Move(BATTLEFIELD)` flicker (see Splash Portal);
+ * the +1/+1 counter is a chained `AddCounters` once the card is back on the battlefield (the
+ * target handle still resolves to the freshly-returned permanent). Flashback is a keyword
+ * ability so the card can be re-cast from the graveyard for {2}{W}.
+ */
+val Daydream = card("Daydream") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target creature you control, then return that card to the battlefield " +
+        "under its owner's control with a +1/+1 counter on it.\n" +
+        "Flashback {2}{W} (You may cast this card from your graveyard for its flashback cost. " +
+        "Then exile it.)"
+
+    spell {
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.Move(creature, Zone.EXILE)
+            .then(Effects.Move(creature, Zone.BATTLEFIELD))
+            .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature))
+    }
+
+    keywordAbility(KeywordAbility.flashback("{2}{W}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Nia Kovalevski"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2b16cb2-b8b2-45df-9695-3c16e9d89e28.jpg?1775936973"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MuseSeeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MuseSeeker.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Muse Seeker
+ * {1}{U}
+ * Creature — Elf Wizard
+ * 1/2
+ *
+ * Opus — Whenever you cast an instant or sorcery spell, draw a card. Then discard a card
+ * unless five or more mana was spent to cast that spell.
+ *
+ * "Opus" is an ability word (flavor only). The `opus { }` builder wires the spell-cast trigger
+ * and the 5+ mana tier. The discard is the *low* tier here: base = draw then discard, and when
+ * five or more mana was spent the discard is dropped — so `insteadIfFiveOrMore` replaces the
+ * base with a bare draw.
+ */
+val MuseSeeker = card("Muse Seeker") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elf Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "Opus — Whenever you cast an instant or sorcery spell, draw a card. Then discard " +
+        "a card unless five or more mana was spent to cast that spell."
+
+    opus {
+        effect = Effects.DrawCards(1).then(Effects.Discard(1))
+        insteadIfFiveOrMore = Effects.DrawCards(1)
+        description = "Opus — Whenever you cast an instant or sorcery spell, draw a card. Then " +
+            "discard a card unless five or more mana was spent to cast that spell."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Failure can be a reason to quit or fuel for inspiration. The choice is " +
+            "always yours.\"\n—Veyran, dean of perfection"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71cb4a6b-b500-4b28-bcdb-ec4188242f39.jpg?1775937328"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Procrastinate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Procrastinate.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Procrastinate
+ * {X}{U}
+ * Sorcery
+ *
+ * Tap target creature. Put twice X stun counters on it.
+ *
+ * Tap the chosen creature, then drop a dynamic number of stun counters on it: twice the X
+ * paid (`Multiply(XValue, 2)`). The stun-counter rules (a stunned permanent removes a
+ * counter instead of untapping) are engine-handled; this just places them.
+ */
+val Procrastinate = card("Procrastinate") {
+    manaCost = "{X}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Tap target creature. Put twice X stun counters on it. (If a permanent with a " +
+        "stun counter would become untapped, remove one from it instead.)"
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Tap(creature)
+            .then(
+                Effects.AddDynamicCounters(
+                    Counters.STUN,
+                    DynamicAmount.Multiply(DynamicAmount.XValue, 2),
+                    creature
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Elizabeth Peiró"
+        flavorText = "\"None of these projects are due until end of semester. I've still got a " +
+            "whole week to finish them!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1edb449d-620f-4e21-9d76-2c840635eb9d.jpg?1775937356"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WildHypothesis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WildHypothesis.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wild Hypothesis
+ * {X}{G}
+ * Sorcery
+ *
+ * Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.
+ * Surveil 2.
+ *
+ * The Fractal is created (published to the [CREATED_TOKENS] pipeline collection), then a
+ * dynamic X +1/+1 counters land on that just-created token via
+ * `PipelineTarget(CREATED_TOKENS, 0)` (same shape as Fractal Tender). X comes from the
+ * `{X}` in the mana cost ([DynamicAmount.XValue]). Surveil 2 is the standard library
+ * pattern recipe.
+ */
+val WildHypothesis = card("Wild Hypothesis") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\n" +
+        "Surveil 2. (Look at the top two cards of your library, then put any number of them into " +
+        "your graveyard and the rest on top of your library in any order.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN, Color.BLUE),
+            creatureTypes = setOf("Fractal"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+        )
+            .then(
+                Effects.AddDynamicCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmount.XValue,
+                    EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+                )
+            )
+            .then(Patterns.Library.surveil(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04fdfabc-c247-4384-a5bb-f49035f8aae0.jpg?1775938142"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -931,6 +931,73 @@
     ]
 }
 
+// Daydream
+{
+    "name": "Daydream",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target creature you control, then return that card to the battlefield under its owner's control with a +1/+1 counter on it.\nFlashback {2}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{2}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    },
+                    "destination": "Battlefield"
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Nia Kovalevski",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2b16cb2-b8b2-45df-9695-3c16e9d89e28.jpg?1775936973"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dig Site Inventory
 {
     "name": "Dig Site Inventory",
@@ -3275,6 +3342,123 @@
     ]
 }
 
+// Muse Seeker
+{
+    "name": "Muse Seeker",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Elf Wizard",
+    "oracleText": "Opus — Whenever you cast an instant or sorcery spell, draw a card. Then discard a card unless five or more mana was spent to cast that spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "ContextProperty",
+                                "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 5
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Opus — Whenever you cast an instant or sorcery spell, draw a card. Then discard a card unless five or more mana was spent to cast that spell."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Failure can be a reason to quit or fuel for inspiration. The choice is always yours.\"\n—Veyran, dean of perfection",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71cb4a6b-b500-4b28-bcdb-ec4188242f39.jpg?1775937328"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Muse's Encouragement
 {
     "name": "Muse's Encouragement",
@@ -3924,6 +4108,59 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Procrastinate
+{
+    "name": "Procrastinate",
+    "manaCost": "{X}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Tap target creature. Put twice X stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "stun",
+                    "amount": {
+                        "type": "Multiply",
+                        "amount": "XValue",
+                        "multiplier": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Elizabeth Peiró",
+        "flavorText": "\"None of these projects are due until end of semester. I've still got a whole week to finish them!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1edb449d-620f-4e21-9d76-2c840635eb9d.jpg?1775937356"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5645,6 +5882,100 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Wild Hypothesis
+{
+    "name": "Wild Hypothesis",
+    "manaCost": "{X}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [
+                        "GREEN",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Fractal"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                },
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "PipelineTarget",
+                        "collectionName": "createdTokens"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Lie Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04fdfabc-c247-4384-a5bb-f49035f8aae0.jpg?1775938142"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.nodesTagged
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -82,12 +83,24 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         if (!jsonContains(node, "_CardInExile", "TheCardExiledThisWay")) return@on null
         val flagBlob = compact(node)
         if ("EntersUnderPlayersControl" in flagBlob || "EntersUnderYourControl" in flagBlob) return@on null
-        // We render only the bare "return under its owner's control". Any extra enter flag — a +1/+1
-        // counter (Daydream), entering tapped, etc. — would be silently dropped, producing a
-        // confidently-wrong card, so decline (-> SCAFFOLD) when one is present.
-        if ("EntersWithACounter" in flagBlob || "EntersWithNumberCounters" in flagBlob ||
-            "EntersTapped" in flagBlob) return@on null
-        call("Effects.Move", arg(Lit(tvar)), arg("Zone.BATTLEFIELD"))
+        // Under-owner's-control return. We render the bare return and the one extra enter flag we can
+        // express faithfully: a single fixed ±1/±1 counter on the returned card (Daydream's "with a
+        // +1/+1 counter on it"). A returned card isn't a permanent until it's back on the battlefield,
+        // so the counter is a chained AddCountersEffect after the Move (matching the hand-authored card),
+        // not an enters-with replacement. Any other extra flag — a dynamic/derived counter count,
+        // entering tapped, a non-±1/±1 counter kind — would be silently dropped, so decline -> SCAFFOLD.
+        if ("EntersWithNumberCounters" in flagBlob || "EntersTapped" in flagBlob) return@on null
+        val move = call("Effects.Move", arg(Lit(tvar)), arg("Zone.BATTLEFIELD"))
+        if ("EntersWithACounter" !in flagBlob) return@on move
+        // Pull the EntersWithACounter flag's counter node and render it (counterTypeDsl declines any
+        // non-±1/±1 PTCounter / unnamed kind, downgrading the card to SCAFFOLD rather than guessing).
+        val counterNode = node.nodesTagged("EntersWithACounter")
+            .firstOrNull()?.get("args") ?: return@on null
+        val counter = counterTypeDsl(counterNode) ?: return@on null
+        Composite(listOf(
+            move,
+            call("AddCountersEffect", arg("counterType", counter), arg("count", "1"), arg("target", Lit(tvar))),
+        ))
     }
 
     // "...at the beginning of the next end step" delayed trigger (the return half of exile-then-return).

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -84,4 +84,45 @@ class EffectHandlerTest : StringSpec({
             "t",
         ).shouldBeNull()
     }
+
+    // --- PutExiledCardOntoBattlefield (the return half of the exile-then-return blink) -------------
+
+    "the bare under-owner's-control return renders a plain Move to the battlefield" {
+        layer(
+            """{"_Action":"PutExiledCardOntoBattlefield","args":[{"_CardInExile":"TheCardExiledThisWay"},""" +
+                """[{"_EnterFlag":"EntersUnderOwnersControl"}]]}""",
+            "t",
+        ) shouldBe "Effects.Move(t, Zone.BATTLEFIELD)"
+    }
+
+    "a return with a +1/+1 counter renders the Move then a chained AddCountersEffect (Daydream)" {
+        // The returned card isn't a permanent until it's back on the battlefield, so the counter is a
+        // chained AddCountersEffect after the Move, not an enters-with replacement.
+        layer(
+            """{"_Action":"PutExiledCardOntoBattlefield","args":[{"_CardInExile":"TheCardExiledThisWay"},""" +
+                """[{"_EnterFlag":"EntersUnderOwnersControl"},""" +
+                """{"_EnterFlag":"EntersWithACounter","args":{"_CounterType":"PTCounter","args":[1,1]}}]]}""",
+            "t",
+        ) shouldBe "Effects.Composite(\n" +
+            "            Effects.Move(t, Zone.BATTLEFIELD),\n" +
+            "            AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = t)\n" +
+            "        )"
+    }
+
+    "a return with a non-±1/±1 counter kind declines (-> SCAFFOLD) rather than guess the counter" {
+        layer(
+            """{"_Action":"PutExiledCardOntoBattlefield","args":[{"_CardInExile":"TheCardExiledThisWay"},""" +
+                """[{"_EnterFlag":"EntersUnderOwnersControl"},""" +
+                """{"_EnterFlag":"EntersWithACounter","args":{"_CounterType":"PTCounter","args":[2,2]}}]]}""",
+            "t",
+        ).shouldBeNull()
+    }
+
+    "a return entering tapped still declines (the tapped flag would be silently dropped)" {
+        layer(
+            """{"_Action":"PutExiledCardOntoBattlefield","args":[{"_CardInExile":"TheCardExiledThisWay"},""" +
+                """[{"_EnterFlag":"EntersUnderOwnersControl"},{"_EnterFlag":"EntersTapped"}]]}""",
+            "t",
+        ).shouldBeNull()
+    }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DaydreamScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DaydreamScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Daydream {W} Sorcery — "Exile target creature you control, then return that card to the
+ * battlefield under its owner's control with a +1/+1 counter on it. Flashback {2}{W}."
+ *
+ * Covers the blink-with-counter resolution and the flashback re-cast from the graveyard.
+ */
+class DaydreamScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Daydream — flicker a creature and return it with a +1/+1 counter") {
+
+            test("the targeted creature returns with one +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Daydream")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Daydream", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                val returned = game.findPermanent("Grizzly Bears")
+                withClue("Grizzly Bears should be back on the battlefield") {
+                    (returned != null) shouldBe true
+                }
+                withClue("It returns with exactly one +1/+1 counter") {
+                    plusOneCounters(game, returned!!) shouldBe 1
+                }
+            }
+
+            test("Daydream can be flashed back from the graveyard for {2}{W}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Daydream")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpellFromGraveyard(1, "Daydream", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                val returned = game.findPermanent("Grizzly Bears")!!
+                withClue("Flashback blink also returns the creature with a +1/+1 counter") {
+                    plusOneCounters(game, returned) shouldBe 1
+                }
+                withClue("Flashback exiles Daydream, so it is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Daydream") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MuseSeekerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MuseSeekerScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Muse Seeker {1}{U} 1/2 Elf Wizard — "Opus — Whenever you cast an instant or sorcery spell,
+ * draw a card. Then discard a card unless five or more mana was spent to cast that spell."
+ *
+ * The discard is the *low* tier: base = draw then discard, replaced by a bare draw when 5+ mana
+ * was spent (`insteadIfFiveOrMore`). Exercises both sides of the 5-mana boundary.
+ */
+class MuseSeekerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Muse Seeker — Opus draw, discard unless 5+ mana spent") {
+
+            test("a 1-mana spell: draw then discard (net hand size unchanged)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Muse Seeker")
+                    .withCardInHand(1, "Lightning Bolt") // {R}, 1 mana
+                    .withCardInHand(1, "Forest") // a spare card so the discard is a genuine choice
+                    .withCardInLibrary(1, "Island")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                // Hand: Lightning Bolt + a spare Forest (2 cards) so the discard is a real choice.
+                game.handSize(1) shouldBe 2
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                // Bolt left hand (1 = Forest). Opus trigger resolves: draw Island (hand = 2), then discard.
+                game.resolveStack()
+
+                withClue("1 mana spent → discard decision should be pending") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                val drawn = game.findCardsInHand(1, "Island")
+                game.selectCards(drawn).error shouldBe null
+
+                game.resolveStack()
+                withClue("Drew Island then discarded it → hand back to just the spare Forest") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("a 5-mana spell: draw only, no discard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Muse Seeker")
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardInLibrary(1, "Island")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.handSize(1) shouldBe 1 // Blaze
+
+                // Blaze X=4 → {4}{R} → 5 mana spent.
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("5 mana spent → draw only, no discard decision") {
+                    (game.state.pendingDecision == null) shouldBe true
+                }
+                withClue("Blaze left hand (0), drew Island (1) with no discard → hand size 1") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProcrastinateScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProcrastinateScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Procrastinate {X}{U} Sorcery — "Tap target creature. Put twice X stun counters on it."
+ *
+ * Verifies the tap and the dynamic `2 × X` stun-counter count.
+ */
+class ProcrastinateScenarioTest : ScenarioTestBase() {
+
+    private fun stunCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.get<TappedComponent>() != null
+
+    init {
+        context("Procrastinate — tap and twice-X stun counters") {
+
+            test("X=2 taps the creature and adds 4 stun counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Procrastinate")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castXSpell(1, "Procrastinate", xValue = 2, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be tapped") {
+                    isTapped(game, bears) shouldBe true
+                }
+                withClue("twice X = 2 × 2 = 4 stun counters") {
+                    stunCounters(game, bears) shouldBe 4
+                }
+            }
+
+            test("X=0 still taps the creature but adds no stun counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Procrastinate")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castXSpell(1, "Procrastinate", xValue = 0, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be tapped") {
+                    isTapped(game, bears) shouldBe true
+                }
+                withClue("twice X = 0 stun counters") {
+                    stunCounters(game, bears) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildHypothesisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildHypothesisScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wild Hypothesis {X}{G} Sorcery — "Create a 0/0 green and blue Fractal creature token. Put X
+ * +1/+1 counters on it. Surveil 2."
+ *
+ * Verifies the Fractal token enters with X +1/+1 counters and that the trailing Surveil 2
+ * pauses for the look-at-top-two choice.
+ */
+class WildHypothesisScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Wild Hypothesis — Fractal token with X +1/+1 counters, then Surveil 2") {
+
+            test("X=3 makes a 0/0 Fractal with three +1/+1 counters, then surveils") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wild Hypothesis")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "Wild Hypothesis", xValue = 3).error shouldBe null
+                game.resolveStack()
+
+                val fractal = game.findPermanent("Fractal Token")
+                withClue("A Fractal token should have been created") {
+                    (fractal != null) shouldBe true
+                }
+                withClue("It enters with X = 3 +1/+1 counters (0/0 base)") {
+                    plusOneCounters(game, fractal!!) shouldBe 3
+                }
+
+                // Surveil 2 pauses for the put-in-graveyard / keep-on-top choice; keep both on top.
+                withClue("Surveil 2 should raise a card-selection decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.skipSelection().error shouldBe null
+            }
+
+            test("X=0 makes a 0/0 Fractal with no counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wild Hypothesis")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "Wild Hypothesis", xValue = 0).error shouldBe null
+                game.resolveStack()
+
+                val fractal = game.findPermanent("Fractal Token")!!
+                withClue("X = 0 → no +1/+1 counters on the 0/0 Fractal") {
+                    plusOneCounters(game, fractal) shouldBe 0
+                }
+                game.skipSelection().error shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Secrets of Strixhaven (SOS) cards, all composed from existing SDK primitives (no new engine features), plus an mtgish emitter extension that promotes one of them to a complete AUTO render.

## Cards

| Card | Cost | Effect | mtgish tier |
|------|------|--------|-------------|
| **Daydream** | {W} Sorcery | Exile target creature you control, return it with a +1/+1 counter. Flashback {2}{W}. | **AUTOGEN** ✅ |
| **Procrastinate** | {X}{U} Sorcery | Tap target creature; put twice X stun counters on it. | SCAFFOLD (cast-time X) |
| **Wild Hypothesis** | {X}{G} Sorcery | Create a 0/0 Fractal, put X +1/+1 counters on it; Surveil 2. | SCAFFOLD (cast-time X) |
| **Muse Seeker** | {1}{U} 1/2 Elf Wizard | Opus — cast instant/sorcery → draw, discard unless 5+ mana spent. | SCAFFOLD (opus tree) |

### Implementation notes
- **Daydream** — `Move(EXILE) then Move(BATTLEFIELD) then AddCounters(+1/+1)`; `KeywordAbility.flashback`.
- **Procrastinate** — `Effects.Tap(t) then AddDynamicCounters(STUN, Multiply(XValue, 2))`.
- **Wild Hypothesis** — `CreateToken(0/0 Fractal) then AddDynamicCounters(+1/+1, XValue)` on the created token (`PipelineTarget(CREATED_TOKENS, 0)`, à la Fractal Tender) then `Patterns.Library.surveil(2)`.
- **Muse Seeker** — the `opus { }` ability-word builder: `effect = DrawCards(1) then Discard(1)`, `insteadIfFiveOrMore = DrawCards(1)` (the discard is the low tier; replaced by a bare draw at 5+ mana).

8 scenario tests added (2 per card), all passing. SOS card snapshot re-blessed (only the 4 new cards added; no other card moved).

## mtgish emitter change

Extended the `PutExiledCardOntoBattlefield` handler (`ZoneHandlers.kt`) to render the "return with a +1/+1 counter" case — previously it declined whenever any `EntersWithACounter` flag was present (it even named Daydream). It now emits `Effects.Composite(Move(BATTLEFIELD), AddCountersEffect(+1/+1, 1, t))`, matching the hand-authored card. `counterTypeDsl` still declines any non-±1/±1 / unnamed counter, and the dynamic-count (`EntersWithNumberCounters`) and entering-tapped flags still decline → SCAFFOLD. Added focused `EffectHandlerTest` cases for the new branch and the decline paths.

**Daydream now emits as a complete AUTO render.**

### Why the other three stay SCAFFOLD (deliberate decline, not a gap)
- **Procrastinate / Wild Hypothesis** thread a cast-time X into a counter count (`Twice(ValueX)` / `ValueX`). This is exactly the "inherit a chosen value into a later effect" shape the tooling's creator note says the emitter must decline rather than guess. The existing `PutNumberCountersOfTypeOnPermanent` handler already declines derived counts; left untouched.
- **Muse Seeker**'s faithful gameplay tree is the opus-builder `Gated(>=5, then = draw, otherwise = draw+discard)`. The emitter sees a generic spell-cast trigger with `[DrawACard, Unless(>=5, [DiscardACard])]`; lowering that to the opus tree would mean re-implementing the Opus ability-word transformation inside the emitter — large, lossy-prone tooling work. Per the fidelity policy, it declines.

## Verification

- `coverage-fidelity --emit "Daydream"` → `fidelity tier: AUTO` (complete render).
- `coverage-verify POR` → **GATE PASS, 158/158, 0 mismatch** (no regression from the emitter change).
- `coverage-verify SOS` → unchanged: the 3 reported tree mismatches (Lorehold / Prismari / Silverquill Charm) are **pre-existing and unrelated** to this handler (SOS is `incomplete = true` and not in the gated set list); the new cards are not among them — Daydream tree-matches golden, the other three are in "not emitted (left to hand)".
- `:mtgish-tooling:test` (incl. hermetic EmitterGoldenTest for POR/EOE) — pass; no golden rebless needed (no POR/EOE card uses the counter-return branch).
- `:mtg-sets` `CardDefinitionSnapshotTest` (SOS) + `CardLintTest` — pass.
- All 8 SOS scenario tests — pass.

No SDK surface changed (cards use existing primitives; the emitter change is tooling-only), so no `card-sdk-language-reference.md` update is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)