### PR TITLE
Add four OTJ cards (Badlands Revival, Intimidation Campaign, Sandstorm Verge, Iron-Fist Pulverizer) + mtgish multi-graveyard-target binding

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BadlandsRevival.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BadlandsRevival.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Badlands Revival
+ * {3}{B}{G}
+ * Sorcery
+ *
+ * Return up to one target creature card from your graveyard to the battlefield. Return up to one
+ * target permanent card from your graveyard to your hand.
+ *
+ * Two independent "up to one target" slots (optional targets, minCount 0): the first restricted to
+ * creature cards you own in your graveyard (reanimated to the battlefield), the second to permanent
+ * cards you own in your graveyard (returned to hand). Either slot may be left empty; an empty slot
+ * simply does nothing on resolution.
+ */
+val BadlandsRevival = card("Badlands Revival") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target creature card from your graveyard to the battlefield. " +
+        "Return up to one target permanent card from your graveyard to your hand."
+
+    spell {
+        val creature = target(
+            "creature",
+            TargetObject(optional = true, filter = TargetFilter.CreatureInYourGraveyard),
+        )
+        val permanent = target(
+            "permanent",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.PutOntoBattlefield(creature),
+                Effects.ReturnToHand(permanent),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Carlos Palma Cruchaga"
+        flavorText = "The cactusfolk were a young culture, but they already knew the pains of death " +
+            "and joys of birth."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg?1712356053"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IntimidationCampaign.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IntimidationCampaign.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Intimidation Campaign
+ * {1}{U}{B}
+ * Enchantment
+ *
+ * When this enchantment enters, each opponent loses 1 life, you gain 1 life, and you draw a card.
+ * Whenever you commit a crime, you may return this enchantment to its owner's hand.
+ *
+ * The crime trigger uses [MayEffect] (a yes/no decision gate) so the controller may decline the
+ * whole bounce — `optional = true` on a trigger only loosens target minimums, not the effect
+ * itself. Returning happens only from the battlefield (the [Effects.ReturnToHand] of
+ * [EffectTarget.Self] is a no-op if the source has already left), which matches the reminder text.
+ */
+val IntimidationCampaign = card("Intimidation Campaign") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, each opponent loses 1 life, you gain 1 life, " +
+        "and you draw a card.\n" +
+        "Whenever you commit a crime, you may return this enchantment to its owner's hand. " +
+        "(It returns only from the battlefield. Targeting opponents, anything they control, " +
+        "and/or cards in their graveyards is a crime.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                GainLifeEffect(1, EffectTarget.Controller),
+                Effects.DrawCards(1),
+            ),
+        )
+        description = "When this enchantment enters, each opponent loses 1 life, you gain 1 life, " +
+            "and you draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        effect = MayEffect(Effects.ReturnToHand(EffectTarget.Self))
+        description = "Whenever you commit a crime, you may return this enchantment to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg?1712356111"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IronFistPulverizer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IronFistPulverizer.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Iron-Fist Pulverizer
+ * {4}{R}
+ * Creature — Giant Warrior
+ * 4/5
+ *
+ * Reach
+ * Whenever you cast your second spell each turn, this creature deals 2 damage to target opponent.
+ * Scry 1.
+ *
+ * "Your second spell each turn" → [Triggers.NthSpellCast] with n = 2 scoped to [Player.You]. The
+ * damage source defaults to this permanent. Scry 1 resolves after the damage as part of the same
+ * resolution.
+ */
+val IronFistPulverizer = card("Iron-Fist Pulverizer") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 4
+    toughness = 5
+    oracleText = "Reach\n" +
+        "Whenever you cast your second spell each turn, this creature deals 2 damage to target " +
+        "opponent. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        val opponent = target("opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            listOf(
+                Effects.DealDamage(2, opponent),
+                Patterns.Library.scry(1),
+            ),
+        )
+        description = "Whenever you cast your second spell each turn, this creature deals 2 damage " +
+            "to target opponent. Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Xabi Gaztelua"
+        flavorText = "\"The 3:10 to Omenport will be delayed.\"\n—Prosperity Station announcement"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg?1712355784"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SandstormVerge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SandstormVerge.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sandstorm Verge
+ * Land — Desert
+ *
+ * {T}: Add {C}.
+ * {3}, {T}: Target creature can't block this turn. Activate only as a sorcery.
+ */
+val SandstormVerge = card("Sandstorm Verge") {
+    typeLine = "Land — Desert"
+    colorIdentity = ""
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}, {T}: Target creature can't block this turn. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddColorlessManaEffect(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        val creature = target("creature", TargetCreature())
+        effect = Effects.CantBlock(creature)
+        description = "{3}, {T}: Target creature can't block this turn. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "263"
+        artist = "Jorge Jacinto"
+        flavorText = "\"Ever been caught out in a storm like that? Think of it like drowning, " +
+            "but all the water is knives.\"\n—Annie Flash"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg?1712356353"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -378,6 +378,68 @@
     ]
 }
 
+// Badlands Revival
+{
+    "name": "Badlands Revival",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target creature card from your graveyard to the battlefield. Return up to one target permanent card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Battlefield"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "permanent"
+                    },
+                    "destination": "Hand"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Carlos Palma Cruchaga",
+        "flavorText": "The cactusfolk were a young culture, but they already knew the pains of death and joys of birth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg?1712356053"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Beastbond Outcaster
 {
     "name": "Beastbond Outcaster",
@@ -3696,6 +3758,81 @@
     ]
 }
 
+// Intimidation Campaign
+{
+    "name": "Intimidation Campaign",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, each opponent loses 1 life, you gain 1 life, and you draw a card.\nWhenever you commit a crime, you may return this enchantment to its owner's hand. (It returns only from the battlefield. Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this enchantment enters, each opponent loses 1 life, you gain 1 life, and you draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "descriptionOverride": "Whenever you commit a crime, you may return this enchantment to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg?1712356111"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Inventive Wingsmith
 {
     "name": "Inventive Wingsmith",
@@ -3842,6 +3979,115 @@
                 "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
             }
         ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Iron-Fist Pulverizer
+{
+    "name": "Iron-Fist Pulverizer",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "Reach\nWhenever you cast your second spell each turn, this creature deals 2 damage to target opponent. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "opponent"
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeAs": "scried"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "scried",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "toBottom",
+                                    "storeRemainder": "toTop",
+                                    "selectedLabel": "Put on bottom",
+                                    "remainderLabel": "Put on top"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toBottom",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Bottom"
+                                    }
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toTop",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Top"
+                                    },
+                                    "order": "ControllerChooses"
+                                },
+                                "EmitScriedEvent"
+                            ]
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "opponent"
+                },
+                "descriptionOverride": "Whenever you cast your second spell each turn, this creature deals 2 damage to target opponent. Scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "\"The 3:10 to Omenport will be delayed.\"\n—Prosperity Station announcement",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg?1712355784"
     },
     "colorIdentityOverride": [
         "RED"
@@ -6461,6 +6707,73 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Sandstorm Verge
+{
+    "name": "Sandstorm Verge",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}: Target creature can't block this turn. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{3}, {T}: Target creature can't block this turn. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "UNCOMMON",
+        "artist": "Jorge Jacinto",
+        "flavorText": "\"Ever been caught out in a storm like that? Think of it like drowning, but all the water is knives.\"\n—Annie Flash",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg?1712356353"
+    },
+    "colorIdentityOverride": []
 }
 
 // Scalestorm Summoner

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -99,8 +99,15 @@ private fun EmitCtx.multiTargetLocals(targets: List<JsonObject>, actions: List<J
     // mandatory TargetPermanent). The oracle text is authoritative, so recover per-target optionality
     // from the ordered "target …" clauses there and inject `optional = true` when the IR omitted it.
     val optionalByOrdinal = oracleOptionalTargetOrdinals(targets.size)
+    // The mtgish IR occasionally mistypes one slot of a multi-graveyard-target spell. Badlands Revival's
+    // second slot is "target permanent card from your graveyard", but the IR encodes it as `IsCardtype
+    // Creature` like the first slot. The oracle text is authoritative, so recover the intended
+    // graveyard-card noun ("permanent"/"creature"/…) per ordinal and rebuild the target when the IR
+    // disagrees — rendering correctly rather than emitting the IR's lossy (too-narrow) filter.
+    val graveyardNounByOrdinal = oracleGraveyardTargetNouns(targets.size)
     targets.forEachIndexed { i, t ->
         var node = targetExpr(t, actions) ?: run { reasons.add("target:${t.strField("_Target")}"); return null }
+        graveyardTargetCorrection(t, graveyardNounByOrdinal.getOrNull(i))?.let { node = it }
         if (optionalByOrdinal.getOrNull(i) == true) node = node.withOptionalArg()
         val varName = "t${i + 1}"
         stmts.add(targetLocalNamed(varName, varName, node))
@@ -136,6 +143,52 @@ private fun EmitCtx.oracleOptionalTargetOrdinals(targetCount: Int): List<Boolean
         .findAll(text).map { it.groupValues[1].isNotBlank() }.toList()
     if (mentions.size != targetCount) return List(targetCount) { false }
     return mentions
+}
+
+/**
+ * For each declared target ordinal (oracle order), the noun in a "target <noun> card from … graveyard"
+ * mention, or null if the ordinal's mention isn't a graveyard-card target. Used to repair an IR slot
+ * the mtgish data mistyped (Badlands Revival's "permanent card" slot arriving as `IsCardtype Creature`).
+ * If the count of graveyard-card mentions doesn't line up with [targetCount], returns all-null (no
+ * over-claiming — better an IR-faithful mismatch caught by the gate than a wrongly-recovered noun).
+ */
+private fun EmitCtx.oracleGraveyardTargetNouns(targetCount: Int): List<String?> {
+    val text = oracleText?.lowercase() ?: return List(targetCount) { null }
+    // Each ordered "target <noun> card from [a|an|your|its owner's|…] graveyard" mention -> its noun.
+    val nouns = Regex("""target (\w+) card from [^.]*?graveyard""")
+        .findAll(text).map { it.groupValues[1] }.toList()
+    if (nouns.size != targetCount) return List(targetCount) { null }
+    return nouns
+}
+
+/**
+ * If [target] is a graveyard-card target and the oracle's recovered [oracleNoun] for this slot names
+ * a card type the IR-rendered filter would contradict, returns the oracle-correct target node;
+ * otherwise null (keep the IR-derived node). Only the "permanent card from your graveyard" repair is
+ * modelled (Badlands Revival) — it maps to the same `GameObjectFilter.Permanent.ownedByYou()` in the
+ * GRAVEYARD zone that the single-target path emits for Shepherd of the Clouds.
+ */
+private fun EmitCtx.graveyardTargetCorrection(target: JsonObject, oracleNoun: String?): Dsl? {
+    val ttype = target.strField("_Target")
+    if (ttype != "TargetGraveyardCard" && ttype != "UptoOneTargetGraveyardCard") return null
+    val blob = compact(target)
+    return when (oracleNoun) {
+        // IR says creature, oracle says permanent -> the broader permanent-card-in-graveyard target.
+        "permanent" -> {
+            if ("IsPermanent" in blob) return null // already correct in the IR
+            val owner = when {
+                "\"You\"" in blob -> ".ownedByYou()"
+                "\"Opponent\"" in blob -> ".ownedByOpponent()"
+                else -> ""
+            }
+            val filt = Call(
+                "TargetFilter",
+                listOf(arg(Lit("GameObjectFilter.Permanent$owner")), arg("zone", "Zone.GRAVEYARD")),
+            )
+            Call("TargetObject", listOf(arg("filter", filt)))
+        }
+        else -> null
+    }
 }
 
 private fun refKindForTarget(target: JsonObject): String? = when (target.strField("_Target")) {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -426,10 +426,14 @@ internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     // per-KIND ordered list of target locals (1-based). The IR ordinal counts only targets of that
     // kind, so it must not index the flat target list — that would skew when an earlier slot is a
     // player (Dissection Practice: t1 is the opponent, so Ref_TargetPermanent1 is t2, not t1).
+    // The same suffixing applies to graveyard-card refs (Ref_TargetGraveyardCard1 /
+    // Ref_TargetGraveyardCard2) on spells with two graveyard targets (Badlands Revival's two
+    // "up to one target … card from your graveyard" slots); each action must bind to its own slot.
     if (ref != null && targetVars.isNotEmpty()) {
-        Regex("^Ref_TargetPermanent(\\d+)$").matchEntire(ref)?.let { m ->
-            val idx = m.groupValues[1].toInt() - 1
-            return targetRefVarsByKind["Ref_TargetPermanent"]?.getOrNull(idx)
+        Regex("^(Ref_TargetPermanent|Ref_TargetGraveyardCard)(\\d+)$").matchEntire(ref)?.let { m ->
+            val kind = m.groupValues[1]
+            val idx = m.groupValues[2].toInt() - 1
+            return targetRefVarsByKind[kind]?.getOrNull(idx)
                 ?: targetVars.getOrNull(idx)
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BadlandsRevivalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BadlandsRevivalScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BadlandsRevival
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Badlands Revival (OTJ #194) — {3}{B}{G} Sorcery.
+ *
+ * "Return up to one target creature card from your graveyard to the battlefield. Return up to one
+ *  target permanent card from your graveyard to your hand."
+ *
+ * Verifies the two independent "up to one" slots: a creature card is reanimated to the battlefield
+ * and a (non-creature) permanent card is returned to hand in the same resolution, and that leaving
+ * a slot empty is legal (no second target chosen).
+ */
+class BadlandsRevivalScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BadlandsRevival)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("reanimates a creature to the battlefield and returns a permanent to hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")     // creature card
+        val land = driver.putCardInGraveyard(me, "Forest")            // permanent (land) card
+
+        val spell = driver.putCardInHand(me, "Badlands Revival")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.castSpellWithTargets(
+            me,
+            spell,
+            listOf(
+                ChosenTarget.Card(bear, me, Zone.GRAVEYARD),
+                ChosenTarget.Card(land, me, Zone.GRAVEYARD),
+            ),
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the spell
+
+        // Creature reanimated to battlefield; permanent returned to hand.
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        driver.getHand(me).contains(land) shouldBe true
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(bear) shouldBe false
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(land) shouldBe false
+    }
+
+    test("each slot is optional: choosing only the creature leaves the permanent slot empty") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(me, "Badlands Revival")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 3)
+        // Only the creature slot is filled; the permanent slot is left empty (up to one).
+        driver.castSpellWithTargets(
+            me,
+            spell,
+            listOf(ChosenTarget.Card(bear, me, Zone.GRAVEYARD)),
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(bear) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntimidationCampaignScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntimidationCampaignScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.IntimidationCampaign
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Intimidation Campaign (OTJ #208) — {1}{U}{B} Enchantment.
+ *
+ * "When this enchantment enters, each opponent loses 1 life, you gain 1 life, and you draw a card.
+ *  Whenever you commit a crime, you may return this enchantment to its owner's hand."
+ *
+ * Verifies the ETB drain/gain/draw, and the optional crime trigger that may bounce the enchantment
+ * back to its owner's hand (exercised by casting a spell that targets the opponent — a crime).
+ */
+class IntimidationCampaignScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(IntimidationCampaign)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("enters: each opponent loses 1, you gain 1, you draw a card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val handBefore = driver.getHand(me).size
+
+        val campaign = driver.putCardInHand(me, "Intimidation Campaign")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, campaign).isSuccess shouldBe true
+        driver.bothPass() // resolve enchantment -> enters -> ETB trigger on stack
+        driver.bothPass() // resolve the ETB trigger
+
+        driver.getLifeTotal(opp) shouldBe 19
+        driver.getLifeTotal(me) shouldBe 21
+        // +1 from the draw effect (mana was injected, no land was played from the draw).
+        driver.getHand(me).size shouldBe handBefore + 1
+    }
+
+    test("committing a crime offers to return the enchantment to hand; accepting bounces it") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val campaign = driver.putPermanentOnBattlefield(me, "Intimidation Campaign")
+
+        // Commit a crime: cast Lightning Bolt targeting the opponent.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp)).isSuccess shouldBe true
+        // Crime is committed at cast; the bounce trigger goes on the stack above the Bolt and
+        // resolves first, presenting the "may" prompt.
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true) // choose to return it
+
+        driver.getHand(me).contains(campaign) shouldBe true
+    }
+
+    test("committing a crime: declining the may leaves the enchantment on the battlefield") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val campaign = driver.putPermanentOnBattlefield(me, "Intimidation Campaign")
+
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false) // decline
+
+        driver.getHand(me).contains(campaign) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IronFistPulverizerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IronFistPulverizerScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.IronFistPulverizer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Iron-Fist Pulverizer (OTJ #131) — {4}{R} Creature — Giant Warrior 4/5.
+ *
+ * "Reach
+ *  Whenever you cast your second spell each turn, this creature deals 2 damage to target opponent.
+ *  Scry 1."
+ *
+ * Verifies the second-spell trigger deals 2 to the opponent and then scries; and that it does not
+ * fire on the controller's first spell.
+ */
+class IronFistPulverizerScenarioTest : FunSpec({
+
+    // Drain scry's two prompts (bottom-pick, top-reorder) without reordering.
+    fun GameTestDriver.drainScry(player: EntityId) {
+        repeat(2) {
+            when (val decision = pendingDecision) {
+                is SelectCardsDecision ->
+                    submitDecision(player, CardsSelectedResponse(decision.id, emptyList()))
+                is ReorderLibraryDecision ->
+                    submitDecision(player, OrderedResponse(decision.id, decision.cards))
+                else -> {}
+            }
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IronFistPulverizer))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Lightning Bolt" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("second spell deals 2 to target opponent and scries; first spell does not trigger") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Iron-Fist Pulverizer")
+
+        // First spell: no trigger.
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.passPriority(me)
+        driver.passPriority(opp)
+        driver.getLifeTotal(opp) shouldBe 17 // only the Bolt
+
+        // Second spell: trigger fires (2 damage to opponent, then scry 1).
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        // Stack: trigger (top), Bolt (bottom). Resolve trigger first.
+        driver.passPriority(me)
+        driver.passPriority(opp)
+        driver.drainScry(me) // resolve the scry prompts
+        // Resolve the Bolt.
+        driver.passPriority(me)
+        driver.passPriority(opp)
+
+        // 17 - 2 (trigger) - 3 (bolt) = 12
+        driver.getLifeTotal(opp) shouldBe 12
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandstormVergeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandstormVergeScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SandstormVerge
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sandstorm Verge (OTJ #263) — Land — Desert.
+ *
+ * "{T}: Add {C}.
+ *  {3}, {T}: Target creature can't block this turn. Activate only as a sorcery."
+ *
+ * Verifies the sorcery-speed {3},{T} ability makes a target creature unable to block this turn
+ * (projected `cantBlock`).
+ */
+class SandstormVergeScenarioTest : FunSpec({
+
+    val cantBlockAbilityId = SandstormVerge.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SandstormVerge)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("the {3},{T} ability makes a target creature unable to block this turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val verge = driver.putPermanentOnBattlefield(me, "Sandstorm Verge")
+        // Lands aren't summoning-sick for tapping, but clear it to be safe for the {T} cost.
+        driver.removeSummoningSickness(verge)
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        driver.giveColorlessMana(me, 3)
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = verge,
+                abilityId = cantBlockAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bears)),
+            ),
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the ability
+
+        driver.state.projectedState.cantBlock(bears) shouldBe true
+    }
+})


### PR DESCRIPTION
## Cards (all Outlaws of Thunder Junction, OTJ originals → canonical = OTJ)

Each card is pure authoring over existing SDK primitives and has a passing rules-engine scenario test.

- **Badlands Revival** `{3}{B}{G}` Sorcery — *Return up to one target creature card from your graveyard to the battlefield. Return up to one target permanent card from your graveyard to your hand.* Two independent optional graveyard-card target slots; `PutOntoBattlefield` + `ReturnToHand`.
- **Intimidation Campaign** `{1}{U}{B}` Enchantment — ETB: each opponent loses 1, you gain 1, draw a card. Crime trigger modelled with `MayEffect` (a yes/no decision gate) so the controller may decline the bounce — `optional = true` on a trigger only loosens target minimums, not the whole effect.
- **Sandstorm Verge** Land — Desert — `{T}: Add {C}`; `{3},{T}` sorcery-speed *target creature can't block this turn*.
- **Iron-Fist Pulverizer** `{4}{R}` 4/5 Giant Warrior — Reach; *whenever you cast your second spell each turn, deal 2 to target opponent, scry 1.*

No new engine/SDK surface, so no `card-sdk-language-reference.md` change.

## mtgish-tooling (fix the generator, not the cards)

Badlands Revival was the only one of the four that didn't auto-emit correctly; the other three already emitted and matched golden. Two emitter fixes:

- **`EmitCtx.refTargetFromRef`** — generalize the suffixed multi-target ref resolver from `Ref_TargetPermanent1/2` to also cover `Ref_TargetGraveyardCard1/2`, so each graveyard-card action binds to its own target slot (both previously collapsed onto `t1`).
- **`CardStructure.multiTargetLocals`** — recover the per-ordinal graveyard-card noun from oracle text and repair a slot the mtgish IR mistypes: Badlands Revival's "permanent card" slot arrives as `IsCardtype Creature`. We render the correct `GameObjectFilter.Permanent`-in-graveyard target rather than the IR's too-narrow filter.

## Verification

- `just coverage-verify OTJ`: all four cards auto-emit and gameplay-tree-match golden. (The 4 remaining OTJ mismatches are pre-existing cards owned by other work — Desperate Bloodseeker, Magebane Lizard, Shoot the Sheriff, Spring Splasher — untouched here.)
- `just coverage-verify POR`: GATE PASS, 0 mismatches, 158/158.
- `:mtgish-tooling:test` (incl. EmitterGoldenTest POR + EOE) — green; no fixture rebless needed.
- Four new scenario tests, `CardDefinitionSnapshotTest`, `CardLintTest` — all green. OTJ snapshot golden reblessed (additions only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)