### PR TITLE
OTJ: Metamorphic Blast + Trick Shot (+ mtgish BecomeCreature emitter)

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -358,6 +358,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.IsNontoken
     )
 
+    /** Must be a token */
+    fun token() = copy(
+        cardPredicates = cardPredicates + CardPredicate.IsToken
+    )
+
     /** Must not be of the creature type chosen on the source permanent */
     fun notOfSourceChosenType() = copy(
         cardPredicates = cardPredicates + CardPredicate.NotOfSourceChosenType

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MetamorphicBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MetamorphicBlast.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Metamorphic Blast {U}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.
+ * + {3} — Target player draws two cards.
+ *
+ * Spree (CR 702.166) is modeled as a [ModalEffect] with `minChooseCount = 1`,
+ * `chooseCount = modes.size`, and per-mode `additionalManaCost`. At least one mode
+ * must be chosen; the same mode can't be chosen more than once (`allowRepeat`
+ * stays at its default `false`). Each chosen mode targets independently.
+ *
+ * Mode 1 uses [Effects.BecomeCreature] to set the target's base power/toughness to
+ * 0/1 (Layer 7b SET_VALUES), its creature type to Rabbit (Layer 4), and its color
+ * to white (Layer 5), all until end of turn.
+ */
+val MetamorphicBlast = card("Metamorphic Blast") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.\n" +
+        "+ {3} — Target player draws two cards."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.BecomeCreature(
+                        target = EffectTarget.ContextTarget(0),
+                        power = 0,
+                        toughness = 1,
+                        creatureTypes = setOf("Rabbit"),
+                        colors = setOf(Color.WHITE.name),
+                        duration = Duration.EndOfTurn
+                    ),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {1} — Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.DrawCards(2, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Player),
+                    description = "+ {3} — Target player draws two cards.",
+                    additionalManaCost = "{3}"
+                )
+            ),
+            chooseCount = 2,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Michal Ivan"
+        flavorText = "Rundo's craving for revenge was replaced by a craving for vegetables."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg?1712860596"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TrickShot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TrickShot.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trick Shot {4}{R}
+ * Instant
+ *
+ * Trick Shot deals 6 damage to target creature and 2 damage to up to one other
+ * target creature token.
+ *
+ * Two independent target requirements: a mandatory "target creature" (index 0) and
+ * an optional "up to one other target creature token" (index 1). The second is
+ * wrapped in [TargetOther] so it must differ from the first target, and uses an
+ * `optional` [TargetObject] over the creature-token filter so it can be omitted.
+ * The optional second [Effects.DealDamage] is a no-op when no second target is
+ * chosen (the executor resolves an unset target to nothing).
+ */
+val TrickShot = card("Trick Shot") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Trick Shot deals 6 damage to target creature and 2 damage to up to one other target creature token."
+
+    spell {
+        target("creature", TargetObject(filter = TargetFilter.Creature))
+        target(
+            "tokenCreature",
+            TargetOther(
+                baseRequirement = TargetObject(
+                    optional = true,
+                    filter = TargetFilter(GameObjectFilter.Creature.token())
+                )
+            )
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.DealDamage(6, EffectTarget.ContextTarget(0)),
+                Effects.DealDamage(2, EffectTarget.ContextTarget(1))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Brian Valeza"
+        flavorText = "\"Cowerin' behind your buddy ain't gonna help, ya yellow-bellied lowlife.\"\n—Tyron, Slickshot duelist"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg?1712355870"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5498,6 +5498,92 @@
     ]
 }
 
+// Metamorphic Blast
+{
+    "name": "Metamorphic Blast",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.\n+ {3} — Target player draws two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "BecomeCreature",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "power": 0,
+                        "toughness": 1,
+                        "creatureTypes": [
+                            "Rabbit"
+                        ],
+                        "colors": [
+                            "WHITE"
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetPlayer"
+                    ],
+                    "description": "+ {3} — Target player draws two cards.",
+                    "additionalManaCost": "{3}"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Michal Ivan",
+        "flavorText": "Rundo's craving for revenge was replaced by a craving for vegetables.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg?1712860596",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mine Raider
 {
     "name": "Mine Raider",
@@ -9990,6 +10076,72 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Trick Shot
+{
+    "name": "Trick Shot",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Trick Shot deals 6 damage to target creature and 2 damage to up to one other target creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature token"
+                    }
+                },
+                "id": "tokenCreature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Brian Valeza",
+        "flavorText": "\"Cowerin' behind your buddy ain't gonna help, ya yellow-bellied lowlife.\"\n—Tyron, Slickshot duelist",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg?1712355870"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -324,6 +324,13 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
     // The layer-effects list (mtgish always shapes the action's args as [target/filter, list, expiration]).
     val layerEffects = (node["args"].asArr)?.getOrNull(1) as? JsonArray ?: return null
     if (layerEffects.isEmpty()) return null
+
+    // "becomes a [color] [creature-type] with base power and toughness P/T" (Metamorphic Blast's Spree
+    // mode) — a SetPT alongside an optional SetColor and/or SetCreatureType, and nothing else. This is the
+    // engine's atomic `Effects.BecomeCreature` shape (one effect spanning the COLOR/TYPE/P_T layers), so a
+    // per-layer Composite would diverge from the hand-authored tree. Render BecomeCreature only for the
+    // single-target case (BecomeCreature has no group form). Any other layer effect alongside declines.
+    if (!mass) becomeCreatureLayerEffect(layerEffects, target)?.let { return it }
     val inner = mutableListOf<Dsl>()
     for (le in layerEffects) {
         val leObj = le as? JsonObject ?: return null
@@ -397,6 +404,72 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
         return call("Effects.ForEachInGroup", arg(filter), arg(effect))
     }
     return effect
+}
+
+/** Colour names mtgish's `SimpleColorList` uses -> the `Color` enum constant. */
+private val LAYER_EFFECT_COLOR = mapOf(
+    "White" to "WHITE", "Blue" to "BLUE", "Black" to "BLACK", "Red" to "RED", "Green" to "GREEN",
+)
+
+/**
+ * The "becomes a [color] [creature-type] with base power and toughness P/T" shape — a layer-effect list
+ * whose entries are exactly one `SetPT` plus an optional `SetColor` and/or `SetCreatureType`, and nothing
+ * else. Renders the engine's atomic `Effects.BecomeCreature(target, power, toughness, creatureTypes,
+ * colors, duration = EndOfTurn)` (CR 613, layers 5/4/7b), matching the hand-authored idiom (Metamorphic
+ * Blast). Returns null — so the caller falls through to the per-layer renderer or scaffolds — whenever:
+ *  - there's no `SetPT` (no "becomes a P/T" base — not a become-creature shape),
+ *  - any layer effect other than Set{PT,Color,CreatureType} is present (e.g. AddCardtype, AddAbility),
+ *  - a colour isn't one of the five renderable mono-colours, or a SetColor lists more/zero than one,
+ *  - the P/T values aren't plain integers.
+ * The duration is always end-of-turn here (the engine's `Effects.BecomeCreature` facade defaults to it),
+ * so a non-EOT expiration on this shape declines via the caller's `expirationDsl` guard before this runs.
+ */
+internal fun EmitCtx.becomeCreatureLayerEffect(layerEffects: JsonArray, target: String): Dsl? {
+    val effects = layerEffects.filterIsInstance<JsonObject>()
+    if (effects.size != layerEffects.size) return null
+    if (effects.none { it.strField("_LayerEffect") == "SetPT" }) return null
+    if (effects.any { it.strField("_LayerEffect") !in setOf("SetPT", "SetColor", "SetCreatureType") }) return null
+    // A BARE SetPT ("becomes a 5/1 until end of turn", no type/colour change) is a base-P/T set, not a
+    // "becomes a creature" — keep it as SetBasePowerToughnessEffect (the per-layer renderer). Only the
+    // genuine "becomes a [colour] [type] creature" shape (SetColor and/or SetCreatureType present) maps
+    // to BecomeCreature.
+    if (effects.none { it.strField("_LayerEffect") in setOf("SetColor", "SetCreatureType") }) return null
+
+    var power: Int? = null
+    var toughness: Int? = null
+    val creatureTypes = mutableListOf<String>()
+    val colors = mutableListOf<String>()
+    for (le in effects) {
+        when (le.strField("_LayerEffect")) {
+            "SetPT" -> {
+                val pt = (le["args"] as? JsonObject)?.get("args").asArr ?: return null
+                if (pt.size != 2) return null
+                power = pt[0].asInt() ?: return null
+                toughness = pt[1].asInt() ?: return null
+            }
+            "SetCreatureType" -> {
+                val sub = le["args"].asStr() ?: return null
+                creatureTypes.add(sub)
+            }
+            "SetColor" -> {
+                val names = (le["args"] as? JsonObject)?.takeIf { it.strField("_SettableColor") == "SimpleColorList" }
+                    ?.get("args").asArr?.mapNotNull { it.asStr() } ?: return null
+                if (names.size != 1) return null  // multicolour / colourless set isn't this shape
+                colors.add(LAYER_EFFECT_COLOR[names[0]] ?: return null)
+            }
+        }
+    }
+    if (power == null || toughness == null) return null
+
+    val parts = mutableListOf(arg("target", Lit(target)), arg("power", "$power"), arg("toughness", "$toughness"))
+    if (creatureTypes.isNotEmpty()) {
+        parts.add(arg("creatureTypes", call("setOf", *creatureTypes.map { arg(Lit("\"${ktStr(it)}\"")) }.toTypedArray())))
+    }
+    if (colors.isNotEmpty()) {
+        parts.add(arg("colors", call("setOf", *colors.map { arg(Lit("Color.$it.name")) }.toTypedArray())))
+    }
+    parts.add(arg("duration", Lit("Duration.EndOfTurn")))
+    return Call("Effects.BecomeCreature", parts)
 }
 
 /** A ±X modifier (`PlusX` / `MinusX` / `Zero`) applied to a dynamic amount: PlusX keeps it; MinusX

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -85,6 +85,20 @@ class EffectHandlerTest : StringSpec({
         ).shouldBeNull()
     }
 
+    "'becomes a white Rabbit with base P/T 0/1' renders the atomic BecomeCreature (Metamorphic Blast)" {
+        // SetColor + SetCreatureType + SetPT together are the engine's atomic BecomeCreature shape (one
+        // effect across the COLOUR/TYPE/P-T layers), not a per-layer Composite.
+        layer(
+            """{"_Action":"CreatePermanentLayerEffectUntil","args":[{"_Permanent":"Ref_TargetPermanent"},""" +
+                """[{"_LayerEffect":"SetColor","args":{"_SettableColor":"SimpleColorList","args":["White"]}},""" +
+                """{"_LayerEffect":"SetCreatureType","args":"Rabbit"},""" +
+                """{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[0,1]}}],{"_Expiration":"UntilEndOfTurn"}]}""",
+            "EffectTarget.ContextTarget(0)",
+        ) shouldBe "Effects.BecomeCreature(target = EffectTarget.ContextTarget(0), power = 0, " +
+            "toughness = 1, creatureTypes = setOf(\"Rabbit\"), colors = setOf(Color.WHITE.name), " +
+            "duration = Duration.EndOfTurn)"
+    }
+
     // --- PutExiledCardOntoBattlefield (the return half of the exile-then-return blink) -------------
 
     "the bare under-owner's-control return renders a plain Move to the battlefield" {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjMetamorphicBlastTrickShotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjMetamorphicBlastTrickShotScenarioTest.kt
@@ -1,0 +1,212 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.MetamorphicBlast
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TrickShot
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for OTJ batch (schemes/spells): Metamorphic Blast (Spree) and Trick Shot.
+ *
+ * Metamorphic Blast exercises the per-mode Spree shape plus [Effects.BecomeCreature]
+ * setting base 0/1 + Rabbit type + white color; and the draw-two mode.
+ * Trick Shot exercises a two-target damage spell whose second target is an optional
+ * "other" creature **token** (the new `GameObjectFilter.token()` filter modifier).
+ */
+class OtjMetamorphicBlastTrickShotScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + MetamorphicBlast + TrickShot)
+        return driver
+    }
+
+    // ---------------------------------------------------------------------
+    // Metamorphic Blast
+    // ---------------------------------------------------------------------
+
+    test("Metamorphic Blast mode 1 makes target a white Rabbit with base power/toughness 0/1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2 Zombie
+
+        val spell = driver.putCardInHand(player, "Metamorphic Blast")
+        driver.giveMana(player, Color.BLUE, 1) // {U} base
+        driver.giveColorlessMana(player, 1)     // {1} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear)))
+            )
+        )
+        driver.bothPass()
+
+        // Base P/T set to 0/1, type set to Rabbit, color set to white.
+        projector.getProjectedPower(driver.state, bear) shouldBe 0
+        projector.getProjectedToughness(driver.state, bear) shouldBe 1
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(bear, "Rabbit") shouldBe true
+        projected.hasSubtype(bear, "Zombie") shouldBe false
+        projected.getColors(bear) shouldBe setOf("WHITE")
+    }
+
+    test("Metamorphic Blast mode 2 makes target player draw two cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val handBefore = driver.getHandSize(player)
+        val spell = driver.putCardInHand(player, "Metamorphic Blast")
+        driver.giveMana(player, Color.BLUE, 1) // {U} base
+        driver.giveColorlessMana(player, 3)     // {3} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(player)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(player)))
+            )
+        )
+        driver.bothPass()
+
+        // handBefore captured before adding the Blast: +1 (Blast) -1 (cast) +2 (drawn) = +2.
+        driver.getHandSize(player) shouldBe handBefore + 2
+    }
+
+    test("Metamorphic Blast both modes: transform a creature AND draw two cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+        val handBefore = driver.getHandSize(player)
+
+        val spell = driver.putCardInHand(player, "Metamorphic Blast")
+        driver.giveMana(player, Color.BLUE, 1) // {U} base
+        driver.giveColorlessMana(player, 4)     // {1} + {3}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear), ChosenTarget.Player(player)),
+                chosenModes = listOf(0, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(bear)),
+                    listOf(ChosenTarget.Player(player))
+                )
+            )
+        )
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, bear) shouldBe 0
+        projector.getProjectedToughness(driver.state, bear) shouldBe 1
+        // +1 (Blast added) -1 (cast) +2 (drawn) = +2
+        driver.getHandSize(player) shouldBe handBefore + 2
+    }
+
+    // ---------------------------------------------------------------------
+    // Trick Shot
+    // ---------------------------------------------------------------------
+
+    test("Trick Shot deals 6 to target creature and 2 to a creature token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val realCreature = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2 nontoken
+        val tokenCreature = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+        driver.addComponent(tokenCreature, TokenComponent) // mark as a token
+
+        val spell = driver.putCardInHand(player, "Trick Shot")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 4) // {4}{R}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(realCreature),
+                    ChosenTarget.Permanent(tokenCreature)
+                )
+            )
+        )
+        driver.bothPass()
+
+        // 6 damage kills the 2/2; 2 damage kills the 2/2 token. No "Black Creature" left.
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+    }
+
+    test("Trick Shot can be cast with only the mandatory target (omit the optional token)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val realCreature = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Trick Shot")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 4)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(realCreature))
+            )
+        )
+        driver.bothPass()
+
+        // 6 damage kills the 2/2.
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+    }
+
+    test("Trick Shot cannot choose a nontoken creature as its second target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val first = driver.putCreatureOnBattlefield(opponent, "Black Creature")
+        val secondNonToken = driver.putCreatureOnBattlefield(opponent, "Artifact Creature") // 2/2, not a token
+
+        val spell = driver.putCardInHand(player, "Trick Shot")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 4)
+        driver.submitExpectFailure(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(first),
+                    ChosenTarget.Permanent(secondNonToken)
+                )
+            )
+        )
+    }
+})


### PR DESCRIPTION
Implements two Outlaws of Thunder Junction (OTJ) spells and teaches the mtgish emitter the "becomes a [colour] [type] creature" layer-effect shape.

## Cards implemented

- **Metamorphic Blast** `{U}` (Instant — Spree) — `ModalEffect(minChooseCount = 1)` with two modes:
  - `+ {1}` — target creature becomes a white Rabbit with base power/toughness 0/1 until end of turn (`Effects.BecomeCreature`: SET_VALUES P/T + Rabbit type + white colour, layers 7b/4/5).
  - `+ {3}` — target player draws two cards.
- **Trick Shot** `{4}{R}` (Instant) — 6 damage to target creature **and** 2 damage to up to one **other** target creature **token**. Two named target requirements; the second is a `TargetOther` over an optional creature-token `TargetObject`. Adds a `GameObjectFilter.token()` filter modifier (mirror of the existing `nontoken()`).

Both are OTJ-original cards (only printing → OTJ is canonical), verified against Scryfall.

## Cards skipped (need `add-feature`, not card authoring)

- **Another Round** — "exile any number of creatures you control, return them, then repeat X more times". Needs a repeat-N-times (with cast-time X) exile/return blink effect; no such effect/executor exists (`RepeatableActionsNumTimes` is BLOCKED in the bridge).
- **Make Your Own Luck** — "exile a nonland card from among them; it becomes plotted". Plotting is currently only wired as the **Plot special action** (`PlotCardHandler`); there is no effect that makes an arbitrary card become plotted (stamp `PlottedComponent` + free-cast permission + emit `BecomesPlottedEvent`). That's a new SDK effect + executor.

## Scenario tests

`OtjMetamorphicBlastTrickShotScenarioTest` (rules-engine), 6 cases, all green:
- Metamorphic Blast mode 1 sets base 0/1 + Rabbit subtype + white colour (projected state); mode 2 draws two; both modes together.
- Trick Shot 6/2 to a creature + a creature token; cast with only the mandatory target; **rejects** a nontoken second target.

## mtgish-tooling changes

- New `becomeCreatureLayerEffect` recognizer in the `CreatePermanentLayerEffectUntil` renderer: a `SetColor` and/or `SetCreatureType` alongside a `SetPT` → the atomic `Effects.BecomeCreature(...)`, matching the hand-authored idiom. A **bare** `SetPT` still renders `SetBasePowerToughnessEffect`.
- Result: **Metamorphic Blast now emits AUTO** (whole render) and gameplay-tree matches the implemented card. Added an `EffectHandlerTest` case pinning the shape.
- **Trick Shot stays SCAFFOLD** — declined rather than mis-rendered. Whole-rendering it would need a cross-target `TargetOther` (never emitted before) + token filter recovery + `SpellDealsMultipleDamage`, a multi-part emitter feature out of scope here.

### Gate status
- `coverage-verify POR` — **GATE PASS, 0 mismatch** (158/158).
- `coverage-verify OTJ` — **GATE PASS, 0 mismatch** (118/147).
- `EmitterGoldenTest` (POR/ONS/TMP/CHK/RAV/ISD/INR/10E/EOE) — all pass, no drift (pure addition).

## Tests
- `OtjMetamorphicBlastTrickShotScenarioTest` — 6/6 pass.
- `:mtg-sets CardDefinitionSnapshotTest` — re-blessed (OTJ.json: only the two new cards added).
- `:mtg-sets CardLintTest` — pass.
- `:mtg-sdk:test`, `:mtgish-tooling:test` — pass.

SDK reference: the `.token()` modifier was already documented in `card-sdk-language-reference.md` §filters; the code now matches the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)