### PR TITLE
Add 4 OTJ Outlaws & Creatures cards + mtgish AdjustPT crime-static emitter

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CactusfolkSureshot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CactusfolkSureshot.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Cactusfolk Sureshot — Outlaws of Thunder Junction #199
+ * {2}{R}{G} · Creature — Plant Mercenary · Uncommon
+ * 4/4
+ *
+ * Reach
+ * Ward {2}
+ * At the beginning of combat on your turn, other creatures you control with power 4 or
+ * greater gain trample and haste until end of turn.
+ *
+ * The combat trigger grants both keywords to every *other* creature you control with power
+ * ≥ 4 at resolution via [Patterns.Group] (iterates the projected battlefield, so a creature
+ * whose power drops below 4 before resolution is skipped, and Cactusfolk itself is excluded).
+ */
+val CactusfolkSureshot = card("Cactusfolk Sureshot") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Plant Mercenary"
+    power = 4
+    toughness = 4
+    oracleText = "Reach\n" +
+        "Ward {2} (Whenever this creature becomes the target of a spell or ability an " +
+        "opponent controls, counter it unless that player pays {2}.)\n" +
+        "At the beginning of combat on your turn, other creatures you control with power 4 " +
+        "or greater gain trample and haste until end of turn."
+
+    keywords(Keyword.REACH)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.TRAMPLE,
+            Filters.Group.creaturesYouControl.powerAtLeast(4).other()
+        ).then(
+            Patterns.Group.grantKeywordToAll(
+                Keyword.HASTE,
+                Filters.Group.creaturesYouControl.powerAtLeast(4).other()
+            )
+        )
+        description = "other creatures you control with power 4 or greater gain trample and " +
+            "haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "199"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg?1712356071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RakishCrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RakishCrew.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rakish Crew — Outlaws of Thunder Junction #99
+ * {2}{B} · Enchantment · Uncommon
+ *
+ * When this enchantment enters, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ * Whenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life.
+ *
+ * The token is the standard OTJ Mercenary token (same as Prickly Pair / Mourner's Surprise).
+ * The death payoff is an ANY-binding battlefield→graveyard trigger filtered to outlaw
+ * creatures you control ([Filters.OutlawCreature] = the Assassin/Mercenary/Pirate/Rogue/Warlock
+ * subtype group), draining each opponent 1 and gaining you 1 — it fires once per outlaw that
+ * dies.
+ */
+val RakishCrew = card("Rakish Crew") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n" +
+        "Whenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life. " +
+        "(Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+        description = "create a 1/1 red Mercenary creature token with \"{T}: Target creature " +
+            "you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = Filters.OutlawCreature.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            listOf(
+                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                GainLifeEffect(1, EffectTarget.Controller),
+            )
+        )
+        description = "Whenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Ilse Gort"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg?1712355636"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SlickshotVaultBuster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SlickshotVaultBuster.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Slickshot Vault-Buster — Outlaws of Thunder Junction #68
+ * {2}{U} · Creature — Human Rogue · Common
+ * 1/4
+ *
+ * Vigilance
+ * This creature gets +2/+0 as long as you've committed a crime this turn.
+ *
+ * The buff is a [ConditionalStaticAbility] gated on the turn-scoped crime tracker
+ * ([Conditions.YouCommittedCrimeThisTurn]) — once any crime is committed it stays a 3/4 for
+ * the rest of the turn, then reverts at cleanup when the tracker resets.
+ */
+val SlickshotVaultBuster = card("Slickshot Vault-Buster") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "This creature gets +2/+0 as long as you've committed a crime this turn. (Targeting " +
+        "opponents, anything they control, and/or cards in their graveyards is a crime.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(2, 0, Filters.Self),
+            condition = Conditions.YouCommittedCrimeThisTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Julia Metzger"
+        flavorText = "\"Sure it's risky, but that's what makes it fun! That and the money. " +
+            "And the bankers' faces.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg?1712355501"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VisageBandit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VisageBandit.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Visage Bandit — Outlaws of Thunder Junction #76
+ * {3}{U} · Creature — Shapeshifter Rogue · Uncommon
+ * 2/2
+ *
+ * You may have this creature enter as a copy of a creature you control, except it's a
+ * Shapeshifter Rogue in addition to its other types.
+ * Plot {2}{U}
+ *
+ * The enter-as-copy clause is the standard [EntersAsCopy] clone replacement, restricted to a
+ * creature *you control* and adding both Shapeshifter and Rogue to the copy's subtypes. Plot
+ * uses the existing `KeywordAbility.plot` special action.
+ */
+val VisageBandit = card("Visage Bandit") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shapeshifter Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "You may have this creature enter as a copy of a creature you control, except " +
+        "it's a Shapeshifter Rogue in addition to its other types.\n" +
+        "Plot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a " +
+        "sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            copyFilter = GameObjectFilter.Creature.youControl(),
+            additionalSubtypes = listOf("Shapeshifter", "Rogue")
+        )
+    )
+
+    keywordAbility(KeywordAbility.plot("{2}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Miranda Meeks"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg?1712355536"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1349,6 +1349,89 @@
     ]
 }
 
+// Cactusfolk Sureshot
+{
+    "name": "Cactusfolk Sureshot",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Plant Mercenary",
+    "oracleText": "Reach\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of combat on your turn, other creatures you control with power 4 or greater gain trample and haste until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature pow>=4 ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature pow>=4 ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "other creatures you control with power 4 or greater gain trample and haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg?1712356071"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Canyon Crab
 {
     "name": "Canyon Crab",
@@ -7543,6 +7626,126 @@
     ]
 }
 
+// Rakish Crew
+{
+    "name": "Rakish Crew",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "descriptionOverride": "create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Assassin",
+                                    "Mercenary",
+                                    "Pirate",
+                                    "Rogue",
+                                    "Warlock"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Ilse Gort",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg?1712355636"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Rambling Possum
 {
     "name": "Rambling Possum",
@@ -9149,6 +9352,47 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Slickshot Vault-Buster
+{
+    "name": "Slickshot Vault-Buster",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Vigilance\nThis creature gets +2/+0 as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "PlayerCommittedCrimeThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Julia Metzger",
+        "flavorText": "\"Sure it's risky, but that's what makes it fun! That and the money. And the bankers' faces.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg?1712355501"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -10915,6 +11159,53 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Visage Bandit
+{
+    "name": "Visage Bandit",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Shapeshifter Rogue",
+    "oracleText": "You may have this creature enter as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{U}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "copyFilter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ],
+                    "controllerPredicate": "ControlledByYou"
+                },
+                "additionalSubtypes": [
+                    "Shapeshifter",
+                    "Rogue"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Miranda Meeks",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg?1712355536"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -579,8 +579,14 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
     // -> ConditionalStaticAbility(GrantKeyword(Keyword.X, Filters.Self), Not(YouCastSpellsThisTurn(1))).
     // Omenport Vigilante: "This creature has double strike as long as you've committed a crime this
     //   turn." — same shape with a `CommitedACrimeThisTurn` gate.
-    // Only the SELF "grant a single keyword to this permanent" inner shape renders; any other layer
-    // effect (stat change, multi-keyword, group filter) declines -> SCAFFOLD.
+    // Slickshot Vault-Buster: "This creature gets +2/+0 as long as you've committed a crime this
+    //   turn." — same SELF gated-static shape, but the layer effect is a fixed stat buff:
+    //   If(PlayerPassesFilter(You, CommitedACrimeThisTurn))
+    //     [ PermanentLayerEffect(ThisPermanent, [ AdjustPT(p, t) ]) ]
+    // -> ConditionalStaticAbility(ModifyStats(p, t, Filters.Self), Conditions.YouCommittedCrimeThisTurn).
+    // Only the SELF "grant a single keyword to this permanent" or "fixed +p/+t to this permanent"
+    // inner shape renders; any other layer effect (dynamic P/T, multi-keyword, group filter) declines
+    // -> SCAFFOLD.
     if (innerRule.strField("_Rule") == "PermanentLayerEffect" &&
         jsonContains(innerRule, "_Permanent", "ThisPermanent")
     ) {
@@ -589,17 +595,34 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
             ?: run { reasons.add("If"); return null }
         val layerEffects = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
         val le = layerEffects?.singleOrNull()
-        if (le == null || le.strField("_StaticLayerEffect") != "AddAbility") { reasons.add("If"); return null }
-        // An AddAbility whose granted rule is anything richer than a plain keyword (an activated ability,
-        // landwalk, protection-from-color) isn't a bare keyword grant — decline rather than mis-render.
-        val granted = (le["args"] as? JsonArray)?.singleOrNull() as? JsonObject
-        if (granted?.strField("_Rule") != null && granted.size > 1) { reasons.add("If"); return null }
-        val kw = keywordOf(le) ?: run { reasons.add("If"); return null }
-        return listOf(staticAbilityStmt(call(
-            "ConditionalStaticAbility",
-            arg("ability", call("GrantKeyword", arg("Keyword.$kw"), arg("Filters.Self"))),
-            arg("condition", Lit(condDsl)),
-        )))
+        when (le?.strField("_StaticLayerEffect")) {
+            "AddAbility" -> {
+                // An AddAbility whose granted rule is anything richer than a plain keyword (an activated
+                // ability, landwalk, protection-from-color) isn't a bare keyword grant — decline.
+                val granted = (le["args"] as? JsonArray)?.singleOrNull() as? JsonObject
+                if (granted?.strField("_Rule") != null && granted.size > 1) { reasons.add("If"); return null }
+                val kw = keywordOf(le) ?: run { reasons.add("If"); return null }
+                return listOf(staticAbilityStmt(call(
+                    "ConditionalStaticAbility",
+                    arg("ability", call("GrantKeyword", arg("Keyword.$kw"), arg("Filters.Self"))),
+                    arg("condition", Lit(condDsl)),
+                )))
+            }
+            "AdjustPT" -> {
+                // A fixed +p/+t buff: `args` is the [p, t] pair. Anything else (a dynamic AdjustPTX /
+                // AdjustPTForEach) declines rather than dropping the variable count.
+                val pt = le["args"].asArr
+                val p = pt?.getOrNull(0).asInt()
+                val t = pt?.getOrNull(1).asInt()
+                if (pt == null || pt.size != 2 || p == null || t == null) { reasons.add("If"); return null }
+                return listOf(staticAbilityStmt(call(
+                    "ConditionalStaticAbility",
+                    arg("ability", call("ModifyStats", arg("$p"), arg("$t"), arg("Filters.Self"))),
+                    arg("condition", Lit(condDsl)),
+                )))
+            }
+            else -> { reasons.add("If"); return null }
+        }
     }
 
     // Dust Animus: "If you control five or more untapped lands, this creature enters with two +1/+1

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -614,6 +614,19 @@ class TriggerMatcher(
                             if (!typeLine.hasSubtype(predicate.subtype)) return false
                         }
                     }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes -> {
+                        // Same LKI handling as HasSubtype, for the "any one of these subtypes"
+                        // (OR) form used by the Outlaw subtype group. For dying/leaving creatures
+                        // the entity (and its CardComponent) may already be gone, so read the
+                        // last-known type line rather than the generic cardComponent path.
+                        if (event.toZone == Zone.BATTLEFIELD) {
+                            if (predicate.subtypes.none { projected.hasSubtype(event.entityId, it.value) }) return false
+                        } else {
+                            if (isFaceDown) return false
+                            if (typeLine == null) return false
+                            if (predicate.subtypes.none { typeLine.hasSubtype(it) }) return false
+                        }
+                    }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasKeyword -> {
                         // For entering creatures: use projected state (they're on battlefield)
                         // For dying/leaving creatures: use lastKnownKeywords from the event since

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CactusfolkSureshotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CactusfolkSureshotScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cactusfolk Sureshot (OTJ #199).
+ *
+ * {2}{R}{G} · Creature — Plant Mercenary · 4/4
+ * Reach, Ward {2}
+ * "At the beginning of combat on your turn, other creatures you control with power 4 or
+ * greater gain trample and haste until end of turn."
+ *
+ * Verifies the begin-combat trigger: every *other* creature you control whose power is ≥ 4
+ * at resolution gains both trample and haste; a power-3-or-less creature is skipped, and
+ * Cactusfolk itself (the source) is excluded by the "other" clause.
+ */
+class CactusfolkSureshotScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.advanceToPlayer1BeginCombat() {
+        passPriorityUntil(Step.BEGIN_COMBAT)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.BEGIN_COMBAT)
+            safety++
+        }
+    }
+
+    test("begin-combat trigger grants trample and haste to other power-4+ creatures only") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+
+        val cactusfolk = driver.putCreatureOnBattlefield(driver.player1, "Cactusfolk Sureshot")
+        val crawWurm = driver.putCreatureOnBattlefield(driver.player1, "Craw Wurm") // 6/4, power >= 4
+        val bears = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // 2/2, power < 4
+        val theirWurm = driver.putCreatureOnBattlefield(
+            driver.getOpponent(driver.player1),
+            "Craw Wurm"
+        ) // opponent's power-6 creature is untouched
+
+        driver.advanceToPlayer1BeginCombat()
+        // Resolve the begin-combat trigger.
+        driver.bothPass()
+
+        // Power-6 creature I control gains both keywords.
+        projector.hasProjectedKeyword(driver.state, crawWurm, Keyword.TRAMPLE) shouldBe true
+        projector.hasProjectedKeyword(driver.state, crawWurm, Keyword.HASTE) shouldBe true
+
+        // Power-2 creature is below the threshold — unaffected.
+        projector.hasProjectedKeyword(driver.state, bears, Keyword.TRAMPLE) shouldBe false
+        projector.hasProjectedKeyword(driver.state, bears, Keyword.HASTE) shouldBe false
+
+        // Cactusfolk itself is excluded by "other creatures".
+        projector.hasProjectedKeyword(driver.state, cactusfolk, Keyword.TRAMPLE) shouldBe false
+        projector.hasProjectedKeyword(driver.state, cactusfolk, Keyword.HASTE) shouldBe false
+
+        // Opponent's creature is untouched.
+        projector.hasProjectedKeyword(driver.state, theirWurm, Keyword.TRAMPLE) shouldBe false
+        projector.hasProjectedKeyword(driver.state, theirWurm, Keyword.HASTE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RakishCrewScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RakishCrewScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RakishCrew
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rakish Crew — {2}{B} Enchantment.
+ *
+ * "When this enchantment enters, create a 1/1 red Mercenary creature token ..."
+ * "Whenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life."
+ *
+ * Verifies the ETB makes a Mercenary token (an outlaw you control) and that when that outlaw
+ * dies, the drain fires: each opponent loses 1 life and you gain 1 life.
+ */
+class RakishCrewScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RakishCrew)
+        return driver
+    }
+
+    test("Mercenary token death drains each opponent for 1 and gains you 1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tokensBefore = driver.state.getBattlefield().filter {
+            val e = driver.state.getEntity(it)
+            e?.has<TokenComponent>() == true && e.get<ControllerComponent>()?.playerId == me
+        }.toSet()
+
+        // Cast Rakish Crew, resolve it and its ETB token trigger.
+        val crew = driver.putCardInHand(me, "Rakish Crew")
+        driver.giveMana(me, Color.BLACK, 3)
+        driver.castSpell(me, crew).isSuccess shouldBe true
+        var guard = 0
+        while (driver.stackSize > 0 && !driver.isPaused && guard++ < 10) driver.bothPass()
+
+        val token = (driver.state.getBattlefield().filter {
+            val e = driver.state.getEntity(it)
+            e?.has<TokenComponent>() == true && e.get<ControllerComponent>()?.playerId == me
+        }.toSet() - tokensBefore).single()
+
+        val myLifeBefore = driver.getLifeTotal(me)
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        // Kill the Mercenary token (an outlaw I control) with Lightning Bolt.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(token))
+        // Resolve Bolt; SBAs then kill the token, putting the drain trigger on the stack;
+        // keep passing until the stack settles (bolt -> death -> drain trigger).
+        guard = 0
+        while ((driver.stackSize > 0 || driver.isPaused) && guard++ < 20) driver.bothPass()
+
+        // Outlaw died → opponent loses 1, I gain 1.
+        driver.getLifeTotal(opp) shouldBe oppLifeBefore - 1
+        driver.getLifeTotal(me) shouldBe myLifeBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickshotVaultBusterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickshotVaultBusterScenarioTest.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SlickshotVaultBuster
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Slickshot Vault-Buster — {2}{U} 1/4 Creature — Human Rogue, Vigilance.
+ *
+ * "This creature gets +2/+0 as long as you've committed a crime this turn."
+ *
+ * Verifies the conditional static buff: a 1/4 until any crime is committed this turn, then a
+ * 3/4 for the rest of the turn (the crime tracker is turn-scoped).
+ */
+class SlickshotVaultBusterScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SlickshotVaultBuster)
+        return driver
+    }
+
+    test("buff is inactive until a crime is committed, then makes it a 3/4") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 60), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val buster = driver.putCreatureOnBattlefield(me, "Slickshot Vault-Buster")
+
+        // No crime yet — base 1/4.
+        projector.getProjectedPower(driver.state, buster) shouldBe 1
+        projector.getProjectedToughness(driver.state, buster) shouldBe 4
+
+        // Commit a crime: cast Lightning Bolt at the opponent.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> commit-crime tracker flips
+
+        // Crime committed this turn — now 3/4.
+        projector.getProjectedPower(driver.state, buster) shouldBe 3
+        projector.getProjectedToughness(driver.state, buster) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VisageBanditScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VisageBanditScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.VisageBandit
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Visage Bandit — {3}{U} 2/2 Creature — Shapeshifter Rogue.
+ *
+ * "You may have this creature enter as a copy of a creature you control, except it's a
+ * Shapeshifter Rogue in addition to its other types."
+ * Plot {2}{U}.
+ *
+ * Verifies the restricted EntersAsCopy: only creatures *you control* are offered, the copy
+ * picks up the source's P/T, and Shapeshifter + Rogue are added to its subtypes. Declining
+ * leaves it a plain 2/2 Visage Bandit.
+ */
+class VisageBanditScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(VisageBandit)
+        return driver
+    }
+
+    test("enters as a copy of a creature you control, gaining Shapeshifter and Rogue") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val giant = driver.putCreatureOnBattlefield(me, "Hill Giant") // 3/3 I control
+        val theirGiant = driver.putCreatureOnBattlefield(opp, "Hill Giant") // not copyable
+
+        val bandit = driver.putCardInHand(me, "Visage Bandit")
+        driver.giveMana(me, Color.BLUE, 4)
+        driver.castSpell(me, bandit)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Only my creature is offered — the opponent's is excluded by "you control".
+        decision.options shouldContain giant
+        decision.options shouldNotContain theirGiant
+
+        driver.submitCardSelection(me, listOf(giant))
+
+        // Now a 3/3 Hill Giant copy.
+        projector.getProjectedPower(driver.state, bandit) shouldBe 3
+        projector.getProjectedToughness(driver.state, bandit) shouldBe 3
+        val card = driver.state.getEntity(bandit)?.get<CardComponent>()!!
+        card.name shouldBe "Hill Giant"
+
+        // Plus Shapeshifter and Rogue in addition to its copied types.
+        val projected = projector.project(driver.state)
+        val subtypes = projected.getSubtypes(bandit)
+        subtypes shouldContain "Shapeshifter"
+        subtypes shouldContain "Rogue"
+        subtypes shouldContain "Giant"
+    }
+
+    test("declining leaves it a plain 2/2 Visage Bandit") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(me, "Hill Giant")
+
+        val bandit = driver.putCardInHand(me, "Visage Bandit")
+        driver.giveMana(me, Color.BLUE, 4)
+        driver.castSpell(me, bandit)
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(me, emptyList())
+
+        driver.state.getBattlefield() shouldContain bandit
+        projector.getProjectedPower(driver.state, bandit) shouldBe 2
+        projector.getProjectedToughness(driver.state, bandit) shouldBe 2
+        driver.state.getEntity(bandit)?.get<CardComponent>()!!.name shouldBe "Visage Bandit"
+    }
+})


### PR DESCRIPTION
## Cards implemented (OTJ — Outlaws & Creatures batch)

All four implemented with passing rules-engine scenario tests:

- **Cactusfolk Sureshot** — Reach, Ward {2}, and a begin-combat trigger that grants trample + haste to *other* creatures you control with power 4 or greater (`Patterns.Group.grantKeywordToAll` over `Filters.Group.creaturesYouControl.powerAtLeast(4).other()`).
- **Slickshot Vault-Buster** — Vigilance + `ConditionalStaticAbility(ModifyStats(2,0,Filters.Self))` gated on `Conditions.YouCommittedCrimeThisTurn` (+2/+0 while you've committed a crime this turn).
- **Visage Bandit** — `EntersAsCopy` restricted to a creature *you control*, adding Shapeshifter + Rogue to the copy's subtypes; Plot {2}{U}.
- **Rakish Crew** — ETB creates the standard OTJ Mercenary token (sorcery-speed +1/+0 pump), plus a "whenever an outlaw you control dies" drain (each opponent loses 1 life, you gain 1).

None of the four were Tier-3 blocked gaps, so none were skipped.

## Engine fix

`TriggerMatcher` now resolves `CardPredicate.HasAnyOfSubtypes` from the **last-known type line** on battlefield→graveyard zone-change triggers, mirroring the existing `HasSubtype` LKI path. Without it, Rakish Crew's "an outlaw you control dies" trigger never fired for a token already swept by SBAs (its `CardComponent` is gone by match time). Full rules-engine suite stays green.

## mtgish-tooling changes

Extended the `If`-block static handler (`CardStructure.ifRuleBlock`) to render a SELF `AdjustPT` layer effect as `ConditionalStaticAbility(ModifyStats(p, t, Filters.Self), <gate>)`, alongside the existing `AddAbility` keyword-grant case. **Slickshot Vault-Buster now emits at AUTO tier** (matches the hand-written card exactly).

- POR stays **0-mismatch** (`coverage-verify POR` → GATE PASS, 158/158).
- `EmitterGoldenTest` unchanged — the new branch is additive, no committed-fixture set drifted, so no golden re-bless was needed.
- The other three cards remain **SCAFFOLD**: their shapes (begin-combat group-keyword-grant trigger, enters-as-copy-with-added-types, outlaw-dies drain trigger) need substantial new emitter work and were declined rather than emit a lossy approximation, per the fidelity policy.

## Pre-existing failure (not mine)

`:mtg-sets` `SuccessCriterionValidationTest` fails on **Highway Robbery** (committed in 34babcf45 by another agent's outlaw-pressure work) — its "if you do" gate lacks an inferable `SuccessCriterion`. Untouched here; reported per the collaboration rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)