### PR TITLE
Add Station multi-select activation shortcut

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2515,6 +2515,20 @@ composite abilities).
   Spacecraft that grant `GrantKeyword(...)` / `GrantCardType("CREATURE", …)`, or threshold-gated activated abilities
   for Planets — each gated on `Conditions.SourceCounterCountAtLeast(Counters.CHARGE, N)` (see §12). No dedicated
   `Keyword.STATION`: the layout/symbols are display-only and the ability is the whole mechanic.
+  - **Multi-select activation shortcut.** Because the station ability has no chosen targets and its
+    effect stacks, the player may station with several creatures in one gesture: the cost-selection
+    UI lets them pick 1..N distinct untapped creatures and the engine queues one activation per
+    creature on the stack (each taps exactly its creature and charges by *that* creature's power).
+    This is a pure UX convenience over activating station repeatedly — the resulting state is
+    identical to doing it one creature at a time — and is wired generically, not just for station:
+    any single-creature (`count == 1`) `TapPermanents`-cost activated ability with no target
+    requirements, a repeat-stacking effect, and no once-/max-per-turn restriction is offered the
+    same batch. It rides the existing `ActivateAbility.repeatCount` batch-activation path; the
+    server advertises the cap as `AdditionalCostInfo.tapBatchMaxActivations` (the count of legal tap
+    targets) and `ActivateAbilityHandler` slices `costPayment.tappedPermanents` one creature per
+    activation. Selecting a single creature is the unchanged single-station behaviour. (Saddle/Mount,
+    by contrast, already taps any number of creatures within one activation — a different shape —
+    so it is unaffected.)
 - `Morph(cost)` — cast face-down for `{3}`, flip for cost.
 - `Unmorph(cost, effect)` — turn-face-up cost + bonus effect.
 - `Equip(cost)` — Equipment attach cost. The `equipAbility(cost, genericCostReduction = …)` DSL

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -103,6 +103,13 @@ class ActivateAbilityHandler(
 ) : ActionHandler<ActivateAbility> {
     override val actionType: KClass<ActivateAbility> = ActivateAbility::class
 
+    /** The first [CostAtom.TapPermanents] atom anywhere in this cost, or null if it has none. */
+    private fun AbilityCost.firstTapPermanentsAtomOrNull(): CostAtom.TapPermanents? = when (this) {
+        is AbilityCost.Atom -> atom as? CostAtom.TapPermanents
+        is AbilityCost.Composite -> costs.firstNotNullOfOrNull { it.firstTapPermanentsAtomOrNull() }
+        else -> null
+    }
+
     override fun validate(state: GameState, action: ActivateAbility): String? {
         // `opponentTargetsChosen` is an internal resume marker for "… of an opponent's choice"
         // targets (Cuombajj Witches). Only the engine's resumer sets it, and the resumer re-enters
@@ -204,6 +211,30 @@ class ActivateAbilityHandler(
             ability.targetRequirements.map { it.applyTextReplacement(textReplacement) }
         } else {
             ability.targetRequirements
+        }
+
+        // Station-style multi-select batch (CR 702.184a): repeatCount > 1 over a tap-permanents
+        // cost means "queue one activation per chosen creature". Validate the batch is well-formed
+        // so a malformed action can't, e.g., tap one creature for three activations or reuse the
+        // same creature twice. Per-creature legality (untapped/controlled/filter) is re-checked at
+        // payment time in CostHandler.payTapPermanents for every slice.
+        if (action.repeatCount > 1) {
+            val tapAtom = effectiveCost.firstTapPermanentsAtomOrNull()
+            if (tapAtom != null) {
+                if (tapAtom.count != 1) {
+                    return "Batch activation is only supported for single-creature tap costs"
+                }
+                if (effectiveTargetReqs.isNotEmpty()) {
+                    return "Batch activation is not supported for abilities that require targets"
+                }
+                val tapped = action.costPayment?.tappedPermanents ?: emptyList()
+                if (tapped.size != action.repeatCount) {
+                    return "Batch tap-cost activation needs ${action.repeatCount} creatures, got ${tapped.size}"
+                }
+                if (tapped.toSet().size != tapped.size) {
+                    return "Cannot tap the same creature for more than one activation"
+                }
+            }
         }
 
         // Check timing for planeswalker abilities
@@ -627,12 +658,26 @@ class ActivateAbilityHandler(
             }
         }
 
+        // Station-style multi-select batch (CR 702.184a): when repeatCount > 1 over a single-
+        // creature tap cost, `tappedPermanents` holds one creature per queued activation. Each
+        // activation taps exactly its own creature, so slice the list — this activation gets the
+        // first creature; the repeat loop below consumes the rest one at a time. For every other
+        // ability (no tap cost, or repeatCount == 1) the slice is the whole list, unchanged.
+        val tapBatchAtom = if (action.repeatCount > 1) effectiveCost.firstTapPermanentsAtomOrNull() else null
+        val isTapBatch = tapBatchAtom != null && tapBatchAtom.count == 1 &&
+            (action.costPayment?.tappedPermanents?.size ?: 0) == action.repeatCount
+        val firstTapSlice = if (isTapBatch) {
+            listOf(action.costPayment!!.tappedPermanents.first())
+        } else {
+            action.costPayment?.tappedPermanents ?: emptyList()
+        }
+
         // Build cost payment choices from the action
         val costChoices = CostPaymentChoices(
             sacrificeChoices = action.costPayment?.sacrificedPermanents ?: emptyList(),
             discardChoices = action.costPayment?.discardedCards ?: emptyList(),
             exileChoices = action.costPayment?.exiledCards ?: emptyList(),
-            tapChoices = action.costPayment?.tappedPermanents ?: emptyList(),
+            tapChoices = firstTapSlice,
             bounceChoices = action.costPayment?.bouncedPermanents ?: emptyList(),
             xValue = xValue,
             counterRemovalChoices = action.costPayment?.counterRemovals ?: emptyMap(),
@@ -647,7 +692,7 @@ class ActivateAbilityHandler(
 
         // Mirror sacrifice snapshots for tapped-as-cost permanents — they may leave the
         // battlefield in response while the ability is on the stack.
-        val tappedTargetIds = action.costPayment?.tappedPermanents ?: emptyList()
+        val tappedTargetIds = firstTapSlice
         val tappedSnapshots = capturePermanentSnapshots(tappedTargetIds, currentState.projectedState)
 
         // When using Explicit payment, mana sources were already tapped above —
@@ -1096,7 +1141,7 @@ class ActivateAbilityHandler(
             effect = finalEffect,
             sacrificedPermanents = sacrificedSnapshots,
             xValue = action.xValue,
-            tappedPermanents = action.costPayment?.tappedPermanents ?: emptyList(),
+            tappedPermanents = firstTapSlice,
             tappedPermanentSnapshots = tappedSnapshots,
             descriptionOverride = ability.descriptionOverride
         )
@@ -1139,9 +1184,17 @@ class ActivateAbilityHandler(
                     events.addAll(autoTapResult.events)
                 }
 
+                // Station-style batch: this activation taps the i-th chosen creature (1-indexed
+                // list, so iteration `i` consumes element `i - 1`). Other repeatable abilities
+                // (mana-only) carry no tap choices, so the slice is empty and the cost re-pays from
+                // mana as before. Snapshot the creature before it's tapped (Rule 112.7a) so
+                // DynamicAmount.StationCharge reads its power off this instance's own snapshot.
+                val repeatTapSlice = if (isTapBatch) listOf(action.costPayment!!.tappedPermanents[i - 1]) else emptyList()
+                val repeatTapSnapshots = capturePermanentSnapshots(repeatTapSlice, currentState.projectedState)
+
                 // Pay the cost
                 val repeatCostResult = costHandler.payAbilityCost(
-                    currentState, effectiveCost, action.sourceId, action.playerId, repeatPool, CostPaymentChoices(), executeAbilityContext
+                    currentState, effectiveCost, action.sourceId, action.playerId, repeatPool, CostPaymentChoices(tapChoices = repeatTapSlice), executeAbilityContext
                 )
                 if (!repeatCostResult.success) break // Can't pay — stop early
 
@@ -1169,7 +1222,8 @@ class ActivateAbilityHandler(
                     effect = finalEffect,
                     sacrificedPermanents = emptyList(),
                     xValue = action.xValue,
-                    tappedPermanents = emptyList(),
+                    tappedPermanents = repeatTapSlice,
+                    tappedPermanentSnapshots = repeatTapSnapshots,
                     descriptionOverride = ability.descriptionOverride
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -257,6 +257,15 @@ data class AdditionalCostData(
     val sacrificeCount: Int = 1,
     val validTapTargets: List<EntityId> = emptyList(),
     val tapCount: Int = 0,
+    /**
+     * Station-style multi-select shortcut (CR 702.184a). When > 1, this single-creature
+     * (`tapCount == 1`) tap cost belongs to a no-target, stacking activated ability that may be
+     * activated several times in one gesture: the player selects 1..[tapBatchMaxActivations]
+     * distinct creatures and the engine queues one activation per creature (each taps exactly its
+     * creature). 1 means "no batch" — the cost is paid by tapping exactly [tapCount] creatures for
+     * a single activation, the prior behaviour.
+     */
+    val tapBatchMaxActivations: Int = 1,
     val validDiscardTargets: List<EntityId> = emptyList(),
     val discardCount: Int = 0,
     val validBounceTargets: List<EntityId> = emptyList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -599,6 +599,30 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     else -> emptyList()
                 }
 
+                // Station-style multi-select shortcut (CR 702.184a): a single-creature tap cost
+                // with no chosen targets and a per-activation effect that stacks can be queued
+                // several times in one gesture — the player taps multiple distinct creatures and
+                // one activation per creature goes on the stack (each taps exactly its creature,
+                // each produces its own effect). This is a UX shortcut over repeated single
+                // activations, not a rules change. Restricted to `count == 1` so the client offers
+                // a plain 1..N creature pick (no multiple-of-count grouping); the once/max-per-turn
+                // and "effect must stack" guards mirror the mana repeat path above.
+                val tapBatchMaxActivations: Int = run {
+                    val atom = tapCost
+                    if (atom != null
+                        && atom.count == 1
+                        && tapTargets != null
+                        && tapTargets.size > 1
+                        && ability.targetRequirements.isEmpty()
+                        && effectStacksOnRepeat(ability.effect)
+                        && !ability.restrictions.any {
+                            it is ActivationRestriction.OncePerTurn || it is ActivationRestriction.Once ||
+                                it is ActivationRestriction.MaxPerTurn ||
+                                (it is ActivationRestriction.All && it.restrictions.any { r -> r is ActivationRestriction.OncePerTurn || r is ActivationRestriction.Once || r is ActivationRestriction.MaxPerTurn })
+                        }
+                    ) tapTargets.size else 1
+                }
+
                 // Build additional cost info for sacrifice, tap, bounce, or counter removal costs
                 val costInfo = buildAdditionalCostInfo(
                     ability, tapTargets, tapCost, hasTapXPermanentsCost,
@@ -608,7 +632,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     blightCost, blightCreatures,
                     discardCost, discardTargets,
                     craftCost, craftMaterials,
-                    exileCost, exileTargets
+                    exileCost, exileTargets,
+                    tapBatchMaxActivations
                 )
 
                 // Calculate X cost info for activated abilities with X in their mana cost
@@ -931,7 +956,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         craftCost: AbilityCost.Craft? = null,
         craftMaterials: List<EntityId> = emptyList(),
         exileCost: CostAtom.ExileFrom? = null,
-        exileTargets: List<EntityId>? = null
+        exileTargets: List<EntityId>? = null,
+        tapBatchMaxActivations: Int = 1
     ): AdditionalCostData? {
         if (craftCost != null) {
             // Craft (CR 702.167) is handled exclusively: when a Composite cost contains a
@@ -956,6 +982,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 costType = "TapPermanents",
                 validTapTargets = tapTargets,
                 tapCount = tapCost.count,
+                tapBatchMaxActivations = tapBatchMaxActivations,
                 counterRemovalCreatures = counterRemovalCreatures
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -136,6 +136,7 @@ class LegalActionEnricher(
         sacrificeCount = sacrificeCount,
         validTapTargets = validTapTargets,
         tapCount = tapCount,
+        tapBatchMaxActivations = tapBatchMaxActivations,
         validDiscardTargets = validDiscardTargets,
         discardCount = discardCount,
         validBounceTargets = validBounceTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -175,6 +175,9 @@ data class AdditionalCostInfo(
     val sacrificeCount: Int = 1,
     val validTapTargets: List<EntityId> = emptyList(),
     val tapCount: Int = 0,
+    /** Station-style shortcut: when > 1, up to this many single-creature tap activations may be
+     *  queued in one gesture (select 1..N distinct creatures, one activation each). 1 = no batch. */
+    val tapBatchMaxActivations: Int = 1,
     val validDiscardTargets: List<EntityId> = emptyList(),
     val discardCount: Int = 0,
     val validBounceTargets: List<EntityId> = emptyList(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StationMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StationMechanicTest.kt
@@ -313,5 +313,150 @@ class StationMechanicTest : ScenarioTestBase() {
                 }
             }
         }
+
+        // The multi-select shortcut: a single gesture taps several creatures and queues one station
+        // activation per creature on the stack (each taps exactly its creature). This is purely a
+        // convenience over activating station repeatedly — the resulting game state is identical to
+        // doing it one creature at a time, so it is modelled on the existing `repeatCount`
+        // batch-activation path rather than a rules change.
+        context("Station multi-select shortcut") {
+
+            test("the legal action advertises a batch cap equal to the number of tappable creatures") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wedgelight Rammer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Spined Wurm", summoningSickness = false) // 5/4
+                    .withCardOnBattlefield(1, "Test Bulwark", summoningSickness = false) // 1/5
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rammer = game.findPermanent("Wedgelight Rammer")!!
+                val stationAction = game.getLegalActions(1).single {
+                    (it.action as? ActivateAbility)?.let { a -> a.sourceId == rammer } == true
+                }
+                withClue("two other untapped creatures ⇒ up to two activations can be queued at once") {
+                    stationAction.additionalCostInfo?.tapBatchMaxActivations shouldBe 2
+                }
+            }
+
+            test("selecting two creatures queues two station activations, each charging by its own creature's power") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wedgelight Rammer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Spined Wurm", summoningSickness = false) // power 5
+                    .withCardOnBattlefield(1, "Test Bulwark", summoningSickness = false) // power 1
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rammer = game.findPermanent("Wedgelight Rammer")!!
+                val wurm = game.findPermanent("Spined Wurm")!!
+                val wall = game.findPermanent("Test Bulwark")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rammer,
+                        abilityId = stationAbilityId("Wedgelight Rammer"),
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(wurm, wall)),
+                        repeatCount = 2
+                    )
+                )
+                withClue("batch station activation should succeed: ${result.error}") { result.error shouldBe null }
+                withClue("one ability per chosen creature is on the stack") { game.state.stack.size shouldBe 2 }
+                withClue("both chosen creatures are tapped to pay") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(wall)?.has<TappedComponent>() shouldBe true
+                }
+
+                game.resolveStack()
+
+                // 5 (Wurm) + 1 (Bulwark) = 6. A single shared snapshot would give 10 or 2; the
+                // distinct total proves each queued activation read its own creature's power.
+                withClue("charge = sum of each tapped creature's power (5 + 1)") {
+                    game.state.getEntity(rammer)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) shouldBe 6
+                }
+            }
+
+            test("picking a single creature still works while the batch shortcut is available (back-compat)") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wedgelight Rammer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Spined Wurm", summoningSickness = false) // power 5
+                    .withCardOnBattlefield(1, "Test Bulwark", summoningSickness = false) // power 1
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rammer = game.findPermanent("Wedgelight Rammer")!!
+                val wurm = game.findPermanent("Spined Wurm")!!
+                val wall = game.findPermanent("Test Bulwark")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rammer,
+                        abilityId = stationAbilityId("Wedgelight Rammer"),
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(wurm))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.state.getEntity(rammer)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) shouldBe 5
+                withClue("the unchosen creature is left untapped") {
+                    game.state.getEntity(wall)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("a batch whose creature count does not match repeatCount is rejected") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wedgelight Rammer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Spined Wurm", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Bulwark", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rammer = game.findPermanent("Wedgelight Rammer")!!
+                val wurm = game.findPermanent("Spined Wurm")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rammer,
+                        abilityId = stationAbilityId("Wedgelight Rammer"),
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(wurm)), // only 1
+                        repeatCount = 2 // but asked for 2 activations
+                    )
+                )
+                withClue("one creature can't pay for two activations") { result.error shouldNotBe null }
+            }
+
+            test("a batch cannot tap the same creature for more than one activation") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wedgelight Rammer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Spined Wurm", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rammer = game.findPermanent("Wedgelight Rammer")!!
+                val wurm = game.findPermanent("Spined Wurm")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rammer,
+                        abilityId = stationAbilityId("Wedgelight Rammer"),
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(wurm, wurm)),
+                        repeatCount = 2
+                    )
+                )
+                withClue("the same creature can't be tapped twice in one batch") { result.error shouldNotBe null }
+            }
+        }
     }
 }

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -360,6 +360,19 @@ export function mergeResult(
         return { ...action, additionalCostPayment }
       }
       if (action.type === 'ActivateAbility') {
+        // Station-style multi-select shortcut: when the tap cost is batch-activatable, the number
+        // of creatures chosen becomes repeatCount — one activation per creature goes on the stack,
+        // each tapping its own creature (the engine slices `tappedPermanents` per activation).
+        if (
+          costType === 'TapPermanents' &&
+          (_actionInfo.additionalCostInfo?.tapBatchMaxActivations ?? 1) > 1
+        ) {
+          return {
+            ...action,
+            costPayment: { tappedPermanents: selectedTargets },
+            repeatCount: selectedTargets.length,
+          }
+        }
         const costPayment =
           costType === 'TapPermanents'
             ? { tappedPermanents: selectedTargets }
@@ -586,19 +599,30 @@ export function enterPhase(
           break
         case 'TapPermanents': {
           validTargets = [...(costInfo.validTapTargets ?? [])]
-          // `tapCount = 0` from the server is the TapXPermanents sentinel for "variable,
-          // equals the chosen X". The xSelection pipeline phase already ran and put the
-          // chosen value on action.xValue; use it as the required tap count so the prompt
-          // reads "Select 3/3" instead of "Select 0/0".
-          const xTapCount =
-            actionInfo.hasXCost &&
-            (action.type === 'ActivateAbility' || action.type === 'CastSpell') &&
-            typeof action.xValue === 'number'
-              ? action.xValue
-              : null
-          const requiredTaps = xTapCount ?? costInfo.tapCount ?? 1
-          minTargets = requiredTaps
-          maxTargets = requiredTaps
+          // Station-style multi-select shortcut (CR 702.184a): each chosen creature becomes its
+          // own activation on the stack (one tap each). Let the player pick 1..N distinct
+          // creatures; mergeResult sets repeatCount to the number chosen. tapBatchMaxActivations
+          // is the server-validated cap (the count of legal tap targets). Picking one is the
+          // unchanged single-station behaviour, so this is strictly additive.
+          const batchMax = costInfo.tapBatchMaxActivations ?? 1
+          if (batchMax > 1) {
+            minTargets = 1
+            maxTargets = Math.min(batchMax, validTargets.length)
+          } else {
+            // `tapCount = 0` from the server is the TapXPermanents sentinel for "variable,
+            // equals the chosen X". The xSelection pipeline phase already ran and put the
+            // chosen value on action.xValue; use it as the required tap count so the prompt
+            // reads "Select 3/3" instead of "Select 0/0".
+            const xTapCount =
+              actionInfo.hasXCost &&
+              (action.type === 'ActivateAbility' || action.type === 'CastSpell') &&
+              typeof action.xValue === 'number'
+                ? action.xValue
+                : null
+            const requiredTaps = xTapCount ?? costInfo.tapCount ?? 1
+            minTargets = requiredTaps
+            maxTargets = requiredTaps
+          }
           flags.isSacrificeSelection = true
           flags.isTapPermanentSelection = true
           break

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -874,6 +874,13 @@ export interface AdditionalCostInfo {
   readonly sacrificeCount?: number
   readonly validTapTargets?: readonly EntityId[]
   readonly tapCount?: number
+  /**
+   * Station-style multi-select shortcut (CR 702.184a). When > 1, this single-creature tap cost
+   * belongs to a no-target, stacking ability that may be activated several times in one gesture:
+   * select 1..tapBatchMaxActivations distinct creatures and one activation per creature is queued
+   * (repeatCount = number selected). 1 / absent means the normal "tap exactly tapCount" behaviour.
+   */
+  readonly tapBatchMaxActivations?: number
   readonly validDiscardTargets?: readonly EntityId[]
   readonly discardCount?: number
   readonly validBounceTargets?: readonly EntityId[]


### PR DESCRIPTION
## What

Station (CR 702.184a) taps **one** creature per activation, so charging up a Spacecraft with several creatures meant activating it once per creature — clicking through priority each time. This adds a one-gesture shortcut: **select N distinct untapped creatures and the engine queues one Station activation per creature** on the stack, each tapping exactly its creature and charging by *that* creature's own power.

It's a pure UX convenience over repeated single activations (the resulting game state is identical to doing it one creature at a time), so it rides the existing `ActivateAbility.repeatCount` batch-activation path rather than changing any rules.

## Scope

- **Station** gets the shortcut. Picking a single creature is the unchanged single-station behaviour, so the change is strictly additive.
- **Saddle / Mount is intentionally untouched** — Saddle already taps *any number* of creatures within a single activation (a different shape; one ability on the stack).
- Wired **generically**, not special-cased to Station: any single-creature (`count == 1`) `TapPermanents`-cost activated ability with no target requirements, a repeat-stacking effect, and no once-/max-per-turn restriction is offered the same batch.

## How it threads through the layers

- **Enumerator** (`ActivatedAbilityEnumerator`) advertises the cap as `AdditionalCostInfo.tapBatchMaxActivations` (= count of legal tap targets). `1` means "no batch".
- **Handler** (`ActivateAbilityHandler`) validates the batch (creature count matches `repeatCount`, distinct creatures, `count == 1`, no targets) and slices `costPayment.tappedPermanents` one creature per activation — snapshotting each so `DynamicAmount.StationCharge` reads the right power per stack instance (including last-known-information when a tapped creature leaves in response).
- **DTO**: new field on `AdditionalCostData` → `AdditionalCostInfo` → `messages.ts`.
- **Client** (`pipelinePhases.ts`): the `TapPermanents` cost phase becomes a `1..N` pick when batch-eligible; the number of creatures chosen becomes `repeatCount`.

## Tests

5 new cases in `StationMechanicTest` (all green; full `rules-engine` suite green):
- the legal action advertises the batch cap;
- selecting two creatures queues two activations and charges by **each** creature's power (5 + 1 = 6 — a shared snapshot would give 10 or 2);
- single-select still works while the shortcut is available (back-compat);
- a count/`repeatCount` mismatch is rejected;
- the same creature can't be tapped twice in one batch.

## UI note

The player-facing surface reuses the **existing on-battlefield tap-selection** component — the only change is that the selectable range becomes `1..N` instead of fixed `1`, with the usual `x / N selected` + confirm. No new visual component, so no screenshot is attached; happy to add one if a reviewer wants the live capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)