### PR TITLE
Add OTJ spells/removal batch (Rustler Rampage, Requisition Raid, Unfortunate Accident, Take for a Ride)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RequisitionRaid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RequisitionRaid.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Requisition Raid {W}
+ * Sorcery
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — Destroy target artifact.
+ * + {1} — Destroy target enchantment.
+ * + {1} — Put a +1/+1 counter on each creature target player controls.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`,
+ * `chooseCount = modes.size`, and per-mode `additionalManaCost` (CR 702.166).
+ * Mode 2 distributes a +1/+1 counter over every creature the targeted player
+ * controls (`ForEachInGroup` over a target-relative group filter, with the counter
+ * placed on each iterated permanent via [EffectTarget.Self]).
+ */
+val RequisitionRaid = card("Requisition Raid") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — Destroy target artifact.\n" +
+        "+ {1} — Destroy target enchantment.\n" +
+        "+ {1} — Put a +1/+1 counter on each creature target player controls."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Artifact),
+                    description = "+ {1} — Destroy target artifact.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Enchantment),
+                    description = "+ {1} — Destroy target enchantment.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.ForEachInGroup(
+                        filter = GroupFilter(
+                            GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))
+                        ),
+                        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                    ),
+                    targetRequirements = listOf(Targets.Player),
+                    description = "+ {1} — Put a +1/+1 counter on each creature target player controls.",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "Viko Menezes"
+        flavorText = "The Freestriders believe in liberation, in all its many forms."
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg?1712860601"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RustlerRampage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RustlerRampage.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rustler Rampage {W}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — Untap all creatures target player controls.
+ * + {1} — Target creature gains double strike until end of turn.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`,
+ * `chooseCount = modes.size`, and per-mode `additionalManaCost` (CR 702.166).
+ * Each chosen mode targets independently, so the player/creature target is
+ * resolved per-mode via [EffectTarget.ContextTarget]. Mode 1 untaps every creature
+ * the targeted player controls (`ForEachInGroup` over a target-relative group
+ * filter); mode 2 grants double strike until end of turn.
+ */
+val RustlerRampage = card("Rustler Rampage") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — Untap all creatures target player controls.\n" +
+        "+ {1} — Target creature gains double strike until end of turn."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.ForEachInGroup(
+                        filter = GroupFilter(
+                            GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))
+                        ),
+                        effect = Effects.Untap(EffectTarget.Self)
+                    ),
+                    targetRequirements = listOf(Targets.Player),
+                    description = "+ {1} — Untap all creatures target player controls.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {1} — Target creature gains double strike until end of turn.",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 2,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Release the cows!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg?1712860605"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TakeForARide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TakeForARide.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Take for a Ride {2}{R}
+ * Sorcery
+ *
+ * Take for a Ride has flash as long as you've committed a crime this turn.
+ * (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.
+ *
+ * A "Threaten" variant: gain control / untap / grant haste, all threading the single
+ * creature target. The conditional-flash clause is the card-level `conditionalFlash`
+ * field (gated on [Conditions.YouCommittedCrimeThisTurn]); the crime-this-turn tracker
+ * is consulted whenever the engine recomputes castable timing.
+ */
+val TakeForARide = card("Take for a Ride") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Take for a Ride has flash as long as you've committed a crime this turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n" +
+        "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn."
+
+    conditionalFlash = Conditions.YouCommittedCrimeThisTurn
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GainControl(t, Duration.EndOfTurn),
+            Effects.Untap(t),
+            Effects.GrantKeyword(Keyword.HASTE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Artur Treffner"
+        flavorText = "\"Your horse deserves a braver rider!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg?1712355858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/UnfortunateAccident.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/UnfortunateAccident.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Unfortunate Accident {B}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2}{B} — Destroy target creature.
+ * + {1} — Create a 1/1 red Mercenary creature token with "{T}: Target creature you
+ *   control gets +1/+0 until end of turn. Activate only as a sorcery."
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`,
+ * `chooseCount = modes.size`, and per-mode `additionalManaCost` (CR 702.166).
+ * The token's granted tap-ability mirrors the standard OTJ Mercenary token
+ * (cf. Hellspur Posse Boss): sorcery-speed `{T}` pump of a creature you control.
+ */
+val UnfortunateAccident = card("Unfortunate Accident") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2}{B} — Destroy target creature.\n" +
+        "+ {1} — Create a 1/1 red Mercenary creature token with \"{T}: Target creature you " +
+        "control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {2}{B} — Destroy target creature.",
+                    additionalManaCost = "{2}{B}"
+                ),
+                Mode(
+                    effect = CreateTokenEffect(
+                        count = DynamicAmount.Fixed(1),
+                        power = 1,
+                        toughness = 1,
+                        colors = setOf(Color.RED),
+                        creatureTypes = setOf("Mercenary"),
+                        activatedAbilities = listOf(
+                            ActivatedAbility(
+                                cost = AbilityCost.Tap,
+                                effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                                targetRequirements = listOf(Targets.CreatureYouControl),
+                                timing = TimingRule.SorcerySpeed
+                            )
+                        ),
+                        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+                    ),
+                    description = "+ {1} — Create a 1/1 red Mercenary creature token with \"{T}: " +
+                        "Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 2,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "Josiah \"Jo\" Cameron"
+        flavorText = "\"Looks like you've got a train to catch.\"\n—Laughing Jasper Flint"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg?1712860615"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -7934,6 +7934,122 @@
     "colorIdentityOverride": []
 }
 
+// Requisition Raid
+{
+    "name": "Requisition Raid",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — Destroy target artifact.\n+ {1} — Destroy target enchantment.\n+ {1} — Put a +1/+1 counter on each creature target player controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Destroy target artifact.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Destroy target enchantment.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "body": {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetPlayer"
+                    ],
+                    "description": "+ {1} — Put a +1/+1 counter on each creature target player controls.",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "UNCOMMON",
+        "artist": "Viko Menezes",
+        "flavorText": "The Freestriders believe in liberation, in all its many forms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg?1712860601",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Resilient Roadrunner
 {
     "name": "Resilient Roadrunner",
@@ -8351,6 +8467,99 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Rustler Rampage
+{
+    "name": "Rustler Rampage",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — Untap all creatures target player controls.\n+ {1} — Target creature gains double strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "body": {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetPlayer"
+                    ],
+                    "description": "+ {1} — Untap all creatures target player controls.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Target creature gains double strike until end of turn.",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Release the cows!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg?1712860605",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -10110,6 +10319,65 @@
     ]
 }
 
+// Take for a Ride
+{
+    "name": "Take for a Ride",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Take for a Ride has flash as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "conditionalFlash": "PlayerCommittedCrimeThisTurn"
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Treffner",
+        "flavorText": "\"Your horse deserves a braver rider!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg?1712355858"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Take the Fall
 {
     "name": "Take the Fall",
@@ -10747,6 +11015,114 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Unfortunate Accident
+{
+    "name": "Unfortunate Accident",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2}{B} — Destroy target creature.\n+ {1} — Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {2}{B} — Destroy target creature.",
+                    "additionalManaCost": "{2}{B}"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "RED"
+                        ],
+                        "creatureTypes": [
+                            "Mercenary"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                        "activatedAbilities": [
+                            {
+                                "id": "ability_1",
+                                "cost": "CostTap",
+                                "effect": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "creature ctrl:you"
+                                        }
+                                    }
+                                ],
+                                "timing": "SorcerySpeed"
+                            }
+                        ]
+                    },
+                    "description": "+ {1} — Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "Josiah \"Jo\" Cameron",
+        "flavorText": "\"Looks like you've got a train to catch.\"\n—Laughing Jasper Flint",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg?1712860615",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -469,6 +469,14 @@ private fun EmitCtx.youControlAtLeastConditionDsl(condNode: JsonElement?): Strin
  * "you control a [filter]" condition the shared [youControlConditionDsl] renders exactly produces a
  * line; any other flash condition declines (null -> SCAFFOLD) so the emitter never grants flash on a
  * condition it can't reproduce.
+ *
+ * Note: the OTJ "...as long as you've committed a crime this turn" flash condition
+ * ([youCommittedCrimeConditionDsl]) is renderable in isolation, but every OTJ card that carries it
+ * (e.g. Take for a Ride) also has a spell body the mtgish IR renders lossily — Take for a Ride's
+ * "It gains haste until end of turn" is absent from the IR, so a whole-card AUTO render would silently
+ * drop it. Rendering the flash gate while the body stays lossy would ship a confidently-wrong card, so
+ * we keep declining (-> SCAFFOLD) here rather than emit a partial card. Revisit if/when the IR carries
+ * the full spell body.
  */
 internal fun EmitCtx.conditionalFlashLines(rule: JsonObject): List<Stmt>? {
     val cond = youControlConditionDsl(rule["args"]) ?: run { reasons.add("FlashForCasters"); return null }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -896,8 +896,13 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
             playersKind == "Opponent" -> node.dot("opponentControls")
             playersKind == "Other" && playerRef == "You" -> node.dot("opponentControls")
             playersKind == "SinglePlayer" && playerRef == "You" -> node.dot("youControl")
-            // Any other player scope (Ref_TargetPlayer, Trigger_ThatPlayer, YourTeam, …) has no
+            // "...target player controls" (Rustler Rampage / Requisition Raid): the group is keyed to
+            // a player target the spell/mode declares. In every shape this surface renders (a single
+            // chosen player), that target lives in the first slot, so bind the controller predicate to
+            // ContextTarget(0). Any other player scope (Trigger_ThatPlayer, YourTeam, …) has no
             // rendering here; widening to every permanent would be confidently wrong, so decline.
+            playersKind == "SinglePlayer" && playerRef == "Ref_TargetPlayer" ->
+                node.dot("targetPlayerControls", arg("EffectTarget.ContextTarget(0)"))
             else -> return null
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRequisitionRaidScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRequisitionRaidScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RequisitionRaid
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Requisition Raid (OTJ Spree sorcery).
+ *
+ * Mode 0/1: destroy target artifact / enchantment. Mode 2 ({1}): put a +1/+1 counter
+ * on each creature the targeted player controls (`ForEachInGroup` over a target-relative
+ * group filter, counter placed on each iterated permanent via `EffectTarget.Self`).
+ */
+class OtjRequisitionRaidScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RequisitionRaid)
+        return driver
+    }
+
+    test("Mode 2 puts a +1/+1 counter on each creature the targeted player controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val a = driver.putCreatureOnBattlefield(player, "Black Creature") // 2/2
+        val b = driver.putCreatureOnBattlefield(player, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Requisition Raid")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 2
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(player)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(player)))
+            )
+        )
+        driver.bothPass()
+
+        // Both 2/2 creatures get a +1/+1 counter -> 3/3.
+        projector.getProjectedPower(driver.state, a) shouldBe 3
+        projector.getProjectedToughness(driver.state, a) shouldBe 3
+        projector.getProjectedPower(driver.state, b) shouldBe 3
+        projector.getProjectedToughness(driver.state, b) shouldBe 3
+    }
+
+    test("Mode 0 destroys target artifact") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val artifact = driver.putCreatureOnBattlefield(opponent, "Artifact Creature") // 2/2 artifact
+
+        val spell = driver.putCardInHand(player, "Requisition Raid")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(artifact)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(artifact)))
+            )
+        )
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Artifact Creature") shouldBe null
+    }
+
+    test("Multiple modes: destroy an artifact AND counter up your team") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val artifact = driver.putCreatureOnBattlefield(opponent, "Artifact Creature")
+        val mine = driver.putCreatureOnBattlefield(player, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Requisition Raid")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 2)      // {1} (mode 0) + {1} (mode 2)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(artifact), ChosenTarget.Player(player)),
+                chosenModes = listOf(0, 2),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(artifact)),
+                    listOf(ChosenTarget.Player(player))
+                )
+            )
+        )
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Artifact Creature") shouldBe null
+        projector.getProjectedPower(driver.state, mine) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRustlerRampageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRustlerRampageScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RustlerRampage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rustler Rampage (OTJ Spree instant).
+ *
+ * Mode 0 ({1}): untap all creatures the targeted player controls (`ForEachInGroup`
+ * over a target-relative group filter). Mode 1 ({1}): target creature gains double
+ * strike until end of turn. Both modes resolve their own target via `ContextTarget(0)`.
+ */
+class OtjRustlerRampageScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RustlerRampage)
+        return driver
+    }
+
+    test("Mode 0 untaps all creatures the targeted player controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val a = driver.putCreatureOnBattlefield(player, "Black Creature")
+        val b = driver.putCreatureOnBattlefield(player, "Black Creature")
+        driver.tapPermanent(a)
+        driver.tapPermanent(b)
+        driver.isTapped(a) shouldBe true
+        driver.isTapped(b) shouldBe true
+
+        val spell = driver.putCardInHand(player, "Rustler Rampage")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(player)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(player)))
+            )
+        )
+        driver.bothPass()
+
+        driver.isTapped(a) shouldBe false
+        driver.isTapped(b) shouldBe false
+    }
+
+    test("Mode 1 grants double strike to target creature until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(player, "Black Creature")
+        projector.project(driver.state).hasKeyword(creature, Keyword.DOUBLE_STRIKE) shouldBe false
+
+        val spell = driver.putCardInHand(player, "Rustler Rampage")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(creature)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(creature)))
+            )
+        )
+        driver.bothPass()
+
+        projector.project(driver.state).hasKeyword(creature, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+
+    test("Both modes: untap your creatures AND grant double strike") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tapped = driver.putCreatureOnBattlefield(player, "Black Creature")
+        val attacker = driver.putCreatureOnBattlefield(player, "Black Creature")
+        driver.tapPermanent(tapped)
+
+        val spell = driver.putCardInHand(player, "Rustler Rampage")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 2)      // {1} + {1}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(player), ChosenTarget.Permanent(attacker)),
+                chosenModes = listOf(0, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Player(player)),
+                    listOf(ChosenTarget.Permanent(attacker))
+                )
+            )
+        )
+        driver.bothPass()
+
+        driver.isTapped(tapped) shouldBe false
+        projector.project(driver.state).hasKeyword(attacker, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjTakeForARideScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjTakeForARideScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TakeForARide
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Take for a Ride (OTJ {2}{R} sorcery, Threaten variant).
+ *
+ * Effect: gain control of target creature until end of turn, untap it, it gains haste.
+ * Conditional flash: castable at instant speed only while you've committed a crime this turn.
+ */
+class OtjTakeForARideScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + TakeForARide)
+        return driver
+    }
+
+    test("gains control of target creature, untaps it, grants haste") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stolen = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+        driver.tapPermanent(stolen)
+        driver.isTapped(stolen) shouldBe true
+
+        val spell = driver.putCardInHand(player, "Take for a Ride")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 2) // {2}{R}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(stolen))
+            )
+        )
+        driver.bothPass()
+
+        // Now controlled by the caster (control change is a projected floating effect),
+        // untapped, and has haste.
+        val projected = projector.project(driver.state)
+        projected.getController(stolen) shouldBe player
+        driver.isTapped(stolen) shouldBe false
+        projected.hasKeyword(stolen, Keyword.HASTE) shouldBe true
+    }
+
+    test("conditional flash: not castable at instant speed until you've committed a crime") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        val player = driver.player1
+        val opponent = driver.player2
+
+        // Move to the opponent's turn so it's an instant-speed window for player1.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP)
+        val onOpponentTurn = driver.state.activePlayerId == opponent
+
+        // Take for a Ride needs a legal creature target to be offered at all.
+        driver.putCreatureOnBattlefield(opponent, "Black Creature")
+
+        val ride = driver.putCardInHand(player, "Take for a Ride")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 2)
+
+        fun canCast(): Boolean {
+            val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+            val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            return actions.any { (it.action as? CastSpell)?.cardId == ride }
+        }
+
+        // Without a crime committed: no instant-speed cast offered on the opponent's turn.
+        if (onOpponentTurn) {
+            canCast() shouldBe false
+        }
+
+        // Mark a crime committed this turn → conditional flash unlocks instant-speed casting.
+        driver.replaceState(
+            driver.state.copy(playersWhoCommittedCrimeThisTurn = setOf(player))
+        )
+        if (onOpponentTurn) {
+            canCast() shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjUnfortunateAccidentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjUnfortunateAccidentScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.UnfortunateAccident
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Unfortunate Accident (OTJ Spree instant).
+ *
+ * Mode 0 ({2}{B}): destroy target creature. Mode 1 ({1}): create a 1/1 red Mercenary
+ * token with the standard OTJ "{T}: target creature you control gets +1/+0" pump.
+ */
+class OtjUnfortunateAccidentScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + UnfortunateAccident)
+        return driver
+    }
+
+    test("Mode 0 destroys target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Unfortunate Accident")
+        driver.giveMana(player, Color.BLACK, 2) // {B} base + {B} of {2}{B}
+        driver.giveColorlessMana(player, 2)      // {2} of {2}{B}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(victim)))
+            )
+        )
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+    }
+
+    test("Mode 1 creates a 1/1 red Mercenary token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val battlefieldBefore = driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size
+
+        val spell = driver.putCardInHand(player, "Unfortunate Accident")
+        driver.giveMana(player, Color.BLACK, 1) // {B} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass()
+
+        // One new permanent on the battlefield (the Mercenary token).
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size shouldBe battlefieldBefore + 1
+    }
+
+    test("Both modes: destroy a creature AND create a token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Black Creature")
+        val battlefieldBefore = driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size
+
+        val spell = driver.putCardInHand(player, "Unfortunate Accident")
+        driver.giveMana(player, Color.BLACK, 2) // {B} base + {B}
+        driver.giveColorlessMana(player, 3)      // {2} (mode 0) + {1} (mode 1)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                chosenModes = listOf(0, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(victim)),
+                    emptyList()
+                )
+            )
+        )
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size shouldBe battlefieldBefore + 1
+    }
+})


### PR DESCRIPTION
## Cards implemented (Outlaws of Thunder Junction — Spells & Removal)

All four implemented and passing scenario tests:

- **Rustler Rampage** `{W}` — Spree instant. + {1} untap all creatures target player controls; + {1} target creature gains double strike until end of turn. (`ModalEffect` Spree shape; mode 0 = `ForEachInGroup(Creature.targetPlayerControls(ContextTarget(0)), Untap(Self))`; mode 1 = `GrantKeyword(DOUBLE_STRIKE)`.)
- **Requisition Raid** `{W}` — Spree sorcery. + {1} destroy target artifact; + {1} destroy target enchantment; + {1} +1/+1 counter on each creature target player controls.
- **Unfortunate Accident** `{B}` — Spree instant. + {2}{B} destroy target creature; + {1} create a 1/1 red Mercenary token with the standard OTJ "{T}: target creature you control gets +1/+0, sorcery speed" pump (matches Hellspur Posse Boss's token).
- **Take for a Ride** `{2}{R}` — Threaten variant: gain control of target creature until end of turn, untap it, it gains haste. Card-level `conditionalFlash = Conditions.YouCommittedCrimeThisTurn`.

All cards use existing SDK primitives — no new SDK surface, so no `card-sdk-language-reference.md` change needed.

### Skipped
None. All four were implementable; none are in the Tier-3 blocked list.

## mtgish-tooling changes

- **`TargetRecovery.groupFilterExpr`**: now renders the "...target player controls" controller clause (`ControlledByAPlayer → SinglePlayer/Ref_TargetPlayer`) as `.targetPlayerControls(EffectTarget.ContextTarget(0))` instead of declining. This turns **Rustler Rampage**, **Requisition Raid**, and **Unfortunate Accident** into complete (AUTO) renders.
- **`CardStructure.conditionalFlashLines`**: documented (comment only) why the "you've committed a crime this turn" flash condition is intentionally left declining — every OTJ carrier (Take for a Ride) also has a spell body the mtgish IR renders lossily (its "gains haste until end of turn" clause is **absent from the IR**), so a whole-card AUTO render would silently drop it. **Take for a Ride correctly stays SCAFFOLD** rather than emit a lossy card (render-correctly-or-decline).

### Verification
- `coverage-verify POR` → **GATE PASS, 158/158, 0 mismatch** (unchanged).
- `EmitterGoldenTest` → all committed sets (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE) unchanged — the emitter change only affects the previously-declined `Ref_TargetPlayer` case, so no rebless required.
- `coverage-verify OTJ` → my three AUTO cards are now gameplay-tree-equivalent to golden; Take for a Ride is in NOT EMITTED (declines to scaffold). The sole remaining OTJ gameplay-tree mismatch is **Freestrider Lookout**, which is **pre-existing and untouched** by this change.

## Pre-existing failures (not caused by this branch, not reverted)
- `:mtg-sets SuccessCriterionValidationTest` fails on **Highway Robbery** (a previously-committed OTJ card, commit `34babcf45`): its "if you do" gate has no inferable `SuccessCriterion`. Reported per the hard rule; not touched.
- `coverage-verify OTJ` Freestrider Lookout mismatch (above), pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)