### PR TITLE
Fix implementation key leaking into card text (Wash Out, #710)

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -24,7 +24,7 @@ data class CollectionContainsMatch(
     val collection: String,
     val filter: GameObjectFilter = GameObjectFilter.Any
 ) : Condition {
-    override val description: String = "if the $collection cards contain a ${filter.description}"
+    override val description: String = "if those cards contain a ${filter.description}"
     override fun applyTextReplacement(replacer: TextReplacer): Condition {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -148,7 +148,7 @@ data class AddCountersToCollectionEffect(
     val count: Int = 1
 ) : Effect {
     override val description: String =
-        "Put $count $counterType counter${if (count != 1) "s" else ""} on each permanent in $collectionName"
+        "Put $count $counterType counter${if (count != 1) "s" else ""} on each of those permanents"
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -177,7 +177,7 @@ data class CastFromCollectionWithoutPayingCostEffect(
     val from: String,
 ) : Effect {
     override val description: String =
-        "Cast the $from card without paying its mana cost"
+        "Cast that card without paying its mana cost"
 }
 
 /**
@@ -208,7 +208,7 @@ data class CastAnyNumberFromCollectionWithoutPayingCostEffect(
     val from: String,
 ) : Effect {
     override val description: String =
-        "Cast any number of the $from cards without paying their mana costs"
+        "Cast any number of those cards without paying their mana costs"
 }
 
 @SerialName("Cascade")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -543,7 +543,7 @@ data class CaptureControllersEffect(
     val from: String,
     val storeAs: String
 ) : Effect {
-    override val description: String = "Capture the controllers of the $from cards"
+    override val description: String = "Capture the controllers of those cards"
 }
 
 /**
@@ -589,7 +589,7 @@ data class ForEachCapturedControllerEffect(
     val effects: List<Effect>
 ) : Effect {
     override val description: String = buildString {
-        append("For each player who controlled at least one of the $collection cards, ")
+        append("For each player who controlled at least one of those cards, ")
         append(effects.joinToString(". ") { it.description.replaceFirstChar { c -> c.lowercase() } })
     }
 
@@ -622,7 +622,7 @@ data class GatherSubtypesEffect(
     val from: String,
     val storeAs: String
 ) : Effect {
-    override val description: String = "gather subtypes of the $from entities"
+    override val description: String = "gather subtypes of those cards"
 }
 
 /**
@@ -685,7 +685,7 @@ data class RevealCollectionEffect(
     val fromZone: com.wingedsheep.sdk.core.Zone? = null,
     val toZone: com.wingedsheep.sdk.core.Zone? = null
 ) : Effect {
-    override val description: String = "Reveal the $from cards"
+    override val description: String = "Reveal those cards"
 }
 
 /**
@@ -748,7 +748,7 @@ data class SelectFromCollectionEffect(
     override val description: String = buildString {
         if (chooser == Chooser.Opponent) append("An opponent ")
         append(selection.description.replaceFirstChar { it.uppercase() })
-        append(" from the $from cards")
+        append(" of those cards")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
@@ -863,8 +863,10 @@ data class MoveCollectionEffect(
     val markEnteredViaSourceAbility: Boolean = false
 ) : Effect {
     override val description: String = buildString {
-        if (revealed) append("Reveal and put") else append("Put")
-        append(" the $from cards ")
+        if (revealed) append("Reveal and put ") else append("Put ")
+        append("those cards ")
+        // `from` is an internal pipeline-collection key — never surface it to players.
+        append(if ((destination as? CardDestination.ToZone)?.zone == Zone.BATTLEFIELD) "onto " else "into ")
         append(destination.description)
     }
 }
@@ -1059,7 +1061,7 @@ data class GrantMayPlayFromExileEffect(
     val landEntersTapped: Boolean = false
 ) : Effect {
     override val description: String = buildString {
-        append("${expiry.description.replaceFirstChar { it.uppercase() }}, you may play the $from cards from exile")
+        append("${expiry.description.replaceFirstChar { it.uppercase() }}, you may play those cards from exile")
         if (condition != null) {
             append(" ")
             append(condition.description)
@@ -1101,11 +1103,11 @@ data class ConditionalOnCollectionEffect(
     override val description: String = buildString {
         val restrict = if (filter == GameObjectFilter.Companion.Any) "" else " ${filter.description}"
         if (minSize <= 1) {
-            append("If $collection contains a$restrict card, ")
+            append("If those cards include a$restrict card, ")
         } else if (countDistinctCardTypes) {
-            append("If $collection covers at least $minSize card types, ")
+            append("If those cards cover at least $minSize card types, ")
         } else {
-            append("If $collection has at least $minSize$restrict cards, ")
+            append("If those cards include at least $minSize$restrict cards, ")
         }
         append(ifNotEmpty.description.replaceFirstChar { it.lowercase() })
         if (ifEmpty != null) {
@@ -1138,7 +1140,7 @@ data class GrantPlayWithoutPayingCostEffect(
     val from: String
 ) : Effect {
     override val description: String =
-        "Until end of turn, you may play the $from cards without paying their mana costs"
+        "Until end of turn, you may play those cards without paying their mana costs"
 }
 
 /**
@@ -1160,7 +1162,7 @@ data class GrantPlayWithAdditionalCostEffect(
     val additionalCost: AdditionalCost
 ) : Effect {
     override val description: String =
-        "Until end of turn, casting the $from cards requires: ${additionalCost.description}"
+        "Until end of turn, casting those cards requires: ${additionalCost.description}"
 }
 
 /**
@@ -1184,7 +1186,7 @@ data class GrantPlayWithCostIncreaseEffect(
     val amount: Int
 ) : Effect {
     override val description: String =
-        "Each spell cast from $from costs {$amount} more to cast"
+        "Each of those spells costs {$amount} more to cast"
 }
 
 /**
@@ -1368,7 +1370,7 @@ data class FilterCollectionEffect(
     val storeMatching: String,
     val storeNonMatching: String? = null
 ) : Effect {
-    override val description: String = "Filter $from collection"
+    override val description: String = "Filter those cards"
 }
 
 /**
@@ -1387,7 +1389,7 @@ data class StoreNumberEffect(
     val name: String,
     val amount: DynamicAmount
 ) : Effect {
-    override val description: String = "Store ${amount.description} as $name"
+    override val description: String = "Note ${amount.description}"
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newAmount = amount.applyTextReplacement(replacer)
         return if (newAmount !== amount) copy(amount = newAmount) else this
@@ -1414,5 +1416,5 @@ data class StoreCardNameEffect(
     val from: String,
     val storeAs: String = "chosenCardName"
 ) : Effect {
-    override val description: String = "Note the name of the $from card"
+    override val description: String = "Note the name of that card"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TapEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TapEffects.kt
@@ -33,7 +33,7 @@ data class TapUntapCollectionEffect(
     val collectionName: String,
     val tap: Boolean = true
 ) : Effect {
-    override val description: String = "${if (tap) "Tap" else "Untap"} each permanent in $collectionName"
+    override val description: String = "${if (tap) "Tap" else "Untap"} each of those permanents"
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -389,7 +389,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     @SerialName("StoredCardManaValue")
     @Serializable
     data class StoredCardManaValue(val collectionName: String) : DynamicAmount {
-        override val description: String = "the mana value of the $collectionName card"
+        override val description: String = "the mana value of that card"
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
@@ -98,7 +98,7 @@ sealed interface EntityReference {
         val collectionName: String,
         val index: Int = 0,
     ) : EntityReference {
-        override val description: String = "the chosen $collectionName"
+        override val description: String = "the chosen card"
     }
 
     /**

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineDescriptionLeakTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineDescriptionLeakTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * Pipeline effects wire their steps together with named-collection keys (`storeAs` / `from`).
+ * Those keys are internal plumbing and must never reach the player-facing `description` —
+ * which, for instants/sorceries, is the text shown on the stack. Regression for issue #710,
+ * where Wash Out rendered "Put the washOut_gathered cards a hand".
+ */
+class PipelineDescriptionLeakTest : DescribeSpec({
+
+    describe("pipeline-collection keys never leak into effect descriptions") {
+
+        it("Wash Out's gather→bounce pipeline reads naturally (issue #710)") {
+            val effect = ChooseColorThenEffect(
+                then = CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.BattlefieldMatching(
+                                filter = GameObjectFilter(
+                                    cardPredicates = listOf(CardPredicate.HasChosenColor),
+                                ),
+                                player = Player.Each,
+                            ),
+                            storeAs = "washOut_gathered",
+                        ),
+                        MoveCollectionEffect(
+                            from = "washOut_gathered",
+                            destination = CardDestination.ToZone(Zone.HAND),
+                        ),
+                    ),
+                ),
+            )
+
+            effect.description shouldNotContain "washOut_gathered"
+            effect.description shouldBe
+                "Choose a color. Look at all of the chosen color permanents on the battlefield. " +
+                "Put those cards into a hand"
+        }
+
+        it("MoveCollection picks the right preposition per destination") {
+            MoveCollectionEffect("x", CardDestination.ToZone(Zone.HAND)).description shouldBe
+                "Put those cards into a hand"
+            MoveCollectionEffect("x", CardDestination.ToZone(Zone.BATTLEFIELD)).description shouldBe
+                "Put those cards onto the battlefield"
+            MoveCollectionEffect("x", CardDestination.ToZone(Zone.EXILE)).description shouldBe
+                "Put those cards into exile"
+        }
+
+        it("collection-referencing effects don't echo their key") {
+            val key = "secret_internal_key"
+            listOf(
+                MoveCollectionEffect(key, CardDestination.ToZone(Zone.GRAVEYARD)).description,
+                GatherSubtypesEffect(key, "out").description,
+                CaptureControllersEffect(key, "out").description,
+                FilterCollectionEffect(key, CollectionFilter.MatchesFilter(GameObjectFilter.Any), "out").description,
+                StoreCardNameEffect(key).description,
+            ).forEach { it shouldNotContain key }
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -11604,7 +11604,7 @@
                         }
                     ]
                 },
-                "descriptionOverride": "Flurry — Whenever you cast your second spell each turn, put 1 +1/+1 counter on this creature. Look at the top 1 cards of your library. Choose up to 1 from the scried cards. Put the toBottom cards a library (bottom). Put the toTop cards a library (top)."
+                "descriptionOverride": "Flurry — Whenever you cast your second spell each turn, put 1 +1/+1 counter on this creature. Look at the top 1 cards of your library. Choose up to 1 of those cards. Put those cards into a library (bottom). Put those cards into a library (top)."
             }
         ]
     },


### PR DESCRIPTION
Fixes #710.

## Problem

Wash Out's stack text rendered **"…Put the washOut_gathered cards a hand"** — `washOut_gathered` is the internal pipeline-collection key (`storeAs`/`from`) that wires the gather → bounce steps together, and it leaked straight into the player-facing description (plus a missing "into" preposition).

This is a **class** of bug, not one card:
- For instants/sorceries, the client always renders the generated effect-tree description as stack text (`ClientStateTransformer.runtimeStackText`) — it never falls back to printed oracle text, so resolved X/modes/conditionals can show. Any pipeline-based instant/sorcery could therefore expose its wiring keys.
- ~18 effect/condition/dynamic-amount descriptions across the SDK spliced their internal collection key (`$from`, `$collection`, `$collectionName`, `$name`) into the description string.

## Fix

- `MoveCollectionEffect.description` now reads `"Put those cards into a hand"` / `"…onto the battlefield"` / `"…into exile"` — no key, correct preposition.
- Replaced every other leaked key with neutral antecedent phrasing (`those cards` / `that card`) across `PipelineEffects`, `LibraryEffects`, `CounterEffects`, `TapEffects`, `GenericConditions`, `DynamicAmount`, `EntityReference`. (`NameEquals` "named $name" left as-is — that's a real card name, not a key.)
- Re-blessed `TDM.json`: its only change was a baked Flurry `descriptionOverride` that had leaked `scried`/`toBottom`/`toTop`, now reading naturally.

Wash Out now reads: *"Choose a color. Look at all of the chosen color permanents on the battlefield. Put those cards into a hand."*

## Tests

- New `PipelineDescriptionLeakTest` (asserts Wash Out's full description, per-destination prepositions, and that key strings never appear in descriptions).
- `:mtg-sdk:test`, `:mtg-sets` `CardLintTest` + `CardDefinitionSnapshotTest`, and engine `MoveCollection*`/`WashOut*`/`FactOrFiction*` scenario tests all pass.

No SDK shapes changed (text-only), so no `card-sdk-language-reference.md` update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)