### PR TITLE
Fix stale TargetRecoveryTest after target-player-controls render

### DIFF
--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -272,14 +272,16 @@ class TargetRecoveryTest : StringSpec({
             "GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES).youControl()"
     }
 
-    "gameObjectFilterDsl declines a group controlled by a target player (Neutralize the Guards)" {
-        // "creatures target opponent controls get -1/-1" — the controller is the chosen Ref_TargetPlayer,
-        // which no static GroupFilter expresses; dropping it would debuff every creature on the battlefield.
+    "gameObjectFilterDsl binds a group controlled by a target player to ContextTarget(0) (Neutralize the Guards)" {
+        // "creatures target opponent controls get -1/-1" — the controller is the chosen Ref_TargetPlayer.
+        // The spell declares the player target in its first slot, so the controller predicate binds to
+        // ContextTarget(0) via .targetPlayerControls; dropping it would debuff every creature on the battlefield.
         val targetPlayersCreatures = obj(
             """{"_Permanents":"And","args":[{"_Permanents":"IsCardtype","args":"Creature"},""" +
                 """{"_Permanents":"ControlledByAPlayer","args":{"_Players":"SinglePlayer","args":{"_Player":"Ref_TargetPlayer"}}}]}""",
         )
-        ctx.gameObjectFilterDsl(targetPlayersCreatures).shouldBeNull()
+        ctx.gameObjectFilterDsl(targetPlayersCreatures) shouldBe
+            "GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))"
     }
 
     "gameObjectFilterDsl renders 'a player other than you' as opponentControls (Artistic Process)" {


### PR DESCRIPTION
## Problem

`:mtgish-tooling:test` was failing:

```
TargetRecoveryTest > gameObjectFilterDsl declines a group controlled by a target player (Neutralize the Guards) FAILED
```

## Root cause

The test was added on 2026-06-13 (`da05ef0a6`) and asserted `shouldBeNull()` (decline) for a creature group controlled by `Ref_TargetPlayer`, on the premise that *no static filter could express it*.

The next day, `51313c78c` ("Add OTJ spells/removal batch + mtgish target-player-controls group filter") **deliberately** taught `gameObjectFilterExpr` to render that exact controller clause:

```kotlin
playersKind == "SinglePlayer" && playerRef == "Ref_TargetPlayer" ->
    node.dot("targetPlayerControls", arg("EffectTarget.ContextTarget(0)"))
```

This turned Rustler Rampage / Requisition Raid AUTO — but the feature commit never updated this pre-existing test, so the assertion went stale and started failing once the branches merged.

## Fix

Update the test to assert the intended rendering instead of decline:

```kotlin
ctx.gameObjectFilterDsl(targetPlayersCreatures) shouldBe
    "GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))"
```

Test-only change; the emitter behaviour is unchanged and intended.

## Verification

`./gradlew :mtgish-tooling:test` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)