### PR TITLE
Add OTJ: Neutralize the Guards, Plan the Heist, Smuggler's Surprise

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NeutralizeTheGuards.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/NeutralizeTheGuards.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Neutralize the Guards
+ * {2}{B}
+ * Instant
+ *
+ * Creatures target opponent controls get -1/-1 until end of turn. Surveil 2.
+ *
+ * The group debuff is scoped to the chosen opponent via
+ * [GameObjectFilter.Creature.targetPlayerControls] + [Patterns.Group.modifyStatsForAll]
+ * (see Wail of War). Surveil 2 follows the debuff in the instruction order via
+ * [Patterns.Library.surveil].
+ */
+val NeutralizeTheGuards = card("Neutralize the Guards") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. " +
+        "(Look at the top two cards of your library, then put any number of them into your " +
+        "graveyard and the rest on top of your library in any order.)"
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Patterns.Group.modifyStatsForAll(
+                power = -1,
+                toughness = -1,
+                filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(opponent))
+            ),
+            Patterns.Library.surveil(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Nereida"
+        flavorText = "\"Don't bother getting up. I'll see myself in.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg?1712355617"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PlanTheHeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/PlanTheHeist.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Plan the Heist
+ * {2}{U}{U}
+ * Sorcery
+ *
+ * Surveil 3 if you have no cards in hand. Then draw three cards.
+ * Plot {3}{U}
+ *
+ * The conditional surveil is gated on [Conditions.EmptyHand], checked at resolution before
+ * the draw (CR/OTJ ruling: "You'll only surveil 3 if you have no cards in hand when Plan the
+ * Heist resolves, but you'll still draw three cards either way"). Surveil precedes the draw in
+ * instruction order, so the empty-hand check happens while the hand is still empty.
+ */
+val PlanTheHeist = card("Plan the Heist") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Surveil 3 if you have no cards in hand. Then draw three cards. " +
+        "(To surveil 3, look at the top three cards of your library, then put any number of " +
+        "them into your graveyard and the rest on top of your library in any order.)\n" +
+        "Plot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a " +
+        "sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    spell {
+        effect = ConditionalEffect(
+            condition = Conditions.EmptyHand,
+            effect = Patterns.Library.surveil(3)
+        ) then Effects.DrawCards(3)
+    }
+
+    keywordAbility(KeywordAbility.plot("{3}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Fariba Khamseh"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg?1712355477"
+
+        ruling("2024-04-12", "You'll only surveil 3 if you have no cards in hand when Plan the Heist resolves, but you'll still draw three cards either way.")
+        ruling("2024-04-12", "If a plotted card has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SmugglersSurprise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SmugglersSurprise.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Smuggler's Surprise
+ * {G}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2} — Mill four cards. You may put up to two creature and/or land cards from among the
+ *         milled cards into your hand.
+ * + {4}{G} — You may put up to two creature cards from your hand onto the battlefield.
+ * + {1} — Creatures you control with power 4 or greater gain hexproof and indestructible
+ *         until end of turn.
+ *
+ * Spree is a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`, per-mode
+ * `additionalManaCost`, and `allowRepeat = false` (CR 700.2 / OTJ release notes). None of the
+ * modes target. Modes always resolve in printed order.
+ *
+ * Mode 1 is the standard mill → gather → select-up-to-two → move-to-hand pipeline (see
+ * Cache Grab), scoped to creature/land cards from among the milled cards. Mode 2 gathers
+ * creature cards from hand and puts up to two onto the battlefield (see Ghalta). Mode 3
+ * grants hexproof + indestructible to your power-4-or-greater creatures via a single
+ * group iteration (see Selfless Safewright).
+ */
+val SmugglersSurprise = card("Smuggler's Surprise") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2} — Mill four cards. You may put up to two creature and/or land cards from " +
+        "among the milled cards into your hand.\n" +
+        "+ {4}{G} — You may put up to two creature cards from your hand onto the battlefield.\n" +
+        "+ {1} — Creatures you control with power 4 or greater gain hexproof and " +
+        "indestructible until end of turn."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                // + {2} — Mill four; put up to two creature/land cards from milled into hand.
+                Mode(
+                    effect = Effects.Composite(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                                storeAs = "smuggler_milled"
+                            ),
+                            MoveCollectionEffect(
+                                from = "smuggler_milled",
+                                destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "smuggler_milled",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                                filter = GameObjectFilter.CreatureOrLand,
+                                storeSelected = "smuggler_to_hand",
+                                showAllCards = true,
+                                prompt = "You may put up to two creature and/or land cards into your hand",
+                                selectedLabel = "Put in hand",
+                                remainderLabel = "Leave in graveyard"
+                            ),
+                            MoveCollectionEffect(
+                                from = "smuggler_to_hand",
+                                destination = CardDestination.ToZone(Zone.HAND)
+                            )
+                        )
+                    ),
+                    description = "+ {2} — Mill four cards. You may put up to two creature and/or " +
+                        "land cards from among the milled cards into your hand.",
+                    additionalManaCost = "{2}"
+                ),
+                // + {4}{G} — Put up to two creature cards from your hand onto the battlefield.
+                Mode(
+                    effect = Effects.Composite(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.Creature),
+                                storeAs = "smuggler_hand_candidates"
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "smuggler_hand_candidates",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                                storeSelected = "smuggler_to_battlefield",
+                                prompt = "You may put up to two creature cards onto the battlefield"
+                            ),
+                            MoveCollectionEffect(
+                                from = "smuggler_to_battlefield",
+                                destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+                            )
+                        )
+                    ),
+                    description = "+ {4}{G} — You may put up to two creature cards from your hand " +
+                        "onto the battlefield.",
+                    additionalManaCost = "{4}{G}"
+                ),
+                // + {1} — Your power-4-or-greater creatures gain hexproof and indestructible.
+                Mode(
+                    effect = Effects.ForEachInGroup(
+                        filter = GroupFilter(
+                            baseFilter = GameObjectFilter.Creature.youControl().powerAtLeast(4)
+                        ),
+                        effect = Effects.Composite(
+                            listOf(
+                                Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.Self, Duration.EndOfTurn),
+                                Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self, Duration.EndOfTurn)
+                            )
+                        )
+                    ),
+                    description = "+ {1} — Creatures you control with power 4 or greater gain " +
+                        "hexproof and indestructible until end of turn.",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "180"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg?1712860610"
+
+        ruling("2024-04-12", "The effect of Smuggler's Surprise's last mode affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get hexproof or indestructible. However, if you chose Smuggler's Surprise's second mode, any creatures you put onto the battlefield that way will gain hexproof and indestructible until end of turn if their power is 4 or greater.")
+        ruling("2024-04-12", "No matter which modes you choose, you always follow the instructions in the order they are written.")
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -6596,6 +6596,118 @@
     ]
 }
 
+// Neutralize the Guards
+{
+    "name": "Neutralize the Guards",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControlledByReferencedPlayer",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target opponent"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Nereida",
+        "flavorText": "\"Don't bother getting up. I'll see myself in.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg?1712355617"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nezumi Linkbreaker
 {
     "name": "Nezumi Linkbreaker",
@@ -7480,6 +7592,117 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Plan the Heist
+{
+    "name": "Plan the Heist",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Surveil 3 if you have no cards in hand. Then draw three cards. (To surveil 3, look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Hand",
+                            "negate": true
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeAs": "surveiled"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "surveiled",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeSelected": "toGraveyard",
+                                "storeRemainder": "toTop",
+                                "selectedLabel": "Put in graveyard",
+                                "remainderLabel": "Put on top"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "order": "ControllerChooses"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg?1712355477",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You'll only surveil 3 if you have no cards in hand when Plan the Heist resolves, but you'll still draw three cards either way."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If a plotted card has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -9955,6 +10178,166 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Smuggler's Surprise
+{
+    "name": "Smuggler's Surprise",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2} — Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.\n+ {4}{G} — You may put up to two creature cards from your hand onto the battlefield.\n+ {1} — Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                },
+                                "storeAs": "smuggler_milled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "smuggler_milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "smuggler_milled",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "filter": "creature|land",
+                                "storeSelected": "smuggler_to_hand",
+                                "prompt": "You may put up to two creature and/or land cards into your hand",
+                                "selectedLabel": "Put in hand",
+                                "remainderLabel": "Leave in graveyard",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "smuggler_to_hand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "+ {2} — Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "smuggler_hand_candidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "smuggler_hand_candidates",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "smuggler_to_battlefield",
+                                "prompt": "You may put up to two creature cards onto the battlefield"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "smuggler_to_battlefield",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "+ {4}{G} — You may put up to two creature cards from your hand onto the battlefield.",
+                    "additionalManaCost": "{4}{G}"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature pow>=4 ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "HEXPROOF",
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "INDESTRUCTIBLE",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    },
+                    "description": "+ {1} — Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg?1712860610",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The effect of Smuggler's Surprise's last mode affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get hexproof or indestructible. However, if you chose Smuggler's Surprise's second mode, any creatures you put onto the battlefield that way will gain hexproof and indestructible until end of turn if their power is 4 or greater."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "No matter which modes you choose, you always follow the instructions in the order they are written."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -575,6 +575,8 @@ internal fun EmitCtx.keywordOf(node: JsonElement?): String? {
  *
  *  - `PlayerPassesFilter(You, ControlsA(<filter>))` ("if you control a <filter>") ->
  *    `Conditions.YouControl(<filter>)` (Take the Fall: "if you control an outlaw" -> the outlaw group).
+ *  - `PlayerPassesFilter(You, NumCardsInHandIs(EqualTo 0))` ("if you have no cards in hand") ->
+ *    `Conditions.EmptyHand` (Plan the Heist: "Surveil 3 if you have no cards in hand.").
  */
 internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
     if (cond == null) return null
@@ -585,6 +587,15 @@ internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
             if (controls?.strField("_Players") == "ControlsA") {
                 val filter = gameObjectFilterDsl(controls["args"])
                 if (filter != null) return render(call("Conditions.YouControl", arg(Lit(filter))))
+            }
+            // "if you have no cards in hand" -> Conditions.EmptyHand. Only the exact
+            // `NumCardsInHandIs(EqualTo 0)` shape renders; any other comparator/count declines.
+            if (controls?.strField("_Players") == "NumCardsInHandIs") {
+                val cmp = controls["args"] as? JsonObject
+                if (cmp?.strField("_Comparison") == "EqualTo") {
+                    val n = cmp["args"].asInt() ?: ((cmp["args"] as? JsonObject)?.get("args").asInt())
+                    if (n == 0) return "Conditions.EmptyHand"
+                }
             }
         }
     }

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -272,14 +272,17 @@ class TargetRecoveryTest : StringSpec({
             "GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES).youControl()"
     }
 
-    "gameObjectFilterDsl declines a group controlled by a target player (Neutralize the Guards)" {
+    "gameObjectFilterDsl renders a group controlled by a target player (Neutralize the Guards)" {
         // "creatures target opponent controls get -1/-1" — the controller is the chosen Ref_TargetPlayer,
-        // which no static GroupFilter expresses; dropping it would debuff every creature on the battlefield.
+        // which binds to the mode/spell's first target slot via `targetPlayerControls(ContextTarget(0))`
+        // (see TargetRecovery's SinglePlayer/Ref_TargetPlayer branch). This is the shape Neutralize the
+        // Guards' hand-authored card uses, scoped to the chosen opponent rather than every creature.
         val targetPlayersCreatures = obj(
             """{"_Permanents":"And","args":[{"_Permanents":"IsCardtype","args":"Creature"},""" +
                 """{"_Permanents":"ControlledByAPlayer","args":{"_Players":"SinglePlayer","args":{"_Player":"Ref_TargetPlayer"}}}]}""",
         )
-        ctx.gameObjectFilterDsl(targetPlayersCreatures).shouldBeNull()
+        ctx.gameObjectFilterDsl(targetPlayersCreatures) shouldBe
+            "GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))"
     }
 
     "gameObjectFilterDsl renders 'a player other than you' as opponentControls (Artistic Process)" {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeutralizeTheGuardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeutralizeTheGuardsScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.NeutralizeTheGuards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Neutralize the Guards — {2}{B} Instant
+ *
+ * "Creatures target opponent controls get -1/-1 until end of turn. Surveil 2."
+ *
+ * Verifies the -1/-1 debuff applies only to the targeted opponent's creatures (and lethally
+ * shrinks 1-toughness creatures), and that surveil 2 follows.
+ */
+class NeutralizeTheGuardsScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(NeutralizeTheGuards)
+        return driver
+    }
+
+    test("opponent's creatures get -1/-1, mine are unaffected, then surveil 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Opponent has a 3/3 and a 1/1; the 1/1 should die to -1/-1.
+        val oppCourser = driver.putCreatureOnBattlefield(opp, "Centaur Courser") // 3/3
+        val oppLion = driver.putCreatureOnBattlefield(opp, "Savannah Lions")     // 1/1
+        // My own creature should be untouched.
+        val myCourser = driver.putCreatureOnBattlefield(me, "Centaur Courser")   // 3/3
+
+        // Seed two known cards on top so surveil presents them.
+        val top2 = driver.putCardOnTopOfLibrary(me, "Swamp")
+        val top1 = driver.putCardOnTopOfLibrary(me, "Swamp")
+
+        val spell = driver.putCardInHand(me, "Neutralize the Guards")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, spell, targets = listOf(opp)).isSuccess shouldBe true
+        driver.bothPass() // resolve the spell -> applies debuff, then pauses for surveil
+
+        // The opponent's 3/3 is now a 2/2.
+        val projected = projector.project(driver.state)
+        projected.getPower(oppCourser) shouldBe 2
+        projected.getToughness(oppCourser) shouldBe 2
+
+        // My 3/3 is unaffected.
+        projected.getPower(myCourser) shouldBe 3
+        projected.getToughness(myCourser) shouldBe 3
+
+        // Surveil 2 pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        (select as SelectCardsDecision).options.size shouldBe 2
+
+        // Mill the top card; reorder the rest.
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(top1)))
+        driver.isPaused shouldBe true
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        driver.submitOrderedResponse(me, reorder.cards)
+        driver.isPaused shouldBe false
+
+        // After resolution completes, SBAs reduce the opponent's 0/0 Lions and it dies.
+        driver.findPermanent(opp, "Savannah Lions") shouldBe null
+
+        driver.getGraveyard(me).contains(top1) shouldBe true
+        driver.state.getLibrary(me).first() shouldBe top2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlanTheHeistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlanTheHeistScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.PlanTheHeist
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Plan the Heist — {2}{U}{U} Sorcery
+ *
+ * "Surveil 3 if you have no cards in hand. Then draw three cards. Plot {3}{U}"
+ *
+ * The empty-hand check happens at resolution before the draw. Casting the spell from a
+ * one-card hand leaves the hand empty as the spell resolves, so surveil 3 happens, then we
+ * draw three. With another card still in hand, surveil is skipped and we only draw three.
+ */
+class PlanTheHeistScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PlanTheHeist)
+        return driver
+    }
+
+    fun emptyHand(driver: GameTestDriver, playerId: EntityId) {
+        val handZone = ZoneKey(playerId, Zone.HAND)
+        var state = driver.state
+        driver.getHand(playerId).toList().forEach { card ->
+            state = state.removeFromZone(handZone, card)
+        }
+        driver.replaceState(state)
+    }
+
+    test("empty hand at resolution: surveil 3, then draw three") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+
+        // Clear the opening hand; only Plan the Heist will be in hand, and once it's on the
+        // stack the hand is empty when the spell resolves.
+        emptyHand(driver, me)
+
+        // Three known cards on top so surveil presents exactly three.
+        driver.putCardOnTopOfLibrary(me, "Island")
+        driver.putCardOnTopOfLibrary(me, "Island")
+        val surveilTop = driver.putCardOnTopOfLibrary(me, "Island")
+
+        val spell = driver.putCardInHand(me, "Plan the Heist")
+        driver.getHand(me).size shouldBe 1
+
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, spell).isSuccess shouldBe true
+        driver.bothPass() // resolve -> hand empty -> surveil 3 pauses
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        (select as SelectCardsDecision).options.size shouldBe 3
+
+        // Mill the top card.
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(surveilTop)))
+        driver.isPaused shouldBe true
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        driver.submitOrderedResponse(me, reorder.cards)
+        driver.isPaused shouldBe false
+
+        driver.getGraveyard(me).contains(surveilTop) shouldBe true
+        // Drew three afterward.
+        driver.getHand(me).size shouldBe 3
+    }
+
+    test("nonempty hand at resolution: no surveil, just draw three") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+
+        // Clear the opening hand, then leave exactly one spare card in hand so the hand is
+        // non-empty while Plan the Heist resolves.
+        emptyHand(driver, me)
+        driver.putCardInHand(me, "Island")
+        val spell = driver.putCardInHand(me, "Plan the Heist")
+
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, spell).isSuccess shouldBe true
+        driver.bothPass() // resolve -> hand non-empty -> no surveil, just draw
+
+        // No surveil decision: spell resolved fully.
+        driver.isPaused shouldBe false
+        // Spare card (1) + drew three (3) = 4.
+        driver.getHand(me).size shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmugglersSurpriseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmugglersSurpriseScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SmugglersSurprise
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Smuggler's Surprise — {G} Instant, Spree
+ *
+ * + {2} — Mill four cards. You may put up to two creature and/or land cards from among the
+ *         milled cards into your hand.
+ * + {4}{G} — You may put up to two creature cards from your hand onto the battlefield.
+ * + {1} — Creatures you control with power 4 or greater gain hexproof and indestructible.
+ */
+class SmugglersSurpriseScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SmugglersSurprise)
+        return driver
+    }
+
+    test("mode + {2}: mill four, put up to two creature/land cards from milled into hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        // Top four (top-down): a creature, a land, a noncreature/nonland instant, and a land.
+        // Only the creature and the two lands are eligible to go to hand (3 options); the
+        // instant is filtered out by the creature/land restriction.
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        val milledLand = driver.putCardOnTopOfLibrary(me, "Forest")
+        val milledCreature = driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Smuggler's Surprise")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(0),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve -> mill 4 -> pause for the up-to-two selection
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        // Three creature/land cards among the four milled are eligible (the instant is filtered out).
+        (select as SelectCardsDecision).options.size shouldBe 3
+
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(milledCreature, milledLand))
+        )
+        driver.isPaused shouldBe false
+
+        // Both chosen cards moved from graveyard to hand.
+        driver.getHand(me).contains(milledCreature) shouldBe true
+        driver.getHand(me).contains(milledLand) shouldBe true
+        driver.getGraveyard(me).contains(milledCreature) shouldBe false
+    }
+
+    test("mode + {1}: power-4+ creatures gain hexproof and indestructible, smaller ones don't") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val big = driver.putCreatureOnBattlefield(me, "Force of Nature") // 5/5
+        val small = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+
+        val spell = driver.putCardInHand(me, "Smuggler's Surprise")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(2),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe false
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(big, Keyword.HEXPROOF) shouldBe true
+        projected.hasKeyword(big, Keyword.INDESTRUCTIBLE) shouldBe true
+        projected.hasKeyword(small, Keyword.HEXPROOF) shouldBe false
+        projected.hasKeyword(small, Keyword.INDESTRUCTIBLE) shouldBe false
+    }
+
+    test("mode + {4}{G}: put a creature card from hand onto the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val creatureInHand = driver.putCardInHand(me, "Force of Nature") // 5/5 creature
+        val spell = driver.putCardInHand(me, "Smuggler's Surprise")
+
+        driver.giveMana(me, Color.GREEN, 2)
+        driver.giveColorlessMana(me, 4)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(1),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve -> pause for the up-to-two hand selection
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(creatureInHand))
+        )
+        driver.isPaused shouldBe false
+
+        // The creature is now on the battlefield under my control.
+        driver.findPermanent(me, "Force of Nature") shouldBe creatureInHand
+        driver.getHand(me).contains(creatureInHand) shouldBe false
+    }
+
+    test("Spree requires at least one mode: casting with no modes fails") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(me, "Smuggler's Surprise")
+        driver.giveMana(me, Color.GREEN, 1)
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = emptyList(),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
## Cards implemented (Outlaws of Thunder Junction)

All three compose existing SDK primitives — **no new engine/SDK surface**.

- **Neutralize the Guards** `{2}{B}` Instant — Creatures target opponent controls get -1/-1 until end of turn, then Surveil 2. Uses `Patterns.Group.modifyStatsForAll` scoped via `GameObjectFilter.Creature.targetPlayerControls(opponent)` + `Patterns.Library.surveil(2)`.
- **Plan the Heist** `{2}{U}{U}` Sorcery — Surveil 3 if you have no cards in hand (gated on `Conditions.EmptyHand`, checked at resolution before the draw per the OTJ ruling), then draw three. **Plot {3}{U}** via `KeywordAbility.plot`.
- **Smuggler's Surprise** `{G}` Instant — **Spree** (`ModalEffect`, `minChooseCount = 1`):
  - `+{2}` Mill four, then put up to two creature/land cards from among the milled cards into hand (gather → mill → select → move pipeline).
  - `+{4}{G}` Put up to two creature cards from hand onto the battlefield (`CardSource.FromZone(HAND)` → select up-to-two → move to battlefield).
  - `+{1}` Your power-4-or-greater creatures gain hexproof and indestructible until end of turn (single group iteration granting both keywords).

### Tests
- New scenario tests in `rules-engine` for all three cards: group debuff scoping + lethal SBA on a 0/0; both empty/non-empty Plan the Heist surveil branches; all three Smuggler's Surprise Spree modes plus the "at least one mode required" gate. All green.
- OTJ card snapshot re-blessed (`OTJ.json` — only the three new cards added, no other card moved).
- `CardLintTest` and `CardDefinitionSnapshotTest` pass; `just check-card-printing` confirms OTJ canonical placement for all three.

## mtgish-tooling changes
- Taught the emitter's resolution-time `actionConditionDsl` (`EmitCtx.kt`) to render `PlayerPassesFilter(You, NumCardsInHandIs(EqualTo 0))` → `Conditions.EmptyHand`. This promotes **Plan the Heist** from SCAFFOLD to **AUTO** (`fidelity --emit` confirmed). The bridge already marks `PlayerPassesFilter` supported, so no bridge change was needed.
- Fixed a **stale** `TargetRecoveryTest` assertion that still expected `gameObjectFilterDsl` to *decline* a target-player-controlled creature group. The committed emitter (prior "+ mtgish target-player-controls group filter" change on main) already renders `GameObjectFilter.Creature.targetPlayerControls(EffectTarget.ContextTarget(0))` — exactly the shape **Neutralize the Guards** relies on for its AUTO render. The test golden was simply never synced to that shipped behavior.
- **POR regression gate: GATE PASS, 158/158, 0 mismatch.** OTJ has 2 pre-existing tree mismatches (Cactusfolk Sureshot, Freestrider Lookout) that are unrelated to these changes (neither uses the `NumCardsInHandIs` path).
- `:mtgish-tooling:test` — all 113 tests pass.

## Skipped / left declined
- **Return the Favor** `{R}{R}` Instant (Spree) — **not implemented.** Its first mode ("Copy target instant spell, sorcery spell, activated ability, or triggered ability") needs a new unified copy effect that dispatches across spells *and* abilities, an executor for copying an **activated ability** (none exists today), and a combined "instant/sorcery spell or activated/triggered ability" target filter — a genuine `add-feature` too large to land cleanly in this batch. This matches the existing gap note in `backlog/otj-engine-gaps.md` (the copy-activated-ability mode of Return the Favor).
- **Smuggler's Surprise** intentionally stays **SCAFFOLD** in the emitter: its Spree modes render to multi-line `Composite` pipelines that the single-line `Mode(...)` Spree emitter deliberately declines to host. Rendering it faithfully would require re-architecting the Spree emitter, not a targeted widening — so it is left declined per the "decline → SCAFFOLD, don't widen recklessly" policy. The hand-authored card + scenario tests are the ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)