### PR TITLE
Add 4 OTJ cards + mtgish emitter (Another Round, At Knifepoint, Claim Jumper, Dance of the Tumbleweeds)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -269,9 +269,11 @@ this turn" can't be expressed. Add the tracker (engine accumulates on draw event
     gated on "as long as this is attacking," with declare-blockers payment enforcement.
     → **Archangel of Tithes**.
 
-14. **Group flicker (mass blink) + repeat-the-whole-effect X+1 times.** No group exile-and-return
-    effect and no generic "repeat this process X more times" loop wrapper.
-    → **Another Round**.
+14. ~~**Group flicker (mass blink) + repeat-the-whole-effect X+1 times.**~~ RESOLVED — no new SDK
+    needed. Composed from existing primitives: an `Effects.Pipeline { gather → chooseAnyNumber →
+    exile(linkToSource) → gather(FromLinkedExile) → move(battlefield, underOwnersControl) }` blink,
+    run once then `RepeatDynamicTimesEffect(amount = DynamicAmount.XValue, body = …)` for "X more times".
+    → **Another Round** (implemented).
 
 15. **Targeted reanimate-attached for Auras/Equipment.** Only `ReturnSelfToBattlefieldAttached`
     (source = self) exists. This mode targets a *separate* graveyard Aura/Equipment and attaches it to

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnotherRound.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnotherRound.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Another Round
+ * {X}{X}{2}{W}
+ * Sorcery
+ *
+ * Exile any number of creatures you control, then return them to the battlefield under their
+ * owner's control. Then repeat this process X more times.
+ *
+ * The "exile any number you control, then return them" blink is one atomic gather → choose →
+ * exile (linked to this spell) → return-from-linked-exile pipeline ([Effects.Pipeline]). The
+ * exiled creatures are returned simultaneously as one batch (a [CardSource.FromLinkedExile]
+ * gather + a single [CardDestination.ToZone] move) under their owners' control, so they all
+ * re-enter at once and any enters-the-battlefield abilities see the whole batch.
+ *
+ * "Then repeat this process X more times" = the process happens X + 1 times total: the body runs
+ * once, then [RepeatDynamicTimesEffect] over [DynamicAmount.XValue] runs it X more times. Each
+ * iteration re-gathers and re-prompts, so the player chooses anew every round. With the `{X}{X}`
+ * cost, [DynamicAmount.XValue] is the chosen value of X (not the doubled mana paid), matching
+ * Devastating Onslaught's `{X}{X}{R}` "create X tokens".
+ */
+val AnotherRound = card("Another Round") {
+    manaCost = "{X}{X}{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile any number of creatures you control, then return them to the battlefield " +
+        "under their owner's control. Then repeat this process X more times."
+
+    spell {
+        // One round: exile a player-chosen set of creatures you control, then return that same
+        // set to the battlefield under their owners' control.
+        val oneRound = Effects.Pipeline(
+            descriptionOverride = "Exile any number of creatures you control, then return them to " +
+                "the battlefield under their owner's control"
+        ) {
+            val controlled = gather(GameObjectFilter.Creature, player = Player.You)
+            val chosen = chooseAnyNumber(
+                from = controlled,
+                useTargetingUI = true,
+                prompt = "Choose any number of creatures you control to exile, then return"
+            )
+            exile(chosen, linkToSource = true)
+            val returning = gather(source = CardSource.FromLinkedExile())
+            move(returning, CardDestination.ToZone(Zone.BATTLEFIELD), underOwnersControl = true)
+        }
+
+        effect = Effects.Composite(
+            listOf(
+                oneRound,
+                RepeatDynamicTimesEffect(amount = DynamicAmount.XValue, body = oneRound)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Darrell Riche"
+        flavorText = "Weary travelers trade stories of the Eversaloon, an extraplanar respite that " +
+            "appears at the moment it is most needed."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg?1712355226"
+
+        ruling("2024-04-12", "The creatures return to the battlefield simultaneously. They're new objects with no relation to their previous existence.")
+        ruling("2024-04-12", "You choose which creatures to exile each time you perform the process. You don't have to exile the same creatures each time, and you can choose to exile no creatures.")
+        ruling("2024-04-12", "If a creature you exile this way is a token, it ceases to exist and won't return to the battlefield.")
+        ruling("2024-04-12", "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment will become unattached but remain on the battlefield. Counters on the exiled creatures will cease to exist.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AtKnifepoint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AtKnifepoint.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * At Knifepoint
+ * {1}{B}{R}
+ * Enchantment
+ *
+ * During your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates,
+ * Rogues, and Warlocks are outlaws.)
+ * Whenever you commit a crime, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery." This ability
+ * triggers only once each turn.
+ *
+ * The first-strike grant is a [GrantKeyword] static over `outlaws you control`
+ * ([Subtype.OUTLAW_TYPES]) gated by [Conditions.IsYourTurn] (the projection layer drops the grant
+ * outside the controller's turn). The crime payoff is the standard [Triggers.YouCommitCrime]
+ * triggered ability with `oncePerTurn = true`; its Mercenary token mirrors the canonical OTJ
+ * Mercenary (cf. Hellspur Posse Boss): a sorcery-speed `{T}` pump of a creature you control.
+ */
+val AtKnifepoint = card("At Knifepoint") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Enchantment"
+    oracleText = "During your turn, outlaws you control have first strike. (Assassins, Mercenaries, " +
+        "Pirates, Rogues, and Warlocks are outlaws.)\n" +
+        "Whenever you commit a crime, create a 1/1 red Mercenary creature token with \"{T}: Target " +
+        "creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\" This " +
+        "ability triggers only once each turn."
+
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(
+            Keyword.FIRST_STRIKE,
+            GroupFilter(
+                GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES).youControl()
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(1),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+        description = "Whenever you commit a crime, create a 1/1 red Mercenary creature token with " +
+            "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a " +
+            "sorcery.\" This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "Francisco Miyara"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg?1712356046"
+
+        ruling("2024-04-12", "A card, spell, or permanent is an outlaw if it has the Assassin, " +
+            "Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more " +
+            "than one of those creature types; as long as it has at least one, it's an outlaw.")
+        ruling("2024-04-12", "You commit a crime as you put a spell or ability that targets an " +
+            "opponent, a permanent an opponent controls, a card in an opponent's graveyard, a " +
+            "spell an opponent controls, or an ability an opponent controls onto the stack.")
+        ruling("2024-04-12", "At Knifepoint's last ability triggers only once each turn, no matter " +
+            "how many crimes you commit that turn.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ClaimJumper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ClaimJumper.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Claim Jumper
+ * {2}{W}
+ * Creature — Rabbit Mercenary
+ * 3/3
+ *
+ * Vigilance
+ * When this creature enters, if an opponent controls more lands than you, you may search your
+ * library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls
+ * more lands than you, repeat this process once. If you search your library this way, shuffle.
+ *
+ * The enters ability is a [Triggers.EntersBattlefield] triggered ability with an intervening-if
+ * ([CardBuilder] `triggerCondition`) of [Conditions.OpponentControlsMoreLands] — checked both as
+ * the trigger goes on the stack and again as it resolves (CR 603.4). Each "process" is an optional
+ * ([MayEffect]) `searchLibrary` for a Plains card straight onto the battlefield tapped, which
+ * shuffles only when a search actually happens (declining the may means no search and no shuffle).
+ * "Repeat this process once" is a single re-run gated by a fresh [ConditionalEffect] check of the
+ * same land-count comparison, so the second search only occurs if an opponent still controls more
+ * lands than you.
+ */
+val ClaimJumper = card("Claim Jumper") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rabbit Mercenary"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "When this creature enters, if an opponent controls more lands than you, you may search " +
+        "your library for a Plains card and put it onto the battlefield tapped. Then if an " +
+        "opponent controls more lands than you, repeat this process once. If you search your " +
+        "library this way, shuffle."
+
+    keywords(Keyword.VIGILANCE)
+
+    // One "process": optionally search for a Plains card and put it onto the battlefield tapped.
+    val searchForPlains = MayEffect(
+        Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land.withSubtype(Subtype.PLAINS),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.OpponentControlsMoreLands
+        effect = Effects.Composite(
+            listOf(
+                searchForPlains,
+                // "Then if an opponent controls more lands than you, repeat this process once."
+                ConditionalEffect(
+                    condition = Conditions.OpponentControlsMoreLands,
+                    effect = searchForPlains
+                )
+            )
+        )
+        description = "When this creature enters, if an opponent controls more lands than you, you " +
+            "may search your library for a Plains card and put it onto the battlefield tapped. Then " +
+            "if an opponent controls more lands than you, repeat this process once. If you search " +
+            "your library this way, shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg?1712355252"
+
+        ruling("2024-04-12", "The number of lands each player controls is checked as Claim Jumper's ability resolves and again before the process repeats.")
+        ruling("2024-04-12", "If you don't search your library, you don't shuffle. You may also choose to search but find no card.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DanceOfTheTumbleweeds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DanceOfTheTumbleweeds.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dance of the Tumbleweeds {1}{G}
+ * Sorcery
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.
+ * + {3} — Create an X/X green Elemental creature token, where X is the number of lands you control.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`,
+ * and per-mode `additionalManaCost` (CR 702.166): at least one mode must be chosen, and no
+ * mode can be chosen more than once. The Elemental token's P/T is a dynamic count of lands
+ * you control at resolution ([DynamicAmount.AggregateBattlefield] over [GameObjectFilter.Land]).
+ */
+val DanceOfTheTumbleweeds = card("Dance of the Tumbleweeds") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.\n" +
+        "+ {3} — Create an X/X green Elemental creature token, where X is the number of lands you control."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Patterns.Library.searchLibrary(
+                        filter = GameObjectFilter.BasicLand or
+                            GameObjectFilter.Land.withSubtype(Subtype.DESERT),
+                        count = 1,
+                        destination = SearchDestination.BATTLEFIELD
+                    ),
+                    description = "+ {1} — Search your library for a basic land card or a Desert " +
+                        "card, put it onto the battlefield, then shuffle.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.CreateDynamicToken(
+                        dynamicPower = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+                        dynamicToughness = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+                        colors = setOf(Color.GREEN),
+                        creatureTypes = setOf("Elemental"),
+                        imageUri = "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1712316611"
+                    ),
+                    description = "+ {3} — Create an X/X green Elemental creature token, where X is " +
+                        "the number of lands you control.",
+                    additionalManaCost = "{3}"
+                )
+            ),
+            chooseCount = 2,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg?1712860584"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "The Elemental's power and toughness are each equal to the number of lands you control as the token's creation resolves.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -236,6 +236,145 @@
     ]
 }
 
+// Another Round
+{
+    "name": "Another Round",
+    "manaCost": "{X}{X}{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile any number of creatures you control, then return them to the battlefield under their owner's control. Then repeat this process X more times.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature",
+                                "player": "You"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "selected1",
+                            "prompt": "Choose any number of creatures you control to exile, then return",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "gathered3"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered3",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ],
+                    "descriptionOverride": "Exile any number of creatures you control, then return them to the battlefield under their owner's control"
+                },
+                {
+                    "type": "RepeatDynamicTimes",
+                    "amount": "XValue",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature",
+                                    "player": "You"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "selected1",
+                                "prompt": "Choose any number of creatures you control to exile, then return",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected1",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "gathered3"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "gathered3",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "underOwnersControl": true
+                            }
+                        ],
+                        "descriptionOverride": "Exile any number of creatures you control, then return them to the battlefield under their owner's control"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "Darrell Riche",
+        "flavorText": "Weary travelers trade stories of the Eversaloon, an extraplanar respite that appears at the moment it is most needed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg?1712355226",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The creatures return to the battlefield simultaneously. They're new objects with no relation to their previous existence."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose which creatures to exile each time you perform the process. You don't have to exile the same creatures each time, and you can choose to exile no creatures."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If a creature you exile this way is a token, it ceases to exist and won't return to the battlefield."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment will become unattached but remain on the battlefield. Counters on the exiled creatures will cease to exist."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Archmage's Newt
 {
     "name": "Archmage's Newt",
@@ -375,6 +514,119 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// At Knifepoint
+{
+    "name": "At Knifepoint",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "During your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you commit a crime, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\" This ability triggers only once each turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\" This ability triggers only once each turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Assassin",
+                                        "Mercenary",
+                                        "Pirate",
+                                        "Rogue",
+                                        "Warlock"
+                                    ]
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "Francisco Miyara",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg?1712356046",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You commit a crime as you put a spell or ability that targets an opponent, a permanent an opponent controls, a card in an opponent's graveyard, a spell an opponent controls, or an ability an opponent controls onto the stack."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "At Knifepoint's last ability triggers only once each turn, no matter how many crimes you commit that turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -1832,6 +2084,171 @@
     ]
 }
 
+// Claim Jumper
+{
+    "name": "Claim Jumper",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Rabbit Mercenary",
+    "oracleText": "Vigilance\nWhen this creature enters, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Library",
+                                            "filter": "land Plains"
+                                        },
+                                        "storeAs": "searchable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "searchable",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "found"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "found",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield",
+                                            "placement": "Tapped"
+                                        }
+                                    },
+                                    "ShuffleLibrary"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "EachOpponent",
+                                        "filter": "land"
+                                    },
+                                    "operator": "GT",
+                                    "right": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "land"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Library",
+                                                "filter": "land Plains"
+                                            },
+                                            "storeAs": "searchable"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "searchable",
+                                            "selection": {
+                                                "type": "ChooseUpTo",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "found"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "found",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield",
+                                                "placement": "Tapped"
+                                            }
+                                        },
+                                        "ShuffleLibrary"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "EachOpponent",
+                        "filter": "land"
+                    },
+                    "operator": "GT",
+                    "right": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg?1712355252",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The number of lands each player controls is checked as Claim Jumper's ability resolves and again before the process repeats."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you don't search your library, you don't shuffle. You may also choose to search but find no card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Colossal Rattlewurm
 {
     "name": "Colossal Rattlewurm",
@@ -2421,6 +2838,133 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dance of the Tumbleweeds
+{
+    "name": "Dance of the Tumbleweeds",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.\n+ {3} — Create an X/X green Elemental creature token, where X is the number of lands you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            {
+                                                "type": "Or",
+                                                "predicates": [
+                                                    "IsBasicLand",
+                                                    {
+                                                        "type": "And",
+                                                        "predicates": [
+                                                            "IsLand",
+                                                            {
+                                                                "type": "HasSubtype",
+                                                                "subtype": "Desert"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            "ShuffleLibrary"
+                        ]
+                    },
+                    "description": "+ {1} — Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 0,
+                        "toughness": 0,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Elemental"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1712316611",
+                        "dynamicPower": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "land"
+                        },
+                        "dynamicToughness": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "land"
+                        }
+                    },
+                    "description": "+ {3} — Create an X/X green Elemental creature token, where X is the number of lands you control.",
+                    "additionalManaCost": "{3}"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg?1712860584",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The Elemental's power and toughness are each equal to the number of lands you control as the token's creation resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -92,6 +92,19 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("ChooseACreatureType", UNIVERSAL)
     envelope("ChooseAColor", UNIVERSAL)
     envelope("IfElse", UNIVERSAL)
+
+    // Loop / repeat control-flow. The capability is the nested action body + a repeat count; the engine
+    // expresses bounded repeats via `RepeatDynamicTimesEffect` and "repeat until a condition" via a
+    // `RepeatWhileEffect`. These are STRUCTURAL — the real capability is the nested actions, scored on
+    // their own. The emitter declines (a loop's exact bound — "X more times" vs "once" vs "while" — is
+    // card-specific around the engine's still-rough cast-time X / extra-cost handling), so cards using
+    // them stay SCAFFOLD even though the capability is present.
+    //   - "… Then repeat this process X more times." (Another Round) — a count-bounded repeat.
+    envelope("RepeatableActionsNumTimes", "envelope: repeat a sequence N times (RepeatDynamicTimesEffect)", composes = listOf("RepeatDynamicTimes"))
+    //   - "… Then if [cond], repeat this process [once]." (Claim Jumper) — a do-once-then-repeat loop.
+    envelope("RepeatableActions", "envelope: repeatable action sequence (RepeatDynamicTimes / RepeatWhile)", composes = listOf("RepeatDynamicTimes", "RepeatWhile"))
+    //   - The "repeat this process" loop-back marker inside a RepeatableActions body.
+    supported("RepeatThisProcess", "loop-back marker inside a repeatable action sequence")
     // "[Effect]. [Bigger effect] instead if you controlled a [filter] as you cast this spell" — the OTJ
     // cast-time condition capture (CR 601.2i). Structural: the capability is the nested condition
     // (PlayerPassesFilter) and the two branch effects, scored on their own. The engine freezes the

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -34,6 +34,14 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // condition still scaffolds, so these are accepted as supported vocabulary (the emitter is the gate).
     supported("PermanentPassesFilter", "condition: a permanent matches a filter (e.g. ThisPermanent IsSaddled -> Conditions.SourceIsSaddled)")
     supported("PlayerPassesFilter", "condition: a player matches a filter (e.g. You HasntCastASpellThisTurn)")
+    // "an opponent matches [filter]" — APlayerPassesFilter(Opponent, …). Used by Claim Jumper's
+    // intervening-if "if an opponent controls more lands than you". The engine has
+    // Conditions.OpponentControlsMoreLands; the emitter declines the surrounding repeatable-search loop,
+    // so this is capability-only (-> SCAFFOLD).
+    supported("APlayerPassesFilter", "condition: a player (e.g. an opponent) matches a filter")
+    // "controls more [permanents] than [player]" -> Conditions.OpponentControlsMoreLands (for the
+    // Land/You scope). Capability vocabulary; the emitter declines the loop body that uses it.
+    supported("ControlsMorePermanentThanPlayer", "predicate: a player controls more [filter] than another (Opponent>You Lands -> Conditions.OpponentControlsMoreLands)")
     supported("IsSaddled", "predicate: this permanent is saddled (CR 702.171b)")
     // "during your turn" — IsPlayersTurn(You) -> Conditions.IsYourTurn, the gate on Overzealous Muscle's
     // "Whenever you commit a crime during your turn, …". Renders as a triggerCondition when it wraps a

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -60,4 +60,17 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("ExileEachPermanent", UNIVERSAL, composes = listOf("MoveCollection", "MoveToZone"))
     composed("MillNumberCards", UNIVERSAL, composes = listOf("MoveCollection"))
     composed("MillCards", UNIVERSAL, composes = listOf("MoveCollection"))
+
+    // "Exile any number of [permanents] you control, then return them …" — the player-chosen blink
+    // (Another Round). A Gather -> ChooseAnyNumber -> MoveCollection(-> exile, linked) pipeline; the
+    // return half is `PutEachExiledCardOntoTheBattlefield`. The emitter declines (the loop/return shape
+    // is card-specific), so this is capability-only -> SCAFFOLD.
+    composed("ExileAnyNumberOfPermanents", "Gather->ChooseAnyNumber->MoveCollection (battlefield->exile, linked)", composes = listOf("MoveCollection", "MoveToZone"))
+    // "Return them to the battlefield under their owner's control" — the return half of a blink:
+    // Gather(from linked exile) + MoveCollection(-> battlefield, underOwnersControl).
+    composed("PutEachExiledCardOntoTheBattlefield", "Gather(linked exile) + MoveCollection (exile->battlefield, owners' control)", composes = listOf("MoveCollection", "MoveToZone"))
+    // "If you searched your library this way, shuffle" — a deferred shuffle gated on whether a search
+    // happened (Claim Jumper). The search itself shuffles per `searchLibrary`, so the engine expresses
+    // this; capability-only here (the loop body is card-specific) -> SCAFFOLD.
+    composed("ShuffleLibraryIfSearched", "ShuffleLibrary, gated on whether a search occurred", composes = listOf("ShuffleLibrary"))
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -440,6 +440,19 @@ private fun EmitCtx.youControlConditionDsl(condNode: JsonElement?): String? {
 }
 
 /**
+ * "during your turn" condition (`IsPlayersTurn(You)`) -> the `Conditions.IsYourTurn` DSL string, or
+ * null when the turn isn't scoped to You. Used by the [ifRuleBlock] conditional-lord gate (At
+ * Knifepoint's "during your turn, outlaws you control have first strike"); the projected-state read
+ * drops the grant the moment it stops being the controller's turn.
+ */
+private fun isYourTurnConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "IsPlayersTurn") return null
+    if (!jsonContains(cond["args"], "_Player", "You")) return null
+    return "Conditions.IsYourTurn"
+}
+
+/**
  * "you control N or more [filter]" condition (`PlayerPassesFilter(You, ControlsNum([Comparison
  * GreaterThanOrEqualTo Integer N], <filter>))`) -> `Conditions.YouControlAtLeast(N, <filter>)`, or null
  * when the player isn't You, the comparison isn't `>= N` (a fixed integer), or the filter doesn't render
@@ -631,6 +644,17 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
             }
             else -> { reasons.add("If"); return null }
         }
+    }
+
+    // At Knifepoint: "During your turn, outlaws you control have first strike."
+    //   If(IsPlayersTurn(You)) [ EachPermanentLayerEffect(<group>, [AddAbility(<keyword>) | AdjustPT]) ]
+    // -> one `staticAbility { condition = Conditions.IsYourTurn; ability = <lord ability> }` per layer
+    // effect, reusing the always-on lord renderer (staticLordBlock) but gated on the controller's turn.
+    // Only the "during YOUR turn" gate renders; any other turn scope declines (-> SCAFFOLD). The lord
+    // renderer itself still declines any group/ability it can't reproduce exactly.
+    if (innerRule.strField("_Rule") == "EachPermanentLayerEffect") {
+        val condDsl = isYourTurnConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        return staticLordBlock(innerRule, condition = condDsl)
     }
 
     // Dust Animus: "If you control five or more untapped lands, this creature enters with two +1/+1

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -428,8 +428,19 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // it would silently widen the count's filter to GameObjectFilter.Any and over-count every permanent.
         // Decline (-> SCAFFOLD) rather than misrender (The Spirit Oasis's "draw a card for each Shrine").
         if (subtype == null && node.firstArgWordTagged("IsEnchantmentType") != null) return null
-        val filter = if (subtype != null) Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$subtype\""))
-                     else landSearchFilterExpr(node)
+        // A bare "number of LANDS [you control]" battlefield tally (Dance of the Tumbleweeds) is an
+        // explicit `IsCardtype Land` with no land subtype or basic-land signal. Render
+        // `GameObjectFilter.Land` directly: `landSearchFilterExpr` is search-oriented and its
+        // "basic land" oracle fallback would narrow a *lands* count to basics whenever the card's text
+        // also mentions a basic-land search elsewhere (Dance's mode 0). Land subtypes / basic-land
+        // signals still route through the search helper below.
+        val bareLandCount = subtype == null && "\"Land\"" in countBlob &&
+            "IsLandType" !in countBlob && "IsBasicLand" !in countBlob && "IsSupertype" !in countBlob
+        val filter = when {
+            subtype != null -> Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$subtype\""))
+            bareLandCount -> Lit("GameObjectFilter.Land")
+            else -> landSearchFilterExpr(node)
+        }
         return call("DynamicAmount.AggregateBattlefield", arg(player), arg(filter))
     }
     return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.json.JsonObject
 internal fun staticAbilityStmt(ability: Dsl): Stmt = Sub(Block("staticAbility", listOf(Assign("ability", ability))))
 
 /** `staticAbility { condition = <cond>; ability = <ability> }` — a threshold-gated static ability row. */
-private fun gatedStaticAbilityStmt(cond: String, ability: Dsl): Stmt =
+internal fun gatedStaticAbilityStmt(cond: String, ability: Dsl): Stmt =
     Sub(Block("staticAbility", listOf(Assign("condition", Lit(cond)), Assign("ability", ability))))
 
 /**
@@ -125,11 +125,12 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<Stmt>? {
  * excludeSelf for "other …", or `GroupFilter.ChosenSubtypeCreatures()` for "creatures of the chosen
  * type"). Anything we can't render exactly scaffolds.
  */
-internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
+internal fun EmitCtx.staticLordBlock(rule: JsonObject, condition: String? = null): List<Stmt>? {
     val args = rule["args"] as? JsonArray
     val layerEffects = (args?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
     if (args == null || layerEffects.isNullOrEmpty()) { reasons.add("EachPermanentLayerEffect"); return null }
     val group = lordGroupFilterExpr(args.getOrNull(0)) ?: run { reasons.add("EachPermanentLayerEffect"); return null }
+    fun emit(ability: Dsl): Stmt = if (condition != null) gatedStaticAbilityStmt(condition, ability) else staticAbilityStmt(ability)
     val stmts = mutableListOf<Stmt>()
     for (le in layerEffects) {
         val ability: Dsl = when (le.strField("_StaticLayerEffect")) {
@@ -167,7 +168,7 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
             }
             else -> return scaffoldLord()
         }
-        stmts.add(staticAbilityStmt(ability))
+        stmts.add(emit(ability))
     }
     return stmts
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjAnotherRoundScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjAnotherRoundScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AnotherRound
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Another Round — {X}{X}{2}{W} Sorcery.
+ *
+ * "Exile any number of creatures you control, then return them to the battlefield under their
+ *  owner's control. Then repeat this process X more times."
+ *
+ * The blink is composed atomically (gather creatures you control → choose any number → exile
+ * linked → return from linked exile under owners' control). The process runs X + 1 times total.
+ */
+class OtjAnotherRoundScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AnotherRound)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Cast Another Round paying its {X}{X}{2}{W} cost from an explicit mana pool. With X=N the
+    // generic + colored remainder is {2}{W} plus 2N for the doubled X.
+    fun GameTestDriver.castAnotherRound(player: EntityId, spell: EntityId, xValue: Int) {
+        giveMana(player, Color.WHITE, 1)            // {W}
+        giveColorlessMana(player, 2 + 2 * xValue)   // {2} + {X}{X}
+        submit(CastSpell(playerId = player, cardId = spell, xValue = xValue))
+    }
+
+    test("X=0 blinks a chosen creature once and returns it") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(me, "Another Round")
+        driver.castAnotherRound(me, spell, xValue = 0)
+        driver.bothPass() // begin resolving -> the (single) choose-any-number decision
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        driver.submitCardSelection(me, listOf(bear))
+
+        // The creature returned to the battlefield (new object), still controlled by me.
+        val returned = driver.findPermanent(me, "Grizzly Bears")
+        returned shouldNotBe null
+        driver.getController(returned!!) shouldBe me
+    }
+
+    test("X=0 may exile no creatures (choose none is legal)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(me, "Another Round")
+        driver.castAnotherRound(me, spell, xValue = 0)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        decision.minSelections shouldBe 0
+        driver.submitCardSelection(me, emptyList())
+
+        // Nothing was exiled; the bear is still on the battlefield.
+        driver.findPermanent(me, "Grizzly Bears") shouldNotBe null
+    }
+
+    test("X=1 performs the process twice (a second choose-any-number decision)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(me, "Another Round")
+        driver.castAnotherRound(me, spell, xValue = 1)
+        driver.bothPass() // first round's choose decision
+
+        val first = driver.pendingDecision
+        (first is SelectCardsDecision) shouldBe true
+        driver.submitCardSelection(me, listOf(bear))
+
+        // After returning, the second round prompts again.
+        val second = driver.pendingDecision
+        (second is SelectCardsDecision) shouldBe true
+        second as SelectCardsDecision
+        val bear2 = driver.findPermanent(me, "Grizzly Bears")!!
+        driver.submitCardSelection(me, listOf(bear2))
+
+        driver.findPermanent(me, "Grizzly Bears") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjAtKnifepointScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjAtKnifepointScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AtKnifepoint
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * At Knifepoint — {1}{B}{R} Enchantment.
+ *
+ * "During your turn, outlaws you control have first strike."
+ * "Whenever you commit a crime, create a 1/1 red Mercenary creature token ... This ability
+ *  triggers only once each turn."
+ *
+ * Ragavan, Nimble Pilferer (a Monkey Pirate, hence an outlaw) is the test outlaw.
+ */
+class OtjAtKnifepointScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AtKnifepoint)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.commitCrime(caster: EntityId, opponent: EntityId) {
+        val bolt = putCardInHand(caster, "Lightning Bolt")
+        giveMana(caster, Color.RED, 1)
+        castSpell(caster, bolt, targets = listOf(opponent))
+        bothPass() // resolve Bolt -> commit-crime -> token trigger on stack
+        bothPass() // resolve token trigger
+    }
+
+    test("outlaws you control have first strike during your turn, not an opponent's outlaw") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putPermanentOnBattlefield(me, "At Knifepoint")
+
+        val myPirate = driver.putCreatureOnBattlefield(me, "Ragavan, Nimble Pilferer")
+        val oppPirate = driver.putCreatureOnBattlefield(opp, "Ragavan, Nimble Pilferer")
+
+        // It's my turn: my outlaw gains first strike, the opponent's does not (not mine).
+        driver.state.projectedState.hasKeyword(myPirate, Keyword.FIRST_STRIKE) shouldBe true
+        driver.state.projectedState.hasKeyword(oppPirate, Keyword.FIRST_STRIKE) shouldBe false
+    }
+
+    test("the grant turns off when it is no longer your turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(me, "At Knifepoint")
+        val myPirate = driver.putCreatureOnBattlefield(me, "Ragavan, Nimble Pilferer")
+
+        driver.state.projectedState.hasKeyword(myPirate, Keyword.FIRST_STRIKE) shouldBe true
+
+        // Pass to the opponent's turn.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe driver.getOpponent(me)
+
+        driver.state.projectedState.hasKeyword(myPirate, Keyword.FIRST_STRIKE) shouldBe false
+    }
+
+    test("committing a crime creates a Mercenary token, but only once each turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putPermanentOnBattlefield(me, "At Knifepoint")
+
+        val before = driver.state.getZone(ZoneKey(me, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)).size
+
+        driver.commitCrime(me, opp)
+        val afterFirst = driver.state.getZone(ZoneKey(me, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)).size
+        afterFirst shouldBe before + 1
+        driver.findPermanent(me, "Mercenary Token")?.let { driver.getCardName(it) } shouldBe "Mercenary Token"
+
+        // A second crime the same turn must NOT make another token (once per turn).
+        driver.commitCrime(me, opp)
+        driver.state.getZone(ZoneKey(me, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)).size shouldBe afterFirst
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjClaimJumperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjClaimJumperScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ClaimJumper
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Claim Jumper — {2}{W} Creature — Rabbit Mercenary 3/3, Vigilance.
+ *
+ * "When this creature enters, if an opponent controls more lands than you, you may search your
+ *  library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls
+ *  more lands than you, repeat this process once. If you search your library this way, shuffle."
+ */
+class OtjClaimJumperScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + ClaimJumper)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Resolve one "may search" process step: answer the may, then select a Plains if offered. */
+    fun GameTestDriver.resolveMaySearch(player: EntityId, accept: Boolean) {
+        val may = pendingDecision
+        (may is YesNoDecision) shouldBe true
+        submitYesNo(player, accept)
+        if (accept) {
+            val search = pendingDecision
+            (search is SelectCardsDecision) shouldBe true
+            search as SelectCardsDecision
+            submitCardSelection(player, listOf(search.options.first()))
+        }
+    }
+
+    test("when an opponent controls more lands, may fetch up to two tapped Plains (process repeats once)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Opponent controls more lands than me: 0 vs 3.
+        repeat(3) { driver.putLandOnBattlefield(opp, "Plains") }
+
+        val landsBefore = driver.getLands(me).size
+
+        val jumper = driver.putCardInHand(me, "Claim Jumper")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(com.wingedsheep.engine.core.CastSpell(playerId = me, cardId = jumper))
+        driver.bothPass() // resolve Jumper onto battlefield
+        driver.bothPass() // begin resolving the ETB trigger -> first may-search
+
+        driver.resolveMaySearch(me, accept = true)  // first Plains, tapped
+        driver.resolveMaySearch(me, accept = true)  // still behind -> repeat once
+
+        val newLands = driver.getLands(me).filter { driver.getCardName(it) == "Plains" }
+        driver.getLands(me).size shouldBe landsBefore + 2
+        // Fetched lands enter tapped.
+        newLands.count { driver.isTapped(it) } shouldBe 2
+    }
+
+    test("no trigger ability does anything when you are not behind on lands") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // I control more lands than the opponent: 2 vs 0. Intervening-if fails, no search.
+        repeat(2) { driver.putLandOnBattlefield(me, "Plains") }
+        val landsBefore = driver.getLands(me).size
+
+        val jumper = driver.putCardInHand(me, "Claim Jumper")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(com.wingedsheep.engine.core.CastSpell(playerId = me, cardId = jumper))
+        driver.bothPass() // resolve onto battlefield
+        driver.bothPass() // ETB trigger should do nothing (intervening-if fails)
+
+        // Jumper entered, but the intervening-if failed: no may decision, no land fetched.
+        driver.findPermanent(me, "Claim Jumper") shouldNotBe null
+        (driver.pendingDecision is YesNoDecision) shouldBe false
+        driver.getLands(me).size shouldBe landsBefore
+    }
+
+    test("declining the may search performs no search and skips the repeat") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        repeat(3) { driver.putLandOnBattlefield(opp, "Plains") }
+        val landsBefore = driver.getLands(me).size
+
+        val jumper = driver.putCardInHand(me, "Claim Jumper")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(com.wingedsheep.engine.core.CastSpell(playerId = me, cardId = jumper))
+        driver.bothPass()
+        driver.bothPass()
+
+        // Decline the first may. Still behind on lands, so the process repeats; decline again.
+        driver.resolveMaySearch(me, accept = false)
+        driver.resolveMaySearch(me, accept = false)
+
+        driver.getLands(me).size shouldBe landsBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjDanceOfTheTumbleweedsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjDanceOfTheTumbleweedsScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DanceOfTheTumbleweeds
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Dance of the Tumbleweeds — {1}{G} Sorcery (Spree).
+ *
+ * + {1} — Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.
+ * + {3} — Create an X/X green Elemental creature token, where X is the number of lands you control.
+ */
+class OtjDanceOfTheTumbleweedsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + DanceOfTheTumbleweeds)
+        return driver
+    }
+
+    test("Mode 0 fetches a basic land onto the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val landsBefore = driver.getLands(player).size
+
+        val spell = driver.putCardInHand(player, "Dance of the Tumbleweeds")
+        driver.giveMana(player, Color.GREEN, 1) // {G} base
+        driver.giveColorlessMana(player, 2)      // {1} base generic + {1} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass() // resolve search
+
+        // Find a Forest in the library to put onto the battlefield.
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+
+        driver.getLands(player).size shouldBe landsBefore + 1
+    }
+
+    test("Mode 1 creates an X/X Elemental equal to the number of lands you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        repeat(4) { driver.putLandOnBattlefield(player, "Forest") }
+
+        val spell = driver.putCardInHand(player, "Dance of the Tumbleweeds")
+        driver.giveMana(player, Color.GREEN, 1) // {G}
+        driver.giveColorlessMana(player, 4)      // {1} base + {3} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass() // resolve token creation
+
+        val token = driver.findPermanent(player, "Elemental Token")
+        token shouldNotBe null
+        driver.state.projectedState.getPower(token!!) shouldBe 4
+        driver.state.projectedState.getToughness(token) shouldBe 4
+    }
+
+    test("Both modes can be chosen together") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        repeat(2) { driver.putLandOnBattlefield(player, "Forest") }
+        val bfBefore = driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size
+
+        val spell = driver.putCardInHand(player, "Dance of the Tumbleweeds")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 5) // {1} base + {1} mode0 + {3} mode1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(0, 1),
+                modeTargetsOrdered = listOf(emptyList(), emptyList())
+            )
+        )
+        driver.bothPass() // begin resolving; search decision first
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+
+        // A land entered (search) AND an Elemental token was created.
+        driver.findPermanent(player, "Elemental Token") shouldNotBe null
+        // +2: the fetched land and the token.
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).size shouldBe bfBefore + 2
+    }
+})


### PR DESCRIPTION
## Cards implemented (Outlaws of Thunder Junction)

All four are composed from existing SDK primitives — no new SDK surface, so no `card-sdk-language-reference.md` change.

| Card | Cost | How it's modeled |
|------|------|------------------|
| **Dance of the Tumbleweeds** | {1}{G} | Spree (`ModalEffect`, `minChooseCount=1`): mode 0 searches a basic land **or** Desert onto the battlefield; mode 1 makes an X/X green Elemental where X = lands you control (`CreateDynamicToken` + `AggregateBattlefield(Player.You, GameObjectFilter.Land)`). |
| **At Knifepoint** | {1}{B}{R} | Conditional outlaw lord (`GrantKeyword(FIRST_STRIKE, outlaws-you-control)` gated on `Conditions.IsYourTurn`) + a once-per-turn commit-crime trigger that makes the standard OTJ Mercenary token. |
| **Another Round** | {X}{X}{2}{W} | Player-chosen mass blink as an `Effects.Pipeline` (gather creatures you control → `chooseAnyNumber` → exile linked → gather from linked exile → return to battlefield under owners' control), run once then `RepeatDynamicTimesEffect(amount = XValue)` for "X more times" (X+1 total). |
| **Claim Jumper** | {2}{W} | Vigilance + ETB intervening-if (`Conditions.OpponentControlsMoreLands`) optional Plains fetch onto the battlefield tapped, with the "repeat once" gated again via `ConditionalEffect`. |

Each card has a passing `rules-engine` scenario test (12 tests total). The OTJ `CardDefinitionSnapshotTest` golden was re-blessed (only these 4 cards added; nothing else moved).

**No cards skipped** — all four implemented.

## mtgish-tooling changes

- **Emitter — At Knifepoint now AUTOGEN.** New `ifRuleBlock` branch for `If(IsPlayersTurn You)[EachPermanentLayerEffect]` → a conditional lord. `staticLordBlock` gained an optional `condition` parameter (emits `staticAbility { condition = …; ability = … }`); added `isYourTurnConditionDsl`.
- **Emitter fix — Dance now AUTOGEN.** A bare "number of lands you control" battlefield count rendered `GameObjectFilter.BasicLand` because `landSearchFilterExpr`'s card-wide `"basic land" in oracle` fallback misfired (Dance's mode 0 mentions a basic-land *search*). Fixed at the dynamic-count site (`dynamicAmountExpr`) to render `GameObjectFilter.Land` for an explicit `IsCardtype Land` count with no land-subtype/basic signal — the shared search helper is untouched, so all 9 committed `EmitterGoldenTest` fixtures (POR/ONS/TMP/CHK/RAV/ISD/INR/10E/EOE) are unchanged.
- **Bridge — capability entries** for `ExileAnyNumberOfPermanents`, `PutEachExiledCardOntoTheBattlefield`, `ShuffleLibraryIfSearched`, `RepeatableActionsNumTimes`, `RepeatableActions`, `RepeatThisProcess`, `APlayerPassesFilter`, `ControlsMorePermanentThanPlayer` — so **Another Round** and **Claim Jumper** score *coverable* rather than BLOCKED.
- **Another Round & Claim Jumper deliberately stay SCAFFOLD** (emitter declines). Their shapes — a count/condition-bounded `RepeatableActions` loop and a player-chosen "exile any number then return" blink — are too card-specific to render faithfully from the general IR (the loop bound "X more times" vs "once" vs "while", plus the engine's still-rough cast-time-X / extra-cost handling flagged in the tooling README). Per the fidelity policy, declined rather than emit a confidently-wrong render.

## Gates / tests

- `coverage-verify POR` → **GATE PASS (158/158, 0 mismatch)** — no regression.
- `EmitterGoldenTest` (all 9 committed sets) → **PASS**, card-for-card.
- `coverage-verify OTJ`: Dance & At Knifepoint now gameplay-tree-match their golden. The 2 remaining OTJ mismatches — **Cactusfolk Sureshot** (Ward body) and **Freestrider Lookout** (look-at-top prompt) — are **pre-existing** and not touched by this change (OTJ has never been a 0-mismatch set).
- New scenario tests + full `:mtg-sets:test` (snapshot/lint/facade) → green.

## Pre-existing issue found (not addressed here)

`:mtgish-tooling` `TargetRecoveryTest > "…declines a group controlled by a target player (Neutralize the Guards)"` **fails on the branch baseline**: the committed source (commit `da05ef0a6`) renders `targetPlayerControls(…)` for a `Ref_TargetPlayer` controller, but the committed test still asserts `.shouldBeNull()`. Neither file is touched by this PR — flagging it for the owner rather than reverting another agent's in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)