### PR TITLE
Batch may-question for identical optional triggers (backlog §B)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -51,6 +51,7 @@ class DecisionResponder(
             is ChooseTargetsDecision -> respondTargets(state, decision, playerId)
             is SelectCardsDecision -> respondSelectCards(state, decision, playerId)
             is YesNoDecision -> respondYesNo(state, decision, playerId)
+            is BatchYesNoDecision -> respondBatchYesNo(state, decision, playerId)
             is ChooseModeDecision -> respondModes(state, decision, playerId)
             is ChooseColorDecision -> respondColor(state, decision, playerId)
             is ChooseNumberDecision -> respondNumber(state, decision, playerId)
@@ -230,6 +231,23 @@ class DecisionResponder(
         val yesScore = evaluateResult(yesResult, playerId)
         val noScore = evaluateResult(noResult, playerId)
         return YesNoResponse(decision.id, yesScore >= noScore)
+    }
+
+    /**
+     * Batched "you may …" raised once for a run of identical optional triggers. The AI evaluates the
+     * two whole-run outcomes (yes-to-all vs no-to-all) and applies the better one to the entire run —
+     * the same value the AI would reach answering each instance the same way, in one decision.
+     */
+    private fun respondBatchYesNo(
+        state: GameState,
+        decision: BatchYesNoDecision,
+        playerId: EntityId
+    ): DecisionResponse {
+        val yesResult = simulator.simulateDecision(state, BatchYesNoResponse(decision.id, choice = true, applyToAll = true))
+        val noResult = simulator.simulateDecision(state, BatchYesNoResponse(decision.id, choice = false, applyToAll = true))
+        val yesScore = evaluateResult(yesResult, playerId)
+        val noScore = evaluateResult(noResult, playerId)
+        return BatchYesNoResponse(decision.id, choice = yesScore >= noScore, applyToAll = true)
     }
 
     // ── Mode selection ───────────────────────────────────────────────────

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
@@ -240,6 +240,8 @@ private fun randomDecisionResponse(decision: PendingDecision, rng: Random): Deci
 
         is YesNoDecision -> YesNoResponse(decision.id, rng.nextBoolean())
 
+        is BatchYesNoDecision -> BatchYesNoResponse(decision.id, choice = rng.nextBoolean(), applyToAll = true)
+
         is ChooseReplacementDecision -> {
             val fromIndex = rng.nextInt(decision.fromOptions.size)
             val allowed = decision.allowedToByFrom.getOrNull(fromIndex)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3704,6 +3704,23 @@ batch decisions can group structurally identical triggers and persistent yields 
 copies. Null for synthesized sources with no card definition (e.g. spell copies). See
 `backlog/stack-collapse-and-batch-decisions.md` §C.2.
 
+### Batched may-question (engine-internal, not authored)
+
+When a run of structurally identical **optional, targeted** triggers ("Whenever …, you may … *target* …") fires off one
+event, the engine asks the controller a single `BatchYesNoDecision` instead of one `YesNoDecision` per trigger — Magic
+Online's "auto-stack identical triggers" affordance (`backlog/stack-collapse-and-batch-decisions.md` §B). Cards author
+nothing: `TriggerProcessor` groups contiguous `liveTriggers` sharing one (controller, `AbilityIdentity`) key (and that would
+actually raise the may-question rather than fizzle for lack of targets) into one decision carrying a `count`. The reply,
+`BatchYesNoResponse(choice, applyToAll)`, is fanned back out by `BatchMayTriggerContinuation`:
+
+- `applyToAll = true` resolves the whole run (`no` drops it; `yes` unwraps each may-gate and routes every instance through
+  ordinary per-trigger target selection — only the yes/no is shared, never the target).
+- `applyToAll = false` peels one instance off (answered with `choice`) and re-raises the batch for the remainder.
+
+Only same-controller, same-identity, targeted-may triggers batch; targetless "may" triggers still decide at resolution, and a
+lone trigger uses the plain per-trigger yes/no. The guard guarantees the engine never makes a meaningful target/ordering
+choice on the player's behalf.
+
 ## 21. Structural lint (`CardLinter`)
 
 Every registered card is structurally validated at build time: `CardValidator.validate` runs

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
@@ -76,6 +76,7 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
             is SelectCardsDecision -> "Selecting cards"
             is ChooseTargetsDecision -> "Choosing targets"
             is YesNoDecision -> "Making a choice"
+            is BatchYesNoDecision -> "Making a choice"
             is ChooseModeDecision -> "Choosing mode"
             is ChooseColorDecision -> "Choosing a color"
             is ChooseNumberDecision -> "Choosing a number"

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
@@ -78,6 +78,7 @@ class SpectatorStateBuilder(
             is SelectCardsDecision -> "Selecting cards"
             is ChooseTargetsDecision -> "Choosing targets"
             is YesNoDecision -> "Making a choice"
+            is BatchYesNoDecision -> "Making a choice"
             is ChooseModeDecision -> "Choosing mode"
             is ChooseColorDecision -> "Choosing a color"
             is ChooseNumberDecision -> "Choosing a number"

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -25,6 +25,8 @@ import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.BatchYesNoDecision
+import com.wingedsheep.engine.core.BatchYesNoResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.gym.GameEnvironment
@@ -261,6 +263,12 @@ class AlphaZeroSearch<T>(
      */
     private fun foldSimpleDecision(d: PendingDecision): List<DecisionResponse>? = when (d) {
         is YesNoDecision -> listOf(YesNoResponse(d.id, true), YesNoResponse(d.id, false))
+        // The batched may-question folds to two whole-run actions; per-instance peel-off isn't an
+        // MCTS action (the search treats the run as one decision, matching the AI heuristic).
+        is BatchYesNoDecision -> listOf(
+            BatchYesNoResponse(d.id, choice = true, applyToAll = true),
+            BatchYesNoResponse(d.id, choice = false, applyToAll = true),
+        )
         is ChooseNumberDecision -> (d.minValue..d.maxValue).map { NumberChosenResponse(d.id, it) }
         is ChooseColorDecision -> d.availableColors.map { ColorChosenResponse(d.id, it) }
         is ChooseOptionDecision -> d.options.indices.map { OptionChosenResponse(d.id, it) }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.gym.contract
 
 import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.BatchYesNoDecision
+import com.wingedsheep.engine.core.BatchYesNoResponse
 import com.wingedsheep.engine.core.CombatResolutionDecision
 import com.wingedsheep.engine.core.BudgetModalDecision
 import com.wingedsheep.engine.core.BudgetModalResponse
@@ -341,6 +343,16 @@ class ObservationBuilder(
                 val responses = listOf(
                     YesNoResponse(decision.id, true),
                     YesNoResponse(decision.id, false)
+                )
+                val view = baseView(decision, PendingDecisionKind.YES_NO, baseShape, structured = false)
+                view to ActionRegistry.ofDecisionResponses(responses)
+            }
+            is BatchYesNoDecision -> {
+                // Folded to two whole-run actions (yes-to-all / no-to-all); peel-off isn't an
+                // observation action. Reuses the YES_NO encoding kind.
+                val responses = listOf(
+                    BatchYesNoResponse(decision.id, choice = true, applyToAll = true),
+                    BatchYesNoResponse(decision.id, choice = false, applyToAll = true)
                 )
                 val view = baseView(decision, PendingDecisionKind.YES_NO, baseShape, structured = false)
                 view to ActionRegistry.ofDecisionResponses(responses)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -300,6 +300,26 @@ data class MayTriggerContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller answers a [com.wingedsheep.engine.core.BatchYesNoDecision] raised on
+ * behalf of a run of structurally identical optional ("you may … target …") triggers.
+ *
+ * The run shares one may-question; on resume the answer is fanned back out:
+ *  - "yes to all" unwraps the may-gate on every trigger in [triggers] and processes them as ordinary
+ *    targeted triggers (each then chooses its own target via the existing per-trigger machinery);
+ *  - "no to all" drops the whole run;
+ *  - a peel-off answer ("yes/no to this one") resolves [triggers].first() that way and re-runs the
+ *    rest (which re-batch if still ≥ 2), so the player can change their mind partway.
+ *
+ * Triggers after the run are queued separately as a [PendingTriggersContinuation] beneath this frame
+ * when the batch is raised, so they resume in APNAP order regardless of the answer.
+ */
+@Serializable
+data class BatchMayTriggerContinuation(
+    override val decisionId: String,
+    val triggers: List<PendingTrigger>,
+) : ContinuationFrame
+
+/**
  * One snapshotted iteration item of a [com.wingedsheep.sdk.scripting.effects.ForEachEffect].
  * The variant corresponds to (but is deliberately decoupled from) the effect's
  * [com.wingedsheep.sdk.scripting.effects.IterationSpace]: targets iterate [OfTarget],

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -201,6 +201,36 @@ data class YesNoDecision(
 ) : PendingDecision
 
 /**
+ * A single yes/no decision raised once on behalf of N simultaneous, structurally identical
+ * optional triggers (same controller + same [DecisionContext.abilityIdentity]) so the controller
+ * answers the repeated "you may …" once instead of N times — Magic Online's "auto-stack identical
+ * triggers" affordance (see `backlog/stack-collapse-and-batch-decisions.md` §B).
+ *
+ * The answer is a [BatchYesNoResponse] carrying both `choice` (yes/no) and `applyToAll`:
+ *  - `applyToAll = true` resolves the whole run of [count] instances with `choice`.
+ *  - `applyToAll = false` peels one instance off (answered with `choice`) and re-raises the batch
+ *    for the remaining `count - 1` — "this one, then ask me about the rest".
+ *
+ * Only the *yes/no* is batched. Per-instance target selection still happens individually after a
+ * "yes" (a swarm of identical pingers shares the may-question but each still picks its own target),
+ * so this never makes a meaningful target/ordering choice on the player's behalf.
+ */
+@Serializable
+@SerialName("BatchYesNoDecision")
+data class BatchYesNoDecision(
+    override val id: String,
+    override val playerId: EntityId,
+    override val prompt: String,
+    override val context: DecisionContext,
+    /** How many identical instances this one answer can cover. Always ≥ 2 when raised. */
+    val count: Int,
+    /** What "yes" means (for UI button text) */
+    val yesText: String = "Yes",
+    /** What "no" means (for UI button text) */
+    val noText: String = "No",
+) : PendingDecision
+
+/**
  * Player must choose from multiple modes (modal spells like Cryptic Command).
  *
  * @property modes Available modes with descriptions
@@ -547,6 +577,21 @@ data class CardsSelectedResponse(
 data class YesNoResponse(
     override val decisionId: String,
     val choice: Boolean
+) : DecisionResponse
+
+/**
+ * Response to [BatchYesNoDecision].
+ *
+ * @property choice the yes/no answer applied to the peeled instance (or whole run).
+ * @property applyToAll when true, [choice] resolves every instance the batch covers; when false,
+ *   it resolves a single instance and the batch re-raises for the rest.
+ */
+@Serializable
+@SerialName("BatchYesNoResponse")
+data class BatchYesNoResponse(
+    override val decisionId: String,
+    val choice: Boolean,
+    val applyToAll: Boolean,
 ) : DecisionResponse
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -149,6 +149,7 @@ val engineSerializersModule = SerializersModule {
         subclass(SearchLibraryDecision::class)
         subclass(ReorderLibraryDecision::class)
         subclass(SelectManaSourcesDecision::class)
+        subclass(BatchYesNoDecision::class)
     }
 
     // DecisionResponse hierarchy
@@ -169,6 +170,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CombatResolutionResponse::class)
         subclass(CancelDecisionResponse::class)
         subclass(ManaSourcesSelectedResponse::class)
+        subclass(BatchYesNoResponse::class)
     }
 
     // ContinuationFrame hierarchy
@@ -274,6 +276,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MayPayManaTriggerContinuation::class)
         subclass(MayPayXContinuation::class)
         subclass(MayTriggerContinuation::class)
+        subclass(BatchMayTriggerContinuation::class)
         subclass(PutOnBottomOfLibraryContinuation::class)
         subclass(ReflexiveTriggerResolveContinuation::class)
         subclass(ReflexiveTriggerTargetContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -74,7 +74,19 @@ class TriggerProcessor(
         var currentState = state
         val allEvents = mutableListOf<GameEvent>()
 
-        for ((index, trigger) in liveTriggers.withIndex()) {
+        var index = 0
+        while (index < liveTriggers.size) {
+            // Batch the may-question for a run of structurally identical optional ("you may …
+            // target …") triggers (MTGO's auto-stack-identical-triggers affordance). A run of ≥ 2
+            // is answered once with a BatchYesNoDecision instead of one yes/no per trigger; the
+            // remainder of the list resumes (and re-batches) after the answer.
+            val run = batchRunAt(currentState, liveTriggers, index)
+            if (run != null) {
+                val remainingTriggers = liveTriggers.drop(index + run.size)
+                return raiseBatchMayDecision(currentState, run, remainingTriggers, allEvents)
+            }
+
+            val trigger = liveTriggers[index]
             val result = processSingleTrigger(currentState, trigger)
 
             if (!result.isSuccess && !result.isPaused) {
@@ -116,9 +128,120 @@ class TriggerProcessor(
 
             currentState = result.newState
             allEvents.addAll(result.events)
+            index++
         }
 
         return ExecutionResult.success(currentState, allEvents)
+    }
+
+    /**
+     * Stable key for "the same batchable may-question": same controller + same definition-scoped
+     * [com.wingedsheep.sdk.scripting.AbilityIdentity]. Two such triggers share an identical "you may
+     * …" prompt (the prompt is the ability's static effect description, identical per identity), so
+     * one answer can cover both.
+     */
+    private data class BatchKey(
+        val controllerId: EntityId,
+        val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity,
+    )
+
+    /**
+     * The [BatchKey] for a trigger that would raise a put-on-stack may-question, or null if it is
+     * not batchable. A trigger is batchable iff it is an optional ("may") trigger that *also* targets
+     * (so the may-question is asked at put-on-stack time, the only point all simultaneous instances
+     * are in hand before priority — see backlog §B.4), it has a definition-scoped ability identity
+     * (synthesized sources like spell copies have none and are never grouped), and it would actually
+     * raise the question rather than fizzle for lack of legal targets.
+     */
+    private fun batchKeyOf(state: GameState, trigger: PendingTrigger): BatchKey? {
+        val ability = trigger.ability
+        val targetRequirement = ability.targetRequirement ?: return null
+        if (ability.effect.asMayDecide() == null) return null
+        val identity = state.abilityIdentityOf(trigger.sourceId, ability.id) ?: return null
+        // Mirror processMayThenTargetTrigger's fizzle guard: a trigger with no legal targets (for a
+        // mandatory-target requirement) fizzles without asking, so it must not join a batch.
+        val legalTargets = targetFinder.findLegalTargets(
+            state = state,
+            requirement = targetRequirement,
+            controllerId = trigger.controllerId,
+            sourceId = trigger.sourceId,
+            triggeringEntityId = trigger.triggerContext.triggeringEntityId
+        )
+        if (legalTargets.isEmpty() && targetRequirement.effectiveMinCount > 0) return null
+        return BatchKey(trigger.controllerId, identity)
+    }
+
+    /**
+     * The maximal contiguous run of batchable triggers starting at [index] that all share one
+     * [BatchKey], or null if fewer than two such triggers start there. Contiguous-only (matching the
+     * stack's LIFO order); a later identical run is re-batched when the remainder resumes.
+     */
+    private fun batchRunAt(
+        state: GameState,
+        triggers: List<PendingTrigger>,
+        index: Int
+    ): List<PendingTrigger>? {
+        val key = batchKeyOf(state, triggers[index]) ?: return null
+        var end = index + 1
+        while (end < triggers.size && batchKeyOf(state, triggers[end]) == key) {
+            end++
+        }
+        return if (end - index >= 2) triggers.subList(index, end).toList() else null
+    }
+
+    /**
+     * Raise one [BatchYesNoDecision] for a [run] of identical optional triggers, queueing
+     * [remainingTriggers] (the triggers after the run) beneath it so they resume in order once the
+     * batch is answered. The [BatchMayTriggerContinuation] carries the whole run; the resumer fans
+     * the single answer back out (see [BatchMayTriggerContinuation]).
+     */
+    private fun raiseBatchMayDecision(
+        state: GameState,
+        run: List<PendingTrigger>,
+        remainingTriggers: List<PendingTrigger>,
+        priorEvents: List<GameEvent>
+    ): ExecutionResult {
+        val first = run.first()
+        val ability = first.ability
+        val decisionId = "batch-may-${java.util.UUID.randomUUID()}"
+        val decision = BatchYesNoDecision(
+            id = decisionId,
+            playerId = first.controllerId,
+            prompt = ability.effect.description,
+            context = DecisionContext(
+                sourceId = first.sourceId,
+                sourceName = first.sourceName,
+                phase = DecisionPhase.RESOLUTION,
+                abilityIdentity = state.abilityIdentityOf(first.sourceId, ability.id)
+            ),
+            count = run.size
+        )
+
+        // Queue the triggers after the run first (deepest), then the batch frame on top, so the
+        // batch resolves before the trailing triggers (APNAP order preserved).
+        var stateWithContinuations = state.withPendingDecision(decision)
+        if (remainingTriggers.isNotEmpty()) {
+            stateWithContinuations = stateWithContinuations.pushContinuation(
+                PendingTriggersContinuation(
+                    decisionId = "pending-triggers-${java.util.UUID.randomUUID()}",
+                    remainingTriggers = remainingTriggers
+                )
+            )
+        }
+        stateWithContinuations = stateWithContinuations.pushContinuation(
+            BatchMayTriggerContinuation(decisionId = decisionId, triggers = run)
+        )
+
+        return ExecutionResult.paused(
+            stateWithContinuations,
+            decision,
+            priorEvents + DecisionRequestedEvent(
+                decisionId = decisionId,
+                playerId = first.controllerId,
+                decisionType = "BATCH_YES_NO",
+                prompt = decision.prompt
+            )
+        )
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.handlers.actions.decision
 
 import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.BatchYesNoDecision
+import com.wingedsheep.engine.core.BatchYesNoResponse
 import com.wingedsheep.engine.core.BudgetModalDecision
 import com.wingedsheep.engine.core.BudgetModalResponse
 import com.wingedsheep.engine.core.CancelDecisionResponse
@@ -75,6 +77,7 @@ object DecisionValidators {
             is SearchLibraryDecision -> validateLibrarySearch(decision, response)
             is ReorderLibraryDecision -> validateLibraryReorder(decision, response)
             is SelectManaSourcesDecision -> validateManaSourcesSelection(response)
+            is BatchYesNoDecision -> validateBatchYesNo(response)
         }
     }
 
@@ -229,6 +232,13 @@ object DecisionValidators {
     private fun validateYesNo(response: DecisionResponse): String? {
         if (response !is YesNoResponse) {
             return "Expected yes/no response"
+        }
+        return null
+    }
+
+    private fun validateBatchYesNo(response: DecisionResponse): String? {
+        if (response !is BatchYesNoResponse) {
+            return "Expected batch yes/no response"
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -268,6 +268,12 @@ class SubmitDecisionHandler(
                 "${sourcePrefix}Chose $choice"
             }
 
+            pending is BatchYesNoDecision && response is BatchYesNoResponse -> {
+                val choice = if (response.choice) "Yes" else "No"
+                val scope = if (response.applyToAll) " to all ${pending.count}" else ""
+                "${sourcePrefix}Chose $choice$scope"
+            }
+
             pending is ChooseNumberDecision && response is NumberChosenResponse -> {
                 "${sourcePrefix}Chose X = ${response.number}"
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -36,6 +36,7 @@ class EffectAndTriggerContinuationResumer(
         resumer(MayRevealCardFromHandContinuation::class, ::resumeMayRevealCardFromHand),
         resumer(BeholdContinuation::class, ::resumeBehold),
         resumer(MayTriggerContinuation::class, ::resumeMayTrigger),
+        resumer(BatchMayTriggerContinuation::class, ::resumeBatchMayTrigger),
         resumer(ReflexiveTriggerResolveContinuation::class, ::resumeReflexiveTriggerResolve)
     )
 
@@ -313,6 +314,80 @@ class EffectAndTriggerContinuationResumer(
         }
 
         return checkForMore(result.newState, result.events.toList())
+    }
+
+    /**
+     * Resume a [BatchMayTriggerContinuation] after the controller answers the batched may-question.
+     * Fans the single [BatchYesNoResponse] back out over the run (see the continuation's docs):
+     *
+     *  - apply-to-all + no  → drop the entire run.
+     *  - apply-to-all + yes → unwrap the may-gate on every trigger and process them as ordinary
+     *    targeted triggers (each picks its own target via the existing per-trigger machinery).
+     *  - peel-off           → resolve the first trigger per [BatchYesNoResponse.choice] and re-run
+     *    the rest (which re-batch if still ≥ 2), enabling "this one, then ask me about the rest".
+     *
+     * Triggers after the run already wait in a [PendingTriggersContinuation] beneath this frame, so
+     * any path that ends in `checkForMore` resumes them in order.
+     */
+    private fun resumeBatchMayTrigger(
+        state: GameState,
+        continuation: BatchMayTriggerContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is BatchYesNoResponse) {
+            return ExecutionResult.error(state, "Expected batch yes/no response for may trigger")
+        }
+
+        val run = continuation.triggers
+
+        if (response.applyToAll) {
+            if (!response.choice) {
+                // No to all — the whole run declines; trailing triggers handled by the frame beneath.
+                return checkForMore(state, emptyList())
+            }
+            // Yes to all — unwrap each may and let the standard pipeline target them one by one.
+            val unwrapped = run.mapNotNull(::unwrapMayTrigger)
+            val result = services.triggerProcessor.processTriggers(state, unwrapped)
+            if (result.isPaused || !result.isSuccess) return result
+            return checkForMore(result.newState, result.events.toList())
+        }
+
+        // Peel one instance off; queue the rest so they re-batch/ask after it resolves.
+        val first = run.first()
+        val rest = run.drop(1)
+        var workingState = state
+        if (rest.isNotEmpty()) {
+            workingState = workingState.pushContinuation(
+                PendingTriggersContinuation(
+                    decisionId = "batch-may-peel-${java.util.UUID.randomUUID()}",
+                    remainingTriggers = rest
+                )
+            )
+        }
+
+        if (!response.choice) {
+            // No to this one — drop it; the rest (and trailing triggers) resume beneath.
+            return checkForMore(workingState, emptyList())
+        }
+
+        val unwrapped = unwrapMayTrigger(first)
+            ?: return ExecutionResult.error(state, "Batch may continuation resumed on a non-may trigger")
+        val result = services.triggerProcessor.processTriggers(workingState, listOf(unwrapped))
+        if (result.isPaused || !result.isSuccess) return result
+        return checkForMore(result.newState, result.events.toList())
+    }
+
+    /**
+     * Strip the bare "may" gate off a trigger, returning a copy whose effect is the inner payoff so
+     * the standard targeted-trigger path handles it. Mirrors [resumeMayTrigger]. Null if the trigger
+     * is not a lowered may (should not happen for a batched trigger).
+     */
+    private fun unwrapMayTrigger(
+        trigger: com.wingedsheep.engine.event.PendingTrigger
+    ): com.wingedsheep.engine.event.PendingTrigger? {
+        val inner = trigger.ability.effect.asMayDecide()?.then ?: return null
+        return trigger.copy(ability = trigger.ability.copy(effect = inner))
     }
 
     private fun resumeMayAbility(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BatchMayQuestionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BatchMayQuestionTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.BatchYesNoDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for feature B — batched may-question (backlog/stack-collapse-and-batch-decisions.md §B).
+ *
+ * When a run of structurally identical optional ("you may … target …") triggers fires off one
+ * event, the controller answers a single [BatchYesNoDecision] instead of one yes/no per trigger.
+ * The guard (MTGO "auto-stack identical triggers"): only same-controller, same-[AbilityIdentity]
+ * triggers are batched, and only the *yes/no* is shared — each instance still picks its own target.
+ *
+ * The board: N copies of "Batch Pinger" ("Whenever another creature you control enters, you may
+ * have Batch Pinger deal 1 damage to any target") plus a vanilla creature whose entry fires them
+ * all at once.
+ */
+class BatchMayQuestionTest : FunSpec({
+
+    val batchPinger = card("Batch Pinger") {
+        manaCost = "{1}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever another creature you control enters the battlefield, you may have " +
+            "Batch Pinger deal 1 damage to any target."
+        triggeredAbility {
+            trigger = Triggers.OtherCreatureEnters
+            val t = target("target", Targets.Any)
+            effect = MayEffect(Effects.DealDamage(1, t))
+        }
+    }
+
+    // Vanilla creature whose entry fires every Batch Pinger's "another creature enters" trigger.
+    val batchBear = card("Batch Bear") {
+        manaCost = "{1}"
+        typeLine = "Creature — Test"
+        power = 2
+        toughness = 2
+    }
+
+    fun driverWithPingers(count: Int): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(batchPinger, batchBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        repeat(count) { driver.putCreatureOnBattlefield(player, "Batch Pinger") }
+
+        driver.giveColorlessMana(player, 1)
+        val bear = driver.putCardInHand(player, "Batch Bear")
+        driver.castSpell(player, bear).isSuccess shouldBe true
+        driver.bothPass() // resolve the bear; it enters and every Batch Pinger triggers
+        return Triple(driver, player, opponent)
+    }
+
+    test("two identical may+target triggers raise ONE BatchYesNoDecision, not two yes/no prompts") {
+        val (driver, player, _) = driverWithPingers(2)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<BatchYesNoDecision>()
+        decision.count shouldBe 2
+        decision.playerId shouldBe player
+        // Carries the shared ability identity (the C.2 key the grouping is built on).
+        val identity = decision.context.abilityIdentity.shouldNotBeNull()
+        identity.cardDefinitionId shouldBe "Batch Pinger"
+    }
+
+    test("yes to all — each instance still targets individually, both resolve") {
+        val (driver, player, opponent) = driverWithPingers(2)
+
+        driver.submitBatchYesNo(player, choice = true, applyToAll = true)
+
+        // Each of the two triggers now asks for its own target.
+        val t1 = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(t1.playerId, listOf(opponent))
+        val t2 = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(t2.playerId, listOf(opponent))
+
+        // Both pings are on the stack; resolve them.
+        val onStack = driver.state.stack.mapNotNull {
+            driver.state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>()
+        }.filter { it.sourceName == "Batch Pinger" }
+        onStack.size shouldBe 2
+
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.assertLifeTotal(opponent, 18) // 20 - 1 - 1
+    }
+
+    test("no to all — the whole run is declined, no targets asked, no damage") {
+        val (driver, player, opponent) = driverWithPingers(2)
+
+        driver.submitBatchYesNo(player, choice = false, applyToAll = true)
+
+        // No further decision, nothing on the stack from the pingers, opponent untouched.
+        driver.pendingDecision shouldBe null
+        driver.state.stack.mapNotNull {
+            driver.state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>()
+        }.none { it.sourceName == "Batch Pinger" } shouldBe true
+        driver.assertLifeTotal(opponent, 20)
+    }
+
+    test("peel-off — yes to this one targets it, the remaining run re-batches") {
+        val (driver, player, opponent) = driverWithPingers(3)
+
+        val batch = driver.pendingDecision.shouldBeInstanceOf<BatchYesNoDecision>()
+        batch.count shouldBe 3
+
+        // "Yes" (this one): peel one off and target it.
+        driver.submitBatchYesNo(player, choice = true, applyToAll = false)
+        val firstTarget = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(firstTarget.playerId, listOf(opponent))
+
+        // The remaining two re-raise as a fresh batch of 2.
+        val reBatch = driver.pendingDecision.shouldBeInstanceOf<BatchYesNoDecision>()
+        reBatch.count shouldBe 2
+
+        // Decline the rest; only the peeled ping resolves.
+        driver.submitBatchYesNo(player, choice = false, applyToAll = true)
+        driver.bothPass()
+        driver.assertLifeTotal(opponent, 19) // exactly one ping landed
+    }
+
+    test("a single trigger is never batched — it raises an ordinary yes/no") {
+        val (driver, _, _) = driverWithPingers(1)
+
+        // One pinger → one may+target trigger → the plain per-trigger path, not a batch.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -1248,6 +1248,19 @@ class GameTestDriver {
     }
 
     /**
+     * Submit a response to a batched may-question ([BatchYesNoDecision]). [applyToAll] resolves the
+     * whole run with [choice]; otherwise it peels one instance and the batch re-raises for the rest.
+     */
+    fun submitBatchYesNo(playerId: EntityId, choice: Boolean, applyToAll: Boolean): ExecutionResult {
+        val decision = pendingDecision as? BatchYesNoDecision
+            ?: throw IllegalStateException("No pending BatchYesNoDecision")
+        return submitDecision(
+            playerId,
+            BatchYesNoResponse(decision.id, choice = choice, applyToAll = applyToAll)
+        )
+    }
+
+    /**
      * Submit a target selection response (for targeted spells/abilities).
      */
     fun submitTargetSelection(playerId: EntityId, targets: List<EntityId>): ExecutionResult {

--- a/web-client/src/components/decisions/BatchYesNoDecisionUI.tsx
+++ b/web-client/src/components/decisions/BatchYesNoDecisionUI.tsx
@@ -1,0 +1,101 @@
+import { useGameStore } from '@/store/gameStore.ts'
+import type { BatchYesNoDecision, ClientGameState } from '@/types'
+import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { AbilityText } from '../ui/ManaSymbols'
+import styles from './DecisionUI.module.css'
+
+/**
+ * Batched yes/no for a run of N identical optional ("you may …") triggers (e.g. a board of
+ * pingers all triggering off one creature entering). The controller answers the repeated
+ * may-question once instead of N times — Magic Online's "auto-stack identical triggers" affordance.
+ *
+ * Four verbs following the bulk-action grammar:
+ *  - Yes / No        → answer just this one; the batch re-raises for the remaining instances.
+ *  - Yes to all N / No to all N → resolve the whole run with one answer.
+ */
+export function BatchYesNoDecisionUI({
+  decision,
+  gameState,
+  onMinimize,
+}: {
+  decision: BatchYesNoDecision
+  gameState: ClientGameState | null
+  onMinimize?: () => void
+}) {
+  const submitBatchYesNoDecision = useGameStore((s) => s.submitBatchYesNoDecision)
+
+  const sourceCard = decision.context.sourceId ? gameState?.cards[decision.context.sourceId] : undefined
+  const sourceImageUrl = sourceCard ? getCardImageUrl(sourceCard.name, sourceCard.imageUri) : undefined
+  const showCardContext = sourceImageUrl != null
+
+  return (
+    <>
+      {showCardContext && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 24, marginBottom: 8 }}>
+          <div style={{ textAlign: 'center', position: 'relative' }}>
+            {/* "deck" shadow hinting at the stack of identical instances */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                transform: 'translate(8px, 8px)',
+                borderRadius: 8,
+                background: 'rgba(0,0,0,0.35)',
+              }}
+            />
+            <img
+              src={sourceImageUrl}
+              alt={sourceCard?.name ?? ''}
+              style={{ position: 'relative', width: 160, borderRadius: 8, boxShadow: '0 4px 16px rgba(0,0,0,0.6)' }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                top: -10,
+                right: -10,
+                background: 'var(--accent, #c9a14a)',
+                color: '#1a1a1a',
+                fontWeight: 700,
+                fontSize: 'var(--font-sm)',
+                borderRadius: 999,
+                padding: '2px 10px',
+                boxShadow: '0 2px 6px rgba(0,0,0,0.5)',
+              }}
+            >
+              ×{decision.count}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <h2 className={styles.title}>
+        <AbilityText text={decision.prompt} size={20} />
+      </h2>
+
+      <p className={styles.subtitle}>
+        {decision.context.sourceName ? `${decision.context.sourceName} — ` : ''}
+        {decision.count} identical triggers
+      </p>
+
+      <div className={styles.buttonContainer}>
+        {onMinimize && (
+          <button onClick={onMinimize} className={styles.viewBattlefieldButton}>
+            View Battlefield
+          </button>
+        )}
+        <button onClick={() => submitBatchYesNoDecision(true, false)} className={styles.yesButton}>
+          <AbilityText text={decision.yesText} size={16} />
+        </button>
+        <button onClick={() => submitBatchYesNoDecision(false, false)} className={styles.noButton}>
+          <AbilityText text={decision.noText} size={16} />
+        </button>
+        <button onClick={() => submitBatchYesNoDecision(true, true)} className={styles.yesButton}>
+          {decision.yesText} to all {decision.count}
+        </button>
+        <button onClick={() => submitBatchYesNoDecision(false, true)} className={styles.noButton}>
+          {decision.noText} to all {decision.count}
+        </button>
+      </div>
+    </>
+  )
+}

--- a/web-client/src/components/decisions/DecisionUI.tsx
+++ b/web-client/src/components/decisions/DecisionUI.tsx
@@ -9,6 +9,7 @@ import { OrderBlockersUI } from './OrderBlockersUI'
 import { CombatDamageAssignmentModal } from './CombatDamageAssignmentModal'
 import { CombatResolutionBoard } from './CombatResolutionBoard'
 import { YesNoDecisionUI } from './YesNoDecisionUI'
+import { BatchYesNoDecisionUI } from './BatchYesNoDecisionUI'
 import { ChooseNumberDecisionUI } from './ChooseNumberDecisionUI'
 import { ChooseOptionDecisionUI } from './ChooseOptionDecisionUI'
 import { ChooseReplacementDecisionUI } from './ChooseReplacementDecisionUI'
@@ -123,6 +124,29 @@ export function DecisionUI() {
     return (
       <div className={styles.overlay}>
         <YesNoDecisionUI
+          decision={pendingDecision}
+          gameState={gameState}
+          onMinimize={() => setDecisionMinimized(true)}
+        />
+      </div>
+    )
+  }
+
+  // Handle BatchYesNoDecision (one yes/no covering N identical optional triggers)
+  if (pendingDecision.type === 'BatchYesNoDecision') {
+    if (decisionMinimized) {
+      return (
+        <button
+          className={styles.floatingReturnButton}
+          onClick={() => setDecisionMinimized(false)}
+        >
+          Return to decision
+        </button>
+      )
+    }
+    return (
+      <div className={styles.overlay}>
+        <BatchYesNoDecisionUI
           decision={pendingDecision}
           gameState={gameState}
           onMinimize={() => setDecisionMinimized(true)}

--- a/web-client/src/store/slices/gameplaySlice.ts
+++ b/web-client/src/store/slices/gameplaySlice.ts
@@ -61,6 +61,7 @@ export interface GameplaySliceActions {
   submitTargetsDecision: (selectedTargets: Record<number, readonly EntityId[]>) => void
   submitOrderedDecision: (orderedObjects: readonly EntityId[]) => void
   submitYesNoDecision: (choice: boolean) => void
+  submitBatchYesNoDecision: (choice: boolean, applyToAll: boolean) => void
   submitNumberDecision: (number: number) => void
   submitOptionDecision: (optionIndex: number) => void
   submitReplacementDecision: (fromIndex: number, toIndex: number) => void
@@ -229,6 +230,26 @@ export const createGameplaySlice: SliceCreator<GameplaySlice> = (set, get) => ({
         type: 'YesNoResponse' as const,
         decisionId: pendingDecision.id,
         choice,
+      },
+    }
+    getWebSocket()?.send(createSubmitActionMessage(action))
+  },
+
+  submitBatchYesNoDecision: (choice, applyToAll) => {
+    const { pendingDecision, playerId } = get()
+    if (!pendingDecision || !playerId) return
+
+    const action = {
+      type: 'SubmitDecision' as const,
+      // Stamp the decision's owner, not the connection's own seat. Equal in normal play;
+      // in hotseat / Mindslaver control the one connection answers the other seat's
+      // decisions, and the engine requires SubmitDecision.playerId == pendingDecision.playerId.
+      playerId: pendingDecision.playerId,
+      response: {
+        type: 'BatchYesNoResponse' as const,
+        decisionId: pendingDecision.id,
+        choice,
+        applyToAll,
       },
     }
     getWebSocket()?.send(createSubmitActionMessage(action))

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -805,6 +805,7 @@ export type GameStore = {
   submitTargetsDecision: (selectedTargets: Record<number, readonly EntityId[]>) => void
   submitOrderedDecision: (orderedObjects: readonly EntityId[]) => void
   submitYesNoDecision: (choice: boolean) => void
+  submitBatchYesNoDecision: (choice: boolean, applyToAll: boolean) => void
   submitNumberDecision: (number: number) => void
   submitOptionDecision: (optionIndex: number) => void
   submitReplacementDecision: (fromIndex: number, toIndex: number) => void

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -186,6 +186,7 @@ export type {
   OpponentDecisionStatus,
   SelectCardsDecision,
   YesNoDecision,
+  BatchYesNoDecision,
   ChooseTargetsDecision,
   TargetRequirementInfo,
   SearchLibraryDecision,

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -659,11 +659,26 @@ export interface BudgetModalDecision extends PendingDecisionBase {
 }
 
 /**
+ * One yes/no raised for a run of N identical optional ("you may …") triggers, answered once
+ * instead of N times. The response carries both the yes/no `choice` and `applyToAll`:
+ * apply-to-all resolves the whole run; otherwise it peels one instance and the batch re-raises for
+ * the rest. See `backlog/stack-collapse-and-batch-decisions.md` §B.
+ */
+export interface BatchYesNoDecision extends PendingDecisionBase {
+  readonly type: 'BatchYesNoDecision'
+  /** How many identical instances one "to all" answer covers (≥ 2). */
+  readonly count: number
+  readonly yesText: string
+  readonly noText: string
+}
+
+/**
  * Union of all pending decision types.
  */
 export type PendingDecision =
   | SelectCardsDecision
   | YesNoDecision
+  | BatchYesNoDecision
   | ChooseTargetsDecision
   | SearchLibraryDecision
   | ReorderLibraryDecision


### PR DESCRIPTION
## What

Implements **feature B — batch decision answering** from `backlog/stack-collapse-and-batch-decisions.md`. When a run of structurally identical **optional, targeted** triggers (`Whenever …, you may … target …`) fires off one event, the controller answers a single `BatchYesNoDecision` instead of one yes/no per trigger — Magic Online's "auto-stack identical triggers" affordance. Builds on the shared `AbilityIdentity` key (§C.2, already on `main` via #720).

## The guard (adopted verbatim from MTGO #7)

Only **same-controller, same-`AbilityIdentity`, targeted-may** triggers are batched, and only the **yes/no** is shared — each instance still picks its own target after a "yes". Targetless "may" triggers still decide at resolution; a lone trigger uses the plain per-trigger yes/no. The engine never makes a meaningful target/ordering choice on the player's behalf.

Batching happens at **put-on-stack time** (before the triggers reach the stack), so it touches no priority window — the "resolve all" concern (§B.4) is left to `AutoPassManager` as the spec requires.

## How it works

`TriggerProcessor.processTriggers` groups contiguous `liveTriggers` sharing one `(controller, AbilityIdentity)` key into one `BatchYesNoDecision` (count ≥ 2), queuing trailing triggers beneath it in APNAP order. `BatchMayTriggerContinuation` fans the single `BatchYesNoResponse(choice, applyToAll)` back out:

- **yes to all** → unwrap each may-gate, route every instance through ordinary per-trigger target selection;
- **no to all** → drop the run;
- **peel-off** (`applyToAll=false`) → resolve one instance and re-raise the batch for the rest ("this one, then ask me about the rest").

## Cross-layer trace

- **Engine** — new decision/response/continuation types, registered + validated; grouping/raise/resume; log description.
- **Server** — opponent/spectator decision-status branch. Decision serialized polymorphically as today; masking unchanged (sent only to the actor).
- **AI** — `DecisionResponder.respondBatchYesNo` simulates yes-to-all vs no-to-all.
- **Gym/trainer** — `AlphaZeroSearch` + `ObservationBuilder` fold the batch to two whole-run actions.
- **Client** — `BatchYesNoDecision` type + `BatchYesNoDecisionUI` (four verbs: Yes / No / Yes to all N / No to all N, with an ×N pile badge), `DecisionUI` routing, `submitBatchYesNoDecision`.
- **Docs** — `card-sdk-language-reference.md` §20.

## Tests

`BatchMayQuestionTest` (rules-engine) pins, via an inline "Batch Pinger" may+target ETB trigger:
- two identical triggers raise **one** `BatchYesNoDecision` (count, identity), not two prompts;
- **yes to all** → each instance targets individually, both resolve (opponent 20→18);
- **no to all** → run dropped, no prompts, no damage;
- **peel-off** → one targeted, remaining run re-batches as count 2;
- a **single** trigger is never batched (plain `YesNoDecision`).

`./gradlew :rules-engine:test`, `:game-server:test`, `:ai:test` green; full `build` + web-client `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)