### PR TITLE
Token quantity aggregation (display-layer)

### DIFF
--- a/backlog/number-explosion-safety.md
+++ b/backlog/number-explosion-safety.md
@@ -7,8 +7,11 @@ before any rule stops it. This doc captures the failure modes, what other engine
 do, and a tiered plan to fix it.
 
 **Status:** Option A implemented (see [`GameLimits`](../rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameLimits.kt),
-`GameLimitsTest`, `NumberExplosionSafetyTest`, and architecture-principles §2.8). Options B and C
-remain open. Items ordered by impact ÷ effort.
+`GameLimitsTest`, `NumberExplosionSafetyTest`, and architecture-principles §2.8). **Option B
+implemented as display-layer aggregation** (see the note under Option B below) — the engine stays
+strictly one entity per permanent; the client collapses identical permanents into one bounded stack
+so a legitimately huge board (up to Option A's cap) renders cheaply. Option C remains open. Items
+ordered by impact ÷ effort.
 
 ## Failure modes (current state)
 
@@ -114,6 +117,37 @@ stack), SBAs, server DTO, the client board renderer (already renders "stacks" vi
 battlefield slot sizing notes), and serialization all need to understand quantity. Significant; do
 only after Option A proves insufficient.
 
+#### Implemented as display-layer aggregation (not engine-level)
+
+Investigation found that, **after Option A's entity cap, the only thing that still made a huge board
+non-functional was the client rendering thousands of DOM nodes.** The engine never holds more than
+the cap; `StateDelta` already ships only changed cards, so steady-state wire traffic is fine. The
+freeze came purely from the renderer: `groupCards` *split* an N-token group into `ceil(N/4)` visual
+stacks and rendered all of them (10k tokens → 10k card elements).
+
+So Option B was delivered where aggregation actually belongs — the presentation layer — rather than
+as the engine-level "one entity, quantity N, split on divergence" rewrite. That rewrite would break
+the engine's load-bearing `1 entity = 1 permanent` invariant and require split-on-divergence guards
+at every mutation site (combat, SBAs, targeting, damage, counters, attachments…) with no single
+chokepoint — high correctness risk for a rare scenario. The implemented version:
+
+- **`web-client/src/store/cardGrouping.ts`** — pure module: `computeCardGroupKey` (two cards share a
+  key only when their whole projected status matches — counters, P/T, tap, damage, combat, chosen
+  attributes, badges, …, so any divergence splits a token back out) and `groupCards` (one
+  `GroupedCard` per key, *however large*, carrying `count` + every member `cardIds`).
+- **Bounded render depth** — `CardStack` paints at most `MAX_VISUAL_STACK_DEPTH` (4) layers plus a
+  `×N` badge; `Battlefield.tsx` slot-sizing counts the capped depth (`visibleStackDepth`). A
+  10k-token horde now renders ~4 nodes + a badge. Every member keeps its server-sent legal action via
+  `cardIds`, so interactivity is unchanged.
+- See `docs/web-client-architecture.md` § "Battlefield card grouping (token quantity aggregation)".
+
+**Deliberate non-goals:** the engine and the `ClientCard`/wire contract are unchanged — no `quantity`
+field was added (it would couple a presentation concern to the engine and add `StateDelta` churn),
+and the engine still holds one entity per token. If a future need arises to shrink the *initial
+full-state* payload of a huge board (deltas already handle the steady state), a server-side
+representative-with-`quantity` could be layered on, but it reintroduces delta-reconstruction
+fragility and was judged not worth it now.
+
 ### Option C — Full loop-shortcut detection (research-grade; likely out of scope)
 
 Detect a repeating game-state delta and resolve the whole loop as a draw (mandatory) or a
@@ -125,3 +159,8 @@ probably not worth it for the current player base. Listed for completeness.
 Do **Option A** now — cheap, removes the crash and the silent-corruption risk entirely. Reach for
 **B** only if massive boards must actually play out, and treat **C** as out of scope unless a
 tournament-correctness need appears.
+
+**Update:** Option A and Option B (as display-layer aggregation — see above) are both implemented.
+Together they make a huge board both safe (no crash/overflow) and functional (renders cheaply).
+Option C (full loop-shortcut detection) remains the only principled answer to genuinely *unbounded*
+growth and stays out of scope until a tournament-correctness need appears.

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -204,6 +204,14 @@ chosen mode, class level, badges, …) are already client state.
   action and lives in `GroupedCard.cardIds`; only the *rendering* is capped. The
   members hidden behind the cap are identical, so targeting/sacrificing "one of
   them" via a rendered layer is equivalent.
+- **Targets split out** — `groupCards(cards, splitOutIds)` forces a permanent that
+  is a chosen target / triggering source of a stack object (or a mid-cast selected
+  target — `useSplitOutTargetIds`) to render on its own card, so its
+  `data-card-id` anchor exists for `TargetingArrows`. Without this, a targeted token
+  hidden behind the cap would silently drop its arrow. This mirrors why attackers /
+  blockers already split out of a group (they too drive distinct arrows). Eligible-
+  but-unchosen targets stay collapsed — identical tokens are interchangeable, so
+  clicking the representative picks one.
 
 Deliberate non-goals (see the backlog): the wire still carries one DTO per entity
 (`StateDelta` already sends only changed cards, so steady-state traffic is fine),

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -175,6 +175,42 @@ App
     └── DeathEffect
 ```
 
+## Battlefield card grouping (token quantity aggregation)
+
+Identical permanents on one player's board collapse into a single visual **stack**
+instead of one card each — the display-layer half of "token quantity aggregation"
+(`backlog/number-explosion-safety.md`, Option B). The engine stays strictly *one
+entity per permanent* (the crash/overflow ceiling is enforced separately by
+`GameLimits`, Option A); aggregation is purely a rendering concern and lives in
+the client, where the divergence axes (counters, P/T, tap, damage, combat,
+chosen mode, class level, badges, …) are already client state.
+
+- **`store/cardGrouping.ts`** — pure, store-free module. `computeCardGroupKey(card)`
+  produces a key that two cards share *only* when their entire projected status is
+  identical; the instant one is buffed, tapped, attacks, gains a counter or an
+  attachment, its key changes and it splits back into its own group.
+  `groupCards(cards)` returns one `GroupedCard` per key — **however large** —
+  carrying `count`, every member `cardIds` (for action handling), and the member
+  `cards`. (Re-exported from `store/selectors.ts` for existing call sites.)
+- **Bounded render depth** — `CardStack` paints at most `MAX_VISUAL_STACK_DEPTH`
+  (4) overlapping layers and shows a `×N` count badge on the front card when
+  members are hidden behind the cap. So a horde of 10,000 identical tokens renders
+  ~4 DOM nodes plus a badge instead of 10,000 — what previously made huge boards
+  freeze the client (groups used to be *split* into `ceil(N/4)` stacks, all
+  rendered). `Battlefield.tsx`'s slot-sizing footprint math counts the capped depth
+  (`visibleStackDepth`), not the raw count, so a horde can't drive cards to the
+  absolute-minimum size.
+- **Interactivity is preserved** — every member still has a server-sent legal
+  action and lives in `GroupedCard.cardIds`; only the *rendering* is capped. The
+  members hidden behind the cap are identical, so targeting/sacrificing "one of
+  them" via a rendered layer is equivalent.
+
+Deliberate non-goals (see the backlog): the wire still carries one DTO per entity
+(`StateDelta` already sends only changed cards, so steady-state traffic is fine),
+and no `quantity` field is added to the `ClientCard` contract — that would couple a
+presentation concern to the engine and add delta churn. Aggregation belongs in the
+layer that renders.
+
 ## Multiplayer (3-4 player) board
 
 A game with more than two seats turns on the multiplayer chrome; a 2-player game renders

--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useBattlefieldCards, groupCards, visibleStackDepth, selectViewingPlayerId } from '@/store/selectors.ts'
+import { useBattlefieldCards, groupCards, visibleStackDepth, useSplitOutTargetIds, selectViewingPlayerId } from '@/store/selectors.ts'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
 import { ResponsiveContext, useResponsiveContext, useSlotSizedResponsive, handleImageError } from './shared'
@@ -67,10 +67,14 @@ export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
   // into child re-renders and invalidate downstream useMemos.
   // Grouped here rather than in BattlefieldContent because the fit constraints
   // below must count rendered stacks, not raw cards.
-  const groupedLands = useMemo(() => groupCards(lands), [lands])
-  const groupedCreatures = useMemo(() => groupCards(creatures), [creatures])
-  const groupedPlaneswalkers = useMemo(() => groupCards(planeswalkers), [planeswalkers])
-  const groupedOther = useMemo(() => groupCards(other), [other])
+  // Permanents that are chosen targets / triggering sources keep their own card so
+  // their targeting arrows can anchor (a member hidden behind the stack render cap
+  // would drop its arrow) — see useSplitOutTargetIds / groupCards.
+  const splitOutIds = useSplitOutTargetIds()
+  const groupedLands = useMemo(() => groupCards(lands, splitOutIds), [lands, splitOutIds])
+  const groupedCreatures = useMemo(() => groupCards(creatures, splitOutIds), [creatures, splitOutIds])
+  const groupedPlaneswalkers = useMemo(() => groupCards(planeswalkers, splitOutIds), [planeswalkers, splitOutIds])
+  const groupedOther = useMemo(() => groupCards(other, splitOutIds), [other, splitOutIds])
 
   // Per-row footprint stats drive the fit constraints in useSlotSizedResponsive
   // — it picks card sizes plus how many wrap lines each row gets, trading

--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useBattlefieldCards, groupCards, selectViewingPlayerId } from '@/store/selectors.ts'
+import { useBattlefieldCards, groupCards, visibleStackDepth, selectViewingPlayerId } from '@/store/selectors.ts'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
 import { ResponsiveContext, useResponsiveContext, useSlotSizedResponsive, handleImageError } from './shared'
@@ -90,8 +90,13 @@ export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
     for (const groups of groupLists) {
       for (const group of groups) {
         count++
-        if (group.cards.some((c) => c.isTapped)) tapped++
-        stackedExtra += group.count - 1
+        // Every member of a group shares its tapped state (it's part of the
+        // group key), so the representative answers for the whole stack.
+        if (group.card.isTapped) tapped++
+        // Only the *rendered* peek layers occupy horizontal space — a collapsed
+        // horde paints at most MAX_VISUAL_STACK_DEPTH cards, so the footprint
+        // (and thus the fit search) must use the capped depth, not the raw count.
+        stackedExtra += visibleStackDepth(group.count) - 1
       }
     }
     return { count, tapped, stackedExtra }

--- a/web-client/src/components/game/card/CardStack.tsx
+++ b/web-client/src/components/game/card/CardStack.tsx
@@ -1,11 +1,19 @@
 import { memo } from 'react'
 import type { GroupedCard } from '@/store/selectors.ts'
+import { MAX_VISUAL_STACK_DEPTH } from '@/store/selectors.ts'
 import { useResponsiveContext } from '../board/shared'
 import { GameCard } from './GameCard'
 
 /**
  * Renders a group of identical cards as an overlapping stack.
- * Each card has its own data-card-id for targeting arrows.
+ * Each rendered card has its own data-card-id for targeting arrows.
+ *
+ * The number of *rendered* layers is capped at MAX_VISUAL_STACK_DEPTH: a group of
+ * N identical tokens paints at most that many peeked cards plus a "×N" count badge
+ * on the front card (GameCard renders it when count > 1), instead of one DOM node
+ * per token. This keeps a legitimately huge board (a horde of tokens) cheap to
+ * display. Members hidden behind the cap are still fully reachable for actions —
+ * the server sends per-entity legal actions and the group carries every id.
  */
 function CardStackImpl({
   group,
@@ -35,12 +43,19 @@ function CardStackImpl({
   // Calculate stack offset (how much each card is offset from the previous)
   const stackOffset = responsive.isMobile ? 12 : 18
 
-  // Calculate total width needed for the stack
-  // Use height for tapped cards since they rotate 90 degrees (visually wider)
-  const hasAnyTapped = group.cards.some(c => c.isTapped)
+  // Render at most MAX_VISUAL_STACK_DEPTH overlapping layers regardless of how
+  // many identical members the group has — the count badge conveys the true size.
+  const renderedCards = group.cards.slice(0, MAX_VISUAL_STACK_DEPTH)
+  // The group key guarantees every member shares the same tapped state, so the
+  // representative answers for the whole stack (O(1), avoids scanning a horde).
+  const hasAnyTapped = group.card.isTapped
   const cardWidth = hasAnyTapped ? responsive.battlefieldCardHeight : responsive.battlefieldCardWidth
-  const totalWidth = cardWidth + stackOffset * (group.count - 1)
+  const totalWidth = cardWidth + stackOffset * (renderedCards.length - 1)
   const stackHeight = responsive.battlefieldCardHeight  // Always use full height for consistent alignment
+  // Only badge the count when members are hidden behind the cap — small stacks
+  // that are fully visible look exactly as before.
+  const hasHiddenMembers = group.count > renderedCards.length
+  const frontIndex = renderedCards.length - 1
 
   return (
     <div
@@ -53,7 +68,7 @@ function CardStackImpl({
         transition: 'width 0.15s, height 0.15s',
       }}
     >
-      {group.cards.map((card, index) => (
+      {renderedCards.map((card, index) => (
         <div
           key={card.id}
           style={{
@@ -68,7 +83,7 @@ function CardStackImpl({
         >
           <GameCard
             card={card}
-            count={1}
+            count={hasHiddenMembers && index === frontIndex ? group.count : 1}
             faceDown={card.isFaceDown}
             interactive={interactive}
             battlefield

--- a/web-client/src/store/cardGrouping.ts
+++ b/web-client/src/store/cardGrouping.ts
@@ -168,14 +168,28 @@ export function visibleStackDepth(count: number): number {
  * capped separately (MAX_VISUAL_STACK_DEPTH / CardStack), not here, so callers
  * that need every member (action handling via cardIds, footprint stats) still see
  * the full group.
+ *
+ * [splitOutIds] forces specific permanents to render on their own (a singleton
+ * group keyed by id) even if otherwise identical to their twins. This is how a
+ * permanent that is the *target* of a stack object — or the triggering source, or
+ * a mid-cast selected target — keeps a `data-card-id` DOM anchor: targeting arrows
+ * resolve to that element, and a member hidden behind the render cap would make
+ * its arrow silently drop. It mirrors why attackers/blockers already split out
+ * (they drive distinct arrows). The set is small (a handful of chosen targets), so
+ * it doesn't re-explode a horde.
  */
-export function groupCards(cards: readonly ClientCard[]): readonly GroupedCard[] {
+export function groupCards(
+  cards: readonly ClientCard[],
+  splitOutIds?: ReadonlySet<EntityId>,
+): readonly GroupedCard[] {
   if (cards.length === 0) return []
 
   const groups = new Map<string, { cards: ClientCard[]; cardIds: EntityId[] }>()
 
   for (const card of cards) {
-    const key = computeCardGroupKey(card)
+    // A split-out permanent must render individually so its arrow can anchor —
+    // a unique key guarantees it never merges with a twin.
+    const key = splitOutIds?.has(card.id) ? `solo:${card.id}` : computeCardGroupKey(card)
     const existing = groups.get(key)
     if (existing) {
       existing.cards.push(card)

--- a/web-client/src/store/cardGrouping.ts
+++ b/web-client/src/store/cardGrouping.ts
@@ -1,0 +1,201 @@
+import type { EntityId, ClientCard } from '@/types'
+
+/**
+ * Pure, store-free card-grouping logic for the battlefield.
+ *
+ * Identical permanents collapse into one visual stack and split back out the
+ * moment one diverges (counter, P/T, tap, damage, combat, attachment, …). This is
+ * the display-layer half of "token quantity aggregation"
+ * (backlog/number-explosion-safety.md, Option B): the engine still holds one
+ * entity per token — Option A caps how many can exist — and grouping plus a
+ * bounded render depth make a legitimately huge board cheap to display.
+ *
+ * Kept in its own module (rather than selectors.ts) so it stays a pure function of
+ * its inputs with no store/React dependency — directly unit-testable. Re-exported
+ * from selectors.ts for existing call sites.
+ */
+
+/**
+ * Represents a group of identical cards for display purposes.
+ */
+export interface GroupedCard {
+  /** The representative card to display (first card in group) */
+  card: ClientCard
+  /** Number of cards in this group */
+  count: number
+  /** All card IDs in this group (for action handling) */
+  cardIds: readonly EntityId[]
+  /** All cards in this group (for stacked rendering) */
+  cards: readonly ClientCard[]
+}
+
+/**
+ * Computes a grouping key for a card based on properties that make cards "different".
+ * Cards with different keys should NOT be grouped together.
+ *
+ * The goal is that two cards share a key only when they have *exactly the same projected
+ * status* — same printed identity AND same battlefield state (counters, P/T, damage,
+ * tapped, combat assignment, summoning sickness, chosen attributes, granted keywords,
+ * designations, …). That way a stack of N identical tokens collapses into one visual
+ * group, but the moment one of them is buffed, tapped, attacks, etc. it splits back out.
+ */
+export function computeCardGroupKey(card: ClientCard): string {
+  const parts: string[] = [card.name]
+
+  // Cards with counters are different
+  const counterEntries = Object.entries(card.counters).filter(([, count]) => count && count > 0)
+  if (counterEntries.length > 0) {
+    const sortedCounters = counterEntries.sort(([a], [b]) => a.localeCompare(b))
+    parts.push(`counters:${JSON.stringify(sortedCounters)}`)
+  }
+
+  // Cards with modified P/T are different
+  if (card.power !== card.basePower || card.toughness !== card.baseToughness) {
+    parts.push(`pt:${card.power}/${card.toughness}`)
+  }
+
+  // Cards with attachments (auras/equipment) should never be grouped — use unique ID
+  if (card.attachments.length > 0) {
+    parts.push(`id:${card.id}`)
+  }
+
+  // Cards with linked-exiled cards (e.g. Suspension Field) carry hidden state — never group
+  if (card.linkedExile && card.linkedExile.length > 0) {
+    parts.push(`id:${card.id}`)
+  }
+
+  // Cards with damage are different (for battlefield creatures)
+  if (card.damage != null && card.damage > 0) {
+    parts.push(`damage:${card.damage}`)
+  }
+
+  // Tapped cards are different from untapped
+  if (card.isTapped) {
+    parts.push('tapped')
+  }
+
+  // Combat participants are different from idle permanents, and from each other when they
+  // attack/block different things (drives distinct targeting arrows, so they can't share a slot).
+  if (card.isAttacking) {
+    parts.push(`attacking:${card.attackingTarget ?? ''}`)
+  }
+  if (card.isBlocking) {
+    parts.push(`blocking:${card.blockingTarget ?? ''}`)
+  }
+
+  // Summoning-sick creatures behave differently (can't attack/tap) — keep them visually distinct.
+  if (card.hasSummoningSickness) {
+    parts.push('sick')
+  }
+
+  // Phased-out permanents render translucent and are functionally absent — never mix with present ones.
+  if (card.isPhasedOut) {
+    parts.push('phased')
+  }
+
+  // Transformed cards are different
+  if (card.isTransformed) {
+    parts.push('transformed')
+  }
+
+  // Face-down cards are different
+  if (card.isFaceDown) {
+    parts.push('facedown')
+  }
+
+  // "As enters, choose ..." selections (creature type / color / mode) are rendered as badges.
+  if (card.chosenCreatureType) parts.push(`ct:${card.chosenCreatureType}`)
+  if (card.chosenColor) parts.push(`cc:${card.chosenColor}`)
+  if (card.chosenMode) parts.push(`cm:${card.chosenMode}`)
+
+  // Class/Saga progress is a per-permanent badge, not shared identity.
+  if (card.classLevel != null) parts.push(`class:${card.classLevel}`)
+
+  // Special designations carry prominent badges.
+  if (card.isSuspected) parts.push('suspected')
+  if (card.isRingBearer) parts.push('ringbearer')
+  if (card.isCommander) parts.push('commander')
+
+  // Copy provenance is badged and shown in details, so a token copy doesn't merge with the original.
+  if (card.copyOf) parts.push(`copy:${card.copyOf}`)
+  if (card.nonLegendaryCopy) parts.push('nonleg')
+
+  // Granted/projected keywords, ability flags and protections differ when one copy is
+  // pumped or granted an ability (without an attachment) but its twin isn't.
+  if (card.keywords.length > 0) {
+    parts.push(`kw:${[...card.keywords].sort().join(',')}`)
+  }
+  if (card.abilityFlags && card.abilityFlags.length > 0) {
+    parts.push(`af:${[...card.abilityFlags].sort().join(',')}`)
+  }
+  if (card.protections && card.protections.length > 0) {
+    parts.push(`prot:${[...card.protections].sort().join(',')}`)
+  }
+  if (card.hexproofFromColors && card.hexproofFromColors.length > 0) {
+    parts.push(`hpx:${[...card.hexproofFromColors].sort().join(',')}`)
+  }
+
+  return parts.join('|')
+}
+
+/**
+ * Maximum number of overlapping card layers rendered for a single battlefield
+ * stack. A group with more identical members than this collapses to this many
+ * peeked layers plus a "×N" count badge (see CardStack) rather than painting one
+ * DOM node per token — so a horde of 10,000 identical tokens renders ~4 cards
+ * instead of 10,000. This is the display-layer half of "token quantity
+ * aggregation" (backlog/number-explosion-safety.md, Option B): the engine still
+ * holds one entity per token (Option A caps how many can exist), and grouping +
+ * the render cap make a legitimately huge board cheap to display.
+ *
+ * Action handling is unaffected — GroupedCard.cardIds always lists every member,
+ * so targeting/combat still reach the tokens hidden behind the cap.
+ */
+export const MAX_VISUAL_STACK_DEPTH = 4
+
+/** How many overlapping layers a stack of [count] identical cards actually renders. */
+export function visibleStackDepth(count: number): number {
+  return Math.min(Math.max(count, 0), MAX_VISUAL_STACK_DEPTH)
+}
+
+/**
+ * Groups an array of cards by identical projected status (see computeCardGroupKey).
+ *
+ * Each distinct status becomes exactly ONE group — however many members it has.
+ * A horde of identical tokens collapses into a single group; the moment one of
+ * them is buffed, tapped, attacks, gains a counter, etc. its key changes and it
+ * splits back into its own group automatically. The rendered depth of a group is
+ * capped separately (MAX_VISUAL_STACK_DEPTH / CardStack), not here, so callers
+ * that need every member (action handling via cardIds, footprint stats) still see
+ * the full group.
+ */
+export function groupCards(cards: readonly ClientCard[]): readonly GroupedCard[] {
+  if (cards.length === 0) return []
+
+  const groups = new Map<string, { cards: ClientCard[]; cardIds: EntityId[] }>()
+
+  for (const card of cards) {
+    const key = computeCardGroupKey(card)
+    const existing = groups.get(key)
+    if (existing) {
+      existing.cards.push(card)
+      existing.cardIds.push(card.id)
+    } else {
+      groups.set(key, { cards: [card], cardIds: [card.id] })
+    }
+  }
+
+  const result: GroupedCard[] = []
+  for (const { cards: groupedCards, cardIds } of groups.values()) {
+    const firstCard = groupedCards[0]
+    if (!firstCard) continue // Should never happen, but satisfies TypeScript
+    result.push({
+      card: firstCard,
+      count: groupedCards.length,
+      cardIds,
+      cards: groupedCards,
+    })
+  }
+
+  return result
+}

--- a/web-client/src/store/groupCards.test.ts
+++ b/web-client/src/store/groupCards.test.ts
@@ -101,6 +101,27 @@ describe('groupCards — token quantity aggregation (display layer)', () => {
   it('handles an empty battlefield', () => {
     expect(groupCards([])).toEqual([])
   })
+
+  it('splits a targeted member out of its group so its arrow can anchor', () => {
+    const groups = groupCards(
+      [token({ id: 't1' }), token({ id: 't2' }), token({ id: 'targeted' }), token({ id: 't4' })],
+      new Set([entityId('targeted')]),
+    )
+    // The three untouched twins still collapse; the targeted one stands alone.
+    expect(groups).toHaveLength(2)
+    const solo = groups.find((g) => g.cardIds.includes(entityId('targeted')))!
+    expect(solo.count).toBe(1)
+    expect(groups.find((g) => g.cardIds.includes(entityId('t1')))!.count).toBe(3)
+  })
+
+  it('splits two identical targeted members into separate singletons', () => {
+    const groups = groupCards(
+      [token({ id: 'a' }), token({ id: 'b' })],
+      new Set([entityId('a'), entityId('b')]),
+    )
+    expect(groups).toHaveLength(2)
+    expect(groups.every((g) => g.count === 1)).toBe(true)
+  })
 })
 
 describe('visibleStackDepth', () => {

--- a/web-client/src/store/groupCards.test.ts
+++ b/web-client/src/store/groupCards.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { groupCards, computeCardGroupKey, visibleStackDepth, MAX_VISUAL_STACK_DEPTH } from './cardGrouping'
+import type { ClientCard } from '@/types'
+import { entityId } from '@/types'
+
+/**
+ * Minimal battlefield-permanent factory. Defaults every field that
+ * computeCardGroupKey reads so a bare token groups with its twins; override only
+ * the divergence axis under test.
+ */
+function token({ id, ...over }: { id: string } & Record<string, unknown>): ClientCard {
+  return {
+    id: entityId(id),
+    name: 'Saproling',
+    counters: {},
+    power: 1,
+    toughness: 1,
+    basePower: 1,
+    baseToughness: 1,
+    damage: 0,
+    attachments: [],
+    linkedExile: [],
+    keywords: [],
+    abilityFlags: [],
+    protections: [],
+    hexproofFromColors: [],
+    isTapped: false,
+    isAttacking: false,
+    isBlocking: false,
+    attackingTarget: null,
+    blockingTarget: null,
+    hasSummoningSickness: false,
+    isPhasedOut: false,
+    isTransformed: false,
+    isFaceDown: false,
+    isSuspected: false,
+    isRingBearer: false,
+    isCommander: false,
+    nonLegendaryCopy: false,
+    ...over,
+  } as unknown as ClientCard
+}
+
+describe('groupCards — token quantity aggregation (display layer)', () => {
+  it('collapses N identical tokens into ONE group regardless of size', () => {
+    const cards = Array.from({ length: 10_000 }, (_, i) => token({ id: `e${i}` }))
+    const groups = groupCards(cards)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.count).toBe(10_000)
+    // Every member is retained for action handling, even though only a few render.
+    expect(groups[0]!.cardIds).toHaveLength(10_000)
+    expect(groups[0]!.cards).toHaveLength(10_000)
+    // Representative is the first member.
+    expect(groups[0]!.card.id).toBe(entityId('e0'))
+  })
+
+  it.each([
+    ['a +1/+1 counter', { counters: { PLUS_ONE_PLUS_ONE: 1 }, power: 2, toughness: 2 }],
+    ['tapped', { isTapped: true }],
+    ['marked damage', { damage: 1 }],
+    ['attacking', { isAttacking: true, attackingTarget: entityId('opp') }],
+    ['blocking', { isBlocking: true, blockingTarget: entityId('atk') }],
+    ['summoning sickness', { hasSummoningSickness: true }],
+    ['a granted keyword', { keywords: ['FLYING'] }],
+    ['transformed', { isTransformed: true }],
+  ])('splits a member that diverges by %s back into its own group', (_label, diff) => {
+    const groups = groupCards([
+      token({ id: 'plain1' }),
+      token({ id: 'plain2' }),
+      token({ id: 'diverged', ...diff }),
+    ])
+    expect(groups).toHaveLength(2)
+    const plain = groups.find((g) => g.cardIds.includes(entityId('plain1')))!
+    expect(plain.count).toBe(2)
+    const diverged = groups.find((g) => g.cardIds.includes(entityId('diverged')))!
+    expect(diverged.count).toBe(1)
+  })
+
+  it('never groups a permanent that has attachments (auras/equipment)', () => {
+    const groups = groupCards([
+      token({ id: 'bare1' }),
+      token({ id: 'bare2' }),
+      token({ id: 'enchanted', attachments: [entityId('aura')] }),
+    ])
+    // bare1+bare2 collapse; the enchanted one stands alone (key uses its unique id).
+    expect(groups).toHaveLength(2)
+    expect(groups.find((g) => g.cardIds.includes(entityId('enchanted')))!.count).toBe(1)
+  })
+
+  it('keeps distinct token kinds in separate groups', () => {
+    const groups = groupCards([
+      token({ id: 's1', name: 'Saproling' }),
+      token({ id: 'z1', name: 'Zombie' }),
+      token({ id: 's2', name: 'Saproling' }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.find((g) => g.card.name === 'Saproling')!.count).toBe(2)
+    expect(groups.find((g) => g.card.name === 'Zombie')!.count).toBe(1)
+  })
+
+  it('handles an empty battlefield', () => {
+    expect(groupCards([])).toEqual([])
+  })
+})
+
+describe('visibleStackDepth', () => {
+  it('caps the rendered depth at MAX_VISUAL_STACK_DEPTH', () => {
+    expect(visibleStackDepth(10_000)).toBe(MAX_VISUAL_STACK_DEPTH)
+    expect(visibleStackDepth(MAX_VISUAL_STACK_DEPTH + 1)).toBe(MAX_VISUAL_STACK_DEPTH)
+  })
+
+  it('returns the true count when below the cap', () => {
+    expect(visibleStackDepth(1)).toBe(1)
+    expect(visibleStackDepth(3)).toBe(3)
+    expect(visibleStackDepth(0)).toBe(0)
+  })
+})
+
+describe('computeCardGroupKey', () => {
+  it('is identical for two bare twins and differs once one is tapped', () => {
+    expect(computeCardGroupKey(token({ id: 'a' }))).toBe(computeCardGroupKey(token({ id: 'b' })))
+    expect(computeCardGroupKey(token({ id: 'a' }))).not.toBe(
+      computeCardGroupKey(token({ id: 'b', isTapped: true })),
+    )
+  })
+})

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -552,6 +552,37 @@ export function useStackCards(): readonly ClientCard[] {
   }, [gameState])
 }
 
+const EMPTY_ID_SET: ReadonlySet<EntityId> = Object.freeze(new Set<EntityId>())
+
+/**
+ * Permanents that must render on their own card (not collapsed into a stack) so a
+ * targeting arrow can anchor to their `data-card-id` DOM node — see
+ * `groupCards(cards, splitOutIds)`. These are the chosen targets and triggering
+ * sources of objects on the stack, plus any target already picked in an in-progress
+ * cast. The set is tiny, so splitting them out doesn't re-explode a horde of tokens.
+ *
+ * Eligible-but-unchosen targets are deliberately NOT included: identical tokens are
+ * interchangeable, so the player can click the collapsed stack's representative to
+ * pick one. Only a *committed* target needs its specific arrow to resolve.
+ */
+export function useSplitOutTargetIds(): ReadonlySet<EntityId> {
+  const stackCards = useStackCards()
+  const targetingState = useGameStore(selectTargetingState)
+  return useMemo(() => {
+    const selected = targetingState?.selectedTargets
+    if (stackCards.length === 0 && (!selected || selected.length === 0)) return EMPTY_ID_SET
+    const ids = new Set<EntityId>()
+    for (const card of stackCards) {
+      for (const t of card.targets) {
+        if (t.type === 'Permanent') ids.add(t.entityId)
+      }
+      if (card.triggeringEntityId) ids.add(card.triggeringEntityId)
+    }
+    if (selected) for (const id of selected) ids.add(id)
+    return ids
+  }, [stackCards, targetingState])
+}
+
 /**
  * Hook to check if a card is a valid target for current targeting.
  */

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -10,6 +10,13 @@ import type {
 } from '@/types'
 import { ZoneType, zoneIdEquals, graveyard, library } from '@/types'
 import { seatColor, type SeatColor } from '@/styles/seatColors'
+import {
+  type GroupedCard,
+  computeCardGroupKey,
+  MAX_VISUAL_STACK_DEPTH,
+  visibleStackDepth,
+  groupCards,
+} from './cardGrouping'
 
 /**
  * Select the game state (works for both normal play and spectating).
@@ -576,174 +583,10 @@ export function useCombatState() {
   return null
 }
 
-/**
- * Represents a group of identical cards for display purposes.
- */
-export interface GroupedCard {
-  /** The representative card to display (first card in group) */
-  card: ClientCard
-  /** Number of cards in this group */
-  count: number
-  /** All card IDs in this group (for action handling) */
-  cardIds: readonly EntityId[]
-  /** All cards in this group (for stacked rendering) */
-  cards: readonly ClientCard[]
-}
-
-/**
- * Computes a grouping key for a card based on properties that make cards "different".
- * Cards with different keys should NOT be grouped together.
- *
- * The goal is that two cards share a key only when they have *exactly the same projected
- * status* — same printed identity AND same battlefield state (counters, P/T, damage,
- * tapped, combat assignment, summoning sickness, chosen attributes, granted keywords,
- * designations, …). That way a stack of N identical tokens collapses into one visual
- * group, but the moment one of them is buffed, tapped, attacks, etc. it splits back out.
- */
-export function computeCardGroupKey(card: ClientCard): string {
-  const parts: string[] = [card.name]
-
-  // Cards with counters are different
-  const counterEntries = Object.entries(card.counters).filter(([, count]) => count && count > 0)
-  if (counterEntries.length > 0) {
-    const sortedCounters = counterEntries.sort(([a], [b]) => a.localeCompare(b))
-    parts.push(`counters:${JSON.stringify(sortedCounters)}`)
-  }
-
-  // Cards with modified P/T are different
-  if (card.power !== card.basePower || card.toughness !== card.baseToughness) {
-    parts.push(`pt:${card.power}/${card.toughness}`)
-  }
-
-  // Cards with attachments (auras/equipment) should never be grouped — use unique ID
-  if (card.attachments.length > 0) {
-    parts.push(`id:${card.id}`)
-  }
-
-  // Cards with linked-exiled cards (e.g. Suspension Field) carry hidden state — never group
-  if (card.linkedExile && card.linkedExile.length > 0) {
-    parts.push(`id:${card.id}`)
-  }
-
-  // Cards with damage are different (for battlefield creatures)
-  if (card.damage != null && card.damage > 0) {
-    parts.push(`damage:${card.damage}`)
-  }
-
-  // Tapped cards are different from untapped
-  if (card.isTapped) {
-    parts.push('tapped')
-  }
-
-  // Combat participants are different from idle permanents, and from each other when they
-  // attack/block different things (drives distinct targeting arrows, so they can't share a slot).
-  if (card.isAttacking) {
-    parts.push(`attacking:${card.attackingTarget ?? ''}`)
-  }
-  if (card.isBlocking) {
-    parts.push(`blocking:${card.blockingTarget ?? ''}`)
-  }
-
-  // Summoning-sick creatures behave differently (can't attack/tap) — keep them visually distinct.
-  if (card.hasSummoningSickness) {
-    parts.push('sick')
-  }
-
-  // Phased-out permanents render translucent and are functionally absent — never mix with present ones.
-  if (card.isPhasedOut) {
-    parts.push('phased')
-  }
-
-  // Transformed cards are different
-  if (card.isTransformed) {
-    parts.push('transformed')
-  }
-
-  // Face-down cards are different
-  if (card.isFaceDown) {
-    parts.push('facedown')
-  }
-
-  // "As enters, choose ..." selections (creature type / color / mode) are rendered as badges.
-  if (card.chosenCreatureType) parts.push(`ct:${card.chosenCreatureType}`)
-  if (card.chosenColor) parts.push(`cc:${card.chosenColor}`)
-  if (card.chosenMode) parts.push(`cm:${card.chosenMode}`)
-
-  // Class/Saga progress is a per-permanent badge, not shared identity.
-  if (card.classLevel != null) parts.push(`class:${card.classLevel}`)
-
-  // Special designations carry prominent badges.
-  if (card.isSuspected) parts.push('suspected')
-  if (card.isRingBearer) parts.push('ringbearer')
-  if (card.isCommander) parts.push('commander')
-
-  // Copy provenance is badged and shown in details, so a token copy doesn't merge with the original.
-  if (card.copyOf) parts.push(`copy:${card.copyOf}`)
-  if (card.nonLegendaryCopy) parts.push('nonleg')
-
-  // Granted/projected keywords, ability flags and protections differ when one copy is
-  // pumped or granted an ability (without an attachment) but its twin isn't.
-  if (card.keywords.length > 0) {
-    parts.push(`kw:${[...card.keywords].sort().join(',')}`)
-  }
-  if (card.abilityFlags && card.abilityFlags.length > 0) {
-    parts.push(`af:${[...card.abilityFlags].sort().join(',')}`)
-  }
-  if (card.protections && card.protections.length > 0) {
-    parts.push(`prot:${[...card.protections].sort().join(',')}`)
-  }
-  if (card.hexproofFromColors && card.hexproofFromColors.length > 0) {
-    parts.push(`hpx:${[...card.hexproofFromColors].sort().join(',')}`)
-  }
-
-  return parts.join('|')
-}
-
-/**
- * Maximum cards per visual group. Groups larger than this are split.
- */
-const MAX_GROUP_SIZE = 4
-
-/**
- * Groups an array of cards by identical properties.
- * Cards are grouped if they have the same name and no distinguishing modifiers.
- * Groups are limited to MAX_GROUP_SIZE (4) cards - larger groups are split.
- */
-export function groupCards(cards: readonly ClientCard[]): readonly GroupedCard[] {
-  if (cards.length === 0) return []
-
-  const groups = new Map<string, { cards: ClientCard[]; cardIds: EntityId[] }>()
-
-  for (const card of cards) {
-    const key = computeCardGroupKey(card)
-    const existing = groups.get(key)
-    if (existing) {
-      existing.cards.push(card)
-      existing.cardIds.push(card.id)
-    } else {
-      groups.set(key, { cards: [card], cardIds: [card.id] })
-    }
-  }
-
-  // Split groups larger than MAX_GROUP_SIZE into multiple groups
-  const result: GroupedCard[] = []
-  for (const { cards: groupCards, cardIds } of groups.values()) {
-    for (let i = 0; i < groupCards.length; i += MAX_GROUP_SIZE) {
-      const slicedCards = groupCards.slice(i, i + MAX_GROUP_SIZE)
-      const slicedIds = cardIds.slice(i, i + MAX_GROUP_SIZE)
-      const firstCard = slicedCards[0]
-      if (!firstCard) continue // Should never happen, but satisfies TypeScript
-      result.push({
-        card: firstCard,
-        count: slicedCards.length,
-        cardIds: slicedIds,
-        cards: slicedCards,
-      })
-    }
-  }
-
-  return result
-}
+// Battlefield card grouping ("token quantity aggregation", display layer) lives in
+// its own store-free module (imported at the top) so it stays purely a function of
+// its inputs and is directly unit-testable. Re-exported here for existing call sites.
+export { type GroupedCard, computeCardGroupKey, MAX_VISUAL_STACK_DEPTH, visibleStackDepth, groupCards }
 
 /**
  * Hook to get cards in a zone, grouped by identical properties.


### PR DESCRIPTION
## What

Implements **Option B** of `backlog/number-explosion-safety.md` — *token quantity aggregation* — as a **display-layer** change. Identical permanents on a player's board collapse into one bounded visual stack, so a legitimately huge board (up to Option A's ~10k entity cap) renders cheaply instead of painting one DOM node per token and freezing the client.

## Why display-layer, not engine-level

After Option A's entity cap, the only thing still making a huge board non-functional was the **client rendering thousands of DOM nodes** — `groupCards` *split* an N-token group into `ceil(N/4)` visual stacks and rendered all of them (10k tokens → 10k card elements). The engine never holds more than the cap, and `StateDelta` already ships only changed cards, so steady-state wire traffic is fine.

So aggregation was delivered where it belongs — the presentation layer — rather than as the engine-level *"one entity, quantity N, split on divergence"* rewrite. That rewrite would break the engine's load-bearing `1 entity = 1 permanent` invariant and require split-on-divergence guards at every mutation site (combat, SBAs, targeting, damage, counters, attachments…) with no single chokepoint — high correctness risk for a rare scenario. **The engine, the `ClientCard`/wire contract, and serialization are unchanged.**

## How

- **`web-client/src/store/cardGrouping.ts`** (new) — pure, store-free, directly unit-testable module:
  - `computeCardGroupKey(card)` — two cards share a key only when their *entire projected status* matches (counters, P/T, tap, damage, combat, chosen attributes, badges, …). The instant one diverges, its key changes and it splits back into its own group.
  - `groupCards(cards)` — one `GroupedCard` per key, **however large**, carrying `count` + every member `cardIds` (for action handling). Replaces the old `MAX_GROUP_SIZE` chunking.
  - Re-exported from `store/selectors.ts` for existing call sites.
- **`CardStack`** renders at most `MAX_VISUAL_STACK_DEPTH` (4) overlapping layers + a `×N` count badge on the front card when members are hidden. A 10k-token horde paints ~4 nodes + a badge. Every member keeps its server-sent legal action via `cardIds`, so **interactivity is preserved**.
- **`Battlefield.tsx`** slot-sizing footprint counts the capped depth (`visibleStackDepth`), not the raw count, so a horde can't drive cards to the absolute-minimum size.

## Tests

`web-client/src/store/groupCards.test.ts` pins: N-token collapse into one group (with full `cardIds`), per-axis divergence splits (counter / tapped / damage / attacking / blocking / sickness / keyword / transformed), the attachment carve-out, distinct-kind separation, and the render-depth cap.

- `npm run typecheck` — clean
- `npx vitest run` — full client suite green (153 tests), incl. 15 new

## Docs

- `docs/web-client-architecture.md` — new § "Battlefield card grouping (token quantity aggregation)".
- `backlog/number-explosion-safety.md` — Option B marked done as display-layer aggregation, with the deliberate non-goals (no engine/DTO/wire change; engine-level aggregation and a server `quantity` field judged not worth the fragility now).

## Deliberate non-goals

- No `quantity` field on the `ClientCard` contract (would couple a presentation concern to the engine and add `StateDelta` churn).
- Engine still holds one entity per token. Full loop-shortcut handling for *unbounded* growth remains Option C (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)