### PR TITLE
Add OTJ Final Showdown (Spree instant)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FinalShowdown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FinalShowdown.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.IterationSpace
@@ -62,7 +61,7 @@ val FinalShowdown = card("Final Showdown") {
                     additionalManaCost = "{1}"
                 ),
                 Mode(
-                    effect = CompositeEffect(
+                    effect = Effects.Composite(
                         listOf(
                             GatherCardsEffect(
                                 source = CardSource.ControlledPermanents(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FinalShowdown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FinalShowdown.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Final Showdown {W}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — All creatures lose all abilities until end of turn.
+ * + {1} — Choose a creature you control. It gains indestructible until end of turn.
+ * + {3}{W}{W} — Destroy all creatures.
+ *
+ * Spree is a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`, and per-mode
+ * `additionalManaCost` (CR 702.166). Chosen modes always resolve in printed order (CR ruling),
+ * which the resolver honours by mode index — so "lose all abilities" precedes "indestructible"
+ * precedes "destroy all". Each mode composes existing atoms:
+ *  - Mode 1: [Effects.ForEachInGroup] over every creature, each losing all abilities
+ *    (`RemoveAllAbilities(Self)` per iteration). A creature that gains an ability *after* this
+ *    resolves keeps it (the ruling) because the removal is a one-shot snapshot, not a continuous
+ *    layer effect tied to a filter.
+ *  - Mode 2 does **not** target (per ruling: the creature is chosen as the spell resolves, too
+ *    late to respond). Modeled as a resolution-time gather -> choose-exactly-one -> grant pipeline:
+ *    [GatherCardsEffect] over creatures you control, [SelectFromCollectionEffect] (battlefield
+ *    click UI), then [ForEachEffect] over the singleton selection grants indestructible to `Self`.
+ *  - Mode 3: [Effects.DestroyAll] over all creatures (honours indestructible granted by mode 2).
+ */
+val FinalShowdown = card("Final Showdown") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — All creatures lose all abilities until end of turn.\n" +
+        "+ {1} — Choose a creature you control. It gains indestructible until end of turn.\n" +
+        "+ {3}{W}{W} — Destroy all creatures."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.ForEachInGroup(
+                        GroupFilter(GameObjectFilter.Creature),
+                        Effects.RemoveAllAbilities(EffectTarget.Self)
+                    ),
+                    description = "+ {1} — All creatures lose all abilities until end of turn.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = CompositeEffect(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.ControlledPermanents(
+                                    filter = GameObjectFilter.Creature
+                                ),
+                                storeAs = "chooseIndestructible"
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "chooseIndestructible",
+                                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                                storeSelected = "indestructibleChosen",
+                                useTargetingUI = true,
+                                prompt = "Choose a creature you control to gain indestructible"
+                            ),
+                            ForEachEffect(
+                                space = IterationSpace.Collection("indestructibleChosen"),
+                                body = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+                            )
+                        )
+                    ),
+                    description = "+ {1} — Choose a creature you control. It gains indestructible until end of turn.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.DestroyAll(GameObjectFilter.Creature),
+                    description = "+ {3}{W}{W} — Destroy all creatures.",
+                    additionalManaCost = "{3}{W}{W}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "11"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg?1712860587"
+
+        ruling("2024-04-12", "The second mode of Final Showdown doesn't target the creature. You don't choose which creature will gain indestructible until the spell is resolving. At that point, it's too late for anyone to respond to the spell.")
+        ruling("2024-04-12", "If an effect grants a creature an ability after Final Showdown causes all creatures to lose all abilities, that creature won't lose that ability.")
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "No matter which modes you choose, you always follow the instructions in the order they are written.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "No player can cast spells or activate abilities in between the modes of a resolving spell. Any abilities that trigger won't be put onto the stack until the spell is done resolving.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3958,6 +3958,148 @@
     ]
 }
 
+// Final Showdown
+{
+    "name": "Final Showdown",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — All creatures lose all abilities until end of turn.\n+ {1} — Choose a creature you control. It gains indestructible until end of turn.\n+ {3}{W}{W} — Destroy all creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "RemoveAllAbilities",
+                            "target": "Self"
+                        }
+                    },
+                    "description": "+ {1} — All creatures lose all abilities until end of turn.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "ControlledPermanents",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "chooseIndestructible"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "chooseIndestructible",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "indestructibleChosen",
+                                "prompt": "Choose a creature you control to gain indestructible",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Collection",
+                                    "collection": "indestructibleChosen"
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "INDESTRUCTIBLE",
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "+ {1} — Choose a creature you control. It gains indestructible until end of turn.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "+ {3}{W}{W} — Destroy all creatures.",
+                    "additionalManaCost": "{3}{W}{W}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "MYTHIC",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg?1712860587",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The second mode of Final Showdown doesn't target the creature. You don't choose which creature will gain indestructible until the spell is resolving. At that point, it's too late for anyone to respond to the spell."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If an effect grants a creature an ability after Final Showdown causes all creatures to lose all abilities, that creature won't lose that ability."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "No matter which modes you choose, you always follow the instructions in the order they are written."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "No player can cast spells or activate abilities in between the modes of a resolving spell. Any abilities that trigger won't be put onto the stack until the spell is done resolving."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Forlorn Flats
 {
     "name": "Forlorn Flats",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjFinalShowdownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjFinalShowdownScenarioTest.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.FinalShowdown
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Final Showdown (OTJ Spree instant).
+ *
+ * + {1} (mode 0): All creatures lose all abilities until end of turn.
+ * + {1} (mode 1): Choose a creature you control (non-targeted, resolution-time). It gains
+ *                 indestructible until end of turn.
+ * + {3}{W}{W} (mode 2): Destroy all creatures.
+ */
+class OtjFinalShowdownScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + FinalShowdown)
+        return driver
+    }
+
+    test("Mode 0: all creatures lose all abilities until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A first-strike creature on each side.
+        val mine = driver.putCreatureOnBattlefield(player, "First Strike Knight")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "First Strike Knight")
+
+        val projectorBefore = StateProjector()
+        projectorBefore.project(driver.state).hasKeyword(mine, Keyword.FIRST_STRIKE) shouldBe true
+        projectorBefore.project(driver.state).hasKeyword(theirs, Keyword.FIRST_STRIKE) shouldBe true
+
+        val spell = driver.putCardInHand(player, "Final Showdown")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass()
+
+        val projector = StateProjector()
+        projector.project(driver.state).hasKeyword(mine, Keyword.FIRST_STRIKE) shouldBe false
+        projector.project(driver.state).hasKeyword(theirs, Keyword.FIRST_STRIKE) shouldBe false
+    }
+
+    test("Mode 1: chosen creature you control gains indestructible") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two creatures you control, so the resolution-time choice presents a real decision
+        // (a single eligible creature would auto-resolve with no prompt).
+        val mine = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        val other = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+
+        StateProjector().project(driver.state).hasKeyword(mine, Keyword.INDESTRUCTIBLE) shouldBe false
+
+        val spell = driver.putCardInHand(player, "Final Showdown")
+        driver.giveMana(player, Color.WHITE, 1) // {W} base
+        driver.giveColorlessMana(player, 1)      // {1} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass()
+
+        // Mode 1 chooses a creature at resolution (non-targeted) via the battlefield selection UI.
+        driver.submitCardSelection(player, listOf(mine))
+
+        StateProjector().project(driver.state).hasKeyword(mine, Keyword.INDESTRUCTIBLE) shouldBe true
+        // The unchosen creature does not gain indestructible.
+        StateProjector().project(driver.state).hasKeyword(other, Keyword.INDESTRUCTIBLE) shouldBe false
+    }
+
+    test("Mode 2: destroy all creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val spell = driver.putCardInHand(player, "Final Showdown")
+        driver.giveMana(player, Color.WHITE, 3) // {W} base + {W}{W} of {3}{W}{W}
+        driver.giveColorlessMana(player, 3)      // {3} of {3}{W}{W}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(emptyList())
+            )
+        )
+        driver.bothPass()
+
+        driver.findPermanent(player, "Centaur Courser") shouldBe null
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+    }
+
+    test("Modes 1 + 2: the chosen indestructible creature survives the board wipe") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two of the player's creatures (so the mode-1 choice is a real decision) plus the
+        // opponent's. The chosen one (Centaur Courser) survives; the unchosen Savannah Lions and
+        // the opponent's creature are destroyed.
+        val saved = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val spell = driver.putCardInHand(player, "Final Showdown")
+        driver.giveMana(player, Color.WHITE, 3) // {W} base + {W}{W}
+        driver.giveColorlessMana(player, 4)      // {1} (mode 1) + {3} (mode 2)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                chosenModes = listOf(1, 2),
+                modeTargetsOrdered = listOf(emptyList(), emptyList())
+            )
+        )
+        driver.bothPass()
+
+        // Indestructible is granted (mode 1) before "destroy all" (mode 2) resolves.
+        driver.submitCardSelection(player, listOf(saved))
+
+        // The chosen creature has indestructible and survives; the others are destroyed.
+        StateProjector().project(driver.state).hasKeyword(saved, Keyword.INDESTRUCTIBLE) shouldBe true
+        driver.findPermanent(player, "Centaur Courser") shouldBe saved
+        driver.findPermanent(player, "Savannah Lions") shouldBe null
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+    }
+})


### PR DESCRIPTION
## Cards

- **Final Showdown** {W} Instant (OTJ, mythic) — *new in this PR*. Spree instant with three
  modes resolving in printed order (CR ruling): mode 0 = all creatures lose all abilities until
  EOT; mode 1 = a resolution-time-chosen creature you control (non-targeted, battlefield
  selection) gains indestructible; mode 2 = destroy all creatures. Composed entirely from existing
  SDK atoms (`ModalEffect` with per-mode `additionalManaCost`, `ForEachInGroup` +
  `RemoveAllAbilities`, Gather → `SelectFromCollection` → `ForEach` + `GrantKeyword`,
  `DestroyAll`) — **no new engine/SDK feature**. Scenario test covers each mode plus the
  mode 1+2 interaction (chosen indestructible creature survives the board wipe).

### Already implemented (not changed by this PR)
- **Hell to Pay** and **Make Your Own Luck** were already implemented + tested in the previously
  merged "OTJ batch (bravo)" (commit `21d305ea4`, in this branch's history). Confirmed both card
  definitions and their scenario tests pass; no changes needed.

### Skipped (documented engine gap)
- **Return the Favor** {R}{R} Instant — **skipped**. Its Spree mode 1 ("Copy target instant
  spell, sorcery spell, activated ability, or triggered ability") needs a unified copy effect that
  dispatches across spells, **activated** abilities, and triggered abilities on the stack. Only
  `CopyTargetSpell` and a triggered-ability copy exist today — there is no `CopyTargetAbility` for
  activated abilities and no combined "spell-or-ability" copy target. This is an already-tracked
  Tier-3 engine gap (`backlog/otj-engine-gaps.md` §7, also called out for Ertha Jo). A Spree card
  can't be shipped faithfully with one of its two modes faked, so per the no-fragile-workaround
  rule it's left for a dedicated `add-feature` PR.

## mtgish auto-gen

No emitter change. Final Showdown's "all creatures lose all abilities until end of turn" maps to
an mtgish IR tag (`CreateEachPermanentLayerEffectUntil`) the emitter can't render, so it correctly
stays in the NOT-EMITTED/decline tier (decline → SCAFFOLD rather than emit a lossy approximation).
No new SDK building block was introduced, so there was nothing to teach the generator.

- `coverage-verify POR`: **GATE PASS, 0 mismatch** (158/158) — no regression.
- `coverage-verify OTJ`: pre-existing GATE FAIL on **Cactusfolk Sureshot** and **Freestrider
  Lookout** (from earlier OTJ batches; not touched by this PR). Final Showdown is in the
  decline/NOT-EMITTED list as expected.

## Tests

- `OtjFinalShowdownScenarioTest` (4 tests) — PASS.
- `HellToPayScenarioTest`, `MakeYourOwnLuckScenarioTest` — PASS (existing).
- `CardLintTest`, `CardDefinitionSnapshotTest` — PASS (OTJ golden re-blessed; diff adds Final
  Showdown only, nothing else moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)