### PR TITLE
Add 4 OTJ cards (Boom Box, Thunder Lasso, Mobile Homestead, Outlaws' Fury) + mtgish Equipment shapes

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1169,7 +1169,11 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 
 - `count = 1` — maximum number of targets.
 - `minCount = count` — minimum; set below `count` for "one or two target creatures".
-- `optional = false` — when `true`, minimum becomes 0 ("up to N target ...").
+- `optional = false` — when `true`, minimum becomes 0 ("up to N target ..."). An activated ability
+  whose controller-chosen requirements are **all** optional (e.g. Boom Box's "Destroy up to one target
+  artifact, up to one target creature, and up to one target land") is legal to activate with an *empty*
+  target list — choosing no targets for every slot — and still resolves; the engine only requires a
+  target when at least one controller requirement has a non-zero effective minimum.
 - `unlimited = false` — when `true`, **"any number of target ..."** — no upper cap. The practical
   maximum is the number of legal targets, which the engine sends to the client; validation imposes
   no limit and the minimum is 0. Use this instead of a large placeholder `count` (Phyrexian Purge,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoomBox.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoomBox.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Boom Box
+ * {2}
+ * Artifact
+ *
+ * {6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, up to one
+ * target creature, and up to one target land.
+ *
+ * Each of the three "up to one target" requirements is its own optional prompt with its
+ * own legal-target list, so the player may choose any subset (including none) and any
+ * combination of the three types. Rather than bind each chosen target positionally, the
+ * effect gathers every chosen target ([CardSource.ChosenTargets]) into one collection and
+ * destroys them — mirroring Pull Through the Weft, which keeps multi-optional-target
+ * routing correct even when the per-requirement chosen counts differ.
+ */
+val BoomBox = card("Boom Box") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, " +
+        "up to one target creature, and up to one target land."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{6}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        target(
+            "up to one target artifact",
+            TargetObject(optional = true, filter = TargetFilter.Artifact)
+        )
+        target(
+            "up to one target creature",
+            TargetObject(optional = true, filter = TargetFilter.Creature)
+        )
+        target(
+            "up to one target land",
+            TargetObject(optional = true, filter = TargetFilter.Land)
+        )
+        effect = Effects.Pipeline {
+            val chosen = gather(CardSource.ChosenTargets)
+            destroy(chosen)
+        }
+        description = "{6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, " +
+            "up to one target creature, and up to one target land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Caio Monteiro"
+        flavorText = "The cruel irony of explosives is they're most interesting exactly when " +
+            "you should be running away as fast as you can."
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg?1712356258"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MobileHomestead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MobileHomestead.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mobile Homestead
+ * {2}
+ * Artifact — Vehicle
+ * 3/3
+ *
+ * This Vehicle has haste as long as you control a Mount.
+ * Whenever this Vehicle attacks, look at the top card of your library. If it's a land
+ * card, you may put it onto the battlefield tapped.
+ * Crew 2
+ *
+ * Conditional haste mirrors Tribal Golem (GrantKeyword + ControlCreatureOfType). The
+ * attack trigger mirrors Fecund Greenshell's top-card pipeline, minus the "otherwise to
+ * hand" leg — Mobile Homestead leaves a non-land (or a declined land) on top of the library.
+ */
+val MobileHomestead = card("Mobile Homestead") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    oracleText = "This Vehicle has haste as long as you control a Mount.\n" +
+        "Whenever this Vehicle attacks, look at the top card of your library. If it's a land " +
+        "card, you may put it onto the battlefield tapped.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 3
+    toughness = 3
+
+    // This Vehicle has haste as long as you control a Mount.
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter.source())
+        condition = Conditions.ControlCreatureOfType(Subtype("Mount"))
+    }
+
+    // Whenever this Vehicle attacks, look at the top card of your library.
+    // If it's a land card, you may put it onto the battlefield tapped.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            listOf(
+                // Look at top 1 card.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "looked",
+                ),
+                // Keep only land cards as candidates.
+                FilterCollectionEffect(
+                    from = "looked",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
+                    storeMatching = "landCards",
+                ),
+                // You may put the land onto the battlefield tapped; otherwise it stays on top.
+                SelectFromCollectionEffect(
+                    from = "landCards",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "toBattlefield",
+                    selectedLabel = "Put onto the battlefield tapped",
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                ),
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "245"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg?1712356276"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutlawsFury.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutlawsFury.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Outlaws' Fury
+ * {2}{R}
+ * Instant
+ *
+ * Creatures you control get +2/+0 until end of turn. If you control an outlaw, exile the
+ * top card of your library. Until the end of your next turn, you may play that card.
+ * (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+ *
+ * The team pump uses [Patterns.Group.modifyStatsForAll]. "If you control an outlaw" gates
+ * the impulse-draw with [Conditions.YouControl] over [Filters.OutlawCreature]; the impulse
+ * itself mirrors Season of the Bold — exile the top card, then grant
+ * [GrantMayPlayFromExileEffect] with [MayPlayExpiry.UntilEndOfNextTurn].
+ */
+val OutlawsFury = card("Outlaws' Fury") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+0 until end of turn. If you control an outlaw, " +
+        "exile the top card of your library. Until the end of your next turn, you may play that " +
+        "card. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)"
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                // Creatures you control get +2/+0 until end of turn.
+                Patterns.Group.modifyStatsForAll(2, 0, Filters.Group.creaturesYouControl),
+                // If you control an outlaw, exile the top card and let it be played until your next turn ends.
+                ConditionalEffect(
+                    Conditions.YouControl(Filters.OutlawCreature),
+                    Effects.Composite(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                                storeAs = "exiledCard",
+                            ),
+                            MoveCollectionEffect(
+                                from = "exiledCard",
+                                destination = CardDestination.ToZone(Zone.EXILE),
+                            ),
+                            GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.UntilEndOfNextTurn),
+                        )
+                    ),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Diego Gisbert"
+        flavorText = "The only witness to their rampage was the stoic visage of the moon."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg?1712355807"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThunderLasso.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThunderLasso.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Thunder Lasso
+ * {2}{W}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, attach it to target creature you control.
+ * Equipped creature gets +1/+1.
+ * Whenever equipped creature attacks, tap target creature defending player controls.
+ * Equip {2}
+ *
+ * The attack trigger binds to the attached (equipped) creature
+ * ([TriggerBinding.ATTACHED]); "creature defending player controls" is the opponent's
+ * creature during your attack, matching Heart-Piercer Bow's "defending player controls".
+ */
+val ThunderLasso = card("Thunder Lasso") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target creature you control.\n" +
+        "Equipped creature gets +1/+1.\n" +
+        "Whenever equipped creature attacks, tap target creature defending player controls.\n" +
+        "Equip {2}"
+
+    // ETB: attach to target creature you control
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+    }
+
+    // Equipped creature gets +1/+1
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // Whenever equipped creature attacks, tap target creature defending player controls
+    triggeredAbility {
+        trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+        val creature = target("creature defending player controls", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Camille Alquier"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg?1712355369"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1032,6 +1032,89 @@
     ]
 }
 
+// Boom Box
+{
+    "name": "Boom Box",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, up to one target creature, and up to one target land.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "up to one target artifact"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "up to one target creature"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "up to one target land"
+                    }
+                ],
+                "descriptionOverride": "{6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, up to one target creature, and up to one target land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "flavorText": "The cruel irony of explosives is they're most interesting exactly when you should be running away as fast as you can.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg?1712356258"
+    },
+    "colorIdentityOverride": []
+}
+
 // Botanical Sanctum
 {
     "name": "Botanical Sanctum",
@@ -7371,6 +7454,109 @@
     ]
 }
 
+// Mobile Homestead
+{
+    "name": "Mobile Homestead",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "This Vehicle has haste as long as you control a Mount.\nWhenever this Vehicle attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "landCards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "landCards",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBattlefield",
+                            "selectedLabel": "Put onto the battlefield tapped"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Mount"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg?1712356276"
+    },
+    "colorIdentityOverride": []
+}
+
 // Mourner's Surprise
 {
     "name": "Mourner's Surprise",
@@ -8254,6 +8440,110 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Outlaws' Fury
+{
+    "name": "Outlaws' Fury",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+0 until end of turn. If you control an outlaw, exile the top card of your library. Until the end of your next turn, you may play that card. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasAnyOfSubtypes",
+                                        "subtypes": [
+                                            "Assassin",
+                                            "Mercenary",
+                                            "Pirate",
+                                            "Rogue",
+                                            "Warlock"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeAs": "exiledCard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiledCard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "exiledCard",
+                                "expiry": {
+                                    "type": "UntilControllerStep",
+                                    "step": "CLEANUP",
+                                    "includeCurrentTurn": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Diego Gisbert",
+        "flavorText": "The only witness to their rampage was the stoic visage of the moon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg?1712355807"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -12550,6 +12840,105 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Thunder Lasso
+{
+    "name": "Thunder Lasso",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, attach it to target creature you control.\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, tap target creature defending player controls.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "creature you control"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature defending player controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature defending player controls"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Camille Alquier",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg?1712355369"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -52,6 +52,11 @@ internal fun BridgeBuilder.manaCountersAndState() {
         composes = listOf("AnimateLand", "GrantKeyword", "AddCounters", "GrantTriggeredAbility", "MoveToZone"))
 
     effect("RegeneratePermanent", "Regenerate", UNIVERSAL)
+    // "attach it to target …" — an Equipment/Aura attaching ITSELF (the source) to a chosen permanent
+    // (Thunder Lasso's ETB "attach it to target creature you control"). The engine idiom is
+    // AttachEquipment, which always attaches the source. The emitter only renders the self-attach shape
+    // (args[0] a self-ref) and declines anything else -> SCAFFOLD.
+    effect("AttachPermanentToPermanent", "AttachEquipment", "self-attach an Equipment/Aura to a chosen permanent")
     effects("GainControlOfPermanent", "GainControlOfPermanentUntil", tag = "GainControl", note = UNIVERSAL)
     effect("RemoveCreatureFromCombat", "RemoveFromCombat", UNIVERSAL)
     // Ydwen Efreet's "remove from combat and creatures it solely blocked become unblocked" — the same

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1505,6 +1505,12 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         return if (isSelf(trig)) "Triggers.PutIntoGraveyardFromBattlefield" else null
     }
 
+    // "Whenever equipped creature attacks" — an Equipment/Aura whose attack trigger is bound to the
+    // permanent it's attached to (subject SinglePermanent(HostPermanent)). Maps to the ATTACHED binding
+    // (Thunder Lasso, Heart-Piercer Bow). Only the bare host subject renders.
+    if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isHost(trig))
+        return "Triggers.attacks(binding = TriggerBinding.ATTACHED)"
+
     // "Whenever a creature attacks" — only the unrestricted any-creature shape (no subtype / controller /
     // count clause), which maps to a filterless ANY-binding attacks trigger (Righteous Cause).
     if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isPlainCreatureFilter(trig))
@@ -1756,6 +1762,15 @@ private fun isSelf(trig: JsonObject): Boolean {
     val subject = (trig["args"] as? JsonArray)?.firstOrNull() ?: trig["args"]
     return subject.strField("_Permanents") == "SinglePermanent" &&
         subject.field("args").strField("_Permanent") == "ThisPermanent"
+}
+
+/** True when a trigger's subject is the *host* permanent — a direct SinglePermanent(HostPermanent)
+ *  reference. This is the "equipped/enchanted creature" of an Equipment/Aura, mapped to the ATTACHED
+ *  trigger binding. Mirrors [isSelf] but for the attached-to permanent. */
+private fun isHost(trig: JsonObject): Boolean {
+    val subject = (trig["args"] as? JsonArray)?.firstOrNull() ?: trig["args"]
+    return subject.strField("_Permanents") == "SinglePermanent" &&
+        subject.field("args").strField("_Permanent") == "HostPermanent"
 }
 
 /** True when a trigger's permanent filter is a plain "creature" with no subtype / controller / count

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.findRef
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.nodesTagged
 import com.wingedsheep.tooling.coverage.strField
@@ -30,6 +31,19 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         if (jsonContains(node, "_Permanents", "Ref_TargetPermanents")) {
             call("ForEachTargetEffect", arg(call("listOf", arg(call("Effects.Move", arg("EffectTarget.ContextTarget(0)"), arg("Zone.HAND"))))))
         } else null
+    }
+
+    on("AttachPermanentToPermanent") { _, args, tvar ->
+        // "attach it to target …" — an Equipment/Aura attaching ITSELF to a chosen permanent. The
+        // engine idiom is `Effects.AttachEquipment(target)`, which always attaches the source. So this
+        // renders ONLY the self-attach shape: args[0] (the permanent being attached) must be a self-ref
+        // (`ThatEnteringPermanent` for an ETB "attach it to target creature you control", Thunder Lasso).
+        // Anything else (attaching a different permanent) declines -> SCAFFOLD.
+        val arr = args.asArr ?: return@on null
+        val subjectRef = findRef(arr.getOrNull(0)) ?: return@on null
+        if (subjectRef !in SELF_REFS) return@on null
+        val tgt = refTargetFromRef(findRef(arr.getOrNull(1)), tvar) ?: return@on null
+        call("Effects.AttachEquipment", arg(Lit(tgt)))
     }
 
     on("DestroyPermanent") { _, args, tvar ->

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -8379,7 +8379,7 @@ val StitchersGraft = card("Stitcher's Graft") {
     staticAbility {
         ability = ModifyStats(3, 3)
     }
-    // STRUCTURE needs human wiring: trigger-shape
+    // STRUCTURE needs human wiring: PermanentDoesntUntapDuringControllersNextUntap
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "271"

--- a/mtgish-tooling/src/test/resources/fixtures/isd.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/isd.emitted.golden.txt
@@ -8389,7 +8389,7 @@ val TrepanationBlade = card("Trepanation Blade") {
     colorIdentity = ""
     typeLine = "Artifact — Equipment"
     oracleText = "Whenever equipped creature attacks, defending player reveals cards from the top of their library until they reveal a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into their graveyard.\nEquip {2}"
-    // STRUCTURE needs human wiring: trigger-shape
+    // STRUCTURE needs human wiring: PlayerAction
     metadata {
         rarity = Rarity.UNCOMMON
         collectorNumber = "235"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -392,7 +392,13 @@ class ActivateAbilityHandler(
                 return targetError
             }
         } else if (controllerTargetReqs.isNotEmpty() && action.targets.isEmpty()) {
-            return "This ability requires a target"
+            // An empty target list is only illegal when at least one controller-chosen
+            // requirement is mandatory. For an ability whose controller targets are all
+            // optional ("up to one target …", e.g. Boom Box), choosing no targets is a
+            // legal activation, so don't reject it here.
+            if (controllerTargetReqs.any { it.effectiveMinCount > 0 }) {
+                return "This ability requires a target"
+            }
         }
 
         return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoomBoxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoomBoxScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BoomBox
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Boom Box — {2} Artifact
+ *
+ * "{6}, {T}, Sacrifice this artifact: Destroy up to one target artifact, up to one
+ * target creature, and up to one target land."
+ *
+ * Verifies: activating with all three targets destroys an artifact, a creature, and a
+ * land (and sacrifices Boom Box itself); and that with no targets chosen the ability
+ * still resolves, sacrificing Boom Box and destroying nothing.
+ */
+class BoomBoxScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    val abilityId = BoomBox.activatedAbilities[0].id
+
+    test("destroys up to one artifact, creature, and land, and sacrifices itself") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val boomBox = driver.putPermanentOnBattlefield(me, "Boom Box")
+        val artifact = driver.putPermanentOnBattlefield(opp, "Bandit's Haul")
+        val creature = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val land = driver.putLandOnBattlefield(opp, "Mountain")
+
+        driver.giveColorlessMana(me, 6)
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = boomBox,
+                abilityId = abilityId,
+                targets = listOf(
+                    ChosenTarget.Permanent(artifact),
+                    ChosenTarget.Permanent(creature),
+                    ChosenTarget.Permanent(land),
+                ),
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // Boom Box is sacrificed as a cost immediately.
+        driver.assertInGraveyard(me, "Boom Box")
+
+        driver.bothPass() // resolve the ability
+
+        driver.assertInGraveyard(opp, "Bandit's Haul")
+        driver.assertInGraveyard(opp, "Centaur Courser")
+        driver.assertInGraveyard(opp, "Mountain")
+    }
+
+    test("can be activated with no targets — still sacrifices Boom Box, destroys nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val boomBox = driver.putPermanentOnBattlefield(me, "Boom Box")
+        val creature = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.giveColorlessMana(me, 6)
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = boomBox,
+                abilityId = abilityId,
+                targets = emptyList(),
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.assertInGraveyard(me, "Boom Box")
+
+        driver.bothPass() // resolve the ability
+
+        // The untargeted creature survives.
+        driver.getGraveyardCardNames(opp).contains("Centaur Courser") shouldBe false
+        driver.getPermanents(opp).contains(creature) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MobileHomesteadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MobileHomesteadScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.MobileHomestead
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mobile Homestead — {2} Artifact — Vehicle 3/3
+ *
+ * "This Vehicle has haste as long as you control a Mount.
+ *  Whenever this Vehicle attacks, look at the top card of your library. If it's a land
+ *  card, you may put it onto the battlefield tapped.
+ *  Crew 2"
+ *
+ * Verifies the conditional haste static (granted only while a Mount is controlled) and the
+ * attack trigger that puts a land from the top of the library onto the battlefield tapped —
+ * and that a non-land top card is left untouched.
+ */
+class MobileHomesteadScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A vanilla Mount to satisfy "as long as you control a Mount".
+    val testMount = card("Test Mount") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Horse Mount"
+        power = 2
+        toughness = 2
+        oracleText = ""
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(testMount)
+        // Forest-heavy deck; we control the top card explicitly in each test.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("has haste only while you control a Mount") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val homestead = driver.putPermanentOnBattlefield(me, "Mobile Homestead")
+
+        // No Mount yet → no haste.
+        projector.project(driver.state).hasKeyword(homestead, Keyword.HASTE) shouldBe false
+
+        // Control a Mount → haste.
+        driver.putCreatureOnBattlefield(me, "Test Mount")
+        projector.project(driver.state).hasKeyword(homestead, Keyword.HASTE) shouldBe true
+    }
+
+    test("attack trigger puts a land from the top of the library onto the battlefield tapped") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val homestead = driver.putPermanentOnBattlefield(me, "Mobile Homestead")
+        driver.removeSummoningSickness(homestead)
+
+        // Crew it so it can attack (Crew 2: a power-2 creature).
+        val crewer = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        driver.submitSuccess(CrewVehicle(me, homestead, listOf(crewer)))
+        driver.bothPass()
+
+        // Put a land on top of the library.
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+        val landsBefore = driver.getPermanents(me).count { driver.getCardName(it) == "Mountain" }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(homestead), driver.player2)
+        // Let the attack trigger go on the stack and resolve, which pauses for the selection.
+        driver.bothPass()
+
+        // Attack trigger offers to put the land onto the battlefield — accept it.
+        val decision = driver.pendingDecision as SelectCardsDecision
+        driver.submitCardSelection(me, decision.options)
+        driver.bothPass()
+
+        val mountainPerms = driver.getPermanents(me).filter { driver.getCardName(it) == "Mountain" }
+        mountainPerms.size shouldBe landsBefore + 1
+        // The single new land entered tapped.
+        driver.isTapped(mountainPerms.single()) shouldBe true
+    }
+
+    test("attack trigger leaves a non-land top card on the library") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val homestead = driver.putPermanentOnBattlefield(me, "Mobile Homestead")
+        driver.removeSummoningSickness(homestead)
+
+        val crewer = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.submitSuccess(CrewVehicle(me, homestead, listOf(crewer)))
+        driver.bothPass()
+
+        // Non-land on top.
+        driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+        val courserPermsBefore = driver.getPermanents(me).count { driver.getCardName(it) == "Centaur Courser" }
+        val handBefore = driver.getHandSize(me)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(homestead), driver.player2)
+        // No land → no decision; trigger resolves with nothing to do.
+        driver.bothPass()
+
+        // The non-land stayed put: not on the battlefield, not drawn to hand.
+        driver.getPermanents(me).count { driver.getCardName(it) == "Centaur Courser" } shouldBe courserPermsBefore
+        driver.getHandSize(me) shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutlawsFuryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutlawsFuryScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Outlaws' Fury — {2}{R} Instant
+ *
+ * "Creatures you control get +2/+0 until end of turn. If you control an outlaw, exile the
+ *  top card of your library. Until the end of your next turn, you may play that card."
+ *
+ * Verifies the unconditional team pump, and the outlaw-gated impulse: an outlaw on the
+ * battlefield exiles the top card; with no outlaw, the library is left untouched.
+ */
+class OutlawsFuryScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("creatures you control get +2/+0; with an outlaw, exiles the top card") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        // Ragavan is a Monkey Pirate — Pirate is an outlaw subtype.
+        val ragavan = driver.putCreatureOnBattlefield(me, "Ragavan, Nimble Pilferer") // 2/1
+        val exileBefore = driver.getExile(me).size
+
+        val fury = driver.putCardInHand(me, "Outlaws' Fury")
+        driver.giveMana(me, Color.RED, 3)
+        driver.castSpell(me, fury)
+        driver.bothPass() // resolve
+
+        // +2/+0 — Ragavan is now 4/1.
+        val projected = projector.project(driver.state)
+        projected.getPower(ragavan) shouldBe 4
+        projected.getToughness(ragavan) shouldBe 1
+
+        // Controlling an outlaw → top card exiled (impulse).
+        driver.getExile(me).size shouldBe exileBefore + 1
+    }
+
+    test("with no outlaw, no card is exiled") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        // A non-outlaw creature (Grizzly Bears — Bear).
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        val exileBefore = driver.getExile(me).size
+
+        val fury = driver.putCardInHand(me, "Outlaws' Fury")
+        driver.giveMana(me, Color.RED, 3)
+        driver.castSpell(me, fury)
+        driver.bothPass() // resolve
+
+        // Pump still happens.
+        projector.project(driver.state).getPower(bear) shouldBe 4
+
+        // No outlaw → nothing exiled.
+        driver.getExile(me).size shouldBe exileBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderLassoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderLassoScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thunder Lasso — {2}{W} Artifact — Equipment
+ *
+ * "When this Equipment enters, attach it to target creature you control.
+ *  Equipped creature gets +1/+1.
+ *  Whenever equipped creature attacks, tap target creature defending player controls.
+ *  Equip {2}"
+ *
+ * Verifies the +1/+1 static buff through the attachment, and that the attack trigger
+ * taps a creature the defending player controls.
+ */
+class ThunderLassoScenarioTest : FunSpec({
+
+    val stateProjector = StateProjector()
+
+    /**
+     * Put the equipment on the battlefield and attach it to a creature directly
+     * (mirrors ForebearsBladeTriggerTest), so static + attack-trigger behaviour can be
+     * exercised without re-testing the ETB attach.
+     */
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c ->
+            c.with(AttachedToComponent(targetCreatureId))
+        }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("equipped creature gets +1/+1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // base 2/2
+        driver.putEquipmentAttached(me, "Thunder Lasso", creature)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(creature) shouldBe 3   // 2 + 1
+        projected.getToughness(creature) shouldBe 3 // 2 + 1
+    }
+
+    test("when equipped creature attacks, tap target creature defending player controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val equipped = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(equipped)
+        driver.putEquipmentAttached(attacker, "Thunder Lasso", equipped)
+
+        // Defender controls a creature to be tapped.
+        val victim = driver.putCreatureOnBattlefield(defender, "Centaur Courser")
+        driver.isTapped(victim) shouldBe false
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(equipped), defender)
+
+        // Attack trigger asks for a target — choose the defender's creature.
+        driver.submitTargetSelection(attacker, listOf(victim))
+
+        // Resolve the triggered ability.
+        driver.bothPass()
+
+        driver.isTapped(victim) shouldBe true
+    }
+})


### PR DESCRIPTION
## Cards (Outlaws of Thunder Junction)

- **Boom Box** — `{2}` Artifact. `{6},{T},Sac: Destroy up to one target artifact, up to one target creature, and up to one target land.` Gathers `ChosenTargets` and destroys them; all three targets optional. Engine fix: `ActivateAbilityHandler` now allows activating with an empty target list when **every** controller-chosen requirement is optional (`effectiveMinCount == 0`) — it previously rejected "this ability requires a target".
- **Thunder Lasso** — `{2}{W}` Artifact — Equipment. ETB attach to target creature you control, equipped creature +1/+1, attack trigger taps a creature defending player controls (ATTACHED binding), Equip `{2}`.
- **Mobile Homestead** — `{2}` Artifact — Vehicle 3/3. Haste while you control a Mount (`GrantKeyword` + `ControlCreatureOfType`); attack trigger looks at the top card and may put a land onto the battlefield tapped; Crew 2.
- **Outlaws' Fury** — `{2}{R}` Instant. Creatures you control get +2/+0; if you control an outlaw, impulse-exile the top card playable until end of your next turn.

All four use existing SDK primitives. Each has a passing Kotest scenario test (Boom Box 2, Thunder Lasso 2, Mobile Homestead 3, Outlaws' Fury 2 — all green). OTJ card snapshot golden re-blessed (adds only these 4 cards). `CardLintTest` + `CardDefinitionSnapshotTest` pass.

## mtgish auto-gen tooling

Taught the emitter two **lossless** Equipment shapes (decline-to-SCAFFOLD preserved for everything else):

- `AttachPermanentToPermanent` **self-attach** → `Effects.AttachEquipment(target)` (only when the attached permanent is a self-ref; bridge capability entry added).
- `WhenACreatureAttacks(HostPermanent)` → `Triggers.attacks(binding = TriggerBinding.ATTACHED)` ("whenever equipped creature attacks"), via a new `isHost()` subject check.

Result: **Thunder Lasso now emits as a complete render (AUTO)** instead of SCAFFOLD. Re-blessed `EmitterGoldenTest` goldens — only INR (Stitcher's Graft) and ISD (Trepanation Blade) shift their scaffold reason one tag deeper now that their equipped-creature attack trigger renders; both remain SCAFFOLD, no other card changed. **POR stays 0-mismatch.**

Boom Box, Mobile Homestead, and Outlaws' Fury remain SCAFFOLD in the generator — they touch multi-optional-target gathers, conditional-static-keyword + may-put-land pipelines, and conditional impulse / player-effect-until shapes that the emitter deliberately declines rather than render lossily.

### Note on `just coverage-verify OTJ`
OTJ is not a committed 0-mismatch gate set; the gate reports 3 gameplay-tree mismatches, of which 2 (Cactusfolk Sureshot, Freestrider Lookout) are pre-existing and unrelated to this change. Thunder Lasso's only divergence is a cosmetic target-name normalization placeholder (`§T1§` vs `§T0§`) between the auto-synthesized equip ability and the hand-authored one — behaviorally identical. The committed gates (POR golden 0-mismatch, `EmitterGoldenTest`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)