### PR TITLE
Persistent per-ability yields (backlog §C)

### DIFF
--- a/backlog/stack-collapse-and-batch-decisions.md
+++ b/backlog/stack-collapse-and-batch-decisions.md
@@ -1,11 +1,20 @@
 # Stack collapse + batch decisions — taming high-volume stacks
 
-_Drafted 2026-06-14. Status: C.2 (the shared `AbilityIdentity` key, PR #720) and **B (batch
-may-question, PR #725)** implemented; A (visual collapse) and C (persistent yields) still
-spec-only. Covers three independent but related features — **A. visual stack collapse**
-(client-only), **B. batch decision answering** (engine + client), **C. persistent per-ability
-yields** (engine + server + client). A is shippable on its own; B and C share an "ability identity
-key" and a yes/no batch path, and C builds on B's machinery._
+_Drafted 2026-06-14. Status: **all phases implemented** — **A (visual collapse, commit
+`5c9274641`)**, C.2 (the shared `AbilityIdentity` key, PR #720), **B (batch may-question, PR #725)**,
+and **C (persistent per-ability yields)**. Covers three independent but related features — **A.
+visual stack collapse** (client-only), **B. batch decision answering** (engine + client), **C.
+persistent per-ability yields** (engine + server + client). A is shippable on its own; B and C share
+an "ability identity key" and a yes/no batch path, and C builds on B's machinery._
+
+_C as built: `PlayerYields` (until-end-of-turn / whole-game auto-pass sets + a yes/no `autoAnswer`
+map, keyed by `AbilityIdentity`) lives on `GameState.yieldsByPlayer` (immutable, serialized, masked
+per-player, `untilEndOfTurn` cleared at cleanup, CR 514). Auto-answer is consulted in the
+`GatedEffectExecutor` `Gate.MayDecide` path and `TriggerProcessor`'s may-with-targets path (scoped to
+the pure may-question — never a pay/target/modal choice, §C.6) and emits a subtle
+`AbilityAutoAnsweredEvent`. Auto-pass is an extra pass reason in `AutoPassManager` keyed on the
+top-of-stack ability identity. Client: a right-click context menu on stack abilities, an "Active
+yields" panel (revoke + clear-all), and log surfacing._
 
 ## 0. The problem
 

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -129,6 +129,30 @@ Sent when the user interacts with the UI.
 }
 ```
 
+### B2. Persistent Yields (Client -> Server)
+
+MTGO-style per-ability yields (backlog §C). Keyed by the ability's **AbilityIdentity**
+(`cardDefinitionId` + `abilityId`), so a preference set once follows every current and future
+copy/instance of that card ability. The server applies the change to the immutable `GameState`
+(`yieldsByPlayer`), so it survives serialization and replays deterministically.
+
+```json
+{ "type": "setAbilityYield", "cardDefinitionId": "Soul Warden#ALA-25", "abilityId": "ability_42",
+  "kind": "ALWAYS_ANSWER_YES" }
+```
+
+`kind` ∈ `YIELD_UNTIL_END_OF_TURN` (auto-pass priority on this ability's stack objects until end of
+turn), `YIELD_WHOLE_GAME` (same, rest of game), `ALWAYS_ANSWER_YES` / `ALWAYS_ANSWER_NO`
+(auto-resolve the ability's optional "you may" may-question). Revoke with
+`{ "type": "clearAbilityYield", "cardDefinitionId": …, "abilityId": … }` or clear everything with
+`{ "type": "clearAllYields" }`.
+
+The viewer's own yields come back in the state update as `activeYields` (masked — a player never sees
+another player's yields), each `{ cardDefinitionId, abilityId, displayName, untilEndOfTurn,
+wholeGame, autoAnswer }`. A triggered/activated ability on the stack carries its `abilityIdentity`
+in its `ClientCard`, so the stack-item context menu can target it. When a yield auto-answers a
+may-question, the server emits an `abilityAutoAnswered` log event (shown only to the controller).
+
 ### C. Connection Liveness (Client <-> Server)
 
 `{"type": "ping"}` (client) is always answered with `{"type": "pong"}` (server), regardless of

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -88,6 +88,9 @@ class GamePlayHandler(
             is ClientMessage.SetFullControl -> handleSetFullControl(session, message)
             is ClientMessage.SetPriorityMode -> handleSetPriorityMode(session, message)
             is ClientMessage.SetStopOverrides -> handleSetStopOverrides(session, message)
+            is ClientMessage.SetAbilityYield -> handleSetAbilityYield(session, message)
+            is ClientMessage.ClearAbilityYield -> handleClearAbilityYield(session, message)
+            is ClientMessage.ClearAllYields -> handleClearAllYields(session)
             is ClientMessage.RequestUndo -> handleRequestUndo(session)
 
             is ClientMessage.RequestResync -> handleRequestResync(session)
@@ -899,6 +902,53 @@ class GamePlayHandler(
         logger.info("Player ${playerSession.playerName} set stop overrides: myTurn=${message.myTurnStops}, opponentTurn=${message.opponentTurnStops}")
 
         // Broadcast state update so the UI reflects the change (and next stop point updates)
+        broadcastStateUpdate(gameSession, emptyList())
+    }
+
+    private fun handleSetAbilityYield(session: WebSocketSession, message: ClientMessage.SetAbilityYield) {
+        val playerSession = sessionRegistry.getPlayerSession(session.id)
+        if (playerSession == null) {
+            sender.sendError(session, ErrorCode.NOT_CONNECTED, "Not connected")
+            return
+        }
+        val gameSession = getGameSession(session, playerSession) ?: return
+
+        val identity = com.wingedsheep.sdk.scripting.AbilityIdentity(
+            message.cardDefinitionId,
+            com.wingedsheep.sdk.scripting.AbilityId(message.abilityId)
+        )
+        gameSession.setAbilityYield(playerSession.playerId, identity, message.kind)
+        logger.info("Player ${playerSession.playerName} set yield ${message.kind} on $identity")
+
+        // Re-broadcast (drives the auto-pass loop in case the yield now lets the game advance).
+        broadcastStateUpdate(gameSession, emptyList())
+    }
+
+    private fun handleClearAbilityYield(session: WebSocketSession, message: ClientMessage.ClearAbilityYield) {
+        val playerSession = sessionRegistry.getPlayerSession(session.id)
+        if (playerSession == null) {
+            sender.sendError(session, ErrorCode.NOT_CONNECTED, "Not connected")
+            return
+        }
+        val gameSession = getGameSession(session, playerSession) ?: return
+
+        val identity = com.wingedsheep.sdk.scripting.AbilityIdentity(
+            message.cardDefinitionId,
+            com.wingedsheep.sdk.scripting.AbilityId(message.abilityId)
+        )
+        gameSession.clearAbilityYield(playerSession.playerId, identity)
+        broadcastStateUpdate(gameSession, emptyList())
+    }
+
+    private fun handleClearAllYields(session: WebSocketSession) {
+        val playerSession = sessionRegistry.getPlayerSession(session.id)
+        if (playerSession == null) {
+            sender.sendError(session, ErrorCode.NOT_CONNECTED, "Not connected")
+            return
+        }
+        val gameSession = getGameSession(session, playerSession) ?: return
+
+        gameSession.clearAllYields(playerSession.playerId)
         broadcastStateUpdate(gameSession, emptyList())
     }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameServerSerializersModule.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameServerSerializersModule.kt
@@ -31,6 +31,7 @@ val gameServerSerializersModule = SerializersModule {
         subclass(ClientEvent.SpellCountered::class)
         subclass(ClientEvent.AbilityTriggered::class)
         subclass(ClientEvent.AbilityActivated::class)
+        subclass(ClientEvent.AbilityAutoAnswered::class)
         subclass(ClientEvent.PermanentTapped::class)
         subclass(ClientEvent.PermanentUntapped::class)
         subclass(ClientEvent.PermanentPhasedOut::class)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
@@ -142,7 +142,24 @@ class AutoPassManager {
                 logger.debug("AUTO-PASS: Own spell/ability on top of stack")
                 return true
             } else {
-                // Opponent's item on top
+                // Opponent's item on top.
+                // Persistent yield (backlog §C): the player explicitly asked to stop being stopped
+                // by this ability, so auto-pass even though it's an opponent's object — an opt-in
+                // per-ability override of the usual "stop on opponent's stack item" rule. A
+                // holdPriority action (a response the player deliberately lined up) still wins, and
+                // this is one more pass reason layered on top of the meaningful-action filter, not
+                // a replacement for it.
+                val topContainer = state.getEntity(topOfStack)
+                val yieldedIdentity = topContainer?.get<TriggeredAbilityOnStackComponent>()?.abilityIdentity
+                    ?: topContainer?.get<ActivatedAbilityOnStackComponent>()?.abilityIdentity
+                if (yieldedIdentity != null &&
+                    state.isYieldingTo(playerId, yieldedIdentity) &&
+                    meaningfulActions.none { it.holdPriority }
+                ) {
+                    logger.debug("AUTO-PASS: Yielded to opponent's ability $yieldedIdentity")
+                    return true
+                }
+
                 // In Stops mode: always stop on opponent's stack items (regardless of type)
                 if (stopsMode) {
                     logger.debug("STOP (Stops mode): Opponent's spell/ability on stack")

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -381,6 +381,32 @@ sealed interface ClientMessage {
     ) : ClientMessage
 
     /**
+     * Set a persistent per-ability yield (MTGO right-click yields — backlog §C). Keyed by the
+     * ability's [com.wingedsheep.sdk.scripting.AbilityIdentity] ([cardDefinitionId] + [abilityId]),
+     * so it applies to every current and future copy/instance of that card ability.
+     */
+    @Serializable
+    @SerialName("setAbilityYield")
+    data class SetAbilityYield(
+        val cardDefinitionId: String,
+        val abilityId: String,
+        val kind: com.wingedsheep.engine.state.YieldKind
+    ) : ClientMessage
+
+    /** Revoke every yield (auto-pass + auto-answer) the player holds against one ability. */
+    @Serializable
+    @SerialName("clearAbilityYield")
+    data class ClearAbilityYield(
+        val cardDefinitionId: String,
+        val abilityId: String
+    ) : ClientMessage
+
+    /** Clear all of the player's yields (the "Clear yields" control; MTGO `5`). */
+    @Serializable
+    @SerialName("clearAllYields")
+    data object ClearAllYields : ClientMessage
+
+    /**
      * Request to undo the last non-respondable action (e.g., play land, declare attackers).
      */
     @Serializable

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -820,6 +820,36 @@ class GameSession(
     }
 
     // =========================================================================
+    // Persistent Yields (MTGO right-click yields — backlog §C)
+    // =========================================================================
+    //
+    // Yields live on the immutable GameState (not a session-side map), so the pure engine can
+    // consult auto-answers during resolution and they replay deterministically. Mutations are pure
+    // GameState transforms applied under the state lock.
+
+    /** Set a persistent yield for [playerId] against [identity]. */
+    fun setAbilityYield(
+        playerId: EntityId,
+        identity: com.wingedsheep.sdk.scripting.AbilityIdentity,
+        kind: com.wingedsheep.engine.state.YieldKind
+    ) = synchronized(stateLock) {
+        gameState = gameState?.withYield(playerId, identity, kind)
+    }
+
+    /** Revoke every yield [playerId] holds against [identity]. */
+    fun clearAbilityYield(
+        playerId: EntityId,
+        identity: com.wingedsheep.sdk.scripting.AbilityIdentity
+    ) = synchronized(stateLock) {
+        gameState = gameState?.withoutYield(playerId, identity)
+    }
+
+    /** Drop all of [playerId]'s yields. */
+    fun clearAllYields(playerId: EntityId) = synchronized(stateLock) {
+        gameState = gameState?.withoutYields(playerId)
+    }
+
+    // =========================================================================
     // Auto-Pass Management
     // =========================================================================
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
@@ -90,6 +90,9 @@ class GameWebSocketHandler(
                 is ClientMessage.SetFullControl,
                 is ClientMessage.SetPriorityMode,
                 is ClientMessage.SetStopOverrides,
+                is ClientMessage.SetAbilityYield,
+                is ClientMessage.ClearAbilityYield,
+                is ClientMessage.ClearAllYields,
                 is ClientMessage.RequestUndo,
                 is ClientMessage.RequestResync -> gamePlayHandler.handle(session, clientMessage)
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -54,9 +55,13 @@ class AutoPassManagerTest : FunSpec({
         stackItemType: StackItemType = StackItemType.ABILITY,
         blockersHaveBeenDeclared: Boolean = false,
         defendingPlayerId: EntityId? = null,
-        hasAttackers: Boolean = false
+        hasAttackers: Boolean = false,
+        stackAbilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
+        priorityPlayerYieldsToStack: Boolean = false
     ): GameState {
         val state = mockk<GameState>(relaxed = true)
+        // Persistent-yield lookup (backlog §C): default off so existing cases are unaffected.
+        every { state.isYieldingTo(any(), any()) } returns priorityPlayerYieldsToStack
         every { state.priorityPlayerId } returns priorityPlayerId
         every { state.activePlayerId } returns activePlayerId
         every { state.step } returns step
@@ -100,7 +105,8 @@ class AutoPassManagerTest : FunSpec({
                         sourceId = EntityId.generate(),
                         sourceName = "Test Ability",
                         controllerId = controllerId,
-                        effect = mockk(relaxed = true)
+                        effect = mockk(relaxed = true),
+                        abilityIdentity = stackAbilityIdentity
                     )
                     every { stackEntity.get<com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent>() } returns abilityComponent
                     every { stackEntity.get<com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent>() } returns null
@@ -1134,6 +1140,36 @@ class AutoPassManagerTest : FunSpec({
             val state = createMockState(player1, player2, Step.PRECOMBAT_MAIN)
             // With opponent-turn override on BEGIN_COMBAT → stops there, but uses neutral "Pass" on opponent's turn
             autoPassManager.getNextStopPoint(state, player1, false, opponentTurnStops = setOf(Step.BEGIN_COMBAT)) shouldBe "Pass"
+        }
+    }
+
+    context("Persistent yields (backlog §C)") {
+        test("auto-pass on an opponent's ability the player has yielded to") {
+            val state = createMockState(
+                priorityPlayerId = player1,
+                activePlayerId = player2,
+                step = Step.PRECOMBAT_MAIN,
+                stackEmpty = false,
+                stackControllerId = player2,
+                stackItemType = StackItemType.ABILITY,
+                stackAbilityIdentity = AbilityIdentity("Yielded Card", AbilityId("y")),
+                priorityPlayerYieldsToStack = true
+            )
+            autoPassManager.shouldAutoPass(state, player1, listOf(passPriorityAction(player1))) shouldBe true
+        }
+
+        test("without a yield, an opponent's ability on the stack still stops") {
+            val state = createMockState(
+                priorityPlayerId = player1,
+                activePlayerId = player2,
+                step = Step.PRECOMBAT_MAIN,
+                stackEmpty = false,
+                stackControllerId = player2,
+                stackItemType = StackItemType.ABILITY,
+                stackAbilityIdentity = AbilityIdentity("Yielded Card", AbilityId("y")),
+                priorityPlayerYieldsToStack = false
+            )
+            autoPassManager.shouldAutoPass(state, player1, listOf(passPriorityAction(player1))) shouldBe false
         }
     }
 })

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -346,6 +346,11 @@ class CleanupPhaseManager(
         }
         newState = newState.copy(floatingEffects = remainingEffects)
 
+        // 1a. Expire "yield until end of turn" preferences (backlog §C). Whole-game yields and
+        // auto-answers persist; only the per-turn auto-pass opt-in is cleared here at cleanup
+        // (CR 514), keeping the lifecycle replay-deterministic alongside the other end-of-turn resets.
+        newState = newState.clearUntilEndOfTurnYields()
+
         // 1b. Expire temporary counter-placement modifiers (GrantCounterPlacementModifierEffect,
         // e.g. Prairie Dog) whose duration ends at end of turn / end of combat. Longer durations
         // (UntilYourNextTurn, Permanent, …) are kept and handled by their own expiry path.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -442,6 +442,21 @@ data class AbilityFizzledEvent(
 ) : GameEvent
 
 /**
+ * An optional ("you may") ability's may-question was resolved automatically from the controller's
+ * persistent auto-answer yield instead of prompting (MTGO "Always yes/no" — backlog §C). Emitted so
+ * the controller sees in the log that the system acted for them; it carries no rules effect of its
+ * own (the chosen branch's own events follow when [answer] is true).
+ */
+@Serializable
+@SerialName("AbilityAutoAnsweredEvent")
+data class AbilityAutoAnsweredEvent(
+    val sourceId: EntityId,
+    val sourceName: String,
+    val controllerId: EntityId,
+    val answer: Boolean
+) : GameEvent
+
+/**
  * A player committed a crime (CR Outlaws of Thunder Junction). Emitted at the same time
  * as [SpellCastEvent], [AbilityActivatedEvent], or [AbilityTriggeredEvent] when at least
  * one initial target is an opponent, a permanent/spell/ability an opponent controls, or

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -64,6 +64,7 @@ val engineSerializersModule = SerializersModule {
         subclass(SpellFizzledEvent::class)
         subclass(AbilityResolvedEvent::class)
         subclass(AbilityFizzledEvent::class)
+        subclass(AbilityAutoAnsweredEvent::class)
         subclass(AttackersDeclaredEvent::class)
         subclass(BlockersDeclaredEvent::class)
         subclass(BlockerOrderDeclaredEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -209,6 +209,19 @@ class TriggerProcessor(
         // The gated "may" effect's own text is the prompt (GatedEffect.description renders
         // "You may …" for a Gate.MayDecide).
         val sourceName = trigger.sourceName
+        val abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+
+        // Persistent auto-answer yield (backlog §C): a remembered yes/no for this ability resolves
+        // the may-question without prompting. "Yes" still proceeds to per-instance target selection
+        // (only the yes/no is batched, never the targeting — §C.6); "no" skips the trigger.
+        abilityIdentity?.let { state.autoAnswerFor(trigger.controllerId, it) }?.let { auto ->
+            val note = AbilityAutoAnsweredEvent(trigger.sourceId, sourceName, trigger.controllerId, auto)
+            if (!auto) return ExecutionResult.success(state, listOf(note))
+            val innerEffect = ability.effect.asMayDecide()!!.then
+            val unwrappedTrigger = trigger.copy(ability = ability.copy(effect = innerEffect))
+            val result = processTargetedTrigger(state, unwrappedTrigger, targetRequirement)
+            return result.copy(events = listOf(note) + result.events)
+        }
 
         // Create yes/no decision
         val decisionResult = decisionHandler.createYesNoDecision(
@@ -218,7 +231,7 @@ class TriggerProcessor(
             sourceName = sourceName,
             prompt = ability.effect.description,
             phase = DecisionPhase.RESOLUTION,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+            abilityIdentity = abilityIdentity
         )
 
         if (!decisionResult.isPaused || decisionResult.pendingDecision == null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -25,6 +25,14 @@ data class EffectContext(
     val sourceId: EntityId?,
     val controllerId: EntityId,
     /**
+     * Definition-scoped identity of the triggered/activated ability currently resolving, copied
+     * from its stack component (see [com.wingedsheep.sdk.scripting.AbilityIdentity]). Lets a
+     * resolution-time may-question consult the controller's persistent auto-answer yields without
+     * re-deriving the key. Null for spell resolution and synthesized sources with no card
+     * definition (backlog §C).
+     */
+    val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
+    /**
      * The player currently under consideration as a target, bound while evaluating a
      * `TargetPlayer.restriction` / `TargetOpponent.restriction` (CR 115). Resolves
      * [com.wingedsheep.sdk.scripting.references.Player.Candidate]. Null in every normal

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -118,6 +118,23 @@ class GatedEffectExecutor(
             ?.let { TargetResolutionUtils.resolvePlayerTarget(it, context, state) }
             ?: context.controllerId
 
+        // Persistent auto-answer yield (backlog §C): if the decision-maker has remembered a yes/no
+        // for this ability, resolve the "you may" question without prompting and run the matching
+        // branch. Scoped to Gate.MayDecide — the pure may-question — never a cost/pay gate, so a
+        // yield can never spend mana or make a resource decision on the player's behalf (§C.6).
+        if (gate is Gate.MayDecide) {
+            val identity = context.abilityIdentity
+            val auto = identity?.let { state.autoAnswerFor(playerId, it) }
+            if (auto != null) {
+                val sourceName = context.sourceId
+                    ?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "ability"
+                val note = AbilityAutoAnsweredEvent(context.sourceId ?: playerId, sourceName, playerId, auto)
+                val branch = if (auto) effect.then else effect.otherwise
+                val result = branch?.let { effectExecutor(state, it, context) } ?: EffectResult.success(state)
+                return result.copy(events = listOf(note) + result.events)
+            }
+        }
+
         // Gate.MayPay: don't offer an impossible "yes" — fall straight through to `otherwise`.
         if (gate is Gate.MayPay && !canAfford(state, playerId, gate.cost, context)) {
             return effect.otherwise

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1879,6 +1879,7 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
+            abilityIdentity = abilityComponent.abilityIdentity,
             targets = resolvedTargets2,
             triggerDamageAmount = abilityComponent.triggerDamageAmount,
             triggerCounterCount = abilityComponent.triggerCounterCount,
@@ -1974,6 +1975,7 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
+            abilityIdentity = abilityComponent.abilityIdentity,
             targets = activatedTargets,
             sacrificedPermanents = abilityComponent.sacrificedPermanents,
             xValue = abilityComponent.xValue,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import kotlinx.serialization.Serializable
 
 /**
@@ -212,6 +213,17 @@ data class GameState(
      * byte-identical replays/parity. Live IDs look like `e0`, `e1`, … See [EntityId].
      */
     val nextEntityId: Long = 0L,
+
+    /**
+     * Per-player persistent "yield" preferences keyed by [com.wingedsheep.sdk.scripting.AbilityIdentity]
+     * (MTGO right-click yields — see `backlog/stack-collapse-and-batch-decisions.md` §C). Lives on
+     * [GameState] (not the server session) so it survives serialization, replays deterministically,
+     * and is naturally per-player-maskable. The `untilEndOfTurn` slice is cleared at every cleanup
+     * step (CR 514); `wholeGame` / `autoAnswer` persist for the whole game. Read by
+     * [com.wingedsheep.gameserver.priority.AutoPassManager] (auto-pass) and the may-question paths
+     * (auto-answer). Empty entries are pruned, so an absent key means "no yields".
+     */
+    val yieldsByPlayer: Map<EntityId, PlayerYields> = emptyMap(),
 ) {
     /**
      * Cached projection of the game state with all continuous effects (Rule 613) applied.
@@ -260,6 +272,65 @@ data class GameState(
     fun updateEntity(id: EntityId, update: (ComponentContainer) -> ComponentContainer): GameState {
         val existing = entities[id] ?: ComponentContainer.EMPTY
         return withEntity(id, update(existing))
+    }
+
+    // =========================================================================
+    // Persistent Yields (MTGO right-click yields — backlog §C)
+    // =========================================================================
+
+    /** [playerId]'s yield preferences, or [PlayerYields.EMPTY] if none. */
+    fun yieldsFor(playerId: EntityId): PlayerYields = yieldsByPlayer[playerId] ?: PlayerYields.EMPTY
+
+    /** True when [playerId] has asked to auto-pass priority on [identity]'s stack objects. */
+    fun isYieldingTo(playerId: EntityId, identity: AbilityIdentity): Boolean =
+        yieldsFor(playerId).isYieldingTo(identity)
+
+    /**
+     * [playerId]'s remembered may-question answer for [identity] (`true`/`false`), or null if the
+     * player hasn't set an auto-answer for this ability.
+     */
+    fun autoAnswerFor(playerId: EntityId, identity: AbilityIdentity): Boolean? =
+        yieldsFor(playerId).answerFor(identity)
+
+    /** Replace [playerId]'s yields, pruning the entry entirely when it becomes empty. */
+    private fun withYields(playerId: EntityId, yields: PlayerYields): GameState =
+        copy(yieldsByPlayer = if (yields.isEmpty) yieldsByPlayer - playerId else yieldsByPlayer + (playerId to yields))
+
+    /** Apply a [YieldKind] for [playerId] against [identity] (returns new state). */
+    fun withYield(playerId: EntityId, identity: AbilityIdentity, kind: YieldKind): GameState {
+        val current = yieldsFor(playerId)
+        val updated = when (kind) {
+            YieldKind.YIELD_UNTIL_END_OF_TURN -> current.copy(untilEndOfTurn = current.untilEndOfTurn + identity)
+            YieldKind.YIELD_WHOLE_GAME -> current.copy(wholeGame = current.wholeGame + identity)
+            YieldKind.ALWAYS_ANSWER_YES -> current.copy(autoAnswer = current.autoAnswer + (identity to true))
+            YieldKind.ALWAYS_ANSWER_NO -> current.copy(autoAnswer = current.autoAnswer + (identity to false))
+        }
+        return withYields(playerId, updated)
+    }
+
+    /** Remove every yield [playerId] holds against [identity] (revoke), returning new state. */
+    fun withoutYield(playerId: EntityId, identity: AbilityIdentity): GameState {
+        val current = yieldsFor(playerId)
+        return withYields(
+            playerId,
+            current.copy(
+                untilEndOfTurn = current.untilEndOfTurn - identity,
+                wholeGame = current.wholeGame - identity,
+                autoAnswer = current.autoAnswer - identity,
+            ),
+        )
+    }
+
+    /** Drop all of [playerId]'s yields (the "clear yields" control). */
+    fun withoutYields(playerId: EntityId): GameState = copy(yieldsByPlayer = yieldsByPlayer - playerId)
+
+    /** Clear every player's [PlayerYields.untilEndOfTurn] slice (turn-boundary cleanup, CR 514). */
+    fun clearUntilEndOfTurnYields(): GameState {
+        if (yieldsByPlayer.isEmpty()) return this
+        val cleared = yieldsByPlayer
+            .mapValues { (_, y) -> y.copy(untilEndOfTurn = emptySet()) }
+            .filterValues { !it.isEmpty }
+        return copy(yieldsByPlayer = cleared)
     }
 
     // =========================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/PlayerYields.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/PlayerYields.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.state
+
+import com.wingedsheep.sdk.scripting.AbilityIdentity
+import kotlinx.serialization.Serializable
+
+/**
+ * A single player's remembered "yield" preferences, keyed by [AbilityIdentity] (so a preference set
+ * once applies to every current and future copy/instance of that card ability — exactly like MTGO's
+ * right-click yields). See `backlog/stack-collapse-and-batch-decisions.md` §C.
+ *
+ * Three independent dimensions:
+ *  - [untilEndOfTurn] — auto-pass priority on this ability's stack objects for the rest of the turn
+ *    (cleared at every cleanup step, CR 514).
+ *  - [wholeGame] — auto-pass priority on this ability's stack objects for the rest of the game.
+ *  - [autoAnswer] — auto-resolve the ability's optional ("you may") may-question without prompting;
+ *    `true` = always yes, `false` = always no. Whole-game scoped, matching MTGO "Always yes/no".
+ *
+ * Yields only ever *auto-pass* or *auto-answer the controller's own may-question*. They never make a
+ * targeting, ordering, or modal choice on the player's behalf (§C.6).
+ */
+@Serializable
+data class PlayerYields(
+    val untilEndOfTurn: Set<AbilityIdentity> = emptySet(),
+    val wholeGame: Set<AbilityIdentity> = emptySet(),
+    val autoAnswer: Map<AbilityIdentity, Boolean> = emptyMap(),
+) {
+    /** True when priority on [identity]'s stack objects should be auto-passed (either scope). */
+    fun isYieldingTo(identity: AbilityIdentity): Boolean =
+        identity in untilEndOfTurn || identity in wholeGame
+
+    /** The remembered may-question answer for [identity], or null if none is set. */
+    fun answerFor(identity: AbilityIdentity): Boolean? = autoAnswer[identity]
+
+    /** Nothing remembered at all — used to drop empty per-player entries from the map. */
+    val isEmpty: Boolean
+        get() = untilEndOfTurn.isEmpty() && wholeGame.isEmpty() && autoAnswer.isEmpty()
+
+    companion object {
+        val EMPTY = PlayerYields()
+    }
+}
+
+/**
+ * The kind of yield a player is setting, mirroring MTGO's four right-click options. Carried on the
+ * client→server message and applied by [GameState.withYield].
+ */
+@Serializable
+enum class YieldKind {
+    /** Auto-pass priority on the ability's stack objects until end of turn. */
+    YIELD_UNTIL_END_OF_TURN,
+
+    /** Auto-pass priority on the ability's stack objects for the rest of the game. */
+    YIELD_WHOLE_GAME,
+
+    /** Always answer "yes" to the ability's optional may-question (whole game). */
+    ALWAYS_ANSWER_YES,
+
+    /** Always answer "no" to the ability's optional may-question (whole game). */
+    ALWAYS_ANSWER_NO,
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -89,7 +89,42 @@ data class ClientGameState(
      * Distinct from [youAreHijacking], which is the per-turn Mindslaver effect; the two are
      * never set together.
      */
-    val hotseat: Boolean = false
+    val hotseat: Boolean = false,
+
+    /**
+     * The viewing player's active persistent yields (MTGO right-click yields — backlog §C). Masked
+     * per-player: only the viewer's own yields are ever included. Drives the "Active yields" panel
+     * (revoke / clear-all) and lets the client suppress re-prompting cues. Empty for spectators.
+     */
+    val activeYields: List<ClientYield> = emptyList()
+)
+
+/**
+ * Client-facing form of [com.wingedsheep.sdk.scripting.AbilityIdentity] — the stable
+ * (cardDefinitionId, abilityId) key an ability is yielded against (backlog §C).
+ */
+@Serializable
+data class ClientAbilityIdentity(
+    val cardDefinitionId: String,
+    val abilityId: String
+)
+
+/**
+ * One ability the viewing player has set a yield on, flattened from [PlayerYields] for display.
+ * Keyed by its [com.wingedsheep.sdk.scripting.AbilityIdentity] ([cardDefinitionId] + [abilityId]);
+ * [displayName] is the human-readable card name derived from the definition id.
+ */
+@Serializable
+data class ClientYield(
+    val cardDefinitionId: String,
+    val abilityId: String,
+    val displayName: String,
+    /** Auto-pass priority on this ability's stack objects until end of turn. */
+    val untilEndOfTurn: Boolean = false,
+    /** Auto-pass priority on this ability's stack objects for the rest of the game. */
+    val wholeGame: Boolean = false,
+    /** Remembered may-question answer (`true`=always yes, `false`=always no), or null if none. */
+    val autoAnswer: Boolean? = null
 )
 
 /**
@@ -249,6 +284,13 @@ data class ClientCard(
 
     /** Chosen X value for spells with X in their cost (only present on stack) */
     val chosenX: Int? = null,
+
+    /**
+     * For a triggered/activated ability on the stack: the definition-scoped identity of that
+     * ability (backlog §C). Lets the stack-item context menu offer "yield / always yes-no to this
+     * ability". Null for spells and for ability sources with no card definition.
+     */
+    val abilityIdentity: ClientAbilityIdentity? = null,
 
     /** Copy index for storm/copy effects on the stack (1, 2, 3...) */
     val copyIndex: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -242,6 +242,21 @@ sealed interface ClientEvent {
         }
     ) : ClientEvent
 
+    /**
+     * A "you may" may-question was auto-resolved from the viewer's persistent yield (backlog §C).
+     * Surfaced subtly in the log so the player knows the system acted for them.
+     */
+    @Serializable
+    @SerialName("abilityAutoAnswered")
+    data class AbilityAutoAnswered(
+        val sourceId: EntityId,
+        val sourceName: String,
+        val answer: Boolean,
+        override val description: String =
+            if (answer) "Auto-answered Yes to $sourceName (yield)"
+            else "Auto-answered No to $sourceName (yield)"
+    ) : ClientEvent
+
     // =========================================================================
     // State Change Events
     // =========================================================================
@@ -894,6 +909,17 @@ object ClientEventTransformer {
                 controllerId = event.controllerId,
                 isYours = event.controllerId == viewingPlayerId
             )
+
+            // Only the controller (whose yield acted) sees the auto-answer note; it's their own
+            // private preference, so opponents get nothing.
+            is AbilityAutoAnsweredEvent ->
+                if (event.controllerId == viewingPlayerId) {
+                    ClientEvent.AbilityAutoAnswered(
+                        sourceId = event.sourceId,
+                        sourceName = event.sourceName,
+                        answer = event.answer
+                    )
+                } else null
 
             is TappedEvent -> ClientEvent.PermanentTapped(
                 permanentId = event.entityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -279,6 +279,9 @@ class ClientStateTransformer(
             }
         }
 
+        // Persistent yields are private to each player: only ever surface the viewer's own.
+        val activeYields = if (isSpectator) emptyList() else buildClientYields(state.yieldsFor(viewingPlayerId))
+
         return ClientGameState(
             viewingPlayerId = viewingPlayerId,
             cards = cards,
@@ -295,8 +298,28 @@ class ClientStateTransformer(
             voidActive = state.nonlandPermanentLeftBattlefieldThisTurn || state.spellWarpedThisTurn,
             youAreHijacking = youAreHijacking,
             youAreHijackedBy = youAreHijackedBy,
-            hotseat = hotseat
+            hotseat = hotseat,
+            activeYields = activeYields
         )
+    }
+
+    /**
+     * Flatten a player's [com.wingedsheep.engine.state.PlayerYields] into one [ClientYield] per
+     * ability identity, merging the auto-pass scopes and the auto-answer into a single display row.
+     * The display name is the card name carried in the definition id (`"Name#SET-123"` → `"Name"`).
+     */
+    private fun buildClientYields(yields: com.wingedsheep.engine.state.PlayerYields): List<ClientYield> {
+        val identities = yields.untilEndOfTurn + yields.wholeGame + yields.autoAnswer.keys
+        return identities.map { id ->
+            ClientYield(
+                cardDefinitionId = id.cardDefinitionId,
+                abilityId = id.abilityId.value,
+                displayName = id.cardDefinitionId.substringBefore("#"),
+                untilEndOfTurn = id in yields.untilEndOfTurn,
+                wholeGame = id in yields.wholeGame,
+                autoAnswer = yields.autoAnswer[id]
+            )
+        }
     }
 
     /**
@@ -515,7 +538,10 @@ class ClientStateTransformer(
                 isFaceDown = false,
                 targets = targets,
                 imageUri = sourceCard?.imageUri ?: cardDef?.metadata?.imageUri,
-                chosenX = activatedAbility.xValue
+                chosenX = activatedAbility.xValue,
+                abilityIdentity = activatedAbility.abilityIdentity?.let {
+                    ClientAbilityIdentity(it.cardDefinitionId, it.abilityId.value)
+                }
             )
         }
 
@@ -602,6 +628,9 @@ class ClientStateTransformer(
                 imageUri = sourceCard?.imageUri ?: cardDef?.metadata?.imageUri,
                 sourceZone = sourceZone,
                 chosenX = triggeredAbility.xValue,
+                abilityIdentity = triggeredAbility.abilityIdentity?.let {
+                    ClientAbilityIdentity(it.cardDefinitionId, it.abilityId.value)
+                },
                 copyIndex = triggeredAbility.copyIndex,
                 copyTotal = triggeredAbility.copyTotal,
                 chosenModeDescriptions = triggeredModeDescriptions,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PersistentYieldsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PersistentYieldsTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AbilityAutoAnsweredEvent
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.PlayerYields
+import com.wingedsheep.engine.state.YieldKind
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for persistent per-ability yields (backlog/stack-collapse-and-batch-decisions.md §C).
+ *
+ * The yields live on [com.wingedsheep.engine.state.GameState] keyed by [AbilityIdentity]. These pin
+ * the engine-side rules:
+ *  - an `ALWAYS_ANSWER_YES` / `ALWAYS_ANSWER_NO` auto-resolves a "you may" may-question with no
+ *    prompt, taking the matching branch and emitting an [AbilityAutoAnsweredEvent];
+ *  - with no yield set, the may-question still prompts;
+ *  - a yield is keyed by ability identity, so it never fires for a different ability;
+ *  - the per-turn slice is cleared while whole-game yields/answers persist;
+ *  - yields are masked per-player in the client view.
+ * Auto-pass on yielded stack objects is a game-server (`AutoPassManager`) concern covered by its own
+ * unit test; here we cover the engine state + the auto-answer resolution path.
+ */
+class PersistentYieldsTest : ScenarioTestBase() {
+
+    // Fixed ability id so the test can build the exact AbilityIdentity to yield against. Scenario
+    // cards use the card name as their cardDefinitionId (see ScenarioTestBase.createCard), so the
+    // identity is deterministic.
+    private val seerAbilityId = AbilityId("test_yield_seer_may_draw")
+    private val seerIdentity = AbilityIdentity("Yield Seer", seerAbilityId)
+
+    private fun newSeerGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Yield Seer")
+        .withCardInLibrary(1, "Yield Filler")
+        .withCardInLibrary(1, "Yield Filler")
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        // "When this enters, you may draw a card." — a pure Gate.MayDecide may-question raised at
+        // resolution, so the controller's auto-answer yield (if any) decides it without a prompt.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Yield Seer",
+                manaCost = ManaCost.parse("{0}"),
+                subtypes = setOf(Subtype("Wizard")),
+                power = 1,
+                toughness = 1,
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility(
+                            id = seerAbilityId,
+                            trigger = Triggers.EntersBattlefield.event,
+                            binding = Triggers.EntersBattlefield.binding,
+                            effect = GatedEffect(gate = Gate.MayDecide(), then = DrawCardsEffect(1))
+                        )
+                    )
+                )
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Yield Filler", manaCost = ManaCost.parse("{1}"),
+                subtypes = setOf(Subtype("Golem")), power = 1, toughness = 1
+            )
+        )
+
+        test("ALWAYS_ANSWER_YES auto-resolves the may-question and draws without prompting") {
+            val game = newSeerGame()
+            game.state = game.state.withYield(game.player1Id, seerIdentity, YieldKind.ALWAYS_ANSWER_YES)
+
+            val libBefore = game.librarySize(1)
+            game.castSpell(1, "Yield Seer").error shouldBe null
+            val events = game.resolveStack().flatMap { it.events }
+
+            game.hasPendingDecision().shouldBeFalse()
+            game.librarySize(1) shouldBe libBefore - 1 // drew a card
+            events.any { it is AbilityAutoAnsweredEvent && it.answer } shouldBe true
+        }
+
+        test("ALWAYS_ANSWER_NO auto-declines the may-question with no draw") {
+            val game = newSeerGame()
+            game.state = game.state.withYield(game.player1Id, seerIdentity, YieldKind.ALWAYS_ANSWER_NO)
+
+            val libBefore = game.librarySize(1)
+            game.castSpell(1, "Yield Seer").error shouldBe null
+            val events = game.resolveStack().flatMap { it.events }
+
+            game.hasPendingDecision().shouldBeFalse()
+            game.librarySize(1) shouldBe libBefore // declined → no draw
+            events.any { it is AbilityAutoAnsweredEvent && !it.answer } shouldBe true
+        }
+
+        test("with no yield set, the may-question still prompts") {
+            val game = newSeerGame()
+            game.castSpell(1, "Yield Seer").error shouldBe null
+            game.resolveStack()
+            game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+        }
+
+        test("an auto-answer yield is keyed by identity, so it does not fire for a different ability") {
+            val game = newSeerGame()
+            game.state = game.state.withYield(
+                game.player1Id,
+                AbilityIdentity("Some Other Card", AbilityId("other")),
+                YieldKind.ALWAYS_ANSWER_YES,
+            )
+            game.castSpell(1, "Yield Seer").error shouldBe null
+            game.resolveStack()
+            game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+        }
+
+        test("yields are masked per-player in the client view") {
+            val game = newSeerGame()
+            game.state = game.state.withYield(game.player1Id, seerIdentity, YieldKind.YIELD_WHOLE_GAME)
+
+            val p1View = game.getClientState(1).activeYields
+            p1View.map { it.cardDefinitionId } shouldContainExactly listOf("Yield Seer")
+            p1View.single().wholeGame shouldBe true
+            p1View.single().displayName shouldBe "Yield Seer"
+
+            // Player 2 must never see player 1's yields.
+            game.getClientState(2).activeYields.shouldBeEmpty()
+        }
+
+        test("GameState yield helpers set, query, revoke, and clear-all") {
+            val base = newSeerGame().state
+            val p = base.turnOrder.first()
+            val other = AbilityIdentity("Other", AbilityId("o"))
+
+            val withYields = base
+                .withYield(p, seerIdentity, YieldKind.YIELD_UNTIL_END_OF_TURN)
+                .withYield(p, other, YieldKind.ALWAYS_ANSWER_NO)
+
+            withYields.isYieldingTo(p, seerIdentity).shouldBeTrue()
+            withYields.autoAnswerFor(p, other) shouldBe false
+
+            // Turn-boundary clearing drops the until-end-of-turn auto-pass but keeps the auto-answer.
+            val afterCleanup = withYields.clearUntilEndOfTurnYields()
+            afterCleanup.isYieldingTo(p, seerIdentity).shouldBeFalse()
+            afterCleanup.autoAnswerFor(p, other) shouldBe false
+
+            // Revoke + clear-all.
+            afterCleanup.withoutYield(p, other).autoAnswerFor(p, other) shouldBe null
+            withYields.withoutYields(p).yieldsFor(p) shouldBe PlayerYields.EMPTY
+        }
+    }
+}

--- a/web-client/src/components/game/ActiveYieldsPanel.tsx
+++ b/web-client/src/components/game/ActiveYieldsPanel.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import type { ClientYield } from '@/types/gameState'
+
+/**
+ * A small fixed panel listing the player's active persistent yields (MTGO right-click yields —
+ * backlog §C) with per-yield revoke and a clear-all, so a player is never trapped by a yield they
+ * forgot they set. Hidden when there are no yields. Server-authoritative: it reflects
+ * `gameState.activeYields` (masked to the viewer) and dispatches revoke intents.
+ */
+export function ActiveYieldsPanel() {
+  const yields = useGameStore((s) => s.gameState?.activeYields) ?? []
+  const clearAbilityYield = useGameStore((s) => s.clearAbilityYield)
+  const clearAllYields = useGameStore((s) => s.clearAllYields)
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (yields.length === 0) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: 12,
+        bottom: 96,
+        zIndex: 60,
+        width: 230,
+        background: 'rgba(18, 14, 28, 0.94)',
+        border: '1px solid rgba(150, 100, 200, 0.45)',
+        borderRadius: 8,
+        boxShadow: '0 4px 14px rgba(0, 0, 0, 0.5)',
+        color: '#e0d4f0',
+        fontSize: 11,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '6px 10px',
+          background: 'rgba(80, 50, 120, 0.4)',
+          cursor: 'pointer',
+        }}
+        onClick={() => setCollapsed((c) => !c)}
+        title="Persistent yields you've set"
+      >
+        <span style={{ fontWeight: 700 }}>Active yields ({yields.length})</span>
+        <span aria-hidden style={{ color: '#b8a8cc' }}>{collapsed ? '▸' : '▾'}</span>
+      </div>
+
+      {!collapsed && (
+        <div style={{ maxHeight: '40vh', overflowY: 'auto' }}>
+          {yields.map((y) => (
+            <YieldRow
+              key={`${y.cardDefinitionId}|${y.abilityId}`}
+              entry={y}
+              onRevoke={() => clearAbilityYield(y.cardDefinitionId, y.abilityId)}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => clearAllYields()}
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: '7px 10px',
+              background: 'transparent',
+              border: 'none',
+              borderTop: '1px solid rgba(150,100,200,0.25)',
+              color: '#ff9a8c',
+              cursor: 'pointer',
+              font: 'inherit',
+              textAlign: 'center',
+            }}
+          >
+            Clear all yields
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Human-readable summary of which yield dimensions are active on one ability. */
+function describe(y: ClientYield): string {
+  const parts: string[] = []
+  if (y.autoAnswer === true) parts.push('always yes')
+  if (y.autoAnswer === false) parts.push('always no')
+  if (y.wholeGame) parts.push('yield (game)')
+  if (y.untilEndOfTurn) parts.push('yield (turn)')
+  return parts.join(', ')
+}
+
+function YieldRow({ entry, onRevoke }: { entry: ClientYield; onRevoke: () => void }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, padding: '6px 10px' }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {entry.displayName}
+        </div>
+        <div style={{ color: '#b8a8cc', fontSize: 10 }}>{describe(entry)}</div>
+      </div>
+      <button
+        type="button"
+        onClick={onRevoke}
+        title="Revoke this yield"
+        style={{
+          flexShrink: 0,
+          width: 20,
+          height: 20,
+          lineHeight: '18px',
+          textAlign: 'center',
+          background: 'rgba(150, 60, 60, 0.3)',
+          border: '1px solid rgba(200, 90, 90, 0.5)',
+          borderRadius: 4,
+          color: '#ffc0b0',
+          cursor: 'pointer',
+          padding: 0,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -13,6 +13,7 @@ import { CombatArrows } from '../combat/CombatArrows'
 import { TargetingArrows } from '../targeting/TargetingArrows'
 import { DraggedCardOverlay } from './DraggedCardOverlay'
 import { GameLog } from './GameLog'
+import { ActiveYieldsPanel } from './ActiveYieldsPanel'
 import { DrawAnimations } from '../animations/DrawAnimations'
 import { DamageAnimations } from '../animations/DamageAnimations'
 import { RevealAnimations } from '../animations/RevealAnimations'
@@ -1301,6 +1302,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           horizontal space the hand has, and the expanded panel is unusable at
           that size anyway. */}
       {!spectatorMode && !responsive.isMobile && <GameLog />}
+      {!spectatorMode && <ActiveYieldsPanel />}
 
       {/* Draw animations */}
       <DrawAnimations />

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -4,13 +4,14 @@ import { useGameStore } from '@/store/gameStore.ts'
 import { useStackCards, selectGameState } from '@/store/selectors.ts'
 import { seatColor } from '@/styles/seatColors'
 import type { EntityId } from '@/types'
-import type { ClientCard } from '@/types/gameState'
+import type { ClientAbilityIdentity, ClientCard } from '@/types/gameState'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { ActiveEffectBadges } from '../card/CardOverlays'
 import { AbilityText } from '../../ui/ManaSymbols'
 import { useResponsiveContext, handleImageError } from './shared'
 import { styles } from './styles'
 import { groupStackCards, type StackGroup } from './stackGrouping'
+import { YieldContextMenu } from './YieldContextMenu'
 
 /**
  * Stack display - shows spells/abilities waiting to resolve.
@@ -34,6 +35,13 @@ export function StackDisplay() {
   const gameState = useGameStore((state) => state.gameState)
   // Which collapsible piles the player has manually expanded (by groupId = first member's id).
   const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<EntityId>>(() => new Set())
+  // Right-click yield menu (MTGO-style persistent yields — backlog §C), anchored to a stack ability.
+  const [yieldMenu, setYieldMenu] = useState<{ identity: ClientAbilityIdentity; sourceName: string; x: number; y: number } | null>(null)
+  const openYieldMenu = (card: ClientCard, e: React.MouseEvent) => {
+    if (!card.abilityIdentity) return
+    e.preventDefault()
+    setYieldMenu({ identity: card.abilityIdentity, sourceName: card.name, x: e.clientX, y: e.clientY })
+  }
   const toggleGroup = (groupId: EntityId) =>
     setExpandedGroups((prev) => {
       const next = new Set(prev)
@@ -163,6 +171,7 @@ export function StackDisplay() {
           ...highlight,
         }}
         onClick={opts.onClick ?? (() => handleStackItemClick(card.id))}
+        onContextMenu={(e) => openYieldMenu(card, e)}
         onMouseEnter={(e) => hoverCard(card.id, { x: e.clientX, y: e.clientY })}
         onMouseLeave={() => hoverCard(null)}
       >
@@ -352,6 +361,7 @@ export function StackDisplay() {
   }
 
   return (
+    <>
     <div style={{
       position: 'fixed',
       left: responsive.isMobile ? 12 : 120,
@@ -570,5 +580,17 @@ export function StackDisplay() {
       )
     })()}
     </div>
+    {yieldMenu && (
+      <YieldContextMenu
+        identity={yieldMenu.identity}
+        sourceName={yieldMenu.sourceName}
+        position={{ x: yieldMenu.x, y: yieldMenu.y }}
+        existing={gameState?.activeYields?.find(
+          (y) => y.cardDefinitionId === yieldMenu.identity.cardDefinitionId && y.abilityId === yieldMenu.identity.abilityId,
+        )}
+        onClose={() => setYieldMenu(null)}
+      />
+    )}
+    </>
   )
 }

--- a/web-client/src/components/game/board/YieldContextMenu.tsx
+++ b/web-client/src/components/game/board/YieldContextMenu.tsx
@@ -1,0 +1,117 @@
+import type React from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import type { ClientAbilityIdentity, ClientYield } from '@/types/gameState'
+import type { YieldKind } from '@/types'
+
+/**
+ * Right-click / long-press context menu on a stack ability, mirroring MTGO's persistent-yield
+ * options (backlog §C). Lets the controller set "yield until end of turn / always yield / always
+ * yes / always no" against an ability, keyed by its {@link ClientAbilityIdentity} so the preference
+ * follows every current and future copy. The server owns the authoritative yield state.
+ */
+export function YieldContextMenu({
+  identity,
+  sourceName,
+  position,
+  existing,
+  onClose,
+}: {
+  identity: ClientAbilityIdentity
+  sourceName: string
+  position: { x: number; y: number }
+  /** The current yield on this ability, if any — drives the active marks + revoke row. */
+  existing: ClientYield | undefined
+  onClose: () => void
+}) {
+  const setAbilityYield = useGameStore((s) => s.setAbilityYield)
+  const clearAbilityYield = useGameStore((s) => s.clearAbilityYield)
+
+  const apply = (kind: YieldKind) => {
+    setAbilityYield(identity.cardDefinitionId, identity.abilityId, kind)
+    onClose()
+  }
+
+  const items: { label: string; kind: YieldKind; active: boolean }[] = [
+    { label: 'Yield until end of turn', kind: 'YIELD_UNTIL_END_OF_TURN', active: existing?.untilEndOfTurn ?? false },
+    { label: 'Always yield', kind: 'YIELD_WHOLE_GAME', active: existing?.wholeGame ?? false },
+    { label: 'Always answer Yes', kind: 'ALWAYS_ANSWER_YES', active: existing?.autoAnswer === true },
+    { label: 'Always answer No', kind: 'ALWAYS_ANSWER_NO', active: existing?.autoAnswer === false },
+  ]
+
+  // Clamp roughly within the viewport so the menu never opens off-screen.
+  const left = Math.min(position.x, window.innerWidth - 230)
+  const top = Math.min(position.y, window.innerHeight - 200)
+
+  return (
+    <>
+      {/* Click-away backdrop */}
+      <div
+        style={{ position: 'fixed', inset: 0, zIndex: 999 }}
+        onClick={onClose}
+        onContextMenu={(e) => { e.preventDefault(); onClose() }}
+      />
+      <div
+        role="menu"
+        style={{
+          position: 'fixed',
+          left,
+          top,
+          zIndex: 1000,
+          minWidth: 210,
+          background: 'rgba(18, 14, 28, 0.97)',
+          border: '1px solid rgba(150, 100, 200, 0.5)',
+          borderRadius: 8,
+          boxShadow: '0 6px 20px rgba(0, 0, 0, 0.6)',
+          overflow: 'hidden',
+          fontSize: 12,
+          color: '#e0d4f0',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ padding: '7px 12px', fontWeight: 700, color: '#b8a8cc', borderBottom: '1px solid rgba(150,100,200,0.25)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 230 }}>
+          Yields — {sourceName}
+        </div>
+        {items.map((item) => (
+          <MenuButton key={item.kind} label={item.label} active={item.active} onClick={() => apply(item.kind)} />
+        ))}
+        {existing && (
+          <MenuButton
+            label="Revoke yields"
+            danger
+            onClick={() => { clearAbilityYield(identity.cardDefinitionId, identity.abilityId); onClose() }}
+          />
+        )}
+      </div>
+    </>
+  )
+}
+
+function MenuButton({ label, active, danger, onClick }: { label: string; active?: boolean; danger?: boolean; onClick: () => void }) {
+  const base: React.CSSProperties = {
+    display: 'flex',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    padding: '8px 12px',
+    background: 'transparent',
+    border: 'none',
+    borderTop: danger ? '1px solid rgba(150,100,200,0.25)' : undefined,
+    color: danger ? '#ff9a8c' : '#e0d4f0',
+    cursor: 'pointer',
+    textAlign: 'left',
+    font: 'inherit',
+  }
+  return (
+    <button
+      type="button"
+      style={base}
+      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(150, 100, 200, 0.22)' }}
+      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      {active && <span aria-hidden style={{ color: '#7fe0a0', fontWeight: 800 }}>✓</span>}
+    </button>
+  )
+}

--- a/web-client/src/store/slices/gameplaySlice.ts
+++ b/web-client/src/store/slices/gameplaySlice.ts
@@ -15,10 +15,13 @@ import {
   createSetFullControlMessage,
   createSetPriorityModeMessage,
   createSetStopOverridesMessage,
+  createSetAbilityYieldMessage,
+  createClearAbilityYieldMessage,
+  createClearAllYieldsMessage,
   createRequestUndoMessage,
 
 } from '@/types'
-import type { Step, PriorityModeValue } from '@/types'
+import type { Step, PriorityModeValue, YieldKind } from '@/types'
 import { trackEvent } from '@/utils/analytics.ts'
 import { getWebSocket } from './shared'
 
@@ -81,6 +84,9 @@ export interface GameplaySliceActions {
   setFullControl: (enabled: boolean) => void
   cyclePriorityMode: () => void
   toggleStopOverride: (step: Step, isMyTurn: boolean) => void
+  setAbilityYield: (cardDefinitionId: string, abilityId: string, kind: YieldKind) => void
+  clearAbilityYield: (cardDefinitionId: string, abilityId: string) => void
+  clearAllYields: () => void
   requestUndo: () => void
   toggleAutoTap: () => void
   returnToMenu: () => void
@@ -506,6 +512,21 @@ export const createGameplaySlice: SliceCreator<GameplaySlice> = (set, get) => ({
     getWebSocket()?.send(createSetStopOverridesMessage(newOverrides.myTurnStops, newOverrides.opponentTurnStops))
     // Persist to localStorage
     localStorage.setItem('argentum-stop-overrides', JSON.stringify(newOverrides))
+  },
+
+  // Persistent per-ability yields (MTGO right-click yields — backlog §C). The server owns the
+  // authoritative yield state (on GameState); these just dispatch intent and the next state update
+  // reflects it in gameState.activeYields.
+  setAbilityYield: (cardDefinitionId, abilityId, kind) => {
+    getWebSocket()?.send(createSetAbilityYieldMessage(cardDefinitionId, abilityId, kind))
+  },
+
+  clearAbilityYield: (cardDefinitionId, abilityId) => {
+    getWebSocket()?.send(createClearAbilityYieldMessage(cardDefinitionId, abilityId))
+  },
+
+  clearAllYields: () => {
+    getWebSocket()?.send(createClearAllYieldsMessage())
   },
 
   returnToMenu: () => {

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -60,6 +60,7 @@ function getEventLogType(eventType: string): 'action' | 'turn' | 'combat' | 'sys
     case 'creatureAttacked':
     case 'creatureBlocked': return 'combat'
     case 'abilityFizzled':
+    case 'abilityAutoAnswered':
     case 'gameEnded':
     case 'playerLost': return 'system'
     default: return 'action'

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -34,6 +34,7 @@ import type {
   AvailableSet,
   QuickGameLobbyStateMessage,
   DeckFormat,
+  YieldKind,
 } from '@/types'
 import type { ConnectionStatus } from '@/network/websocket.ts'
 import type { CounterRemovalCreatureInfo, SpectatorCombatState, SpectatorDecisionStatus } from '@/types/messages.ts'
@@ -827,6 +828,9 @@ export type GameStore = {
   setFullControl: (enabled: boolean) => void
   cyclePriorityMode: () => void
   toggleStopOverride: (step: Step, isMyTurn: boolean) => void
+  setAbilityYield: (cardDefinitionId: string, abilityId: string, kind: YieldKind) => void
+  clearAbilityYield: (cardDefinitionId: string, abilityId: string) => void
+  clearAllYields: () => void
   returnToMenu: () => void
   setError: (error: ErrorState) => void
   clearError: () => void

--- a/web-client/src/types/events.ts
+++ b/web-client/src/types/events.ts
@@ -23,6 +23,7 @@ export type ClientEvent =
   | SpellCounteredEvent
   | AbilityTriggeredEvent
   | AbilityActivatedEvent
+  | AbilityAutoAnsweredEvent
   | PermanentTappedEvent
   | PermanentUntappedEvent
   | CounterAddedEvent
@@ -186,6 +187,15 @@ export interface AbilityActivatedEvent {
   readonly sourceId: EntityId
   readonly sourceName: string
   readonly abilityDescription: string
+  readonly description: string
+}
+
+/** A "you may" may-question was auto-resolved from the viewer's persistent yield (backlog §C). */
+export interface AbilityAutoAnsweredEvent {
+  readonly type: 'abilityAutoAnswered'
+  readonly sourceId: EntityId
+  readonly sourceName: string
+  readonly answer: boolean
   readonly description: string
 }
 

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -71,6 +71,29 @@ export interface ClientGameState {
    * {@link youAreHijacking}.
    */
   readonly hotseat?: boolean
+
+  /**
+   * The viewing player's active persistent yields (MTGO right-click yields — backlog §C).
+   * Masked per-player: only your own yields appear. Drives the Active Yields panel.
+   */
+  readonly activeYields?: readonly ClientYield[]
+}
+
+/** The stable (cardDefinitionId, abilityId) key an ability is yielded against. */
+export interface ClientAbilityIdentity {
+  readonly cardDefinitionId: string
+  readonly abilityId: string
+}
+
+/** One ability the viewing player has set a yield on (flattened from PlayerYields). */
+export interface ClientYield {
+  readonly cardDefinitionId: string
+  readonly abilityId: string
+  readonly displayName: string
+  readonly untilEndOfTurn?: boolean
+  readonly wholeGame?: boolean
+  /** true = always yes, false = always no, null/absent = no auto-answer. */
+  readonly autoAnswer?: boolean | null
 }
 
 /**
@@ -238,6 +261,12 @@ export interface ClientCard {
 
   /** Chosen X value for spells with X in their cost (only present on stack) */
   readonly chosenX?: number | null
+
+  /**
+   * For a triggered/activated ability on the stack: its definition-scoped identity (backlog §C).
+   * Drives the stack-item yield context menu. Absent for spells.
+   */
+  readonly abilityIdentity?: ClientAbilityIdentity | null
 
   /** Copy index for storm/copy effects on the stack (1, 2, 3...) */
   readonly copyIndex?: number | null

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -300,6 +300,10 @@ export type {
   SetFullControlMessage,
   SetPriorityModeMessage,
   SetStopOverridesMessage,
+  SetAbilityYieldMessage,
+  ClearAbilityYieldMessage,
+  ClearAllYieldsMessage,
+  YieldKind,
   StopOverrideInfo,
   PriorityModeValue,
   // Quick Game Lobby types
@@ -408,6 +412,9 @@ export {
   createSetFullControlMessage,
   createSetPriorityModeMessage,
   createSetStopOverridesMessage,
+  createSetAbilityYieldMessage,
+  createClearAbilityYieldMessage,
+  createClearAllYieldsMessage,
   createRequestUndoMessage,
   createRequestResyncMessage,
   // Quick Game Lobby factories & guards

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1667,6 +1667,9 @@ export type ClientMessage =
   | SetFullControlMessage
   | SetPriorityModeMessage
   | SetStopOverridesMessage
+  | SetAbilityYieldMessage
+  | ClearAbilityYieldMessage
+  | ClearAllYieldsMessage
   // Undo
   | RequestUndoMessage
   // Resync
@@ -2154,6 +2157,38 @@ export interface SetStopOverridesMessage {
 }
 
 /**
+ * A persistent per-ability yield kind (MTGO right-click yields). Serialized as the engine
+ * YieldKind enum name.
+ */
+export type YieldKind =
+  | 'YIELD_UNTIL_END_OF_TURN'
+  | 'YIELD_WHOLE_GAME'
+  | 'ALWAYS_ANSWER_YES'
+  | 'ALWAYS_ANSWER_NO'
+
+/**
+ * Set a persistent yield on an ability, keyed by its AbilityIdentity (cardDefinitionId + abilityId).
+ */
+export interface SetAbilityYieldMessage {
+  readonly type: 'setAbilityYield'
+  readonly cardDefinitionId: string
+  readonly abilityId: string
+  readonly kind: YieldKind
+}
+
+/** Revoke every yield held against one ability. */
+export interface ClearAbilityYieldMessage {
+  readonly type: 'clearAbilityYield'
+  readonly cardDefinitionId: string
+  readonly abilityId: string
+}
+
+/** Clear all of the player's yields. */
+export interface ClearAllYieldsMessage {
+  readonly type: 'clearAllYields'
+}
+
+/**
  * Request to undo the last non-respondable action.
  */
 export interface RequestUndoMessage {
@@ -2319,6 +2354,25 @@ export function createSetPriorityModeMessage(mode: PriorityModeValue): SetPriori
 
 export function createSetStopOverridesMessage(myTurnStops: readonly string[], opponentTurnStops: readonly string[]): SetStopOverridesMessage {
   return { type: 'setStopOverrides', myTurnStops, opponentTurnStops }
+}
+
+export function createSetAbilityYieldMessage(
+  cardDefinitionId: string,
+  abilityId: string,
+  kind: YieldKind,
+): SetAbilityYieldMessage {
+  return { type: 'setAbilityYield', cardDefinitionId, abilityId, kind }
+}
+
+export function createClearAbilityYieldMessage(
+  cardDefinitionId: string,
+  abilityId: string,
+): ClearAbilityYieldMessage {
+  return { type: 'clearAbilityYield', cardDefinitionId, abilityId }
+}
+
+export function createClearAllYieldsMessage(): ClearAllYieldsMessage {
+  return { type: 'clearAllYields' }
 }
 
 export function createRequestUndoMessage(): RequestUndoMessage {


### PR DESCRIPTION
Implements **C (persistent per-ability yields)** from `backlog/stack-collapse-and-batch-decisions.md` — the last unbuilt phase of that backlog (A shipped in `5c9274641`; B and C.2 on their own branches). MTGO-style right-click yields: a player remembers a preference on an ability so it stops prompting, keyed by `AbilityIdentity` so it follows every current and future copy/instance.

## What it does
- **Yield until end of turn / Always yield** — auto-pass priority on that ability's stack objects (turn / whole game).
- **Always answer Yes / No** — auto-resolve the ability's optional "you may" may-question without prompting.
- Revocable per-ability and clear-all; never traps the player.

## Design (cross-layer)
- **Engine state:** `PlayerYields` on `GameState.yieldsByPlayer` — immutable, serialized, masked per-player. `untilEndOfTurn` cleared at cleanup (CR 514); whole-game sets + the yes/no `autoAnswer` map persist. Lives on `GameState` (not the session) so it replays deterministically and the pure engine can read it during resolution.
- **Auto-answer:** consulted in `GatedEffectExecutor` (`Gate.MayDecide`, the targetless may at resolution) and `TriggerProcessor`'s may-with-targets path. **Scoped to the pure may-question only** — never a pay/target/modal choice (§C.6), so a yield can't spend mana or make a real choice for you. Emits a subtle `AbilityAutoAnsweredEvent` (controller-only) so the player sees the system acted. `abilityIdentity` threaded onto `EffectContext` via `StackResolver`.
- **Auto-pass:** `AutoPassManager` gains one extra pass reason — top-of-stack ability identity ∈ priority holder's yields → auto-pass (composes with existing Rule 4; `holdPriority` still wins).
- **Server:** `setAbilityYield` / `clearAbilityYield` / `clearAllYields` messages → `GameWebSocketHandler` → `GamePlayHandler` → `GameSession` applies a pure `GameState` transform and re-broadcasts (which drives the auto-pass loop).
- **Client:** stack-item right-click context menu, an "Active yields" panel (per-yield revoke + clear-all), and log surfacing. `ClientGameState.activeYields` is masked to the viewer; `ClientCard.abilityIdentity` drives the menu.

## Tests
- `PersistentYieldsTest` (rules-engine): auto-answer yes/no resolves without prompting, no-yield still prompts, identity-keying (a yield on another ability doesn't fire), per-player masking, and `GameState` helpers + end-of-turn clearing.
- `AutoPassManagerTest` (game-server): auto-pass on a yielded opponent ability; no-yield still stops.
- Full `:rules-engine:test` + `:game-server:test` green; web-client `typecheck` green.

## Docs
- `docs/data-contracts.md` — new messages + DTO fields.
- Backlog status updated (all three phases now implemented); also corrected the stale "A spec-only" header.

## Notes / scope
- No card-authoring SDK vocabulary added, so `card-sdk-language-reference.md` is unchanged by design; documented in `data-contracts.md` + the backlog.
- Built against `main`; composes cleanly with B (batch may-question) if/when that branch merges — the auto-answer short-circuits the same may-question point B batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)