### PR TITLE
Make disconnect scheduler use daemon threads to stop CI build hangs

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SessionRegistry.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SessionRegistry.kt
@@ -27,8 +27,19 @@ class SessionRegistry : DisposableBean {
     /** Per-session locks for thread-safe WebSocket writes */
     private val sessionLocks = ConcurrentHashMap<String, Any>()
 
-    /** Scheduler for disconnect grace period timers */
-    val disconnectScheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
+    /**
+     * Scheduler for disconnect grace period timers.
+     *
+     * Uses **daemon** threads so a lingering scheduler can never keep a JVM alive. Under a normal
+     * Spring lifecycle [destroy] shuts it down, but `@SpringBootTest` contexts are cached and closed
+     * by a JVM shutdown hook — and a shutdown hook only fires once the JVM is already exiting. With
+     * non-daemon threads the scheduler would itself block that exit, so the hook that would stop it
+     * never runs and the (Gradle test-worker) JVM hangs forever. Daemon threads break that deadlock.
+     */
+    val disconnectScheduler: ScheduledExecutorService =
+        Executors.newScheduledThreadPool(2) { runnable ->
+            Thread(runnable, "session-disconnect-scheduler").apply { isDaemon = true }
+        }
 
     /** Grace period before treating a disconnect as abandonment */
     val disconnectGracePeriodMinutes = 5L


### PR DESCRIPTION
## Problem

The backend CI job intermittently **freezes at `:game-server:build`** — every test passes, but Gradle never prints `BUILD SUCCESSFUL` and the run has to be cancelled, leaving orphan `java` processes in the runner cleanup. ([example run](https://github.com/wingedsheep/argentum-engine/actions/runs/27497466833/job/81274117001))

That's the signature of a **leaked non-daemon thread in a test-worker JVM**.

## Root cause

```kotlin
val disconnectScheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
```

`Executors.newScheduledThreadPool` uses the default thread factory, which creates **non-daemon** threads. `SessionRegistry` shuts the pool down only in `DisposableBean.destroy()`, i.e. on Spring context close.

In tests, `@SpringBootTest` contexts are *cached* and closed via a **JVM shutdown hook** — which only fires once the JVM is already shutting down. A live non-daemon thread is precisely what *prevents* the JVM from shutting down, so:

1. The 2 scheduler threads keep the worker JVM alive after the last test.
2. The shutdown hook that would run `destroy()` → `shutdownNow()` never fires.
3. The worker JVM hangs → Gradle waits on the worker → `BUILD SUCCESSFUL` never prints.

It's intermittent because it depends on which cached context's scheduler is still live at worker exit and on thread/GC timing.

## Fix

Use a daemon-thread factory for the pool. A disconnect-grace-timer scheduler never needs to outlive the JVM, so this is correct in production too — `destroy()` stays as the orderly-shutdown path; daemon-ness is the safety net that always lets the JVM exit. This was the **only** non-daemon executor/`Timer` in production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)