### PR TITLE
Add Annie Joins Up, Binding Negotiation, Boneyard Desecrator (OTJ) + mtgish emitter support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnnieJoinsUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnnieJoinsUp.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Annie Joins Up
+ * {1}{R}{G}{W}
+ * Legendary Enchantment
+ *
+ * When Annie Joins Up enters, it deals 5 damage to target creature or planeswalker an
+ * opponent controls.
+ * If a triggered ability of a legendary creature you control triggers, that ability
+ * triggers an additional time.
+ *
+ * The second clause is the generic [AdditionalSourceTriggers] doubler (CR 603.2d),
+ * scoped to legendary creatures you control. Annie herself is an enchantment, so the
+ * "another" exclusion is moot, but excludeSelf stays true to match the filter's
+ * "you control" intent without ever matching the source.
+ */
+val AnnieJoinsUp = card("Annie Joins Up") {
+    manaCost = "{1}{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Enchantment"
+    oracleText = "When Annie Joins Up enters, it deals 5 damage to target creature or planeswalker an opponent controls.\n" +
+        "If a triggered ability of a legendary creature you control triggers, that ability triggers an additional time."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target creature or planeswalker an opponent controls",
+            TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls()))
+        )
+        effect = Effects.DealDamage(5, t)
+    }
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Creature.legendary().youControl(),
+            excludeSelf = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "191"
+        artist = "Wylie Beckert"
+        flavorText = "One last job, then she could retire in peace."
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg?1712356038"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BindingNegotiation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BindingNegotiation.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Binding Negotiation
+ * {1}{B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You may choose a nonland card from it. If you do,
+ * they discard it. Otherwise, you may put a face-up exiled card they own into their
+ * graveyard.
+ *
+ * Modeled entirely from atomic pipeline primitives:
+ *  - Reveal → gather the opponent's hand → `ChooseUpTo(1)` nonland (the "you may choose")
+ *    → discard. The optional selection stores `toDiscard`; an empty selection means no
+ *    card was chosen.
+ *  - The "Otherwise" half is a resolution-time state test ([ConditionalEffect], lowering to
+ *    `Gate.WhenCondition`) gated on `toDiscard` being empty — i.e. nothing was discarded.
+ *    It gathers the opponent's *face-up* exiled cards, offers an optional choice, and moves
+ *    the chosen card to its owner's (the opponent's) graveyard.
+ */
+val BindingNegotiation = card("Binding Negotiation") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You may choose a nonland card from it. " +
+        "If you do, they discard it. Otherwise, you may put a face-up exiled card they own into their graveyard."
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            listOf(
+                // Reveal the opponent's hand.
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "opponentHand"
+                ),
+                // "You may choose a nonland card from it." — optional (ChooseUpTo 1).
+                SelectFromCollectionEffect(
+                    from = "opponentHand",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "You may choose a nonland card for them to discard",
+                    alwaysPrompt = true,
+                    showAllCards = true
+                ),
+                // "If you do, they discard it."
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard
+                ),
+                // "Otherwise, you may put a face-up exiled card they own into their graveyard."
+                // Fires only if no card was discarded (toDiscard is empty).
+                ConditionalEffect(
+                    condition = Conditions.Not(Conditions.CollectionContainsMatch("toDiscard")),
+                    effect = Effects.Composite(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.FromZone(
+                                    zone = Zone.EXILE,
+                                    player = Player.ContextPlayer(0),
+                                    filter = GameObjectFilter.Any.faceUp()
+                                ),
+                                storeAs = "theirExile"
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "theirExile",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                                chooser = Chooser.Controller,
+                                storeSelected = "toBin",
+                                prompt = "You may put a face-up exiled card they own into their graveyard",
+                                alwaysPrompt = true,
+                                showAllCards = true
+                            ),
+                            MoveCollectionEffect(
+                                from = "toBin",
+                                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                                moveType = MoveType.Default
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "Caroline Gariba"
+        flavorText = "\"The tighter I bind them, the looser their tongues become.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg?1712355546"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoneyardDesecrator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BoneyardDesecrator.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Boneyard Desecrator
+ * {3}{B}
+ * Creature — Zombie Mercenary
+ * 3/4
+ *
+ * Menace
+ * {1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature. If an outlaw
+ * was sacrificed this way, create a Treasure token. (Assassins, Mercenaries, Pirates,
+ * Rogues, and Warlocks are outlaws.)
+ *
+ * The "if an outlaw was sacrificed this way" rider reads the cost-sacrificed permanent's
+ * snapshot via the existing [Conditions.SacrificedHadSubtype] condition (which inspects
+ * `EffectContext.sacrificedPermanents`, captured at cost-payment time). "Outlaw" is any of
+ * the five OTJ outlaw creature types, so the gate is an OR ([Conditions.Any]) over
+ * [Subtype.OUTLAW_TYPES] — no card-specific condition needed.
+ */
+val BoneyardDesecrator = card("Boneyard Desecrator") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Mercenary"
+    power = 3
+    toughness = 4
+    oracleText = "Menace\n" +
+        "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature. " +
+        "If an outlaw was sacrificed this way, create a Treasure token. " +
+        "(Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)"
+
+    keywords(Keyword.MENACE)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.Any(
+                        *Subtype.OUTLAW_TYPES
+                            .map { Conditions.SacrificedHadSubtype(it.value) }
+                            .toTypedArray()
+                    ),
+                    effect = Effects.CreateTreasure(1)
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Maxime Minard"
+        flavorText = "It's never too late to start an afterlife of crime."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg?1712355558"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -236,6 +236,67 @@
     ]
 }
 
+// Annie Joins Up
+{
+    "name": "Annie Joins Up",
+    "manaCost": "{1}{R}{G}{W}",
+    "typeLine": "Legendary Enchantment",
+    "oracleText": "When Annie Joins Up enters, it deals 5 damage to target creature or planeswalker an opponent controls.\nIf a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|planeswalker ctrl:opponent"
+                    },
+                    "id": "target creature or planeswalker an opponent controls"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "AdditionalSourceTriggers",
+                "sourceFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        "IsLegendary"
+                    ],
+                    "controllerPredicate": "ControlledByYou"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "RARE",
+        "artist": "Wylie Beckert",
+        "flavorText": "One last job, then she could retire in peace.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg?1712356038"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Another Round
 {
     "name": "Another Round",
@@ -824,6 +885,147 @@
     ]
 }
 
+// Binding Negotiation
+{
+    "name": "Binding Negotiation",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, they discard it. Otherwise, you may put a face-up exiled card they own into their graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RevealHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "opponentHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "opponentHand",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "You may choose a nonland card for them to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Not",
+                            "condition": {
+                                "type": "CollectionContainsMatch",
+                                "collection": "toDiscard"
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Exile",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    },
+                                    "filter": {
+                                        "statePredicates": [
+                                            "IsFaceUp"
+                                        ]
+                                    }
+                                },
+                                "storeAs": "theirExile"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "theirExile",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "toBin",
+                                "prompt": "You may put a face-up exiled card they own into their graveyard",
+                                "showAllCards": true,
+                                "alwaysPrompt": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toBin",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "UNCOMMON",
+        "artist": "Caroline Gariba",
+        "flavorText": "\"The tighter I bind them, the looser their tongues become.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg?1712355546"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blacksnag Buzzard
 {
     "name": "Blacksnag Buzzard",
@@ -1029,6 +1231,103 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Boneyard Desecrator
+{
+    "name": "Boneyard Desecrator",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Mercenary",
+    "oracleText": "Menace\n{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature. If an outlaw was sacrificed this way, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Any",
+                                    "conditions": [
+                                        {
+                                            "type": "SacrificedPermanentHadSubtype",
+                                            "subtype": "Assassin"
+                                        },
+                                        {
+                                            "type": "SacrificedPermanentHadSubtype",
+                                            "subtype": "Mercenary"
+                                        },
+                                        {
+                                            "type": "SacrificedPermanentHadSubtype",
+                                            "subtype": "Pirate"
+                                        },
+                                        {
+                                            "type": "SacrificedPermanentHadSubtype",
+                                            "subtype": "Rogue"
+                                        },
+                                        {
+                                            "type": "SacrificedPermanentHadSubtype",
+                                            "subtype": "Warlock"
+                                        }
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Maxime Minard",
+        "flavorText": "It's never too late to start an afterlife of crime.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg?1712355558"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -87,4 +87,9 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     composed("CreatePreventDamageUntil", "PreventDamageShield (duration-scoped prevention)", composes = listOf("PreventDamageShield"))
     composed("CreateTriggerUntil", "CreateGlobalTriggeredAbility (duration)", composes = listOf("CreateGlobalTriggeredAbility"))
     composed("CreateFutureTrigger", "CreateDelayedTrigger", composes = listOf("CreateDelayedTrigger"))
+
+    // "If a triggered ability of a [filter] you control triggers, that ability triggers an additional
+    // time" (Annie Joins Up, Twinflame Travelers — CR 603.2d). A static doubler over a filtered group;
+    // emitter renders staticAbility { ability = AdditionalSourceTriggers(sourceFilter = …) }.
+    effect("AbilitiesTriggerAnAdditionalTime", "AdditionalSourceTriggers")
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -175,6 +175,7 @@ object Emitter {
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
                 rname == "ReplaceAPlayerWouldCreateTokens" -> block = ctx.replaceTokenCreationBlock(card, rule)
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
+                rname == "AbilitiesTriggerAnAdditionalTime" -> block = ctx.additionalSourceTriggersBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
                 rname == "FromHand" -> block = ctx.fromHandBlock(rule)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -176,6 +176,32 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject, condition: String? = null
 private fun EmitCtx.scaffoldLord(): List<Stmt>? { reasons.add("EachPermanentLayerEffect"); return null }
 
 /**
+ * An `AbilitiesTriggerAnAdditionalTime` rule -> `staticAbility { ability = AdditionalSourceTriggers(
+ * sourceFilter = <filter>, excludeSelf = true) }`. Models "If a triggered ability of a [filter] you
+ * control triggers, that ability triggers an additional time" (Annie Joins Up's legendary-creature
+ * doubler, Twinflame Travelers' Elemental doubler — CR 603.2d).
+ *
+ * The affected ability set is `AbilityOfAPermanent` whose permanent matches a [gameObjectFilterExpr]
+ * filter (e.g. `And[IsSupertype Legendary, IsCardtype Creature, ControlledByAPlayer You]` ->
+ * `GameObjectFilter.Creature.legendary().youControl()`). `excludeSelf = true` matches both the SDK
+ * default and the "another …" wording; the filter renderer declines (-> SCAFFOLD) on any restriction it
+ * can't render exactly, so no constraint is silently dropped.
+ */
+internal fun EmitCtx.additionalSourceTriggersBlock(rule: JsonObject): List<Stmt>? {
+    val abilitySet = rule["args"] as? JsonObject ?: run { reasons.add("AbilitiesTriggerAnAdditionalTime"); return null }
+    // Only the "a triggered ability of a permanent (matching a filter)" shape renders.
+    if (abilitySet.strField("_Abilities") != "AbilityOfAPermanent") { reasons.add("AbilitiesTriggerAnAdditionalTime"); return null }
+    val filterNode = abilitySet["args"]
+    val filterDsl = gameObjectFilterExpr(filterNode) ?: run { reasons.add("AbilitiesTriggerAnAdditionalTime"); return null }
+    val ability = call(
+        "AdditionalSourceTriggers",
+        arg("sourceFilter", filterDsl),
+        arg("excludeSelf", "true"),
+    )
+    return listOf(staticAbilityStmt(ability))
+}
+
+/**
  * A self-buff `PermanentLayerEffect(ThisPermanent, [AdjustPTForEach])` -> one
  * `staticAbility { ability = GrantDynamicStatsEffect(filter = GroupFilter.source(), powerBonus = …,
  * toughnessBonus = …) }`. `AdjustPTForEach`'s args are `[powerMult, toughnessMult, countNode]`:

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -434,6 +434,46 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
             return Call("TargetCreature", parts)
         }
+        // "target creature or planeswalker[, an opponent controls]" (Annie Joins Up's ETB damage):
+        // an Or unioning the two cardtypes Creature and Planeswalker, optionally narrowed by a
+        // controller clause. TargetCreatureOrPlaneswalker carries no filter field, so the controller
+        // restriction is rendered as TargetObject(filter = TargetFilter(
+        // GameObjectFilter.CreatureOrPlaneswalker[.youControl()/.opponentControls()])). Only the bare
+        // two-cardtype Or (optionally one You/Opponent controller clause, no count, subtype, or other
+        // predicate) renders; anything else declines (-> SCAFFOLD) rather than dropping a restriction.
+        run {
+            if (types != setOf("Creature", "Planeswalker")) return@run
+            if (hasCreatureSubtype || "IsNonCardtype" in blob || "IsNonCreatureType" in blob ||
+                jsonContains(args, "_Permanents", "Other")) return@run
+            // Only the union arms (Creature/Planeswalker) and an optional ControlledByAPlayer clause
+            // may be present; any other restrictive predicate must decline.
+            val extras = listOf(
+                "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "PowerIs", "ToughnessIs",
+                "ManaValueIs", "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken",
+                "IsToken", "IsSupertype", "IsArtifactType", "ManaValueAtMost", "ManaValueAtLeast",
+            )
+            if (extras.any { it in blob }) return@run
+            val controller: Link? = when {
+                "ControlledByAPlayer" !in blob -> null
+                "\"You\"" in blob -> Link("youControl")
+                "\"Opponent\"" in blob -> Link("opponentControls")
+                else -> return null
+            }
+            if (controller == null) {
+                // No controller restriction — the named TargetCreatureOrPlaneswalker is exact.
+                val parts = listOfNotNull(
+                    if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) arg("count", "$countInt") else null,
+                    if (ttype == "UptoNumberTargetPermanents" || isUpToOne) arg("optional", "true") else null,
+                )
+                return Call("TargetCreatureOrPlaneswalker", parts)
+            }
+            var g: Dsl = Lit("GameObjectFilter.CreatureOrPlaneswalker").dot(controller.method)
+            val filt = Call("TargetFilter", listOf(arg(g)))
+            val parts = mutableListOf(arg("filter", filt))
+            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
+            if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
+            return Call("TargetObject", parts)
+        }
         // "target Spirit or enchantment" (Urgent Exorcism): an Or unioning a creature subtype with a
         // single non-creature cardtype. The single-type branch below would render the cardtype arm
         // alone, silently dropping the subtype arm — render the faithful union instead. Only the bare
@@ -912,6 +952,16 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
                 node.dot("targetPlayerControls", arg("EffectTarget.ContextTarget(0)"))
             else -> return null
         }
+    }
+    // A supertype restriction (IsSupertype) — only "Legendary" renders here, via `.legendary()`
+    // (e.g. Annie Joins Up's "legendary creature you control" trigger doubler). The basic-land
+    // supertype is handled by its own land-subtype branch and never reaches this surface. Any other
+    // supertype (Snow, World, …) has no GroupFilter rendering, so decline (-> SCAFFOLD) rather than
+    // silently dropping the restriction and widening the group.
+    val supertypes = filterNode.argWordsTagged("IsSupertype")
+    if (supertypes.isNotEmpty()) {
+        if (supertypes == listOf("Legendary")) node = node.dot("legendary")
+        else return null
     }
     return node
 }

--- a/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
@@ -3644,7 +3644,7 @@ val Excavator = card("Excavator") {
     colorIdentity = ""
     typeLine = "Artifact"
     oracleText = "{T}, Sacrifice a basic land: Target creature gains landwalk of each of the land types of the sacrificed land until end of turn. (It can't be blocked as long as defending player controls a land of any of those types.)"
-    // STRUCTURE needs human wiring: CreatePermanentLayerEffectUntil
+    // STRUCTURE needs human wiring: activated-cost
     metadata {
         rarity = Rarity.UNCOMMON
         collectorNumber = "287"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnieJoinsUpTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnieJoinsUpTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AnnieJoinsUp
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Annie Joins Up (OTJ #191).
+ *
+ * 1. ETB: "it deals 5 damage to target creature or planeswalker an opponent controls."
+ * 2. Static: "If a triggered ability of a legendary creature you control triggers, that
+ *    ability triggers an additional time." — the generic AdditionalSourceTriggers doubler
+ *    scoped to legendary creatures you control (CR 603.2d).
+ */
+class AnnieJoinsUpTest : FunSpec({
+
+    // A legendary creature with an ETB draw trigger. Its trigger is what Annie's static doubles.
+    val legendaryDrawer = card("Test Legendary Drawer") {
+        manaCost = "{2}"
+        typeLine = "Legendary Creature — Human"
+        power = 2
+        toughness = 2
+        oracleText = "When Test Legendary Drawer enters, draw a card."
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A non-legendary creature with the same ETB draw trigger, used to prove the doubler is
+    // scoped to legendary creatures only.
+    val plainDrawer = card("Test Plain Drawer") {
+        manaCost = "{2}"
+        typeLine = "Creature — Human"
+        power = 2
+        toughness = 2
+        oracleText = "When Test Plain Drawer enters, draw a card."
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AnnieJoinsUp, legendaryDrawer, plainDrawer))
+        return driver
+    }
+
+    test("ETB deals 5 damage to a target creature an opponent controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A 3/3 opposing creature so we can observe lethal damage.
+        val target = driver.putCreatureOnBattlefield(opponent, "Hill Giant")
+
+        // Cast Annie so her ETB trigger fires, then submit the target.
+        val annie = driver.putCardInHand(you, "Annie Joins Up")
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, annie).isSuccess shouldBe true
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision is ChooseTargetsDecision) && guard++ < 20) {
+            if (driver.state.pendingDecision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(you, listOf(target))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        // Hill Giant is 3/3 — 5 damage is lethal, so it should be gone from the battlefield.
+        driver.getCreatures(opponent).contains(target) shouldBe false
+    }
+
+    test("doubles a legendary creature's ETB trigger — controller draws twice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Annie is already in play, providing her static doubler.
+        driver.putPermanentOnBattlefield(you, "Annie Joins Up")
+
+        // A legendary creature is cast: its ETB draw trigger should fire an additional time.
+        val drawer = driver.putCardInHand(you, "Test Legendary Drawer")
+        driver.giveColorlessMana(you, 2)
+        val before = driver.getHandSize(you)
+        driver.castSpell(you, drawer).isSuccess shouldBe true
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        // Casting moved the card from hand, then two ETB draws (original + additional firing):
+        // net delta = -1 (cast) + 2 (draws) = +1.
+        (driver.getHandSize(you) - before) shouldBe 1
+    }
+
+    test("does not double a non-legendary creature's ETB trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Annie Joins Up")
+
+        val drawer = driver.putCardInHand(you, "Test Plain Drawer")
+        driver.giveColorlessMana(you, 2)
+        val before = driver.getHandSize(you)
+        driver.castSpell(you, drawer).isSuccess shouldBe true
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        // -1 (cast) + 1 (single ETB draw, not doubled) = 0. The doubler is legendary-only.
+        (driver.getHandSize(you) - before) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BindingNegotiationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BindingNegotiationTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BindingNegotiation
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Binding Negotiation (OTJ #78).
+ *
+ * "Target opponent reveals their hand. You may choose a nonland card from it. If you do,
+ *  they discard it. Otherwise, you may put a face-up exiled card they own into their graveyard."
+ *
+ * Two paths:
+ *  - You choose a nonland card → it's discarded; the "Otherwise" half does NOT run.
+ *  - You decline the discard → you may bin a face-up exiled card the opponent owns.
+ */
+class BindingNegotiationTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BindingNegotiation))
+        return driver
+    }
+
+    fun castBindingNegotiation(driver: GameTestDriver, you: com.wingedsheep.sdk.model.EntityId, opponent: com.wingedsheep.sdk.model.EntityId) {
+        val card = driver.putCardInHand(you, "Binding Negotiation")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        // Target the opponent at cast time (the helper builds a ChosenTarget.Player).
+        driver.castSpell(you, card, targets = listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass() // resolve the spell onto the stack -> begin its resolution
+    }
+
+    test("choosing a nonland card discards it; the otherwise clause does not run") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a nonland card in hand and a face-up card in exile.
+        val nonland = driver.putCardInHand(opponent, "Grizzly Bears")
+        val exiled = driver.putCardInExile(opponent, "Hill Giant")
+        val gyBefore = driver.getGraveyard(opponent).size
+
+        castBindingNegotiation(driver, you, opponent)
+
+        // Drain decisions: choose the nonland card to discard.
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision is SelectCardsDecision) && guard++ < 30) {
+            if (driver.state.pendingDecision is SelectCardsDecision) {
+                driver.submitCardSelection(you, listOf(nonland))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        // The nonland card was discarded to the opponent's graveyard.
+        driver.getGraveyard(opponent).contains(nonland) shouldBe true
+        // The exiled card was NOT binned — the otherwise clause is skipped when a discard happened.
+        driver.getExile(opponent).contains(exiled) shouldBe true
+        (driver.getGraveyard(opponent).size - gyBefore) shouldBe 1
+    }
+
+    test("declining the discard lets you bin a face-up exiled card they own") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a nonland card in hand (we'll decline it) and a face-up exiled card.
+        val nonland = driver.putCardInHand(opponent, "Grizzly Bears")
+        val exiled = driver.putCardInExile(opponent, "Hill Giant")
+
+        castBindingNegotiation(driver, you, opponent)
+
+        // Drain decisions: decline the discard (empty selection), then bin the exiled card.
+        var guard = 0
+        var declinedDiscard = false
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision is SelectCardsDecision) && guard++ < 30) {
+            if (driver.state.pendingDecision is SelectCardsDecision) {
+                if (!declinedDiscard) {
+                    driver.submitCardSelection(you, emptyList()) // decline the nonland discard
+                    declinedDiscard = true
+                } else {
+                    driver.submitCardSelection(you, listOf(exiled)) // bin the exiled card
+                }
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        // Nothing was discarded from hand.
+        driver.getHand(opponent).contains(nonland) shouldBe true
+        // The face-up exiled card moved to the opponent's graveyard.
+        driver.getExile(opponent).contains(exiled) shouldBe false
+        driver.getGraveyard(opponent).contains(exiled) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoneyardDesecratorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoneyardDesecratorTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BoneyardDesecrator
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Boneyard Desecrator (OTJ #81).
+ *
+ * {1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature. If an outlaw
+ * was sacrificed this way, create a Treasure token.
+ *
+ * The outlaw rider is an OR over the five OTJ outlaw subtypes against the cost-sacrificed
+ * permanent's snapshot (SacrificedHadSubtype). Proven both ways:
+ *  - Sacrifice a Pirate (an outlaw) → counter added AND a Treasure created.
+ *  - Sacrifice a plain Beast (not an outlaw) → counter added, NO Treasure.
+ */
+class BoneyardDesecratorTest : FunSpec({
+
+    val abilityId = BoneyardDesecrator.activatedAbilities.first().id
+
+    val pirateFodder = CardDefinition.creature(
+        name = "Pirate Fodder",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype.PIRATE),
+        power = 1,
+        toughness = 1,
+    )
+
+    val beastFodder = CardDefinition.creature(
+        name = "Beast Fodder",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 1,
+        toughness = 1,
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BoneyardDesecrator, pirateFodder, beastFodder, PredefinedTokens.Treasure))
+        return driver
+    }
+
+    fun treasureCount(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getBattlefield().count { id ->
+            driver.state.projectedState.getController(id) == player &&
+                driver.state.getEntity(id)
+                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Treasure"
+        }
+
+    test("sacrificing an outlaw adds a counter AND creates a Treasure") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val desecrator = driver.putCreatureOnBattlefield(you, "Boneyard Desecrator")
+        driver.removeSummoningSickness(desecrator)
+        val pirate = driver.putCreatureOnBattlefield(you, "Pirate Fodder")
+
+        val treasuresBefore = treasureCount(driver, you)
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = desecrator,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(pirate))
+            )
+        )
+        result.isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // +1/+1 counter on Boneyard Desecrator.
+        driver.state.getEntity(desecrator)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        // A Treasure was created (outlaw sacrificed).
+        (treasureCount(driver, you) - treasuresBefore) shouldBe 1
+    }
+
+    test("sacrificing a non-outlaw adds a counter but creates NO Treasure") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val desecrator = driver.putCreatureOnBattlefield(you, "Boneyard Desecrator")
+        driver.removeSummoningSickness(desecrator)
+        val beast = driver.putCreatureOnBattlefield(you, "Beast Fodder")
+
+        val treasuresBefore = treasureCount(driver, you)
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = desecrator,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(beast))
+            )
+        )
+        result.isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // +1/+1 counter still added.
+        driver.state.getEntity(desecrator)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        // No Treasure — the sacrificed creature was not an outlaw.
+        (treasureCount(driver, you) - treasuresBefore) shouldBe 0
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -665,6 +665,42 @@ class GameTestDriver {
     }
 
     /**
+     * Put a specific card face-up into a player's exile zone (test helper).
+     * Creates a new card entity from the registry, owned by [playerId], and adds it to
+     * that player's exile zone with no [com.wingedsheep.engine.state.components.identity.FaceDownComponent]
+     * (so it reads as face-up). Used to set up "a face-up exiled card they own" scenarios.
+     */
+    fun putCardInExile(playerId: EntityId, cardName: String): EntityId {
+        val cardDef = cardRegistry.requireCard(cardName)
+        val cardId = EntityId.generate()
+
+        val cardComponent = CardComponent(
+            cardDefinitionId = cardDef.name,
+            name = cardDef.name,
+            manaCost = cardDef.manaCost,
+            typeLine = cardDef.typeLine,
+            oracleText = cardDef.oracleText,
+            baseStats = cardDef.creatureStats,
+            baseKeywords = cardDef.keywords,
+            baseFlags = cardDef.flags,
+            colors = cardDef.colors,
+            ownerId = playerId,
+            spellEffect = cardDef.spellEffect,
+        )
+
+        val container = com.wingedsheep.engine.state.ComponentContainer.of(
+            cardComponent,
+            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            ControllerComponent(playerId)
+        )
+
+        _state = _state.withEntity(cardId, container)
+        _state = _state.addToZone(ZoneKey(playerId, Zone.EXILE), cardId)
+
+        return cardId
+    }
+
+    /**
      * Put a specific card on top of a player's library (test helper).
      * Creates a new card entity from the registry and prepends it to the library.
      */


### PR DESCRIPTION
## Cards added (Outlaws of Thunder Junction)

All three are built from existing SDK primitives (no new SDK surface) and each has a passing rules-engine scenario test.

### Annie Joins Up — `{1}{R}{G}{W}` Legendary Enchantment
- **ETB:** deals 5 damage to target creature or planeswalker an opponent controls — `TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls()))`.
- **Static:** "If a triggered ability of a legendary creature you control triggers, that ability triggers an additional time" — the existing `AdditionalSourceTriggers` doubler scoped to `Creature.legendary().youControl()` (CR 603.2d).
- Test covers the ETB damage, the legendary doubling (draws twice), and that non-legendary creatures are not doubled.

### Binding Negotiation — `{1}{B}` Sorcery
- "Target opponent reveals their hand. You may choose a nonland card from it. If you do, they discard it. **Otherwise**, you may put a face-up exiled card they own into their graveyard."
- Discard half: reveal → gather hand → `SelectFromCollection(ChooseUpTo(1), Nonland)` → discard.
- The "otherwise" half is a `ConditionalEffect` gated on `Not(CollectionContainsMatch("toDiscard"))`, feeding a `FromZone(EXILE, opponent, faceUp)` → `SelectFromCollection(ChooseUpTo(1))` → move-to-graveyard pipeline. **Backlog gap #18 turned out to be buildable from atomic primitives** — no new SDK type.
- Test covers both branches (discard taken → otherwise skipped; discard declined → bin a face-up exiled card).

### Boneyard Desecrator — `{3}{B}` Creature — Zombie Mercenary 3/4 (Menace)
- `{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature. If an outlaw was sacrificed this way, create a Treasure token.`
- The outlaw rider is `Conditions.Any(SacrificedHadSubtype × Subtype.OUTLAW_TYPES)` reading the cost-sacrificed permanent's snapshot. **Backlog gap #17 is already covered** by the existing `SacrificedPermanentHadSubtype` condition + `AnyCondition`.
- Test covers outlaw-sacrificed (counter + Treasure) vs non-outlaw (counter, no Treasure).

Test fixture helper added: `GameTestDriver.putCardInExile` (face-up exile setup).

## mtgish-tooling (predictive auto-gen)

**Annie Joins Up is now a complete `AUTO` render.** Changes:
- `TargetRecovery`: recover "creature or planeswalker[, an opponent controls]" → `TargetObject(TargetFilter(GameObjectFilter.CreatureOrPlaneswalker[.youControl()/.opponentControls()]))`; render `IsSupertype Legendary` as `.legendary()` in `gameObjectFilterExpr`, declining any other supertype rather than silently dropping it.
- `Emitter` + `StaticAbilities`: `AbilitiesTriggerAnAdditionalTime` → `staticAbility { ability = AdditionalSourceTriggers(sourceFilter = …, excludeSelf = true) }`.
- Bridge: `effect("AbilitiesTriggerAnAdditionalTime", "AdditionalSourceTriggers")`.

**Binding Negotiation** (`MayCost` gate) and **Boneyard Desecrator** (`If` rider on a sacrifice-cost activated ability) are left at `SCAFFOLD` per the tooling's fidelity policy on gated / extra-cost shapes (the Creator's note) — declined, not lossily rendered.

## Gates
- `coverage-verify POR` → **GATE PASS (158/158)**.
- `EmitterGoldenTest` → green across all 9 vendored sets (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE).
- Only golden delta: one TMP scaffold-reason line (Excavator) — its basic-land cost filter now declines earlier (still a scaffold, no card emitted), a strictly-more-faithful change; golden re-blessed.
- OTJ is not a 0-mismatch set (pre-existing GATE FAIL); the remaining mismatches are unrelated pre-existing cards (e.g. Cactusfolk Sureshot). None of the three cards in this PR are in the mismatch list.
- `:mtg-sets` and `:mtgish-tooling` full suites pass; card snapshot golden re-blessed (only the 3 new cards added to OTJ.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)