### PR TITLE
Fix backend CI hang at :game-server:build (daemon scheduler + thread-dump watchdog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,36 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Build and test
-        run: ./gradlew build
+        # Wrapped in a watchdog: if the build hasn't finished within the timeout it is almost
+        # certainly the intermittent ":game-server:build" hang where a forked test-worker JVM
+        # never terminates (a lingering non-daemon thread). Before killing it we dump the stacks
+        # of every live JVM (Gradle daemon + test workers) so the exact blocking thread is named
+        # in the log instead of inferred. See SchedulingConfig / SessionRegistry for prior fixes.
+        run: |
+          set -uo pipefail
+          JPS="${JAVA_HOME}/bin/jps"
+          JSTACK="${JAVA_HOME}/bin/jstack"
+          WATCHDOG_TIMEOUT=$((20 * 60))
+
+          ./gradlew build &
+          BUILD_PID=$!
+
+          (
+            sleep "${WATCHDOG_TIMEOUT}"
+            echo "::error::Build exceeded ${WATCHDOG_TIMEOUT}s — assuming the :game-server:build hang. Dumping JVM threads."
+            for pid in $("${JPS}" -q); do
+              echo "===================== jstack ${pid} ====================="
+              "${JSTACK}" -l "${pid}" 2>&1 || true
+            done
+            echo "::error::Killing hung build."
+            kill -9 "${BUILD_PID}" 2>/dev/null || true
+          ) &
+          WATCHDOG_PID=$!
+
+          wait "${BUILD_PID}"
+          STATUS=$?
+          kill "${WATCHDOG_PID}" 2>/dev/null || true
+          exit "${STATUS}"
 
       - name: Generate coverage report
         run: ./gradlew koverXmlReport

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/SchedulingConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/SchedulingConfig.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.gameserver.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+/**
+ * Scheduler backing `@EnableScheduling` / `@Scheduled` (e.g. [com.wingedsheep.gameserver.session.ZombieSessionSweeper]).
+ *
+ * Defining a [org.springframework.scheduling.TaskScheduler] bean replaces the one Spring Boot would
+ * otherwise auto-create — and that default scheduler uses **non-daemon** threads (the `scheduling-N`
+ * threads). A live non-daemon thread keeps the JVM alive.
+ *
+ * In production the scheduler is stopped on context close, so daemon-ness is just a safety net there.
+ * It matters in tests: `@SpringBootTest` contexts are cached and only closed by a JVM shutdown hook,
+ * and a shutdown hook only fires once the JVM is *already* exiting — which a live non-daemon thread
+ * prevents. The Gradle test-worker JVM then never terminates after the last test, Gradle blocks
+ * waiting to reap it, and the backend CI build freezes at `:game-server:build` with `BUILD SUCCESSFUL`
+ * never printed. Daemon threads break that deadlock.
+ *
+ * This mirrors the same fix already applied to `SessionRegistry.disconnectScheduler`; that one was
+ * not the only non-daemon scheduler in the context.
+ */
+@Configuration
+class SchedulingConfig {
+
+    @Bean
+    fun taskScheduler(): ThreadPoolTaskScheduler =
+        ThreadPoolTaskScheduler().apply {
+            poolSize = 2
+            setThreadNamePrefix("scheduling-")
+            setDaemon(true)
+        }
+}


### PR DESCRIPTION
## Symptom

The backend CI job intermittently freezes at `:game-server:build`. The log shows the build is effectively **done** when it hangs:

- every test **PASSES**
- Spring fires its shutdown hook, Tomcat shuts down gracefully
- `koverGenerateArtifact` → `koverVerify` → `check` → `:game-server:build` all run
- then **minutes of silence** — `BUILD SUCCESSFUL` never prints — until the run is cancelled, leaving orphan `java` processes behind

(Confirmed on runs #732 and #734; #733 was cancelled mid-tests.)

Deploy is unaffected because `game-server/Dockerfile` runs `./gradlew :game-server:bootJar` — it never invokes the `test` task. The only thing CI does that deploy doesn't is run the full `@SpringBootTest(RANDOM_PORT)` integration tests.

## Root cause

The forked Gradle **test-worker JVM never terminates** after the last test, so Gradle blocks forever waiting to reap it. A JVM only exits once no **non-daemon** thread is alive.

PR #731 correctly daemonized `SessionRegistry.disconnectScheduler`, but its commit claim that it "was the only non-daemon executor/Timer in production code" was wrong. A live thread dump of the test worker still shows non-daemon threads inside the cached `@SpringBootTest` contexts:

| Thread | daemon? | Source |
|---|---|---|
| `session-disconnect-scheduler` | ✅ | fixed in #731 |
| **`scheduling-1`** | ❌ | `@EnableScheduling` → Spring's default `ThreadPoolTaskScheduler` (drives `ZombieSessionSweeper`) |
| `container-0`, `Catalina-utility-*` | ❌ | embedded Tomcat (closed on context close) |

Spring's default scheduler uses non-daemon threads and is stopped only on context close. Cached `@SpringBootTest` contexts only close on a JVM shutdown hook — which can't fire while a non-daemon thread is keeping the JVM up. Deadlock; intermittent because it depends on the shutdown-ordering race across the cached contexts.

## Changes

- **`SchedulingConfig`** — define the `taskScheduler` bean ourselves with daemon threads, replacing the non-daemon default that `@EnableScheduling` would auto-create. Same rationale as the `disconnectScheduler` fix; production still stops it on context close, daemon-ness is the safety net.
- **`ci.yml`** — wrap the build step in a watchdog: if the build overruns 20 minutes, `jstack` every live JVM (Gradle daemon + test workers) into the log, *then* kill it. The next hang names the exact blocking thread instead of us inferring it.

## Note on PR #723

#723 (`GameLimits`) was suspected, but it's pure engine arithmetic/caps — it spawns no threads and runs entirely inside the test, so it can't produce a "hang after all tests pass and the JVM is shutting down" signature. It does change the token-explosion worst case from "fast OOM crash" to "materialize up to 10k token entities," which could make a future AI game-server test slow — but that's not what these runs show. The watchdog will confirm-or-clear it either way.

## Validation

- `:game-server:compileKotlin` green.
- Could not reproduce the (intermittent) hang locally — `:game-server:test` passed in ~3m here. The watchdog is the mechanism to capture the definitive thread dump on the next CI hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)