### PR TITLE
Add Cyclone to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 67 / 78
+**Implemented:** 69 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -59,7 +59,7 @@
 - [x] Mijae Djinn
 - [x] Rukh Egg
 - [x] Ydwen Efreet
-- [ ] Cyclone
+- [x] Cyclone
 - [x] Desert Twister
 - [x] Drop of Honey
 - [x] Erhnam Djinn

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -510,10 +510,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `AddDynamicMana(amount, allowedColors, restriction?)` — split X across a fixed color set, distinct from `AddManaOfChoice` because it distributes the full X total across multiple colors rather than producing X copies of one chosen color.
 - `AddManaInAnyCombination(amount, allowedColors?, restriction?)` — "Add N mana in any combination of colors" (Wizard's Rockets, Thornvault Forager, Interdimensional Web Watch). Sugar for `AddDynamicMana`; `allowedColors` defaults to all five. The controller colors **each** pip independently at resolution (3+ colors → pip-by-pip color choice; 2 colors → one "how much of the first" prompt; ≤0 → no mana, no prompt), so the result can mix colors — distinct from `AddAnyColorMana`, where all N share one color.
 - `AddOneManaOfEachColorAmong(filter)` — one mana of *each* color found among matching permanents (Bloom Tender shape).
-- `PayDynamicMana(amount, payer?)` — pay a dynamically-computed amount of **generic** mana at resolution; the
+- `PayDynamicMana(amount, payer?, color?)` — pay a dynamically-computed amount of mana at resolution; the
   dynamic, payer-parametric twin of the flat `PayManaCostEffect`. `amount` is a [DynamicAmount](#dynamicamount)
   evaluated at resolution (0 pays nothing and succeeds); `payer` is a `Player` reference defaulting to the
-  controller (`Player.You`). This is the building block for **"pay {N} for each X"** templating — pair it with a
+  controller (`Player.You`). `color` defaults to null (pay `amount` **generic** mana); set it to a `Color` to pay
+  `amount` copies of that **colored** symbol instead — `color = Color.GREEN` → `{G}{G}…`, for "pay {G} for each
+  wind counter" (Cyclone). Affordability and the prompt label honor the color. This is the building block for **"pay {N} for each X"** templating — pair it with a
   pipeline selection and read the selection size via `DynamicAmount.Multiply(DynamicAmount.VariableReference("<collection>_count"), N)`
   — and for **"that player pays"** on each-player triggers (`payer = Player.TriggeringPlayer`, the only effect that
   charges a player other than the ability's controller). Affordability is recognized by `Gate.MayPay`, so wrapping

--- a/manual-scenarios/cards/c/cyclone.json
+++ b/manual-scenarios/cards/c/cyclone.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Cyclone", "counters": {"WIND": 2}},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "BEGINNING",
+  "step": "UPKEEP",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -48,7 +48,8 @@ enum class CounterType {
     VERSE,
     INFLUENCE,
     BURDEN,
-    LOOT
+    LOOT,
+    WIND
 }
 
 /**
@@ -133,6 +134,12 @@ object Counters {
      * activation cost to draw).
      */
     const val LOOT = "loot"
+
+    /**
+     * Wind counter (ARN — Cyclone). Passive counter accumulated each upkeep; the card reads the
+     * count to scale its pay-or-sacrifice cost and the damage it deals. No inherent rule.
+     */
+    const val WIND = "wind"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1189,9 +1189,10 @@ object Effects {
      */
     fun PayDynamicMana(
         amount: DynamicAmount,
-        payer: Player = Player.You
+        payer: Player = Player.You,
+        color: com.wingedsheep.sdk.core.Color? = null
     ): Effect =
-        com.wingedsheep.sdk.scripting.effects.PayDynamicManaCostEffect(amount, payer)
+        com.wingedsheep.sdk.scripting.effects.PayDynamicManaCostEffect(amount, payer, color)
 
     /**
      * Add mana of a color the player chooses from a [ManaColorSet] resolved at resolution

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
@@ -48,9 +48,17 @@ data class PayManaCostEffect(val cost: ManaCost) : Effect {
 data class PayDynamicManaCostEffect(
     val amount: DynamicAmount,
     val payer: com.wingedsheep.sdk.scripting.references.Player =
-        com.wingedsheep.sdk.scripting.references.Player.You
+        com.wingedsheep.sdk.scripting.references.Player.You,
+    /**
+     * When set, the evaluated [amount] is paid as that many copies of this colored symbol
+     * (e.g. `Color.GREEN` → `{G}{G}…`, for "pay {G} for each wind counter" — Cyclone). When null
+     * (the default) the amount is paid as generic mana (`{N}`).
+     */
+    val color: Color? = null
 ) : Effect {
-    override val description: String = "Pay {${amount.description}}"
+    override val description: String =
+        if (color != null) "Pay {${color.symbol}} for each (${amount.description})"
+        else "Pay {${amount.description}}"
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newAmount = amount.applyTextReplacement(replacer)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Cyclone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Cyclone.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cyclone
+ * {2}{G}{G}
+ * Enchantment
+ * At the beginning of your upkeep, put a wind counter on this enchantment, then sacrifice this
+ * enchantment unless you pay {G} for each wind counter on it. If you pay, this enchantment deals
+ * damage equal to the number of wind counters on it to each creature and each player.
+ *
+ * Composition:
+ *  - Each upkeep adds a wind counter (passive [Counters.WIND]), then the pay-or-sacrifice is an
+ *    `OptionalCostEffect` (Gate.MayPay): pay {G} per wind counter (a colored dynamic mana cost via
+ *    `Effects.PayDynamicMana(..., color = GREEN)`) → deal damage; decline → sacrifice.
+ *  - Both the cost amount and the damage scale off `DynamicAmounts.countersOnSelf(WIND)`, evaluated
+ *    after the counter is added so they see the incremented total (CR 608.2c sequencing).
+ *  - The damage hits each creature (`ForEachInGroup(AllCreatures, …)`) and each player.
+ */
+val Cyclone = card("Cyclone") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, put a wind counter on this enchantment, then " +
+        "sacrifice this enchantment unless you pay {G} for each wind counter on it. If you pay, " +
+        "this enchantment deals damage equal to the number of wind counters on it to each creature " +
+        "and each player."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+
+        val windCount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.WIND))
+
+        val dealDamageToAll = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter.AllCreatures,
+                DealDamageEffect(windCount, EffectTarget.Self)
+            ),
+            Effects.DealDamage(windCount, EffectTarget.PlayerRef(Player.Each))
+        )
+
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.WIND, 1, EffectTarget.Self),
+            OptionalCostEffect(
+                cost = Effects.PayDynamicMana(windCount, color = Color.GREEN),
+                ifPaid = dealDamageToAll,
+                ifNotPaid = Effects.SacrificeTarget(EffectTarget.Self)
+            )
+        )
+        description = "At the beginning of your upkeep, put a wind counter on this enchantment, then " +
+            "sacrifice this enchantment unless you pay {G} for each wind counter on it. If you pay, " +
+            "this enchantment deals damage equal to the number of wind counters on it to each creature and each player."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg?1562940349"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -755,6 +755,119 @@
     ]
 }
 
+// Cyclone
+{
+    "name": "Cyclone",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, put a wind counter on this enchantment, then sacrifice this enchantment unless you pay {G} for each wind counter on it. If you pay, this enchantment deals damage equal to the number of wind counters on it to each creature and each player.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "wind",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayPay",
+                                "cost": {
+                                    "type": "PayDynamicManaCost",
+                                    "amount": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": {
+                                                "type": "Named",
+                                                "name": "wind"
+                                            }
+                                        }
+                                    },
+                                    "color": "GREEN"
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "EntityProperty",
+                                                "entity": "Source",
+                                                "numericProperty": {
+                                                    "type": "CounterCount",
+                                                    "counterType": {
+                                                        "type": "Named",
+                                                        "name": "wind"
+                                                    }
+                                                }
+                                            },
+                                            "target": "Self"
+                                        }
+                                    },
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "wind"
+                                                }
+                                            }
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "Each"
+                                        }
+                                    }
+                                ]
+                            },
+                            "otherwise": {
+                                "type": "SacrificeTarget",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a wind counter on this enchantment, then sacrifice this enchantment unless you pay {G} for each wind counter on it. If you pay, this enchantment deals damage equal to the number of wind counters on it to each creature and each player."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Tedin",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg?1562940349"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dancing Scimitar
 {
     "name": "Dancing Scimitar",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -350,7 +350,10 @@ class GatedEffectExecutor(
         when (cost) {
             is PayManaCostEffect -> "Pay ${cost.cost}"
             is PayDynamicManaCostEffect -> {
-                val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context)
+                // Match the `amount <= 0` short-circuit that `execute()` and `canAfford()` apply
+                // before building a ManaCost: a non-positive amount pays nothing, and guarding here
+                // also avoids `"{G}".repeat(negative)` throwing from inside label rendering.
+                val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context).coerceAtLeast(0)
                 "Pay ${PayDynamicManaCostExecutor.dynamicManaCost(amount, cost.color)}"
             }
             else -> null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -351,7 +351,7 @@ class GatedEffectExecutor(
             is PayManaCostEffect -> "Pay ${cost.cost}"
             is PayDynamicManaCostEffect -> {
                 val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context)
-                "Pay {$amount}"
+                "Pay ${PayDynamicManaCostExecutor.dynamicManaCost(amount, cost.color)}"
             }
             else -> null
         }
@@ -367,7 +367,9 @@ class GatedEffectExecutor(
                 val payerId = TargetResolutionUtils
                     .resolvePlayerTarget(EffectTarget.PlayerRef(cost.payer), context, state)
                     ?: playerId
-                amount <= 0 || manaSolver.canPay(state, payerId, ManaCost.parse("{$amount}"))
+                amount <= 0 || manaSolver.canPay(
+                    state, payerId, PayDynamicManaCostExecutor.dynamicManaCost(amount, cost.color)
+                )
             }
             is PayLifeEffect -> {
                 val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/PayDynamicManaCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/PayDynamicManaCostExecutor.kt
@@ -46,6 +46,16 @@ class PayDynamicManaCostExecutor(
             .resolvePlayerTarget(EffectTarget.PlayerRef(effect.payer), context, state)
             ?: context.controllerId
 
-        return payManaCostFromPool(state, playerId, ManaCost.parse("{$amount}"), cardRegistry)
+        return payManaCostFromPool(state, playerId, dynamicManaCost(amount, effect.color), cardRegistry)
+    }
+
+    companion object {
+        /**
+         * Build the [ManaCost] for a [PayDynamicManaCostEffect]: `amount` generic mana when
+         * [color] is null, or `amount` copies of the colored symbol (`{G}{G}…`) otherwise.
+         */
+        fun dynamicManaCost(amount: Int, color: com.wingedsheep.sdk.core.Color?): ManaCost =
+            if (color != null) ManaCost.parse("{${color.symbol}}".repeat(amount))
+            else ManaCost.parse("{$amount}")
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CycloneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CycloneScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cyclone (ARN #45).
+ *
+ * "{2}{G}{G} Enchantment. At the beginning of your upkeep, put a wind counter on this enchantment,
+ *  then sacrifice this enchantment unless you pay {G} for each wind counter on it. If you pay, this
+ *  enchantment deals damage equal to the number of wind counters on it to each creature and each
+ *  player."
+ *
+ * Exercises the colored dynamic mana cost ({G} per wind counter via
+ * `Effects.PayDynamicMana(color = GREEN)`) gated by `OptionalCostEffect`: pay → damage to each
+ * creature and player; decline / can't pay → sacrifice.
+ */
+class CycloneScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cyclone upkeep") {
+
+            test("paying {G} per wind counter deals that much damage to each creature and player") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cyclone")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Mons's Goblin Raiders", summoningSickness = false) // 0/1
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders", summoningSickness = false) // 0/1
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                // Advance to Cyclone's controller's (player 1's) upkeep.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // First wind counter added → cost is {G}; pay it.
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("With 1 wind counter, Cyclone deals 1 to each player") {
+                    game.getLifeTotal(1) shouldBe 19
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("1 damage kills both 0/1 creatures") {
+                    game.isOnBattlefield("Mons's Goblin Raiders") shouldBe false
+                }
+                withClue("The cost was paid, so Cyclone is not sacrificed") {
+                    game.isOnBattlefield("Cyclone") shouldBe true
+                }
+            }
+
+            test("declining to pay sacrifices Cyclone and deals no damage") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cyclone")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // Decline the {G} payment.
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining the cost sacrifices Cyclone") {
+                    game.isOnBattlefield("Cyclone") shouldBe false
+                }
+                withClue("No damage is dealt when the cost isn't paid") {
+                    game.getLifeTotal(2) shouldBe 20
+                    game.isOnBattlefield("Mons's Goblin Raiders") shouldBe true
+                }
+            }
+
+            test("with no green mana available, Cyclone is sacrificed") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cyclone")
+                    // No lands — the {G} cost is unaffordable.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Unable to pay {G}, Cyclone sacrifices itself") {
+                    game.isOnBattlefield("Cyclone") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -104,4 +104,5 @@ export const counterManaClass: Record<string, string> = {
   INFLUENCE: 'counter-devotion',
   BURDEN: 'counter-doom',
   LOOT: 'counter-charge',
+  WIND: 'counter-vortex',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -652,6 +652,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.INFLUENCE,
   CounterType.BURDEN,
   CounterType.LOOT,
+  CounterType.WIND,
 ]
 
 /**

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1632,6 +1632,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   INFLUENCE: { bg: 'rgba(40, 20, 60, 0.95)', border: 'rgba(180, 130, 220, 0.6)', color: '#c898e0' },
   BURDEN: { bg: 'rgba(60, 25, 15, 0.95)', border: 'rgba(220, 160, 60, 0.7)', color: '#e8b860', glow: 'rgba(220, 160, 60, 0.6)' },
   LOOT: { bg: 'rgba(70, 55, 15, 0.95)', border: 'rgba(230, 200, 90, 0.7)', color: '#e8cf68', glow: 'rgba(230, 200, 90, 0.55)' },
+  WIND: { bg: 'rgba(20, 60, 55, 0.95)', border: 'rgba(120, 220, 200, 0.6)', color: '#9ce0d0' },
 }
 
 const fallbackCounterPalette: CounterBadgePalette = { bg: 'rgba(40, 40, 40, 0.95)', border: 'rgba(180, 180, 180, 0.6)', color: '#e0e0e0' }

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -356,6 +356,7 @@ export enum CounterType {
   INFLUENCE = 'INFLUENCE',
   BURDEN = 'BURDEN',
   LOOT = 'LOOT',
+  WIND = 'WIND',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -399,6 +400,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.INFLUENCE]: 'Influence',
   [CounterType.BURDEN]: 'Burden',
   [CounterType.LOOT]: 'Loot',
+  [CounterType.WIND]: 'Wind',
 }
 
 /**


### PR DESCRIPTION
Cyclone ({2}{G}{G} Enchantment): "At the beginning of your upkeep, put a
wind counter on this enchantment, then sacrifice this enchantment unless
you pay {G} for each wind counter on it. If you pay, this enchantment
deals damage equal to the number of wind counters on it to each creature
and each player."

New/extended primitives:
- WIND counter type (passive marker) wired across SDK (CounterType enum +
  Counters constant) and the web client's passive-counter rendering
  (enums, passive-counter list, icon, badge palette).
- PayDynamicManaCostEffect / Effects.PayDynamicMana gain an optional
  `color`: pay the evaluated amount as that many colored symbols
  ({G}{G}…) instead of generic mana — the building block for "pay {G}
  for each X" (cumulative-upkeep-shaped costs). Honored by the executor,
  and by Gate.MayPay's affordability check and prompt label.

The card composes these: each upkeep adds a wind counter, then an
OptionalCostEffect (Gate.MayPay) pays {G}×counters → damage to each
creature (ForEachInGroup) and each player, or sacrifices Cyclone on
decline / when unaffordable. Both cost and damage scale off
DynamicAmounts.countersOnSelf(WIND).

Scenario test covers pay→damage, decline→sacrifice, and
unaffordable→sacrifice. SDK reference updated.