### PR TITLE
Add Outlaw Stitcher, Rattleback Apothecary, Vadmir New Blood (OTJ) + mtgish auto-gen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutlawStitcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OutlawStitcher.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Outlaw Stitcher
+ * {3}{U}
+ * Creature — Human Warlock
+ * 1/4
+ *
+ * When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, then put two
+ * +1/+1 counters on that token for each spell you've cast this turn other than the first.
+ * Plot {4}{U}
+ *
+ * The ETB composes the atomic create-token + add-counters pipeline: [Effects.CreateToken] publishes
+ * the new token's entity id under [CREATED_TOKENS], and [Effects.AddDynamicCounters] addresses it via
+ * `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)`. The "two counters for each spell other than the
+ * first" amount is `2 * max(spellsCastThisTurn - 1, 0)`. Per the 2024-04-12 ruling, the count includes
+ * Outlaw Stitcher itself (if it wasn't the first spell), countered/unresolved spells, and spells still
+ * on the stack — exactly the `spellsCastThisTurnByPlayer` cast-history that [DynamicAmount.SpellsCastThisTurn]
+ * reads.
+ */
+val OutlawStitcher = card("Outlaw Stitcher") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Warlock"
+    power = 1
+    toughness = 4
+    oracleText = "When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, " +
+        "then put two +1/+1 counters on that token for each spell you've cast this turn other than the first.\n" +
+        "Plot {4}{U} (You may pay {4}{U} and exile this card from your hand. Cast it as a sorcery on a later " +
+        "turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.plot("{4}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // 2 counters per spell cast this turn other than the first: 2 * max(spellsCast - 1, 0).
+        val otherThanFirst = DynamicAmount.Max(
+            DynamicAmount.Subtract(
+                DynamicAmount.SpellsCastThisTurn(),
+                DynamicAmount.Fixed(1)
+            ),
+            DynamicAmount.Fixed(0)
+        )
+        val counterAmount = DynamicAmount.Multiply(otherThanFirst, 2)
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLUE, Color.BLACK),
+                creatureTypes = setOf("Zombie", "Rogue"),
+                imageUri = "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+            ),
+            Effects.AddDynamicCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = counterAmount,
+                target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+            )
+        )
+        description = "When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, " +
+            "then put two +1/+1 counters on that token for each spell you've cast this turn other than the first."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Alix Branwyn"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg?1712355468"
+
+        ruling("2024-04-12", "Outlaw Stitcher's ability will count all spells you've cast this turn except the first, including itself (if it wasn't the first spell), spells that were countered or didn't resolve, and spells that are still on the stack.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RattlebackApothecary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RattlebackApothecary.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rattleback Apothecary
+ * {2}{B}
+ * Creature — Gorgon Warlock
+ * 3/2
+ *
+ * Deathtouch
+ * Whenever you commit a crime, target creature you control gains your choice of menace or lifelink
+ * until end of turn.
+ *
+ * The crime trigger ([Triggers.YouCommitCrime]) targets a creature you control and offers a
+ * [ModalEffect.chooseOne] between two [GrantKeywordEffect]s — the same "your choice of keyword X or Y"
+ * shape as Manifold Mouse. Each mode grants its keyword to the chosen creature (ContextTarget(0)) for
+ * `Duration.EndOfTurn`. The crime-this-turn tracker is read at the engine's `CrimeDetector` emit site;
+ * this card only consumes [Triggers.YouCommitCrime].
+ */
+val RattlebackApothecary = card("Rattleback Apothecary") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Gorgon Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "Deathtouch\n" +
+        "Whenever you commit a crime, target creature you control gains your choice of menace or " +
+        "lifelink until end of turn. (Targeting opponents, anything they control, and/or cards in " +
+        "their graveyards is a crime.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(GrantKeywordEffect(Keyword.MENACE, t, Duration.EndOfTurn), "Menace"),
+            Mode.noTarget(GrantKeywordEffect(Keyword.LIFELINK, t, Duration.EndOfTurn), "Lifelink")
+        )
+        description = "Whenever you commit a crime, target creature you control gains your choice of " +
+            "menace or lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Loïc Canavaggia"
+        flavorText = "\"Looking for a little liquid courage? I also stock liquid murder, if that's what you're after.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg?1712355645"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VadmirNewBlood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VadmirNewBlood.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vadmir, New Blood
+ * {1}{B}
+ * Legendary Creature — Vampire Rogue
+ * 2/2
+ *
+ * Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability triggers only once each turn.
+ * As long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.
+ *
+ * The crime trigger is the same once-per-turn `+1/+1` self-counter shape as Blood Hustler. The
+ * keyword grants are two [ConditionalStaticAbility]s wrapping `GrantKeyword(kw, Filters.Self)`, gated by
+ * [Conditions.SourceCounterCountAtLeast]`(+1/+1, 4)` — re-evaluated from projected state, so
+ * menace/lifelink appear the moment the fourth counter lands and vanish if counters are removed below
+ * the threshold.
+ */
+val VadmirNewBlood = card("Vadmir, New Blood") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Vampire Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability triggers " +
+        "only once each turn. (Targeting opponents, anything they control, and/or cards in their " +
+        "graveyards is a crime.)\n" +
+        "As long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink."
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = AddCountersEffect(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = EffectTarget.Self
+        )
+        description = "Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability " +
+            "triggers only once each turn."
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.MENACE, Filters.Self),
+            condition = Conditions.SourceCounterCountAtLeast(Counters.PLUS_ONE_PLUS_ONE, 4)
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.LIFELINK, Filters.Self),
+            condition = Conditions.SourceCounterCountAtLeast(Counters.PLUS_ONE_PLUS_ONE, 4)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Andreas Zafiratos"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg?1712355705"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "A player can commit only one crime per spell or ability they control. Targeting multiple opponents, permanents, spells, abilities, and/or cards with the same spell or ability doesn't constitute committing multiple crimes.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -9218,6 +9218,100 @@
     ]
 }
 
+// Outlaw Stitcher
+{
+    "name": "Outlaw Stitcher",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, then put two +1/+1 counters on that token for each spell you've cast this turn other than the first.\nPlot {4}{U} (You may pay {4}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{4}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "BLUE",
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Zombie",
+                                "Rogue"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "Multiply",
+                                "amount": {
+                                    "type": "Max",
+                                    "left": {
+                                        "type": "Subtract",
+                                        "left": "SpellsCastThisTurn",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                },
+                                "multiplier": 2
+                            },
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, then put two +1/+1 counters on that token for each spell you've cast this turn other than the first."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Alix Branwyn",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg?1712355468",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Outlaw Stitcher's ability will count all spells you've cast this turn except the first, including itself (if it wasn't the first spell), spells that were countered or didn't resolve, and spells that are still on the stack."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Outlaws' Fury
 {
     "name": "Outlaws' Fury",
@@ -10489,6 +10583,75 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rattleback Apothecary
+{
+    "name": "Rattleback Apothecary",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Gorgon Warlock",
+    "oracleText": "Deathtouch\nWhenever you commit a crime, target creature you control gains your choice of menace or lifelink until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            "description": "Menace"
+                        },
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "LIFELINK",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            "description": "Lifelink"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you commit a crime, target creature you control gains your choice of menace or lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "UNCOMMON",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "\"Looking for a little liquid courage? I also stock liquid murder, if that's what you're after.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg?1712355645"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -14471,6 +14634,116 @@
             {
                 "date": "2024-04-12",
                 "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vadmir, New Blood
+{
+    "name": "Vadmir, New Blood",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Vampire Rogue",
+    "oracleText": "Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nAs long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability triggers only once each turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "MENACE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "+1/+1"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "+1/+1"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "RARE",
+        "artist": "Andreas Zafiratos",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg?1712355705",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "A player can commit only one crime per spell or ability they control. Targeting multiple opponents, permanents, spells, abilities, and/or cards with the same spell or ability doesn't constitute committing multiple crimes."
             }
         ]
     },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -516,6 +516,36 @@ private fun EmitCtx.youCommittedCrimeConditionDsl(condNode: JsonElement?): Strin
 }
 
 /**
+ * "this permanent has N or more +1/+1 counters on it"
+ * (`PermanentPassesFilter(ThisPermanent, HasNumCountersOfType(GreaterThanOrEqualTo Integer N,
+ * PTCounter(1,1)))`, Vadmir, New Blood) -> the `Conditions.SourceCounterCountAtLeast(
+ * Counters.PLUS_ONE_PLUS_ONE, N)` DSL string, or null when the subject isn't ThisPermanent, the
+ * comparison isn't `>= N`, or the counter isn't the bare ±1/±1 counter. Used by the [ifRuleBlock]
+ * static gates (Vadmir's "menace and lifelink at 4+ counters"). The predicate reads the source's
+ * counter map under projection, so the gated keywords appear/vanish as counters cross the threshold.
+ *
+ * Only the bare `PTCounter(1,1)` (+1/+1) renders here — a keyword/named counter threshold has different
+ * `Counters.*` plumbing and would change meaning, so it declines (-> SCAFFOLD).
+ */
+private fun EmitCtx.sourceCounterCountAtLeastConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PermanentPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Permanent") != "ThisPermanent") return null
+    val has = args.getOrNull(1) as? JsonObject ?: return null
+    if (has.strField("_Permanents") != "HasNumCountersOfType") return null
+    val hArgs = has["args"].asArr ?: return null
+    val comparison = hArgs.getOrNull(0) as? JsonObject ?: return null
+    if (comparison.strField("_Comparison") != "GreaterThanOrEqualTo") return null
+    val n = (comparison["args"] as? JsonObject)?.takeIf { it.strField("_GameNumber") == "Integer" }
+        ?.get("args").asInt() ?: return null
+    val counter = hArgs.getOrNull(1) as? JsonObject ?: return null
+    val pt = counter.takeIf { it.strField("_CounterType") == "PTCounter" }?.get("args").asArr
+    if (pt?.getOrNull(0).asInt() != 1 || pt?.getOrNull(1).asInt() != 1) return null
+    return "Conditions.SourceCounterCountAtLeast(Counters.PLUS_ONE_PLUS_ONE, $n)"
+}
+
+/**
  * `If{cond}[rules]` permanent rule -> one or more `staticAbility { ability = ... }` blocks gating a
  * continuous effect on a condition. Renders only the exact shapes we can express faithfully:
  *
@@ -605,30 +635,45 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
     //   If(PlayerPassesFilter(You, CommitedACrimeThisTurn))
     //     [ PermanentLayerEffect(ThisPermanent, [ AdjustPT(p, t) ]) ]
     // -> ConditionalStaticAbility(ModifyStats(p, t, Filters.Self), Conditions.YouCommittedCrimeThisTurn).
-    // Only the SELF "grant a single keyword to this permanent" or "fixed +p/+t to this permanent"
-    // inner shape renders; any other layer effect (dynamic P/T, multi-keyword, group filter) declines
+    // Vadmir, New Blood: "As long as Vadmir has four or more +1/+1 counters on it, it has menace and
+    //   lifelink." — same SELF gated-static shape, but the gate is a counter-count threshold and the
+    //   layer effect carries *two* keyword grants:
+    //   If(PermanentPassesFilter(ThisPermanent, HasNumCountersOfType(>= 4, PTCounter(1,1))))
+    //     [ PermanentLayerEffect(ThisPermanent, [ AddAbility(Menace), AddAbility(Lifelink) ]) ]
+    // -> one ConditionalStaticAbility(GrantKeyword(kw, Filters.Self), SourceCounterCountAtLeast(+1/+1, 4))
+    //    per granted keyword.
+    // Only the SELF "grant keyword(s) to this permanent" or "fixed +p/+t to this permanent" inner shape
+    // renders; any other layer effect (dynamic P/T, group filter, non-keyword AddAbility) declines
     // -> SCAFFOLD.
     if (innerRule.strField("_Rule") == "PermanentLayerEffect" &&
         jsonContains(innerRule, "_Permanent", "ThisPermanent")
     ) {
         val condDsl = youHaventCastASpellConditionDsl(cond)
             ?: youCommittedCrimeConditionDsl(cond)
+            ?: sourceCounterCountAtLeastConditionDsl(cond)
             ?: run { reasons.add("If"); return null }
         val layerEffects = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
-        val le = layerEffects?.singleOrNull()
-        when (le?.strField("_StaticLayerEffect")) {
-            "AddAbility" -> {
+            ?: run { reasons.add("If"); return null }
+        // All-AddAbility layer effects: grant each bare keyword to SELF, gated on the same condition.
+        // One layer effect or several (Vadmir grants two) — emit one ConditionalStaticAbility per keyword.
+        if (layerEffects.isNotEmpty() && layerEffects.all { it.strField("_StaticLayerEffect") == "AddAbility" }) {
+            val keywords = layerEffects.map { le ->
                 // An AddAbility whose granted rule is anything richer than a plain keyword (an activated
                 // ability, landwalk, protection-from-color) isn't a bare keyword grant — decline.
                 val granted = (le["args"] as? JsonArray)?.singleOrNull() as? JsonObject
                 if (granted?.strField("_Rule") != null && granted.size > 1) { reasons.add("If"); return null }
-                val kw = keywordOf(le) ?: run { reasons.add("If"); return null }
-                return listOf(staticAbilityStmt(call(
+                keywordOf(le) ?: run { reasons.add("If"); return null }
+            }
+            return keywords.map { kw ->
+                staticAbilityStmt(call(
                     "ConditionalStaticAbility",
                     arg("ability", call("GrantKeyword", arg("Keyword.$kw"), arg("Filters.Self"))),
                     arg("condition", Lit(condDsl)),
-                )))
+                ))
             }
+        }
+        val le = layerEffects.singleOrNull()
+        when (le?.strField("_StaticLayerEffect")) {
             "AdjustPT" -> {
                 // A fixed +p/+t buff: `args` is the [p, t] pair. Anything else (a dynamic AdjustPTX /
                 // AdjustPTForEach) declines rather than dropping the variable count.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -132,6 +132,7 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     echoEffect(actions)?.let { return it }
     counterUnlessPaysEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
+    chooseAbilityGrantEffect(actions, tvar)?.let { return it }
     chooseTypeModifyStatsEffect(actions)?.let { return it }
     chooseCreatureTypeRevealTopEffect(actions)?.let { return it }
     impulseExileTopMayPlay(actions)?.let { return it }
@@ -309,6 +310,12 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
             val argv = node["args"].asArr ?: return null
             val spellsNode = argv.firstOrNull { (it as? JsonObject)?.containsKey("_Spells") == true } as? JsonObject
             val playerNode = argv.firstOrNull { (it as? JsonObject)?.containsKey("_Player") == true } as? JsonObject
+            // "the number of spells you've cast this turn other than the first" (Outlaw Stitcher) —
+            // mtgish models the "other than the first" exclusion as `Other(TheNthSpellCastByPlayerThisTurn(
+            // 1, AnySpell, <player>))`. The engine has no "Nth-spell" exclusion, so render it as the
+            // arithmetic equivalent: max(spellsCastThisTurn - 1, 0). Only the You-scoped, any-spell,
+            // exclude-the-FIRST shape collapses; any other Nth / filter / scope declines (-> SCAFFOLD).
+            spellsCastExcludingFirstAmount(spellsNode, playerNode)?.let { return it }
             val filter = spellsCastThisTurnFilter(spellsNode) ?: return null
             val player = spellsCastThisTurnPlayer(playerNode) ?: return null
             return call("DynamicAmount.SpellsCastThisTurn", arg(player), arg(filter))
@@ -490,6 +497,43 @@ private fun spellsCastThisTurnFilter(spells: JsonObject?): String? = when (spell
     "IsCardtype" -> if (spells.field("args").asStr() == "Creature") "GameObjectFilter.Creature" else null
     "IsNonCardtype" -> if (spells.field("args").asStr() == "Creature") "GameObjectFilter.Noncreature" else null
     else -> null
+}
+
+/**
+ * "the number of spells <player> has cast this turn other than the first" -> a
+ * `DynamicAmount.Max(DynamicAmount.Subtract(DynamicAmount.SpellsCastThisTurn(<player>), Fixed(1)),
+ * Fixed(0))` expression (Outlaw Stitcher), or null when the shape isn't exactly
+ * `Other(TheNthSpellCastByPlayerThisTurn(1, AnySpell, <player>))`.
+ *
+ * mtgish has no "all spells except the Nth" count, so it nests the exclusion as an `Other` of the
+ * first (Nth = 1) cast. The engine's `SpellsCastThisTurn` counts ALL casts (it has no Nth concept),
+ * so "all but the first" is `total - 1`, clamped at 0 (a turn with zero or one spell yields 0). Only
+ * the exclude-the-FIRST, any-spell shape with a [spellsCastThisTurnPlayer]-renderable scope collapses;
+ * excluding any other ordinal, a filtered spell set, or a mismatched player declines (-> SCAFFOLD).
+ */
+private fun EmitCtx.spellsCastExcludingFirstAmount(spells: JsonObject?, playerNode: JsonObject?): Dsl? {
+    if (spells?.strField("_Spells") != "Other") return null
+    val nth = spells["args"] as? JsonObject ?: return null
+    if (nth.strField("_Spell") != "TheNthSpellCastByPlayerThisTurn") return null
+    val nthArgs = nth["args"].asArr ?: return null
+    // [ordinal, spell filter, player]. The excluded ordinal must be the FIRST (1) and the set AnySpell.
+    val ordinal = (nthArgs.getOrNull(0) as? JsonObject)
+        ?.takeIf { it.strField("_GameNumber") == "Integer" }?.get("args").asInt()
+    if (ordinal != 1) return null
+    if ((nthArgs.getOrNull(1) as? JsonObject)?.strField("_Spells") != "AnySpell") return null
+    // The Nth-spell's caster and the outer count's player must be the same renderable scope.
+    val innerPlayer = nthArgs.getOrNull(2) as? JsonObject
+    val player = spellsCastThisTurnPlayer(playerNode) ?: return null
+    if (spellsCastThisTurnPlayer(innerPlayer) != player) return null
+    return call(
+        "DynamicAmount.Max",
+        arg(call(
+            "DynamicAmount.Subtract",
+            arg(call("DynamicAmount.SpellsCastThisTurn", arg(player), arg("GameObjectFilter.Any"))),
+            arg(call("DynamicAmount.Fixed", arg("1"))),
+        )),
+        arg(call("DynamicAmount.Fixed", arg("0"))),
+    )
 }
 
 /** The `Player.*` scope for a [NumSpellsCastByPlayerThisTurn] player ref, or null for a scope we don't
@@ -684,6 +728,60 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
     val parts = mutableListOf(arg("target", Lit(target)))
     if (excluded != null) parts.add(arg("excludedTypes", "listOf(\"${ktStr(excluded)}\")"))
     return Call("BecomeCreatureTypeEffect", parts)
+}
+
+/**
+ * [ChooseAnAbility([kw1, kw2, …]), CreatePermanentLayerEffectUntil(Ref_TargetPermanent,
+ * [AddAbilityVariable(TheChosenAbility)], UntilEndOfTurn)] -> a single
+ * `ModalEffect.chooseOne(Mode.noTarget(GrantKeywordEffect(Keyword.X, <target>, Duration.EndOfTurn),
+ * "X"), …)` ("target … gains your choice of <kw1> or <kw2> until end of turn", Rattleback Apothecary).
+ *
+ * mtgish models "your choice of keyword X or Y" as a `ChooseAnAbility` action listing the keyword
+ * options, then a single layer effect that grants `TheChosenAbility`. The engine has no "chosen
+ * ability variable", so the choice is reified as a `ModalEffect.chooseOne` over one
+ * [GrantKeywordEffect] per option — each granting its keyword to the same target for end of turn. The
+ * mode label is the option's display name (the IR `_Rule` string, e.g. "Menace"), matching the engine's
+ * `Keyword.displayName`.
+ *
+ * Renders only the exact shape: every option a bare keyword the SDK knows, the layer effect a lone
+ * `AddAbilityVariable(TheChosenAbility)` collapsing at end of turn, on a recoverable target. Anything
+ * else (a non-keyword option, a riding +P/T, a non-EOT window, a richer layer-effect list) declines
+ * (null -> SCAFFOLD) rather than emit a lossy grant.
+ */
+internal fun EmitCtx.chooseAbilityGrantEffect(actions: List<JsonObject>, tvar: String?): Dsl? {
+    val chooser = actions.firstOrNull { it.strField("_Action") == "ChooseAnAbility" } ?: return null
+    val layer = actions.firstOrNull {
+        it.strField("_Action") in setOf("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil")
+    } ?: return null
+    // The pair must be the WHOLE effect — a third action would be dropped.
+    if (actions.size != 2) return null
+    // Layer effect: exactly the chosen-ability grant, collapsing at end of turn.
+    if (!jsonContains(layer, "_LayerEffect", "AddAbilityVariable")) return null
+    if (!jsonContains(layer, "_AbilityVariable", "TheChosenAbility")) return null
+    if (jsonContains(layer, "_LayerEffect", "AdjustPT")) return null
+    if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null
+    val layerEffects = (layer["args"].asArr)?.getOrNull(1) as? JsonArray ?: return null
+    if (layerEffects.size != 1) return null  // a lone chosen-ability grant; a riding effect declines
+    val target = refTarget(layer["args"], tvar) ?: return null
+    // The options: each a bare keyword rule the SDK knows. A non-keyword or parameterized option declines.
+    val options = chooser["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    if (options.size < 2) return null
+    val modes = options.map { opt ->
+        if (opt["args"] != null) return null  // a parameterized ability, not a bare keyword
+        val rule = opt.strField("_Rule") ?: return null
+        val kw = pascalToUpperSnake(rule).takeIf { it in keywords } ?: return null
+        call(
+            "Mode.noTarget",
+            arg(call(
+                "GrantKeywordEffect",
+                arg("Keyword.$kw"),
+                arg(Lit(target)),
+                arg("Duration.EndOfTurn"),
+            )),
+            arg(Lit("\"${ktStr(rule)}\"")),
+        )
+    }
+    return Call("ModalEffect.chooseOne", modes.map { arg(it) })
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -131,6 +131,27 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         call("AddCountersEffect", arg("counterType", counter), arg("count", "$count"), arg("target", tgt))
     }
 
+    on("PutNumberCountersOfTypeOnEachPermanent") { _, args, tvar ->
+        // "Put N <counter> counters on <permanents>." — the mass / dynamic-count form. IR args are
+        // [<amount>, <counterType>, <permanents>]. The only recipient we render here is the just-created
+        // token (`TheTokensCreatedThisWay` -> the CREATED_TOKENS pipeline slot, Outlaw Stitcher: "put two
+        // +1/+1 counters on that token for each spell …"); a real "each <group>" filter would need a
+        // ForEach over the group, which this handler deliberately leaves to scaffold. The amount may be
+        // dynamic, so render through AddDynamicCounters with the recovered DynamicAmount. Only the named
+        // ±1/±1 / keyword counters render; an unrenderable amount or non-token recipient declines.
+        val arr = args.asArr ?: return@on null
+        val counter = counterTypeDsl(arr.getOrNull(1)) ?: return@on null
+        val recipient = arr.getOrNull(2) as? JsonObject ?: return@on null
+        if (recipient.strField("_Permanents") != "TheTokensCreatedThisWay") return@on null
+        val amount = dynamicAmount(arr.getOrNull(0)) ?: return@on null
+        call(
+            "Effects.AddDynamicCounters",
+            arg("counterType", counter),
+            arg("amount", Lit(amount)),
+            arg("target", "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"),
+        )
+    }
+
     on("CreateReplaceWouldPutCountersUntil") { node, _, _ ->
         // "Until end of turn, if you would put one or more +1/+1 counters on a creature you control,
         // put that many plus N +1/+1 counters on it instead." (Prairie Dog's {4}{W}.) This installs the

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutlawStitcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutlawStitcherScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.OutlawStitcher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Outlaw Stitcher — {3}{U} 1/4 Creature — Human Warlock
+ *
+ * "When this creature enters, create a 2/2 blue and black Zombie Rogue creature token, then put two
+ * +1/+1 counters on that token for each spell you've cast this turn other than the first."
+ *
+ * Verifies the ETB pipeline: a fresh Zombie Rogue token is created and receives
+ * `2 * max(spellsCastThisTurn - 1, 0)` +1/+1 counters, addressing the just-created token via the
+ * CREATED_TOKENS pipeline collection.
+ */
+class OutlawStitcherScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(OutlawStitcher)
+        return driver
+    }
+
+    fun tokenCounters(driver: GameTestDriver, me: EntityId): Int {
+        val token = driver.getCreatures(me).single { driver.getCardName(it) == "Zombie Rogue Token" }
+        return driver.state.getEntity(token)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    test("as the only spell this turn, the token gets no counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val stitcher = driver.putCardInHand(me, "Outlaw Stitcher")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.castSpell(me, stitcher)
+        driver.bothPass() // resolve Outlaw Stitcher -> ETB trigger on stack
+        driver.bothPass() // resolve ETB trigger
+
+        // First (and only) spell -> "other than the first" = 0 -> 0 counters, a vanilla 2/2.
+        tokenCounters(driver, me) shouldBe 0
+        val token = driver.getCreatures(me).single { driver.getCardName(it) == "Zombie Rogue Token" }
+        driver.state.projectedState.getPower(token) shouldBe 2
+        driver.state.projectedState.getToughness(token) shouldBe 2
+    }
+
+    test("with two prior spells, the token gets four +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Cast two Lightning Bolts this turn before the Stitcher.
+        repeat(2) {
+            val bolt = driver.putCardInHand(me, "Lightning Bolt")
+            driver.giveMana(me, Color.RED, 1)
+            driver.castSpell(me, bolt, targets = listOf(opp))
+            driver.bothPass()
+        }
+
+        // Outlaw Stitcher is the third spell: other-than-first = 2 -> 2*2 = 4 counters.
+        val stitcher = driver.putCardInHand(me, "Outlaw Stitcher")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.castSpell(me, stitcher)
+        driver.bothPass() // resolve Outlaw Stitcher -> ETB trigger
+        driver.bothPass() // resolve ETB trigger
+
+        tokenCounters(driver, me) shouldBe 4
+        val token = driver.getCreatures(me).single { driver.getCardName(it) == "Zombie Rogue Token" }
+        driver.state.projectedState.getPower(token) shouldBe 6
+        driver.state.projectedState.getToughness(token) shouldBe 6
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RattlebackApothecaryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RattlebackApothecaryScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RattlebackApothecary
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rattleback Apothecary — {2}{B} 3/2 Creature — Gorgon Warlock
+ *
+ * "Deathtouch"
+ * "Whenever you commit a crime, target creature you control gains your choice of menace or lifelink
+ * until end of turn."
+ *
+ * Verifies the crime trigger targets a creature you control and grants the chosen keyword (menace or
+ * lifelink) until end of turn, plus the static Deathtouch.
+ */
+class RattlebackApothecaryScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RattlebackApothecary)
+        return driver
+    }
+
+    test("Rattleback Apothecary has deathtouch") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val apothecary = driver.putCreatureOnBattlefield(me, "Rattleback Apothecary")
+        projector.project(driver.state).hasKeyword(apothecary, Keyword.DEATHTOUCH) shouldBe true
+    }
+
+    test("committing a crime grants the chosen creature menace until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val apothecary = driver.putCreatureOnBattlefield(me, "Rattleback Apothecary")
+
+        // Commit a crime: cast Lightning Bolt at the opponent.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+
+        // The crime trigger goes on the stack above Bolt and asks for its target first.
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(me, listOf(apothecary))
+        driver.bothPass() // resolve the crime trigger -> modal choice
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        modeDecision.options shouldBe listOf("Menace", "Lifelink")
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 0))
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(apothecary, Keyword.MENACE) shouldBe true
+        projected.hasKeyword(apothecary, Keyword.LIFELINK) shouldBe false
+    }
+
+    test("choosing lifelink grants lifelink instead") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val apothecary = driver.putCreatureOnBattlefield(me, "Rattleback Apothecary")
+
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(me, listOf(apothecary))
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 1))
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(apothecary, Keyword.LIFELINK) shouldBe true
+        projected.hasKeyword(apothecary, Keyword.MENACE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VadmirNewBloodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VadmirNewBloodScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.VadmirNewBlood
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vadmir, New Blood — {1}{B} 2/2 Legendary Creature — Vampire Rogue
+ *
+ * "Whenever you commit a crime, put a +1/+1 counter on Vadmir. This ability triggers only once each turn."
+ * "As long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink."
+ *
+ * Verifies: the crime trigger adds a counter once per turn; menace+lifelink turn on only at 4+ counters
+ * and turn off again below the threshold (static ability re-evaluated from projected state).
+ */
+class VadmirNewBloodScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(VadmirNewBlood)
+        return driver
+    }
+
+    fun setCounters(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            container.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    test("committing a crime adds a +1/+1 counter, but only once per turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val vadmir = driver.putCreatureOnBattlefield(me, "Vadmir, New Blood")
+
+        driver.state.projectedState.getPower(vadmir) shouldBe 2
+
+        // First crime this turn -> one counter.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> crime -> counter trigger on stack
+        driver.bothPass() // resolve counter trigger
+        driver.state.projectedState.getPower(vadmir) shouldBe 3
+
+        // Second crime same turn -> once-per-turn gate, no extra counter.
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        driver.bothPass()
+        driver.bothPass()
+        driver.state.projectedState.getPower(vadmir) shouldBe 3
+    }
+
+    test("menace and lifelink switch on at 4 counters and off below it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val vadmir = driver.putCreatureOnBattlefield(me, "Vadmir, New Blood")
+
+        // Three counters: still below threshold, no menace/lifelink.
+        setCounters(driver, vadmir, 3)
+        var projected = projector.project(driver.state)
+        projected.hasKeyword(vadmir, Keyword.MENACE) shouldBe false
+        projected.hasKeyword(vadmir, Keyword.LIFELINK) shouldBe false
+
+        // Fourth counter: menace + lifelink turn on.
+        setCounters(driver, vadmir, 4)
+        projected = projector.project(driver.state)
+        projected.hasKeyword(vadmir, Keyword.MENACE) shouldBe true
+        projected.hasKeyword(vadmir, Keyword.LIFELINK) shouldBe true
+
+        // Drop back to 3: keywords turn off again.
+        setCounters(driver, vadmir, 3)
+        projected = projector.project(driver.state)
+        projected.hasKeyword(vadmir, Keyword.MENACE) shouldBe false
+        projected.hasKeyword(vadmir, Keyword.LIFELINK) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
Implements three **Outlaws of Thunder Junction** creatures and extends the `mtgish-tooling` emitter so all three auto-generate as clean AUTO matches.

| Card | Effect |
|------|--------|
| Outlaw Stitcher | ETB creates a 2/2 blue-and-black Zombie Rogue token |
| Rattleback Apothecary | Deathtouch outlaw payoff |
| Vadmir, New Blood | Commit-a-crime → +1/+1 counter growth |

## mtgish-tooling
Emitter changes in `CardStructure.kt`, `EmitCtx.kt`, and `TapLayerStateHandlers.kt` so these cards render correctly. Followed the hard rule — render correctly or decline to SCAFFOLD; no lossy approximations.

## Verification
- ✅ `rules-engine` scenario tests pass for all three cards
- ✅ `mtg-sets` `CardDefinitionSnapshotTest` + `CardLintTest` pass (OTJ snapshot re-blessed)
- ✅ mtgish **POR gate: PASS (158/158)** — no emitter regression
- ✅ mtgish OTJ: the three new cards are clean AUTO matches. Remaining OTJ gameplay-tree mismatches (Cactusfolk Sureshot, Freestrider Lookout, Thunder Lasso) are **pre-existing and unrelated** to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)