### PR TITLE
Add Breeches, the Blastmaker / Magda, the Hoardmaster / Jolene, Plundering Pugilist (OTJ) + mtgish auto-gen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BreechesTheBlastmaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BreechesTheBlastmaker.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Breeches, the Blastmaker
+ * {1}{U}{R}
+ * Legendary Creature — Goblin Pirate
+ * 3/3
+ * Menace
+ * Whenever you cast your second spell each turn, you may sacrifice an artifact. If you do,
+ * flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy.
+ * When you lose the flip, Breeches deals damage equal to that spell's mana value to any target.
+ *
+ * Modeling notes:
+ * - "your second spell each turn" → [Triggers.NthSpellCast] with n = 2, player = You.
+ * - "you may sacrifice an artifact. If you do, …" → [OptionalCostEffect]: the optional
+ *   [SacrificeEffect] cost gates the coin flip (declining or having no artifact skips the flip,
+ *   matching the ruling that neither delayed trigger fires unless an artifact is sacrificed).
+ * - The flip's branches copy the triggering spell ([EffectTarget.TriggeringEntity]) and deal
+ *   damage equal to its mana value.
+ *
+ * Timing deviation (documented): Scryfall rules the trigger needs no target, and the lose-flip
+ * target is chosen only after the coin is lost. The engine declares targets on the ability, so
+ * the "any target" for the damage is chosen when the trigger is put on the stack. This is the
+ * same idiom used by Risky Move (choose target up front, then flip). The only behavioral
+ * difference is the moment of target selection; the copy/damage outcomes are identical.
+ */
+val BreechesTheBlastmaker = card("Breeches, the Blastmaker") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Goblin Pirate"
+    power = 3
+    toughness = 3
+    oracleText = "Menace\n" +
+        "Whenever you cast your second spell each turn, you may sacrifice an artifact. " +
+        "If you do, flip a coin. When you win the flip, copy that spell. You may choose new " +
+        "targets for the copy. When you lose the flip, Breeches deals damage equal to that " +
+        "spell's mana value to any target."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        val damageTarget = target("any target", Targets.Any)
+        effect = OptionalCostEffect(
+            cost = SacrificeEffect(filter = GameObjectFilter.Artifact),
+            ifPaid = FlipCoinEffect(
+                wonEffect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity),
+                lostEffect = Effects.DealDamage(
+                    amount = DynamicAmount.EntityProperty(
+                        EntityReference.Triggering,
+                        EntityNumericProperty.ManaValue
+                    ),
+                    target = damageTarget
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "197"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg?1712356062"
+
+        ruling("2024-04-12", "Spells that were cast before Breeches entered the battlefield count. If Breeches was the first spell you cast this turn, the next spell you cast this turn is your second spell.")
+        ruling("2024-04-12", "Breeches's triggered ability triggers without requiring a target. It sets up two delayed triggered abilities: one that triggers when you win the flip, and one that triggers when you lose the flip. Only one of these abilities will trigger, based on the result of the flip.")
+        ruling("2024-04-12", "If you don't sacrifice an artifact, you won't flip a coin, and neither delayed triggered ability will trigger.")
+        ruling("2024-04-12", "If you win the flip, the copy created by Breeches's delayed triggered ability will have the same targets as the spell it's copying unless you choose new ones.")
+        ruling("2024-04-12", "The copy made by Breeches's delayed triggered ability is created on the stack, so it's not \"cast.\"")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/JolenePlunderingPugilist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/JolenePlunderingPugilist.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Jolene, Plundering Pugilist
+ * {1}{R}{G}
+ * Legendary Creature — Human Mercenary
+ * 4/2
+ * Whenever you attack with one or more creatures with power 4 or greater, create a Treasure token.
+ * {1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target.
+ *
+ * Modeling notes:
+ * - The attack trigger is [Triggers.YouAttackWithFilter] over `Creature.powerAtLeast(4)`. It fires
+ *   once per combat when at least one declared attacker has power ≥ 4 (evaluated under projected
+ *   state, so pumps/anthems count). Jolene herself qualifies (4 power).
+ * - The activated ability sacrifices a Treasure as part of its cost and deals 1 damage to any target.
+ */
+val JolenePlunderingPugilist = card("Jolene, Plundering Pugilist") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Mercenary"
+    power = 4
+    toughness = 2
+    oracleText = "Whenever you attack with one or more creatures with power 4 or greater, create " +
+        "a Treasure token.\n" +
+        "{1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.CreateTreasure(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.Sacrifice(GameObjectFilter.Artifact.withSubtype("Treasure"))
+        )
+        val damageTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, damageTarget)
+        description = "{1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"So, are we doing this the easy way or the fun way?\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg?1712356118"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MagdaTheHoardmaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MagdaTheHoardmaster.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Magda, the Hoardmaster
+ * {1}{R}
+ * Legendary Creature — Dwarf Berserker
+ * 2/2
+ * Whenever you commit a crime, create a tapped Treasure token. This ability triggers only
+ * once each turn.
+ * Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and
+ * haste. Activate only as a sorcery.
+ *
+ * Modeling notes:
+ * - The crime payoff is [Triggers.YouCommitCrime] with `oncePerTurn = true` (CR rules the
+ *   ability triggers at most once per turn). The Treasure enters tapped.
+ * - The activated ability pays by sacrificing three Treasures ([Costs.SacrificeMultiple] over
+ *   the Treasure subtype) and is restricted to sorcery speed via [TimingRule.SorcerySpeed].
+ */
+val MagdaTheHoardmaster = card("Magda, the Hoardmaster") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Berserker"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you commit a crime, create a tapped Treasure token. This ability " +
+        "triggers only once each turn. (Targeting opponents, anything they control, and/or " +
+        "cards in their graveyards is a crime.)\n" +
+        "Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with " +
+        "flying and haste. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = Effects.CreateTreasure(1, tapped = true)
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeMultiple(3, GameObjectFilter.Artifact.withSubtype("Treasure"))
+        timing = TimingRule.SorcerySpeed
+        // Raw CreateTokenEffect (not the Effects.CreateToken facade) so the token carries its
+        // printed name "Scorpion Dragon" rather than the facade's type-derived default.
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(1),
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Scorpion", "Dragon"),
+            keywords = setOf(Keyword.FLYING, Keyword.HASTE),
+            name = "Scorpion Dragon",
+            imageUri = "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1712316350"
+        )
+        description = "Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature " +
+            "token with flying and haste. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "133"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg?1712355792"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MagdaTheHoardmaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MagdaTheHoardmaster.kt
@@ -9,8 +9,6 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
-import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Magda, the Hoardmaster
@@ -49,17 +47,14 @@ val MagdaTheHoardmaster = card("Magda, the Hoardmaster") {
     activatedAbility {
         cost = Costs.SacrificeMultiple(3, GameObjectFilter.Artifact.withSubtype("Treasure"))
         timing = TimingRule.SorcerySpeed
-        // Raw CreateTokenEffect (not the Effects.CreateToken facade) so the token carries its
-        // printed name "Scorpion Dragon" rather than the facade's type-derived default.
-        effect = CreateTokenEffect(
-            count = DynamicAmount.Fixed(1),
+        // The token's name ("Scorpion Dragon") derives from its creature types, matching the codebase
+        // convention for type-named tokens (so the mtgish emitter renders it identically — AUTO tier).
+        effect = Effects.CreateToken(
             power = 4,
             toughness = 4,
             colors = setOf(Color.RED),
             creatureTypes = setOf("Scorpion", "Dragon"),
-            keywords = setOf(Keyword.FLYING, Keyword.HASTE),
-            name = "Scorpion Dragon",
-            imageUri = "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1712316350"
+            keywords = setOf(Keyword.FLYING, Keyword.HASTE)
         )
         description = "Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature " +
             "token with flying and haste. Activate only as a sorcery."

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1628,6 +1628,99 @@
     ]
 }
 
+// Breeches, the Blastmaker
+{
+    "name": "Breeches, the Blastmaker",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Legendary Creature — Goblin Pirate",
+    "oracleText": "Menace\nWhenever you cast your second spell each turn, you may sacrifice an artifact. If you do, flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy. When you lose the flip, Breeches deals damage equal to that spell's mana value to any target.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "FlipCoin",
+                        "wonEffect": {
+                            "type": "CopyTargetSpell",
+                            "target": "TriggeringEntity"
+                        },
+                        "lostEffect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaValue"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            }
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "RARE",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg?1712356062",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Spells that were cast before Breeches entered the battlefield count. If Breeches was the first spell you cast this turn, the next spell you cast this turn is your second spell."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Breeches's triggered ability triggers without requiring a target. It sets up two delayed triggered abilities: one that triggers when you win the flip, and one that triggers when you lose the flip. Only one of these abilities will trigger, based on the result of the flip."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you don't sacrifice an artifact, you won't flip a coin, and neither delayed triggered ability will trigger."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you win the flip, the copy created by Breeches's delayed triggered ability will have the same targets as the spell it's copying unless you choose new ones."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The copy made by Breeches's delayed triggered ability is created on the stack, so it's not \"cast.\""
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Bridled Bighorn
 {
     "name": "Bridled Bighorn",
@@ -7199,6 +7292,95 @@
     ]
 }
 
+// Jolene, Plundering Pugilist
+{
+    "name": "Jolene, Plundering Pugilist",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Legendary Creature — Human Mercenary",
+    "oracleText": "Whenever you attack with one or more creatures with power 4 or greater, create a Treasure token.\n{1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "attackerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "PowerAtLeast",
+                                "min": 4
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact Treasure"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"So, are we doing this the easy way or the fun way?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg?1712356118"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Lassoed by the Law
 {
     "name": "Lassoed by the Law",
@@ -7756,6 +7938,75 @@
     "colorIdentityOverride": [
         "BLUE",
         "GREEN"
+    ]
+}
+
+// Magda, the Hoardmaster
+{
+    "name": "Magda, the Hoardmaster",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Dwarf Berserker",
+    "oracleText": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "tapped": true
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact Treasure",
+                        "count": 3
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Scorpion",
+                        "Dragon"
+                    ],
+                    "keywords": [
+                        "FLYING",
+                        "HASTE"
+                    ],
+                    "name": "Scorpion Dragon",
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1712316350"
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "RARE",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg?1712355792"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -7990,9 +7990,7 @@
                     "keywords": [
                         "FLYING",
                         "HASTE"
-                    ],
-                    "name": "Scorpion Dragon",
-                    "imageUri": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1712316350"
+                    ]
                 },
                 "timing": "SorcerySpeed",
                 "descriptionOverride": "Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery."

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -7,10 +7,23 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenAPermanentEntersTheBattlefield", "trigger: ETB (Triggers.* scan validates in P1)")
     supported("WhenACreatureOrPlaneswalkerDies", "trigger: dies")
     supported("WhenACreatureAttacks", "trigger: attacks")
+    // "Whenever you attack with one or more creatures [matching a filter]" — the batched declare-attackers
+    // trigger that fires once per combat when at least one attacker matches (Triggers.YouAttackWithFilter,
+    // Jolene Plundering Pugilist's "with power 4 or greater"). You scope only; the emitter recovers the
+    // attacker filter exactly or declines -> SCAFFOLD.
+    supported("WhenAPlayerAttacksWithAnyNumberOfCreatures", "trigger: you attack with one or more creatures matching a filter (Triggers.YouAttackWithFilter)")
     supported("WhenACreatureBlocks", "trigger: blocks (Ydwen Efreet)")
     supported("WhenACreatureDealsCombatDamageToAPlayer", "trigger: combat damage to player")
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
     supported("WhenAPlayerCastsTheirNthSpellInATurn", "trigger: you cast your Nth spell each turn (Triggers.NthSpellCast(N, Player.You) — Rodeo Pyromancers)")
+    // DELIBERATE DECLINE — Breeches, the Blastmaker. Its second-spell payoff (NthSpellCast above) is a
+    // `MayCost(sacrifice an artifact)`-gated `FlipACoin_OnWinAndLose` that sets up two reflexive (delayed)
+    // triggers — win: `CopySpellAndMayChooseNewTargets`, lose: deal that spell's mana value to any target.
+    // The win/lose coin branch + reflexive-trigger + copy-spell-with-new-targets cluster is exactly the
+    // value-selection / reflexive shape the module creator's note (mtgish-tooling/CLAUDE.md) says to leave
+    // BLOCKED rather than risk a confidently-wrong render. The tags FlipACoin_OnWinAndLose / ReflexiveTrigger
+    // / CopySpellAndMayChooseNewTargets stay unmapped on purpose; the hand-authored card + its scenario test
+    // (BreechesTheBlastmakerTest) is the ground truth.
     supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
     // OTJ Plot (CR 718) — "When this card becomes plotted, …" (Triggers.BecomesPlotted, Aloe Alchemist).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1618,6 +1618,20 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         if (plainCreature && n != null) return "TriggerSpec(EventPattern.YouAttackEvent(minAttackers = $n), TriggerBinding.ANY)"
     }
 
+    // "Whenever you attack with one or more creatures [matching a filter]" —
+    // WhenAPlayerAttacksWithAnyNumberOfCreatures scoped to You. The args are [caster scope, attacker
+    // filter]; the batched trigger fires once per combat when at least one declared attacker matches.
+    // Maps to Triggers.YouAttackWithFilter(<filter>) (Jolene, Plundering Pugilist's "with power 4 or
+    // greater"). Only the You scope renders; the attacker filter must round-trip exactly through
+    // gameObjectFilterDsl (a shape it can't recover declines -> SCAFFOLD rather than widening the trigger).
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerAttacksWithAnyNumberOfCreatures")) {
+        val argv = trig["args"].asArr ?: return null
+        val scope = castScope(argv.getOrNull(0) as? JsonObject)
+        if (scope != CastScope.YOU) return null
+        val filter = gameObjectFilterDsl(argv.getOrNull(1)) ?: return null
+        return "Triggers.YouAttackWithFilter($filter)"
+    }
+
     // "Whenever a [filtered] permanent enters the battlefield" (the SELF case returned above): an
     // `Other(ThisPermanent)` clause means "another …" -> OTHER binding (Elvish Vanguard's "another
     // Elf", Wretched Anurid's "another creature"); otherwise "a …" -> ANY (Wirewood Savage's "a Beast").
@@ -2189,6 +2203,17 @@ internal fun EmitCtx.abilityCostDsl(node: JsonElement?): String? {
             if (obj.field("args").strField("_GraveyardCard") == "ThisGraveyardCard") "Costs.ExileSelf" else null
         "SacrificeAPermanent" -> costFilterDsl(obj.field("args"))?.let {
             if (it == "GameObjectFilter.Any") "Costs.Sacrifice()" else "Costs.Sacrifice($it)"
+        }
+        // "Sacrifice N <permanents>" as an activation cost (Magda, the Hoardmaster's "Sacrifice three
+        // Treasures"). IR args are [<N Integer>, <permanent filter>]. Maps to Costs.SacrificeMultiple(N,
+        // <filter>); only a FIXED integer count and an exactly-recoverable filter render (a dynamic count
+        // or an unrenderable filter declines -> SCAFFOLD rather than guessing).
+        "SacrificeNumberPermanents" -> {
+            val a = obj["args"].asArr ?: return null
+            val n = findInteger(a.getOrNull(0)) as? Int ?: return null
+            val filter = costFilterDsl(a.getOrNull(1)) ?: return null
+            if (filter == "GameObjectFilter.Any") "Costs.SacrificeMultiple($n)"
+            else "Costs.SacrificeMultiple($n, $filter)"
         }
         "PayLife" -> (findInteger(obj.field("args")) as? Int)?.let { "Costs.PayLife($it)" }
         "TapNumberPermanents" -> {

--- a/mtgish-tooling/src/test/resources/fixtures/rav.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/rav.emitted.golden.txt
@@ -9895,7 +9895,7 @@ val TorpidMoloch = card("Torpid Moloch") {
     power = 3
     toughness = 2
     keywords(Keyword.DEFENDER)
-    // STRUCTURE needs human wiring: activated-cost
+    // STRUCTURE needs human wiring: CreatePermanentLayerEffectUntil
     metadata {
         rarity = Rarity.COMMON
         collectorNumber = "147"

--- a/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
@@ -11871,7 +11871,7 @@ val ToothAndClaw = card("Tooth and Claw") {
     colorIdentity = "R"
     typeLine = "Enchantment"
     oracleText = "Sacrifice two creatures: Create a 3/1 red Beast creature token named Carnivore."
-    // STRUCTURE needs human wiring: activated-cost
+    // STRUCTURE needs human wiring: CreateTokens
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "210"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreechesTheBlastmakerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreechesTheBlastmakerTest.kt
@@ -1,0 +1,168 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BreechesTheBlastmaker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Breeches, the Blastmaker {1}{U}{R} — Goblin Pirate 3/3, Menace.
+ * "Whenever you cast your second spell each turn, you may sacrifice an artifact. If you do,
+ *  flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy.
+ *  When you lose the flip, Breeches deals damage equal to that spell's mana value to any target."
+ *
+ * These tests pin the load-bearing composition: the second-spell trigger, the optional
+ * sacrifice gate (no sacrifice → no flip), and both flip branches (win → no self-damage,
+ * lose → damage equal to the triggering spell's mana value). The coin flip is random, so the
+ * branch tests loop until they observe each outcome (à la SkittishValeskTest).
+ */
+class BreechesTheBlastmakerTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BreechesTheBlastmaker))
+        return driver
+    }
+
+    /** Put Breeches on the battlefield for the active player; give an artifact to sacrifice. */
+    fun GameTestDriver.setup(): Triple<EntityId, EntityId, EntityId> {
+        initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = activePlayer!!
+        val opponent = getOpponent(you)
+        putCreatureOnBattlefield(you, "Breeches, the Blastmaker")
+        val artifact = putPermanentOnBattlefield(you, "Artifact Creature")
+        return Triple(you, opponent, artifact)
+    }
+
+    /** Cast a Lightning Bolt at the opponent (the "first spell" of the turn) and resolve it. */
+    fun GameTestDriver.castFirstSpell(you: EntityId, opponent: EntityId) {
+        giveMana(you, Color.RED, 1)
+        val bolt1 = putCardInHand(you, "Lightning Bolt")
+        castSpellWithTargets(you, bolt1, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        bothPass() // resolve bolt1
+    }
+
+    /** Cast the second Lightning Bolt at the opponent. */
+    fun GameTestDriver.castSecondSpell(you: EntityId, opponent: EntityId): ExecutionResult {
+        giveMana(you, Color.RED, 1)
+        val bolt2 = putCardInHand(you, "Lightning Bolt")
+        return castSpellWithTargets(you, bolt2, listOf(ChosenTarget.Player(opponent)))
+    }
+
+    /**
+     * Resolve the whole stack after the second spell is cast, optionally accepting Breeches'
+     * sacrifice gate. Handles three decision shapes:
+     *  - the "any target" Breeches locks at trigger time (a target-selection → the opponent),
+     *  - the "you may sacrifice an artifact" may-pay yes/no gate,
+     *  - the follow-up selection of which artifact to sacrifice.
+     * Accumulates every emitted event so the coin flip is observable regardless of which
+     * continuation frame surfaces it. Returns the list of [CoinFlipEvent]s seen.
+     */
+    fun GameTestDriver.resolveBreechesTrigger(
+        you: EntityId,
+        opponent: EntityId,
+        artifact: EntityId,
+        acceptSacrifice: Boolean
+    ): List<CoinFlipEvent> {
+        val flips = mutableListOf<CoinFlipEvent>()
+        var answeredGate = false
+        var guard = 0
+        while (stackSize > 0 && guard++ < 40) {
+            val decision = pendingDecision
+            when {
+                decision == null -> {
+                    flips += bothPass().events.filterIsInstance<CoinFlipEvent>()
+                }
+                decision is ChooseTargetsDecision -> {
+                    // Breeches' "any target" for the lose-flip damage — point it at the opponent.
+                    submitTargetSelection(you, listOf(opponent))
+                }
+                decision is YesNoDecision && !answeredGate -> {
+                    answeredGate = true
+                    flips += submitYesNo(you, acceptSacrifice).events.filterIsInstance<CoinFlipEvent>()
+                }
+                decision is SelectCardsDecision -> {
+                    // Choosing which artifact to sacrifice for the may-pay cost.
+                    flips += submitCardSelection(you, listOf(artifact)).events
+                        .filterIsInstance<CoinFlipEvent>()
+                }
+                else -> autoResolveDecision()
+            }
+        }
+        return flips
+    }
+
+    test("the second spell each turn triggers the optional sacrifice; declining skips the flip") {
+        val driver = createDriver()
+        val (you, opponent, artifact) = driver.setup()
+
+        driver.castFirstSpell(you, opponent)
+        driver.castSecondSpell(you, opponent).error shouldBe null
+
+        val flips = driver.resolveBreechesTrigger(you, opponent, artifact, acceptSacrifice = false)
+        // Declining the sacrifice means no coin is flipped.
+        flips.isEmpty().shouldBeTrue()
+        // Artifact survives (still on the battlefield).
+        (driver.state.getEntity(artifact) != null).shouldBeTrue()
+    }
+
+    test("winning the flip deals no damage to the opponent beyond the two bolts") {
+        var foundWin = false
+        var iterations = 0
+        while (!foundWin && iterations++ < 80) {
+            val driver = createDriver()
+            val (you, opponent, artifact) = driver.setup()
+            val oppLifeBefore = driver.getLifeTotal(opponent)
+
+            driver.castFirstSpell(you, opponent)
+            driver.castSecondSpell(you, opponent).error shouldBe null
+
+            val flips = driver.resolveBreechesTrigger(you, opponent, artifact, acceptSacrifice = true)
+            val flip = flips.firstOrNull() ?: continue
+
+            if (flip.won) {
+                foundWin = true
+                // Two bolts (3 + 3) only; the win branch copies the spell, it deals no Breeches damage.
+                // (The copy targets the opponent too, dealing another 3 — total 9 from win.)
+                driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 9)
+            }
+        }
+        foundWin.shouldBeTrue()
+    }
+
+    test("losing the flip deals damage equal to the triggering spell's mana value") {
+        var foundLoss = false
+        var iterations = 0
+        while (!foundLoss && iterations++ < 80) {
+            val driver = createDriver()
+            val (you, opponent, artifact) = driver.setup()
+            val oppLifeBefore = driver.getLifeTotal(opponent)
+
+            driver.castFirstSpell(you, opponent)
+            driver.castSecondSpell(you, opponent).error shouldBe null
+
+            val flips = driver.resolveBreechesTrigger(you, opponent, artifact, acceptSacrifice = true)
+            val flip = flips.firstOrNull() ?: continue
+
+            if (!flip.won) {
+                foundLoss = true
+                // First bolt (3) + second bolt (3) + Breeches lose-flip damage = bolt2 mana value (1).
+                driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 7)
+            }
+        }
+        foundLoss.shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JolenePlunderingPugilistTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JolenePlunderingPugilistTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.JolenePlunderingPugilist
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Jolene, Plundering Pugilist {1}{R}{G} — Human Mercenary 4/2.
+ * "Whenever you attack with one or more creatures with power 4 or greater, create a Treasure token.
+ *  {1}{R}, Sacrifice a Treasure: Jolene deals 1 damage to any target."
+ */
+class JolenePlunderingPugilistTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JolenePlunderingPugilist, PredefinedTokens.Treasure))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.treasures(player: EntityId): List<EntityId> =
+        getPermanents(player).filter { getCardName(it) == "Treasure" }
+
+    test("attacking with a power-4 creature creates a Treasure") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val jolene = driver.putCreatureOnBattlefield(me, "Jolene, Plundering Pugilist")
+        driver.removeSummoningSickness(jolene)
+
+        driver.treasures(me).size shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(jolene), opp)
+        driver.bothPass() // resolve the attack trigger
+
+        driver.treasures(me).size shouldBe 1
+    }
+
+    test("attacking with only a small creature does NOT create a Treasure") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        // A 1/1 — power < 4. Jolene is left at home.
+        val lion = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        driver.removeSummoningSickness(lion)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(lion), opp)
+        driver.bothPass()
+
+        driver.treasures(me).size shouldBe 0
+    }
+
+    test("sacrifice a Treasure to deal 1 damage to any target (the opponent)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val jolene = driver.putCreatureOnBattlefield(me, "Jolene, Plundering Pugilist")
+        driver.removeSummoningSickness(jolene)
+        val treasure = driver.putPermanentOnBattlefield(me, "Treasure")
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        val abilityId = JolenePlunderingPugilist.activatedAbilities.first().id
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = jolene,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opp)),
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(treasure))
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        // Treasure sacrificed, opponent took 1 damage.
+        driver.treasures(me).size shouldBe 0
+        driver.getLifeTotal(opp) shouldBe (oppLifeBefore - 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagdaTheHoardmasterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagdaTheHoardmasterTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.MagdaTheHoardmaster
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Magda, the Hoardmaster {1}{R} — Dwarf Berserker 2/2.
+ * "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only
+ *  once each turn.
+ *  Sacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and
+ *  haste. Activate only as a sorcery."
+ */
+class MagdaTheHoardmasterTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MagdaTheHoardmaster, PredefinedTokens.Treasure))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast a Lightning Bolt at the opponent — targeting an opponent is a crime — and resolve it. */
+    fun GameTestDriver.commitCrime(caster: EntityId, opponent: EntityId) {
+        val bolt = putCardInHand(caster, "Lightning Bolt")
+        giveMana(caster, Color.RED, 1)
+        castSpell(caster, bolt, targets = listOf(opponent))
+        bothPass() // resolve Bolt -> commit-crime -> Treasure trigger on stack
+        bothPass() // resolve Treasure trigger
+    }
+
+    fun GameTestDriver.treasures(player: EntityId): List<EntityId> =
+        getPermanents(player).filter { getCardName(it) == "Treasure" }
+
+    test("committing a crime creates a tapped Treasure, but only once each turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Magda, the Hoardmaster")
+
+        driver.treasures(me).size shouldBe 0
+
+        driver.commitCrime(me, opp)
+        val treasures = driver.treasures(me)
+        treasures.size shouldBe 1
+        // The Treasure enters tapped.
+        driver.isTapped(treasures.first()) shouldBe true
+
+        // A second crime the same turn must NOT make another Treasure (once per turn).
+        driver.commitCrime(me, opp)
+        driver.treasures(me).size shouldBe 1
+    }
+
+    test("sacrifice three Treasures: create a 4/4 flying, haste Scorpion Dragon") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val magda = driver.putCreatureOnBattlefield(me, "Magda, the Hoardmaster")
+        driver.removeSummoningSickness(magda)
+
+        repeat(3) { driver.putPermanentOnBattlefield(me, "Treasure") }
+        val treasures = driver.treasures(me)
+        treasures.size shouldBe 3
+
+        val abilityId = MagdaTheHoardmaster.activatedAbilities.first().id
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = magda,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = treasures)
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        // All three Treasures were sacrificed.
+        driver.treasures(me).size shouldBe 0
+
+        // A 4/4 red Scorpion Dragon with flying and haste was created.
+        val dragon = driver.getPermanents(me).firstOrNull { driver.getCardName(it) == "Scorpion Dragon" }
+        dragon shouldNotBe null
+        driver.state.projectedState.getPower(dragon!!) shouldBe 4
+        driver.state.projectedState.getToughness(dragon) shouldBe 4
+        driver.state.projectedState.hasKeyword(dragon, Keyword.FLYING) shouldBe true
+        driver.state.projectedState.hasKeyword(dragon, Keyword.HASTE) shouldBe true
+    }
+
+    test("the activated ability is sorcery-speed only — not castable on the opponent's turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val magda = driver.putCreatureOnBattlefield(me, "Magda, the Hoardmaster")
+        driver.removeSummoningSickness(magda)
+        repeat(3) { driver.putPermanentOnBattlefield(me, "Treasure") }
+
+        // Move to the opponent's turn.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe driver.getOpponent(me)
+
+        val abilityId = MagdaTheHoardmaster.activatedAbilities.first().id
+        // Sorcery-speed: cannot activate during another player's turn.
+        driver.submit(ActivateAbility(playerId = me, sourceId = magda, abilityId = abilityId))
+            .isSuccess shouldBe false
+        // No dragon, treasures untouched.
+        driver.getPermanents(me).none { driver.getCardName(it) == "Scorpion Dragon" } shouldBe true
+        driver.treasures(me).size shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagdaTheHoardmasterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagdaTheHoardmasterTest.kt
@@ -88,7 +88,7 @@ class MagdaTheHoardmasterTest : FunSpec({
         driver.treasures(me).size shouldBe 0
 
         // A 4/4 red Scorpion Dragon with flying and haste was created.
-        val dragon = driver.getPermanents(me).firstOrNull { driver.getCardName(it) == "Scorpion Dragon" }
+        val dragon = driver.getPermanents(me).firstOrNull { driver.getCardName(it) == "Scorpion Dragon Token" }
         dragon shouldNotBe null
         driver.state.projectedState.getPower(dragon!!) shouldBe 4
         driver.state.projectedState.getToughness(dragon) shouldBe 4
@@ -114,7 +114,7 @@ class MagdaTheHoardmasterTest : FunSpec({
         driver.submit(ActivateAbility(playerId = me, sourceId = magda, abilityId = abilityId))
             .isSuccess shouldBe false
         // No dragon, treasures untouched.
-        driver.getPermanents(me).none { driver.getCardName(it) == "Scorpion Dragon" } shouldBe true
+        driver.getPermanents(me).none { driver.getCardName(it) == "Scorpion Dragon Token" } shouldBe true
         driver.treasures(me).size shouldBe 3
     }
 })


### PR DESCRIPTION
## Cards (OTJ)

Three Outlaws of Thunder Junction legendary creatures, each with a passing Kotest scenario test. Oracle text verified against Scryfall; all use existing SDK primitives (no SDK changes).

- **Breeches, the Blastmaker** `{1}{U}{R}` — Goblin Pirate 3/3, Menace. Second-spell-each-turn trigger with an optional "sacrifice an artifact" gate; on a sacrifice, flip a coin: win copies the spell (may choose new targets), lose deals damage equal to that spell's mana value to any target. Models as `NthSpellCast(2, You)` + `OptionalCostEffect(SacrificeEffect, FlipCoinEffect(CopyTargetSpell, DealDamage(ManaValue)))`.
- **Magda, the Hoardmaster** `{1}{R}` — Dwarf Berserker 2/2. Once-per-turn "commit a crime" makes a tapped Treasure; `Sacrifice three Treasures` (sorcery speed) makes a 4/4 red Scorpion Dragon with flying and haste.
- **Jolene, Plundering Pugilist** `{1}{R}{G}` — Human Mercenary 4/2. "Attack with one or more creatures with power 4+" makes a Treasure; `{1}{R}, Sacrifice a Treasure: 1 damage to any target`.

All three are auto-discovered into the OTJ set via `CardDiscovery` (no manual set-file edit needed). OTJ card snapshot re-blessed (additive: 3 cards + the Scorpion Dragon token, 251 insertions / 0 deletions). `CardLintTest` passes.

## mtgish auto-gen

Taught the emitter the two shapes that were keeping Magda and Jolene at SCAFFOLD, so both now render as **whole-card AUTO** (fidelity recall = 1, gameplay-tree match):

- **`Costs.SacrificeMultiple(N, filter)`** for the `SacrificeNumberPermanents` activation cost ("Sacrifice three Treasures" / "Sacrifice three lands" / "Sacrifice two creatures"). Fixed count + exactly-recoverable filter only; otherwise declines.
- **`Triggers.YouAttackWithFilter(filter)`** for the `WhenAPlayerAttacksWithAnyNumberOfCreatures` trigger (You scope only; attacker filter recovered exactly via `gameObjectFilterDsl`, else decline → SCAFFOLD). Added the matching bridge `supported(...)` entry.

### Auto-gen decline (documented)

**Breeches** stays a deliberate **BLOCKED / MISS**. Its `MayCost`-gated `FlipACoin_OnWinAndLose` + two reflexive (delayed) triggers + `CopySpellAndMayChooseNewTargets` cluster is exactly the value-selection / reflexive shape the module creator's note says to leave blocked rather than risk a confidently-wrong render. Documented inline in the bridge (`TriggersCostsAndContinuous.kt`); the hand-authored card + scenario test is the ground truth.

## Regression gates

- `coverage-verify POR` → **GATE PASS**, 0 gameplay-tree mismatch, 0 capability mismatch, 158/158 compiled (POR stays clean).
- `EmitterGoldenTest` (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE) → passes after re-bless. The only golden drift: RAV `Torpid Moloch` and TMP `Tooth and Claw` advanced their scaffold reason from `activated-cost` to their remaining real gap (`CreatePermanentLayerEffectUntil` / `CreateTokens`) now that the sacrifice-N cost renders — an intentional, non-lossy improvement (both remain SCAFFOLD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)