### PR TITLE
Add Archangel of Tithes / Sheriff of Safe Passage / Duelist of the Mind (OTJ) + AttackTax·BlockTax SDK feature

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -220,13 +220,15 @@ with an OTHER-binding variant for "another creature(s)." Mirrors the existing
 
 </details>
 
-### 6. `CARDS_DRAWN` turn-tracker + characteristic-defining P/T from it
+### 6. `CARDS_DRAWN` turn-tracker + characteristic-defining P/T from it — ✅ DONE
 
-`TurnTracker` has no `CARDS_DRAWN` accumulator, so "power equal to the number of cards you've drawn
-this turn" can't be expressed. Add the tracker (engine accumulates on draw events) and read it via
-`DynamicAmount.TurnTracking` for a CDA power.
+~~`TurnTracker` has no `CARDS_DRAWN` accumulator, so "power equal to the number of cards you've drawn
+this turn" can't be expressed.~~ RESOLVED — added `TurnTracker.CARDS_DRAWN`, backed by the existing
+`CardsDrawnThisTurnComponent` (no new accumulator needed — the engine already tracks per-turn draws
+and resets it at turn start). `DynamicAmountEvaluator` reads the component; the value feeds a CDA
+power via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DRAWN))`.
 
-→ Duelist of the Mind.
+→ Duelist of the Mind (implemented).
 
 ---
 
@@ -265,11 +267,12 @@ this turn" can't be expressed. Add the tracker (engine accumulates on draw event
     duration. The exile-on-ETB half is supported.
     → **Assimilation Aegis**.
 
-13. **Conditional attack-tax + a new block-tax static.** `AttackTax` exists but is unconditional and
-    defender-side. Archangel needs (a) the attack tax gated on "as long as this is untapped," and
-    (b) a brand-new **block-tax** ("creatures can't block unless their controller pays {1} each")
-    gated on "as long as this is attacking," with declare-blockers payment enforcement.
-    → **Archangel of Tithes**.
+13. ~~**Conditional attack-tax + a new block-tax static.**~~ RESOLVED — `AttackTax` gained an optional
+    `condition` gate (Archangel uses `Conditions.SourceIsUntapped`; it already protected the controller's
+    planeswalkers); added a new global **`BlockTax(amountPerBlocker, condition)`** static (Archangel uses
+    `Conditions.SourceIsAttacking`) evaluated in `BlockPhaseManager` and reusing the existing
+    declare-blockers tax-confirmation pause.
+    → **Archangel of Tithes** (implemented; canonical in ORI, reprint row in OTJ).
 
 14. ~~**Group flicker (mass blink) + repeat-the-whole-effect X+1 times.**~~ RESOLVED — no new SDK
     needed. Composed from existing primitives: an `Effects.Pipeline { gather → chooseAnyNumber →
@@ -304,9 +307,8 @@ this turn" can't be expressed. Add the tracker (engine accumulates on draw event
 
 1. ✅ **Saddle N + Mount** (Tier 1) — done.
 2. **Tier 2 shared primitives** — ✅ contributors-this-turn tracker (#2), ✅ spells-cast
-   `DynamicAmount` (#3), ✅ `fromHand` cast-zone flag (#4), ✅ cast-for-free condition (#5).
-   Remaining: `CARDS_DRAWN` (#6). Small, each unlocks a few scattered cards. **Next up: #6
-   (`CARDS_DRAWN`).**
+   `DynamicAmount` (#3), ✅ `fromHand` cast-zone flag (#4), ✅ cast-for-free condition (#5),
+   ✅ `CARDS_DRAWN` tracker (#6). All Tier-2 shared primitives done.
 3. **Tier-3 one-offs** as the relevant legendaries / rares come up — none block large numbers of
    cards; pick them off individually.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2050,14 +2050,25 @@ staticAbility {
   `CantBeBlockedByCreaturesWithLessPowerRule`; both sides use projected power, so a P/T buff raises the
   threshold.
 - `Effects.CreatePermanentEmblem(...)` — emblem with static abilities (planeswalker ultimates).
-- `AttackTax(amountPerAttacker: DynamicAmount)` — Propaganda / Ghostly Prison / Windborn Muse /
-  Collective Restraint. Per-attacker generic-mana tax for attacking the source's controller; the
-  amount is a `DynamicAmount` so it can scale with state (e.g., `DynamicAmounts.domain()` for
-  "{X} where X is your domain"). Evaluated with the source permanent's controller as "you".
-  When `totalTax > 0`, the engine pauses `DeclareAttackers` for a `YesNoDecision` *before* tapping
-  any mana — declining is a clean no-op that leaves the player in `DECLARE_ATTACKERS` to re-declare.
-  The same prompt/cancel pattern applies to block-tax floating effects (e.g. Whipgrass Entangler)
-  via `AttackBlockTaxPerCreatureType`.
+- `AttackTax(amountPerAttacker: DynamicAmount, condition: Condition? = null)` — Propaganda / Ghostly
+  Prison / Windborn Muse / Collective Restraint. Per-attacker generic-mana tax for attacking the
+  source's controller (and their planeswalkers); the amount is a `DynamicAmount` so it can scale with
+  state (e.g., `DynamicAmounts.domain()` for "{X} where X is your domain"). Evaluated with the source
+  permanent's controller as "you". The optional `condition` gates the whole tax on the source's own
+  state, evaluated with the source as "you"/source — e.g. Archangel of Tithes
+  (`condition = Conditions.SourceIsUntapped`, "As long as this creature is untapped, …"); when null
+  the tax is always active. When `totalTax > 0`, the engine pauses `DeclareAttackers` for a
+  `SelectManaSourcesDecision` *before* tapping any mana — declining is a clean no-op that leaves the
+  player in `DECLARE_ATTACKERS` to re-declare.
+- `BlockTax(amountPerBlocker: DynamicAmount, condition: Condition? = null)` — Archangel of Tithes'
+  second ability ("creatures can't block unless their controller pays {1} for each of those
+  creatures"). A *global* per-blocker generic-mana tax: while any permanent with this ability — whose
+  optional `condition` holds — is on the battlefield, every declared blocker is taxed `amountPerBlocker`
+  (multiple sources stack). The optional `condition` gates the tax on the source's own state — e.g.
+  Archangel uses `Conditions.SourceIsAttacking` ("As long as this creature is attacking, …"). Block
+  declaration pauses for the same mana-source confirmation as the attack tax. The pre-existing
+  per-creature-type block tax (Whipgrass Entangler) uses `AttackBlockTaxPerCreatureType` floating
+  effects instead.
 - `CantBeAttackedWithout(keyword, attackerFilter = null)` — Form of the Dragon-style "Creatures
   without flying can't attack you." defender-side restriction. Optional `attackerFilter` narrows
   which attackers are restricted (evaluated with the source permanent as predicate source, so
@@ -3261,6 +3272,10 @@ of `AddMana`. The engine empties pools at end of turn, so:
   count of nontoken permanent cards put into that player's graveyard from any zone.
   Backs `Conditions.YouDescendedThisTurn(atLeast)` and `DynamicAmounts.descendedThisTurn`
   (descend N / fathomless descent ability words).
+- `CARDS_DRAWN` — number of cards a player has drawn this turn (backed by
+  `CardsDrawnThisTurnComponent`, reset to 0 for every player at turn start). Powers
+  characteristic-defining stats like Duelist of the Mind's "power is equal to the number of
+  cards you've drawn this turn" via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DRAWN))`.
 
 ---
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -246,15 +246,67 @@ data class CantBlockUnless(
  * (e.g., [com.wingedsheep.sdk.dsl.DynamicAmounts.domain] for "{X} where X is your
  * domain"). Evaluated with the source permanent's controller as "you".
  *
+ * An optional [condition] gates the whole tax on the source permanent's state — evaluated
+ * with the source permanent as "you"/source. Used for Archangel of Tithes
+ * ("As long as this creature is untapped, …") via [com.wingedsheep.sdk.dsl.Conditions.SourceIsUntapped].
+ * When null (the default) the tax is always active (Ghostly Prison, Propaganda, Windborn Muse).
+ *
  * @property amountPerAttacker Generic mana to pay per attacking creature.
+ * @property condition Optional gate on the source's state; tax is inactive when it fails.
  */
 @SerialName("AttackTax")
 @Serializable
 data class AttackTax(
-    val amountPerAttacker: DynamicAmount
+    val amountPerAttacker: DynamicAmount,
+    val condition: Condition? = null,
 ) : StaticAbility {
-    override val description: String =
-        "Creatures can't attack you unless their controller pays {${amountPerAttacker.description}} for each creature they control that's attacking you"
+    override val description: String = buildString {
+        if (condition != null) append("As long as ${condition.description}, ")
+        append("creatures can't attack you")
+        if (condition != null) append(" or planeswalkers you control")
+        append(" unless their controller pays {${amountPerAttacker.description}} for each ")
+        append(if (condition != null) "of those creatures" else "creature they control that's attacking you")
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newCondition !== condition) copy(condition = newCondition) else this
+    }
+}
+
+/**
+ * Creatures can't block unless their controller pays generic mana for each blocking creature.
+ * The defending side of Archangel of Tithes' second ability
+ * ("creatures can't block unless their controller pays {1} for each of those creatures").
+ *
+ * Unlike [AttackTax] (a defender-side restriction tied to who is being attacked), this is a
+ * *global* restriction: while any permanent with this ability — whose optional [condition]
+ * holds — is on the battlefield, every declared blocker is taxed [amountPerBlocker]. Multiple
+ * sources stack additively. Mirrors the per-creature block-tax pause already used for
+ * [com.wingedsheep.sdk.scripting.effects.GrantAttackBlockTaxPerCreatureTypeEffect].
+ *
+ * An optional [condition] gates the tax on the source permanent's state, evaluated with the
+ * source permanent as "you"/source. Archangel of Tithes uses
+ * [com.wingedsheep.sdk.dsl.Conditions.SourceIsAttacking] ("As long as this creature is attacking, …").
+ * When null (the default) the tax is always active.
+ *
+ * @property amountPerBlocker Generic mana to pay per blocking creature.
+ * @property condition Optional gate on the source's state; tax is inactive when it fails.
+ */
+@SerialName("BlockTax")
+@Serializable
+data class BlockTax(
+    val amountPerBlocker: DynamicAmount,
+    val condition: Condition? = null,
+) : StaticAbility {
+    override val description: String = buildString {
+        if (condition != null) append("As long as ${condition.description}, ")
+        append("creatures can't block unless their controller pays {${amountPerBlocker.description}} for each ")
+        append(if (condition != null) "of those creatures" else "creature they control that's blocking")
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newCondition !== condition) copy(condition = newCondition) else this
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -64,7 +64,13 @@ enum class TurnTracker {
      * permanent cards put into the player's graveyard from any zone. Backs the descend
      * gate and the descend N / fathomless descent ability words.
      */
-    DESCENDED;
+    DESCENDED,
+    /**
+     * Number of cards the player has drawn this turn (CR 120). Backed by
+     * `CardsDrawnThisTurnComponent`, reset to 0 for every player at the start of each turn.
+     * Powers "equal to the number of cards you've drawn this turn" (Duelist of the Mind).
+     */
+    CARDS_DRAWN;
 
     fun descriptionFor(player: Player): String = when (this) {
         CREATURES_DIED -> "the number of creatures that died under ${player.possessive} control this turn"
@@ -82,6 +88,7 @@ enum class TurnTracker {
         FOOD_SACRIFICED -> "whether ${player.description} sacrificed a Food this turn"
         CARDS_LEFT_GRAVEYARD -> "the number of cards that left ${player.possessive} graveyard this turn"
         DESCENDED -> "the number of times ${player.description} descended this turn"
+        CARDS_DRAWN -> "the number of cards ${player.description} have drawn this turn"
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ArchangelOfTithes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ArchangelOfTithes.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.BlockTax
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Archangel of Tithes
+ * {1}{W}{W}{W}
+ * Creature — Angel
+ * 3/5
+ * Flying
+ * As long as Archangel of Tithes is untapped, creatures can't attack you or planeswalkers you
+ * control unless their controller pays {1} for each of those creatures.
+ * As long as Archangel of Tithes is attacking, creatures can't block unless their controller
+ * pays {1} for each of those creatures.
+ *
+ * Canonical earliest printing: Magic Origins (ORI, 2015). Reprinted in OTJ — see the OTJ
+ * `Printing` rows.
+ *
+ * The attack tax is gated on the source being untapped via [Conditions.SourceIsUntapped]; the
+ * block tax is gated on the source attacking via [Conditions.SourceIsAttacking]. Both protect
+ * against tapping the controller's mana without consent (combat tax confirmation pause).
+ */
+val ArchangelOfTithes = card("Archangel of Tithes") {
+    manaCost = "{1}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying\nAs long as this creature is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as this creature is attacking, creatures can't block unless their controller pays {1} for each of those creatures."
+    power = 3
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = AttackTax(
+            amountPerAttacker = DynamicAmount.Fixed(1),
+            condition = Conditions.SourceIsUntapped,
+        )
+    }
+
+    staticAbility {
+        ability = BlockTax(
+            amountPerBlocker = DynamicAmount.Fixed(1),
+            condition = Conditions.SourceIsAttacking,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "4"
+        artist = "Cynthia Sheppard"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg?1562009225"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ArchangelOfTithesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ArchangelOfTithesReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archangel of Tithes reprint in OTJ.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * Magic Origins' (ORI) `cards/` package — its earliest real printing. This file contributes
+ * only the OTJ-specific presentation row, picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ArchangelOfTithesReprint = Printing(
+    oracleId = "ff5caed4-0276-476d-8fae-edae2536df7f",
+    name = "Archangel of Tithes",
+    setCode = "OTJ",
+    collectorNumber = "2",
+    scryfallId = "c853d04c-864b-491c-8c6f-72d2d4874d2f",
+    artist = "Denys Tsiperko",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg?1712355228",
+    releaseDate = "2024-04-19",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DuelistOfTheMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DuelistOfTheMind.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * Duelist of the Mind
+ * {1}{U}
+ * Creature — Human Advisor
+ * Power/toughness: star/3
+ * Flying, vigilance
+ * Duelist of the Mind's power is equal to the number of cards you've drawn this turn.
+ * Whenever you commit a crime, you may draw a card. If you do, discard a card. This ability
+ * triggers only once each turn.
+ *
+ * The characteristic-defining power uses [DynamicAmount.TurnTracking] with the new
+ * [TurnTracker.CARDS_DRAWN] tracker (backed by `CardsDrawnThisTurnComponent`); only power is
+ * dynamic, toughness stays a printed 3, so we set `dynamicPower` directly rather than via the
+ * both-stats `dynamicStats` helper.
+ *
+ * The crime trigger is the standard [Triggers.YouCommitCrime] capped with `oncePerTurn = true`
+ * and runs the optional loot ([MayEffect] wrapping [Patterns.Hand.loot]) — the same composition
+ * as Jeskai Elder.
+ */
+val DuelistOfTheMind = card("Duelist of the Mind") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Advisor"
+    oracleText = "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn."
+    toughness = 3
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.TurnTracking(Player.You, TurnTracker.CARDS_DRAWN)
+    )
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = MayEffect(Patterns.Hand.loot())
+        description = "Whenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "45"
+        artist = "Darren Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg?1716283553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SheriffOfSafePassage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SheriffOfSafePassage.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sheriff of Safe Passage
+ * {2}{W}
+ * Creature — Human Knight
+ * 0/0
+ * This creature enters with a +1/+1 counter on it plus an additional +1/+1 counter on it for
+ * each other creature you control.
+ * Plot {1}{W}
+ *
+ * "Each other creature you control" is naturally captured by counting the controller's creatures
+ * during the enters-with-counters replacement (the Sheriff is not yet on the battlefield when the
+ * count is evaluated — same evaluation timing as Stag Beetle's "other creatures on the
+ * battlefield").
+ */
+val SheriffOfSafePassage = card("Sheriff of Safe Passage") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "This creature enters with a +1/+1 counter on it plus an additional +1/+1 counter on it for each other creature you control.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+    power = 0
+    toughness = 0
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.Add(
+                DynamicAmount.Fixed(1),
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+            )
+        )
+    )
+
+    keywordAbility(KeywordAbility.plot("{1}{W}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg?1712355345"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -1,3 +1,55 @@
+// Archangel of Tithes
+{
+    "name": "Archangel of Tithes",
+    "manaCost": "{1}{W}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nAs long as this creature is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as this creature is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "AttackTax",
+                "amountPerAttacker": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "untapped"
+                }
+            },
+            {
+                "type": "BlockTax",
+                "amountPerBlocker": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "attacking"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "MYTHIC",
+        "artist": "Cynthia Sheppard",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg?1562009225"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Eyeblight Assassin
 {
     "name": "Eyeblight Assassin",

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3888,6 +3888,100 @@
     ]
 }
 
+// Duelist of the Mind
+{
+    "name": "Duelist of the Mind",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "TurnTracking",
+                "player": "You",
+                "tracker": "CARDS_DRAWN"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "RARE",
+        "artist": "Darren Tan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg?1716283553"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dust Animus
 {
     "name": "Dust Animus",
@@ -11973,6 +12067,55 @@
         "artist": "Valera Lutfullina",
         "flavorText": "It catches those who are not ready to fall.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg?1712355336"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sheriff of Safe Passage
+{
+    "name": "Sheriff of Safe Passage",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "This creature enters with a +1/+1 counter on it plus an additional +1/+1 counter on it for each other creature you control.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{1}{W}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "Add",
+                    "left": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "right": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg?1712355345"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -405,6 +405,11 @@ class DynamicAmountEvaluator(
                             ?.get<com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent>()
                             ?.count ?: 0
                     }
+                    TurnTracker.CARDS_DRAWN -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent>()
+                            ?.count ?: 0
+                    }
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -51,6 +51,7 @@ internal class AttackPhaseManager(
 
     private val dynamicAmountEvaluator = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
     private val predicateEvaluator = PredicateEvaluator()
+    private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
 
     /**
      * Validate and declare attackers.
@@ -689,6 +690,11 @@ internal class AttackPhaseManager(
                             sourceId = entityId,
                             controllerId = defenderId,
                         )
+                        // Gate on the source's state (e.g. Archangel of Tithes — only while untapped).
+                        val condition = ability.condition
+                        if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
+                            continue
+                        }
                         val taxPerAttacker = maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerAttacker, ctx, projected))
                         totalGenericTax += taxPerAttacker * attackerCount
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -22,7 +22,9 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.sdk.scripting.BlockTax
 import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
 import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
@@ -49,6 +51,7 @@ internal class BlockPhaseManager(
     private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
 ) {
     private val conditionEvaluator = ConditionEvaluator()
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
 
     /**
      * Validate and declare blockers.
@@ -109,7 +112,8 @@ internal class BlockPhaseManager(
         // player to confirm — same reasoning as attack taxes: don't tap their mana
         // without consent.
         val projected = state.projectedState
-        val totalBlockTax = calculatePerCreatureTax(state, blockers.keys, projected)
+        val totalBlockTax = calculatePerCreatureTax(state, blockers.keys, projected) +
+            calculateBlockTax(state, blockers.keys, projected)
         if (totalBlockTax > 0) {
             return pauseForBlockTaxConfirmation(state, blockingPlayer, blockers, totalBlockTax)
         }
@@ -894,6 +898,43 @@ internal class BlockPhaseManager(
                 }
                 val costPerCreature = ManaCost.parse(mod.manaCostPer).cmc
                 totalTax += costPerCreature * creatureTypeCount
+            }
+        }
+        return totalTax
+    }
+
+    /**
+     * Calculate the generic-mana block tax from [BlockTax] static abilities (Archangel of Tithes —
+     * "creatures can't block unless their controller pays {1} for each of those creatures").
+     *
+     * Unlike [AttackTax], this is a global restriction: every permanent on the battlefield with a
+     * [BlockTax] ability (whose optional condition holds, e.g. "as long as this creature is
+     * attacking") taxes each declared blocker by its per-blocker amount. Multiple sources stack.
+     */
+    private fun calculateBlockTax(
+        state: GameState,
+        blockerIds: Set<EntityId>,
+        projected: ProjectedState
+    ): Int {
+        if (blockerIds.isEmpty()) return 0
+        var totalTax = 0
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            for (ability in cardDef.staticAbilities) {
+                if (ability !is BlockTax) continue
+                val controllerId = projected.getController(entityId) ?: continue
+                val ctx = EffectContext(
+                    sourceId = entityId,
+                    controllerId = controllerId,
+                )
+                val condition = ability.condition
+                if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
+                    continue
+                }
+                val taxPerBlocker = maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerBlocker, ctx, projected))
+                totalTax += taxPerBlocker * blockerIds.size
             }
         }
         return totalTax

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -68,6 +68,7 @@ import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
 import com.wingedsheep.sdk.scripting.AssignCombatDamageAsUnblocked
 import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
 import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.BlockTax
 import com.wingedsheep.sdk.scripting.AttackerCountLimit
 import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
@@ -654,6 +655,7 @@ class StaticAbilityHandler(
             // Combat: attack/block legality (AttackPhaseManager / BlockPhaseManager /
             // AttackRestrictionRules / BlockEvasionRules / CombatEnumerator):
             is AttackTax,
+            is BlockTax,
             is AttackerCountLimit,
             is BlockerCountLimit,
             is CanAttackDespiteDefender,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchangelOfTithesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchangelOfTithesScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ori.cards.ArchangelOfTithes
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Archangel of Tithes (ORI #4, reprinted OTJ #2).
+ *
+ * {1}{W}{W}{W} 3/5 Angel, Flying.
+ * - As long as it is untapped, creatures can't attack you or planeswalkers you control unless
+ *   their controller pays {1} for each of those creatures (gated [AttackTax]).
+ * - As long as it is attacking, creatures can't block unless their controller pays {1} for each
+ *   of those creatures ([BlockTax]).
+ *
+ * Exercises the two new combat-tax gates: the untapped condition on the attack tax and the
+ * attacking condition on the block tax.
+ */
+class ArchangelOfTithesScenarioTest : FunSpec({
+
+    val Bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    val FlyingBear = CardDefinition.creature(
+        name = "Test Flying Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        keywords = setOf(Keyword.FLYING),
+        oracleText = "Flying"
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ArchangelOfTithes, Bear, FlyingBear))
+        return driver
+    }
+
+    test("untapped Archangel taxes attacks against its controller") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        driver.putCreatureOnBattlefield(defender, "Archangel of Tithes")
+        val bear = driver.putCreatureOnBattlefield(attacker, "Test Bear")
+        driver.removeSummoningSickness(bear)
+        // Give the attacker a single untapped Plains so they *can* pay the tax.
+        driver.putPermanentOnBattlefield(attacker, "Plains")
+
+        // Advance to the attacker's (active player's) declare-attackers step.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val result = driver.declareAttackers(attacker, listOf(bear), defender)
+        // The untapped Archangel forces a {1} attack tax → pause for mana-source confirmation.
+        result.newState.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+    }
+
+    test("tapped Archangel does not tax attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val archangel = driver.putCreatureOnBattlefield(defender, "Archangel of Tithes")
+        driver.tapPermanent(archangel)
+        val bear = driver.putCreatureOnBattlefield(attacker, "Test Bear")
+        driver.removeSummoningSickness(bear)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val result = driver.declareAttackers(attacker, listOf(bear), defender)
+
+        // No tax while Archangel is tapped → attack resolves with no mana decision.
+        result.isSuccess shouldBe true
+        (result.newState.pendingDecision is SelectManaSourcesDecision) shouldBe false
+    }
+
+    test("untapped Archangel still pauses when the tax cannot be paid") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        driver.putCreatureOnBattlefield(defender, "Archangel of Tithes")
+        val bear = driver.putCreatureOnBattlefield(attacker, "Test Bear")
+        driver.removeSummoningSickness(bear)
+        // Attacker has no mana sources, so the {1} tax cannot be paid — but a tax is still owed,
+        // so the engine raises the confirmation pause (the player must decline, a clean no-op).
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val result = driver.declareAttackers(attacker, listOf(bear), defender)
+
+        result.newState.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+    }
+
+    test("attacking Archangel taxes the opponent's blockers") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val blockerPlayer = driver.getOpponent(attacker)
+
+        val archangel = driver.putCreatureOnBattlefield(attacker, "Archangel of Tithes")
+        driver.removeSummoningSickness(archangel)
+        // The blocker must be able to block a flier (Archangel has flying).
+        val blocker = driver.putCreatureOnBattlefield(blockerPlayer, "Test Flying Bear")
+        // The blocking player needs untapped mana so the block can pause for payment.
+        driver.putPermanentOnBattlefield(blockerPlayer, "Plains")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Archangel attacks → it becomes "attacking", enabling the block tax. No attack tax
+        // against the opponent (they have no AttackTax permanent).
+        val attackResult = driver.declareAttackers(attacker, listOf(archangel), blockerPlayer)
+        attackResult.isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        val blockResult = driver.declareBlockers(blockerPlayer, mapOf(blocker to listOf(archangel)))
+
+        // The attacking Archangel forces a {1} block tax → pause for mana-source confirmation.
+        blockResult.newState.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DuelistOfTheMindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DuelistOfTheMindScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dom.cards.Divination
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DuelistOfTheMind
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Duelist of the Mind (OTJ #45).
+ *
+ * {1}{U} star/3 Human Advisor. Flying, vigilance.
+ * - Power equals the number of cards you've drawn this turn (CDA via the new
+ *   [com.wingedsheep.sdk.scripting.values.TurnTracker.CARDS_DRAWN] tracker); toughness is a
+ *   printed 3.
+ * - Whenever you commit a crime, you may draw a card. If you do, discard a card. Triggers only
+ *   once each turn.
+ */
+class DuelistOfTheMindScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(DuelistOfTheMind, Divination))
+        return driver
+    }
+
+    test("power equals cards drawn this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val duelist = driver.putCreatureOnBattlefield(me, "Duelist of the Mind")
+
+        // No cards drawn yet this turn -> power 0, toughness 3.
+        projector.getProjectedPower(driver.state, duelist) shouldBe 0
+        projector.getProjectedToughness(driver.state, duelist) shouldBe 3
+
+        // Draw two via Divination -> power becomes 2, toughness still 3.
+        val divination = driver.putCardInHand(me, "Divination")
+        driver.giveMana(me, Color.BLUE, 3)
+        driver.castSpell(me, divination).isSuccess shouldBe true
+        driver.bothPass() // resolve Divination -> draw 2
+
+        driver.isPaused shouldBe false
+        projector.getProjectedPower(driver.state, duelist) shouldBe 2
+        projector.getProjectedToughness(driver.state, duelist) shouldBe 3
+    }
+
+    test("crime trigger loots once each turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40, "Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Duelist of the Mind")
+
+        // First crime: Lightning Bolt the opponent.
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.bothPass() // resolve Bolt -> commit-crime -> loot trigger on stack
+        driver.bothPass() // begin resolving loot trigger
+
+        val handBefore = driver.getHandSize(me)
+
+        // The optional loot: accept the "may draw" then discard the drawn card.
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+        driver.submitYesNo(me, true)
+        // Drawing then discarding nets zero cards in hand.
+        driver.submitCardSelection(me, listOf(driver.getHand(me).last()))
+
+        driver.isPaused shouldBe false
+        driver.getHandSize(me) shouldBe handBefore
+
+        // Second crime the same turn: the once-per-turn ability does NOT trigger again,
+        // so no may-draw decision is raised.
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.isPaused shouldBe false
+        (driver.pendingDecision is YesNoDecision) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SheriffOfSafePassageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SheriffOfSafePassageScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SheriffOfSafePassage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Sheriff of Safe Passage (OTJ #29).
+ *
+ * {2}{W} 0/0 Human Knight.
+ * Enters with a +1/+1 counter plus an additional +1/+1 counter for each *other creature you
+ * control*. Plot {1}{W}.
+ *
+ * The interesting authoring detail is "each OTHER creature YOU control": the count must include
+ * the controller's other creatures but exclude the Sheriff itself and the opponent's creatures.
+ */
+class SheriffOfSafePassageScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SheriffOfSafePassage))
+        return driver
+    }
+
+    test("enters as a 1/1 with no other creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sheriff = driver.putCardInHand(activePlayer, "Sheriff of Safe Passage")
+        driver.giveMana(activePlayer, Color.WHITE, 3)
+
+        driver.castSpell(activePlayer, sheriff).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Base 0/0 + 1 fixed counter = 1/1.
+        projector.getProjectedPower(driver.state, sheriff) shouldBe 1
+        projector.getProjectedToughness(driver.state, sheriff) shouldBe 1
+    }
+
+    test("counts each other creature the controller controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two of the controller's other creatures.
+        driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        val sheriff = driver.putCardInHand(activePlayer, "Sheriff of Safe Passage")
+        driver.giveMana(activePlayer, Color.WHITE, 3)
+
+        driver.castSpell(activePlayer, sheriff).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 1 fixed + 2 other creatures = 3 counters → 3/3.
+        projector.getProjectedPower(driver.state, sheriff) shouldBe 3
+        projector.getProjectedToughness(driver.state, sheriff) shouldBe 3
+    }
+
+    test("does not count the opponent's creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // One of mine, two of the opponent's.
+        driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val sheriff = driver.putCardInHand(activePlayer, "Sheriff of Safe Passage")
+        driver.giveMana(activePlayer, Color.WHITE, 3)
+
+        driver.castSpell(activePlayer, sheriff).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 1 fixed + 1 of my other creatures (opponent's two are ignored) = 2 → 2/2.
+        projector.getProjectedPower(driver.state, sheriff) shouldBe 2
+        projector.getProjectedToughness(driver.state, sheriff) shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary
Three OTJ-relevant cards plus a generalized **combat-tax** SDK feature and a **cards-drawn-this-turn** dynamic amount.

| Card | Notes |
|------|-------|
| **Archangel of Tithes** | Earliest printing = Magic Origins, so the canonical lives in **ORI** with an **OTJ `Printing` row** (reprint). Flying; untapped-gated attack tax + attacking-gated block tax. |
| **Sheriff of Safe Passage** (OTJ) | Enters with +1/+1 counters scaling with other creatures you control; **Plot {1}{W}**. |
| **Duelist of the Mind** (OTJ) | Flying, vigilance; **power = cards drawn this turn**; once-per-turn commit-a-crime loot. |

## SDK feature (`add-feature`)
- **`AttackTax` / `BlockTax`** static abilities with an optional source-state `Condition` gate. Generalizes the always-on taxers (Ghostly Prison, Propaganda, Windborn Muse) *and* Archangel's untapped/attacking gates. Wired through `StaticAbilityHandler` + `AttackPhaseManager` + `BlockPhaseManager`.
- **`DynamicAmount.TurnTracking(CARDS_DRAWN)`** (CR 120), backed by the existing `CardsDrawnThisTurnComponent`.
- `docs/card-sdk-language-reference.md` updated in lockstep.

## Verification
- ✅ Full **`:rules-engine:test` + `:mtg-sets:test`** — BUILD SUCCESSFUL (covers the combat + `DynamicAmount` blast radius; ORI + OTJ snapshots re-blessed; `CardLintTest` passes).
- ✅ Reprint validated: `just check-card-printing "Archangel of Tithes"` → ORI canonical, OTJ reprint.
- ✅ mtgish OTJ gate: the three cards **do not emit lossily** — Archangel's combat tax, Duelist's tracker, and Sheriff's scaling-counters are beyond the emitter and cleanly **decline to SCAFFOLD** (no approximation). Only pre-existing unrelated mismatches remain (Cactusfolk Sureshot, Freestrider Lookout, Thunder Lasso).
- ✅ mtgish **POR gate: PASS (158/158)** — no emitter/SDK regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)