### PR TITLE
Add Bucolic Ranch, Hollow Marauder, Three Steps Ahead (OTJ)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1192,8 +1192,10 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 - `unlimited = false` — when `true`, **"any number of target ..."** — no upper cap. The practical
   maximum is the number of legal targets, which the engine sends to the client; validation imposes
   no limit and the minimum is 0. Use this instead of a large placeholder `count` (Phyrexian Purge,
-  Kaboom, Weaver of Lies). For "**X** target creatures" use `dynamicMaxCount = DynamicAmount.XValue`
-  instead — that clamps the count to the chosen X.
+  Kaboom, Weaver of Lies). Available on `TargetObject` / `TargetCreature(...)` / `TargetPlayer` and
+  on `TargetOpponent` — `TargetOpponent(unlimited = true)` is "any number of target opponents"
+  (Hollow Marauder); pair with `ForEachTargetEffect` to apply a per-opponent body. For "**X** target
+  creatures" use `dynamicMaxCount = DynamicAmount.XValue` instead — that clamps the count to the chosen X.
 - `dynamicMaxCount: DynamicAmount?` — evaluated when the spell/ability hits the stack; the resolved
   value becomes the max ("up to X target creatures", X = board state or chosen X).
 - `sameController = false` — on `TargetObject` / `TargetCreature(...)`; when `true` and the requirement

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -127,12 +127,17 @@ data class TargetPlayer(
 data class TargetOpponent(
     override val count: Int = 1,
     override val optional: Boolean = false,
+    override val unlimited: Boolean = false,
     override val id: String? = null,
     val restriction: Condition? = null,
     private val descriptionOverride: String? = null
 ) : TargetRequirement {
     override val description: String = descriptionOverride
-        ?: if (count == 1) "target opponent" else "target $count opponents"
+        ?: when {
+            unlimited -> "any number of target opponents"
+            count == 1 -> "target opponent"
+            else -> "target $count opponents"
+        }
 
     override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
         val newRestriction = restriction?.applyTextReplacement(replacer)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BucolicRanch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BucolicRanch.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bucolic Ranch
+ * Land — Desert
+ *
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color. Spend this mana only to cast a Mount spell.
+ * {3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and put
+ * it into your hand. If you don't put it into your hand, you may put it on the bottom of your
+ * library.
+ *
+ * The colored mana ability is restricted to casting Mount spells via
+ * [ManaRestriction.SubtypeSpellsOnly] (same shape as Intrepid Stablemaster). The look ability is a
+ * Gather→Select→Move pipeline: top card is gathered, [SelectionMode.ChooseUpTo] gates the optional
+ * "reveal & put into hand" on the Mount-card filter (so non-Mounts can't be taken), and the
+ * remainder is offered to the bottom of the library. Both stay (hand) and bottom are "may", so the
+ * card can also be left on top by declining both choices.
+ */
+val BucolicRanch = card("Bucolic Ranch") {
+    typeLine = "Land — Desert"
+    oracleText = "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any color. Spend this mana only to cast a Mount spell.\n" +
+        "{3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it " +
+        "and put it into your hand. If you don't put it into your hand, you may put it on the " +
+        "bottom of your library."
+
+    // {T}: Add {C}.
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {T}: Add one mana of any color. Spend this mana only to cast a Mount spell.
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddAnyColorMana(
+            amount = 1,
+            restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Mount"))
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and
+    // put it into your hand. If you don't put it into your hand, you may put it on the bottom of
+    // your library.
+    activatedAbility {
+        cost = AbilityCost.Composite(listOf(Costs.Mana("{3}"), AbilityCost.Tap))
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "looked"
+                ),
+                // If it's a Mount card, you may reveal it and put it into your hand.
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(CardPredicate.HasSubtype(Subtype("Mount")))
+                    ),
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Leave"
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                // If you don't put it into your hand, you may put it on the bottom of your library
+                // (otherwise it stays on top — unselected cards are left in place).
+                SelectFromCollectionEffect(
+                    from = "rest",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "toBottom",
+                    storeRemainder = "stayOnTop",
+                    selectedLabel = "Put on bottom",
+                    remainderLabel = "Leave on top"
+                ),
+                MoveCollectionEffect(
+                    from = "toBottom",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "265"
+        artist = "Leonardo Borazio"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg?1712356362"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HollowMarauder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HollowMarauder.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hollow Marauder
+ * {6}{B}
+ * Creature — Specter Rogue
+ * 4/2
+ *
+ * This spell costs {1} less to cast for each creature card in your graveyard.
+ * Flying
+ * When this creature enters, any number of target opponents each discard a card. For each of those
+ * opponents who didn't discard a card with mana value 4 or greater, draw a card.
+ *
+ * Cost reduction is a self-cast [ModifySpellCost] / [CostReductionSource.CardsInGraveyardMatchingFilter]
+ * (mana value is unaffected — always 7, per the ruling). The ETB iterates the chosen opponents via
+ * [ForEachTargetEffect]: per opponent, the opponent discards a card (Gather→Select→Move), then the
+ * controller draws *unless* the discarded card had mana value 4 or greater — modeled by
+ * [ConditionalOnCollectionEffect] restricting the discarded collection to MV≥4 and drawing on its
+ * `ifEmpty` branch. The `ifEmpty` branch also covers an empty-handed opponent (discarded nothing →
+ * didn't discard a MV≥4 card → controller draws).
+ */
+val HollowMarauder = card("Hollow Marauder") {
+    manaCost = "{6}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Specter Rogue"
+    power = 4
+    toughness = 2
+    oracleText = "This spell costs {1} less to cast for each creature card in your graveyard.\n" +
+        "Flying\n" +
+        "When this creature enters, any number of target opponents each discard a card. For each " +
+        "of those opponents who didn't discard a card with mana value 4 or greater, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    // This spell costs {1} less to cast for each creature card in your graveyard.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = GameObjectFilter.Creature,
+                    amountPerCard = 1
+                )
+            )
+        )
+    }
+
+    // When this creature enters, any number of target opponents each discard a card. For each of
+    // those opponents who didn't discard a card with mana value 4 or greater, draw a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("any number of target opponents", TargetOpponent(unlimited = true))
+        effect = ForEachTargetEffect(
+            listOf(
+                // The current target opponent discards a card.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "hm_hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hm_hand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.TargetPlayer,
+                    storeSelected = "hm_discarded",
+                    prompt = "Choose a card to discard"
+                ),
+                MoveCollectionEffect(
+                    from = "hm_discarded",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard
+                ),
+                // Draw a card unless the discarded card had mana value 4 or greater.
+                ConditionalOnCollectionEffect(
+                    collection = "hm_discarded",
+                    filter = GameObjectFilter.Any.manaValueAtLeast(4),
+                    ifNotEmpty = Effects.Composite(emptyList()),
+                    ifEmpty = DrawCardsEffect(count = 1, target = EffectTarget.Controller)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Wero Gallo"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg?1712355599"
+        ruling("2024-04-12", "Hollow Marauder's first ability doesn't change its mana value, which is always 7.")
+        ruling(
+            "2024-04-12",
+            "When the triggered ability resolves, the next target opponent in turn order chooses a " +
+                "card in hand without revealing it, then each other target opponent does the same. " +
+                "All chosen cards are then discarded at the same time."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThreeStepsAhead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThreeStepsAhead.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Three Steps Ahead
+ * {U}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1}{U} — Counter target spell.
+ * + {3} — Create a token that's a copy of target artifact or creature you control.
+ * + {2} — Draw two cards, then discard a card.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`,
+ * per-mode `additionalManaCost`, and `allowRepeat = false` (CR 700.2 / OTJ release notes). Modes
+ * resolve in printed order. Modes that require a target (mode 1 counter, mode 2 copy) can only be
+ * chosen when a legal target exists (CR 601.2c).
+ */
+val ThreeStepsAhead = card("Three Steps Ahead") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1}{U} — Counter target spell.\n" +
+        "+ {3} — Create a token that's a copy of target artifact or creature you control.\n" +
+        "+ {2} — Draw two cards, then discard a card."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                // + {1}{U} — Counter target spell.
+                Mode(
+                    effect = Effects.CounterSpell(),
+                    targetRequirements = listOf(Targets.Spell),
+                    description = "+ {1}{U} — Counter target spell.",
+                    additionalManaCost = "{1}{U}"
+                ),
+                // + {3} — Create a token that's a copy of target artifact or creature you control.
+                Mode(
+                    effect = Effects.CreateTokenCopyOfTarget(
+                        target = EffectTarget.ContextTarget(0)
+                    ),
+                    targetRequirements = listOf(
+                        TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.youControl()))
+                    ),
+                    description = "+ {3} — Create a token that's a copy of target artifact or creature you control.",
+                    additionalManaCost = "{3}"
+                ),
+                // + {2} — Draw two cards, then discard a card.
+                Mode(
+                    effect = Effects.DrawCards(2) then Effects.Discard(1),
+                    description = "+ {2} — Draw two cards, then discard a card.",
+                    additionalManaCost = "{2}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1,
+            allowRepeat = false
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Francisco Miyara"
+        flavorText = "She'd planned for every eventuality, with the obvious exception of failure."
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg?1712860611"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2077,6 +2077,133 @@
     ]
 }
 
+// Bucolic Ranch
+{
+    "name": "Bucolic Ranch",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Mount spell.\n{3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and put it into your hand. If you don't put it into your hand, you may put it on the bottom of your library.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": {
+                        "type": "SubtypeSpellsOnly",
+                        "subtypes": [
+                            "Mount"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "Mount",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Leave"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "rest",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "stayOnTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Leave on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Borazio",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg?1712356362"
+    }
+}
+
 // Cactarantula
 {
     "name": "Cactarantula",
@@ -6410,6 +6537,133 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Hollow Marauder
+{
+    "name": "Hollow Marauder",
+    "manaCost": "{6}{B}",
+    "typeLine": "Creature — Specter Rogue",
+    "oracleText": "This spell costs {1} less to cast for each creature card in your graveyard.\nFlying\nWhen this creature enters, any number of target opponents each discard a card. For each of those opponents who didn't discard a card with mana value 4 or greater, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hm_hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hm_hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "hm_discarded",
+                                "prompt": "Choose a card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "hm_discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "hm_discarded",
+                                "ifNotEmpty": {
+                                    "type": "Composite",
+                                    "effects": []
+                                },
+                                "ifEmpty": {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "mv>=4"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "unlimited": true,
+                    "id": "any number of target opponents"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Wero Gallo",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg?1712355599",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Hollow Marauder's first ability doesn't change its mana value, which is always 7."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "When the triggered ability resolves, the next target opponent in turn order chooses a card in hand without revealing it, then each other target opponent does the same. All chosen cards are then discarded at the same time."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -14349,6 +14603,117 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Three Steps Ahead
+{
+    "name": "Three Steps Ahead",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1}{U} — Counter target spell.\n+ {3} — Create a token that's a copy of target artifact or creature you control.\n+ {2} — Draw two cards, then discard a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "description": "+ {1}{U} — Counter target spell.",
+                    "additionalManaCost": "{1}{U}"
+                },
+                {
+                    "effect": {
+                        "type": "CreateTokenCopyOfTarget",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature|artifact ctrl:you"
+                            }
+                        }
+                    ],
+                    "description": "+ {3} — Create a token that's a copy of target artifact or creature you control.",
+                    "additionalManaCost": "{3}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "description": "+ {2} — Draw two cards, then discard a card.",
+                    "additionalManaCost": "{2}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Francisco Miyara",
+        "flavorText": "She'd planned for every eventuality, with the obvious exception of failure.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg?1712860611"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -79,6 +79,13 @@ private fun manaUseModifierRestriction(modifiers: List<JsonElement>): String? {
     val modifier = modifiers.singleOrNull() as? JsonObject ?: return null
     if (modifier.strField("_ManaUseModifier") != "CanOnlySpendOnSpells") return null
     val spells = modifier["args"] as? JsonObject ?: return null
+
+    // "Spend this mana only to cast a Mount spell" (Bucolic Ranch): a BARE single subtype check, not
+    // wrapped in an Or. Map the one subtype straight to SubtypeSpellsOnly(setOf("Mount")).
+    subtypeOfSpellsCheck(spells)?.let { subtype ->
+        return "ManaRestriction.SubtypeSpellsOnly(setOf(\"$subtype\"))"
+    }
+
     if (spells.strField("_Spells") != "Or") return null
     val branches = spells["args"] as? JsonArray ?: return null
     val cardtypes = branches.mapNotNull { b ->
@@ -91,15 +98,23 @@ private fun manaUseModifierRestriction(modifiers: List<JsonElement>): String? {
     // carries any of those subtypes. Decline if any branch is a non-subtype check rather than drop it.
     val subtypes = branches.map { b ->
         val obj = b as? JsonObject ?: return null
-        when (obj.strField("_Spells")) {
-            "IsCreatureType", "IsArtifactType", "IsEnchantmentType", "IsLandType" ->
-                (obj["args"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: return null
-            else -> return null
-        }
+        subtypeOfSpellsCheck(obj) ?: return null
     }
     if (subtypes.isEmpty()) return null
     return "ManaRestriction.SubtypeSpellsOnly(setOf(${subtypes.joinToString(", ") { "\"$it\"" }}))"
 }
+
+/**
+ * A single `IsCreatureType`/`IsArtifactType`/`IsEnchantmentType`/`IsLandType` spells check carrying a
+ * bare string subtype -> that subtype name, else null. `SubtypeSpellsOnly` matches a spell whose type
+ * line carries the subtype regardless of card type, so all four type-scoped checks map the same way.
+ */
+private fun subtypeOfSpellsCheck(node: JsonObject): String? =
+    when (node.strField("_Spells")) {
+        "IsCreatureType", "IsArtifactType", "IsEnchantmentType", "IsLandType" ->
+            (node["args"] as? kotlinx.serialization.json.JsonPrimitive)?.content
+        else -> null
+    }
 
 /**
  * `{_ManaProduce}` + a recovered restriction token -> the matching restricted mana Effect. Mirrors

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BucolicRanchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BucolicRanchScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BridledBighorn
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BucolicRanch
+import com.wingedsheep.mtg.sets.definitions.otj.cards.IntrepidStablemaster
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bucolic Ranch — Land — Desert
+ *
+ * {3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and put
+ * it into your hand. If you don't put it into your hand, you may put it on the bottom of your
+ * library.
+ *
+ * (The Intrepid Stablemaster card is registered only so the "Mount" creature it represents is
+ * available as a top-of-library card to find.)
+ */
+class BucolicRanchScenarioTest : FunSpec({
+
+    // index 2 is the {3},{T} look ability (0 = {C}, 1 = any-color restricted, 2 = look).
+    val lookAbilityId = BucolicRanch.activatedAbilities[2].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BucolicRanch)
+        driver.registerCard(BridledBighorn) // a Sheep Mount
+        driver.registerCard(IntrepidStablemaster) // not a Mount, used only as a non-Mount top card
+        return driver
+    }
+
+    fun GameTestDriver.handNames(playerId: com.wingedsheep.sdk.model.EntityId): List<String> =
+        getHand(playerId).mapNotNull { getCardName(it) }
+
+    test("look ability: a Mount on top may be put into hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val ranch = driver.putPermanentOnBattlefield(me, "Bucolic Ranch")
+        driver.removeSummoningSickness(ranch)
+        // A Mount creature card on top of the library.
+        val mount = driver.putCardOnTopOfLibrary(me, "Bridled Bighorn")
+        driver.giveColorlessMana(me, 3)
+
+        driver.submit(
+            ActivateAbility(playerId = me, sourceId = ranch, abilityId = lookAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // A select decision for the Mount → choose to take it.
+        if (driver.isPaused) {
+            driver.submitCardSelection(me, listOf(mount))
+            // Possible second (optional bottom) decision over the now-empty remainder: pass through.
+            while (driver.isPaused) {
+                driver.submitCardSelection(me, emptyList())
+            }
+        }
+        driver.handNames(me) shouldContain "Bridled Bighorn"
+    }
+
+    test("look ability: a non-Mount on top cannot be taken into hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val ranch = driver.putPermanentOnBattlefield(me, "Bucolic Ranch")
+        driver.removeSummoningSickness(ranch)
+        // A non-Mount creature card on top.
+        driver.putCardOnTopOfLibrary(me, "Intrepid Stablemaster")
+        driver.giveColorlessMana(me, 3)
+
+        driver.submit(
+            ActivateAbility(playerId = me, sourceId = ranch, abilityId = lookAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Decline every optional selection.
+        while (driver.isPaused) {
+            driver.submitCardSelection(me, emptyList())
+        }
+        // It is not a Mount, so it can never be placed into hand.
+        driver.handNames(me) shouldNotContain "Intrepid Stablemaster"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HollowMarauderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HollowMarauderScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.HollowMarauder
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hollow Marauder — {6}{B} Creature — Specter Rogue, 4/2, Flying
+ *
+ * This spell costs {1} less to cast for each creature card in your graveyard.
+ * When this creature enters, any number of target opponents each discard a card. For each of those
+ * opponents who didn't discard a card with mana value 4 or greater, draw a card.
+ */
+class HollowMarauderScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HollowMarauder)
+        return driver
+    }
+
+    fun GameTestDriver.handNames(playerId: EntityId): List<String> =
+        getHand(playerId).mapNotNull { getCardName(it) }
+
+    // Resolve the spell + ETB trigger, answering each decision as it arrives: the controller picks
+    // the target opponent, and the opponent picks the card to discard. Falls back to bothPass()
+    // to keep the stack moving between decision points.
+    fun drivePassesAndDecisions(
+        driver: GameTestDriver,
+        controller: EntityId,
+        opponent: EntityId,
+        discardCard: EntityId
+    ) {
+        var guard = 0
+        while (guard++ < 30) {
+            when (val decision = driver.pendingDecision) {
+                is ChooseTargetsDecision ->
+                    driver.submitTargetSelection(decision.playerId, listOf(opponent))
+                is SelectCardsDecision ->
+                    driver.submitCardSelection(decision.playerId, listOf(discardCard))
+                null -> {
+                    if (driver.getTopOfStack() == null) return
+                    driver.bothPass()
+                }
+                else -> driver.bothPass()
+            }
+        }
+    }
+
+    test("ETB: opponent discards a low-MV card, controller draws") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Opponent has one cheap card (Lightning Bolt, MV 1) to discard.
+        val oppCard = driver.putCardInHand(opponent, "Lightning Bolt")
+
+        val marauder = driver.putCardInHand(me, "Hollow Marauder")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 6)
+
+        val handBefore = driver.getHandSize(me)
+
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = marauder,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        // Resolve the creature spell + ETB trigger, driving each decision as it appears:
+        //  - controller chooses the target opponent(s)
+        //  - that opponent chooses the card to discard
+        drivePassesAndDecisions(driver, me, opponent, oppCard)
+
+        // The Bolt (MV 1 < 4) was discarded → I draw a card.
+        driver.getGraveyardCardNames(opponent).contains("Lightning Bolt") shouldBe true
+        // Hand: spell left hand (-1), drew 1 (+1) → net unchanged.
+        driver.getHandSize(me) shouldBe handBefore
+    }
+
+    test("ETB: opponent discards a high-MV card, controller draws nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Opponent's only card is Gurmag Angler (MV 7 >= 4).
+        val bigCard = driver.putCardInHand(opponent, "Gurmag Angler")
+
+        val marauder = driver.putCardInHand(me, "Hollow Marauder")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 6)
+
+        val handBefore = driver.getHandSize(me)
+
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = marauder,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        drivePassesAndDecisions(driver, me, opponent, bigCard)
+
+        driver.getGraveyardCardNames(opponent).contains("Gurmag Angler") shouldBe true
+        // High-MV discard → no draw. Hand: spell left hand (-1).
+        driver.getHandSize(me) shouldBe handBefore - 1
+    }
+
+    test("cost reduction: {1} less per creature card in graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Two creature cards in my graveyard → {6}{B} reduces to {4}{B}.
+        driver.putCardInGraveyard(me, "Centaur Courser")
+        driver.putCardInGraveyard(me, "Savannah Lions")
+
+        val marauder = driver.putCardInHand(me, "Hollow Marauder")
+        // Provide only {4}{B} — enough only if the reduction applied.
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 4)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = marauder,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreeStepsAheadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreeStepsAheadScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ThreeStepsAhead
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+
+/**
+ * Three Steps Ahead — {U} Instant, Spree
+ *
+ * + {1}{U} — Counter target spell.
+ * + {3} — Create a token that's a copy of target artifact or creature you control.
+ * + {2} — Draw two cards, then discard a card.
+ */
+class ThreeStepsAheadScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ThreeStepsAhead)
+        return driver
+    }
+
+    test("counter mode: counter target spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val spell = driver.putCardInHand(me, "Three Steps Ahead")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 1) // {U} base + {1}{U} for counter mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Spell(boltOnStack)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(boltOnStack))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+        driver.isPaused shouldBe false
+        driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+    }
+
+    test("copy mode: create a token copy of a creature you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Three Steps Ahead")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 3) // {U} base + {3} for copy mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // Now two Centaur Courser on my battlefield (original + token copy).
+        val bears = driver.state.getBattlefield().filter {
+            driver.getController(it) == me && driver.getCardName(it) == "Centaur Courser"
+        }
+        bears.size shouldBe 2
+    }
+
+    test("draw mode: draw two cards then discard one") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val handBefore = driver.getHandSize(me)
+        val spell = driver.putCardInHand(me, "Three Steps Ahead")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 2) // {U} base + {2} for draw mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(emptyList()),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+        // The discard may pause for a selection if hand has >1 card.
+        if (driver.isPaused) {
+            val discardable = driver.getHand(me)
+            driver.submitCardSelection(me, listOf(discardable.first()))
+        }
+        driver.isPaused shouldBe false
+
+        // Spell left hand (+1 to gy), drew 2, discarded 1: net hand = before + 2 - 1.
+        driver.getHandSize(me) shouldBe handBefore + 1
+        driver.getGraveyardCardNames(me).size shouldBeGreaterThanOrEqual 1
+    }
+
+    test("Spree requires at least one mode") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(me, "Three Steps Ahead")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = emptyList(),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards (canonical OTJ printings) plus a small SDK addition and an mtgish-tooling emitter improvement.

## Cards

- **Bucolic Ranch** — Land — Desert.
  - `{T}: Add {C}` and `{T}: Add one mana of any color. Spend this mana only to cast a Mount spell` (`Effects.AddAnyColorMana(restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Mount")))`).
  - `{3}, {T}`: look at the top card; if it's a Mount you may put it into your hand, otherwise you may put it on the bottom. Modeled as Gather → Select (ChooseUpTo, Mount filter) → Move-to-hand, plus a second optional Select for the "may bottom" (unselected cards stay on top).
- **Hollow Marauder** — `{6}{B}` 4/2 Flying.
  - Self cost reduction: `{1}` less per creature card in your graveyard (`ModifySpellCost(SelfCast, ReduceGenericBy(CardsInGraveyardMatchingFilter(Creature)))`).
  - ETB: any number of target opponents each discard a card; for each opponent who didn't discard a card with mana value 4+, draw a card. Implemented with `ForEachTargetEffect` over the targeted opponents — each opponent discards (Gather → Select → Move), then a `ConditionalOnCollectionEffect` restricting the discarded pile to MV≥4 draws on its `ifEmpty` branch (which also correctly covers an empty-handed opponent).
- **Three Steps Ahead** — `{U}` Instant, **Spree**.
  - `+ {1}{U}` Counter target spell · `+ {3}` Create a token copy of target artifact/creature you control · `+ {2}` Draw two, then discard. Built with `ModalEffect` + per-mode `additionalManaCost` (the existing Spree path).

## SDK

- Added `unlimited` to `TargetOpponent` (mirrors `TargetPlayer`) so "any number of target opponents" works end-to-end through the generic legal-action/`effectiveMinCount` machinery. Updated `docs/card-sdk-language-reference.md`.

## mtgish-tooling

- Taught the emitter's `manaUseModifierRestriction` to recover a **bare single-subtype** `CanOnlySpendOnSpells` modifier (previously only an `Or` of subtypes was handled). "Spend this mana only to cast a Mount spell" now renders `ManaRestriction.SubtypeSpellsOnly(setOf("Mount"))` exactly — a general improvement for any single-subtype restricted-mana card.
- **Could not auto-generate (left at SCAFFOLD, by design):**
  - *Three Steps Ahead* — Spree (per-mode additional costs) is squarely in the "extra costs / value selection" area the tooling's creator note says to keep at SCAFFOLD; not forced.
  - *Hollow Marauder* — the ETB "discard then conditionally draw based on the discarded card's mana value" is a conditional the emitter can't render faithfully.
  - *Bucolic Ranch* — the mana restriction now renders, but the `{3},{T}` look-at-top conditional (reveal-if-Mount / may-bottom) remains unrecovered (`LookAtTopOfLibrary`).
  - In all three cases the emitter declines rather than emit a lossy approximation, per the fidelity policy.

## Verification

- New scenario tests for all three cards pass (`ThreeStepsAheadScenarioTest`, `BucolicRanchScenarioTest`, `HollowMarauderScenarioTest`).
- `coverage-verify POR` stays **0 mismatches**; `EmitterGoldenTest` passes all sets — the emitter change caused no golden drift.
- OTJ card snapshot re-blessed (additive: only the three new cards; no other card moved).
- `CardLintTest` passes.
- The pre-existing OTJ `coverage-verify` mismatches (Cactusfolk Sureshot, Freestrider Lookout, Thunder Lasso) are unrelated to this change (OTJ is not a calibrated 0-mismatch set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)