### PR TITLE
Add Mirage Mesa, Ruthless Lawbringer, Great Train Heist (OTJ)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1913,6 +1913,13 @@ Triggers.youCastSpell(
     Deflecting Palm). Only `DealsDamageEvent` (scoped on the damage source) and `ZoneChangeEvent`
     (scoped on the moving entity) use this; the spec's `GameObjectFilter` is *not* applied — the
     watched entity is the whole scope.
+  - **Recipient-scoped** — set `watchedRecipient` to bind a `DealsDamageEvent` trigger to the damaged
+    *recipient* (rather than the source): "whenever a creature you control deals combat damage to
+    **that player** this turn, …" (Great Train Heist's Treasure-on-hit mode). The target is resolved at
+    creation time (e.g. `EffectTarget.ContextTarget(0)` for a just-chosen target opponent), so the
+    trigger fires only for hits to that specific player. The `TriggerSpec`'s `recipient` / `sourceFilter`
+    still apply on top (use `RecipientFilter.AnyPlayer` + `sourceFilter = Creature.youControl()`).
+    Orthogonal to `watchedTarget` (source scope) — set at most one.
   - **Filter-scoped** — leave `watchedTarget` null and let the `TriggerSpec`'s `GameObjectFilter` +
     `TriggerBinding` describe the group, exactly like a battlefield-resident trigger. Use this for
     "whenever a creature you control enters this turn, …" (Thunder of Unity chapters II/III):

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -566,6 +566,16 @@ data class CreateDelayedTriggerEffect(
      */
     val watchedTarget: EffectTarget? = null,
     /**
+     * For event-based delayed triggers: scopes the trigger to events whose *recipient*
+     * (the damaged / targeted entity) is this target. Whereas [watchedTarget] narrows by
+     * the event's **source**, [watchedRecipient] narrows by the event's **recipient** — i.e.
+     * "whenever a creature you control deals combat damage to *that player* this turn"
+     * (Great Train Heist). Context references (e.g. ContextTarget(0) for the chosen opponent)
+     * are baked into a concrete entity id at creation time by CreateDelayedTriggerExecutor.
+     * Currently honored for [com.wingedsheep.sdk.scripting.EventPattern.DealsDamageEvent].
+     */
+    val watchedRecipient: EffectTarget? = null,
+    /**
      * For event-based delayed triggers: when the ability is removed.
      */
     val expiry: DelayedTriggerExpiry = DelayedTriggerExpiry.EndOfTurn,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GreatTrainHeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GreatTrainHeist.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCombatPhaseEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Great Train Heist {R}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2}{R} — Untap all creatures you control. If it's your combat phase, there is an
+ *            additional combat phase after this phase.
+ * + {2} — Creatures you control get +1/+0 and gain first strike until end of turn.
+ * + {R} — Choose target opponent. Whenever a creature you control deals combat damage to
+ *         that player this turn, create a tapped Treasure token.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`,
+ * and per-mode `additionalManaCost` (CR 702.166).
+ *
+ * Mode 1's extra combat is gated on [Conditions.IsInPhase] — the additional combat phase only
+ * happens if it's the caster's combat phase. [AddCombatPhaseEffect] inserts an additional
+ * combat phase (followed by a main phase) after the current main phase, which is the correct
+ * end result for a spell cast during combat.
+ *
+ * Mode 3 registers a turn-scoped (non-one-shot) event-based delayed trigger via
+ * [CreateDelayedTriggerEffect] whose recipient is scoped to the chosen opponent
+ * (`watchedRecipient`): each time a creature the caster controls deals combat damage to that
+ * specific player this turn, a tapped Treasure is created. It expires at end of turn.
+ */
+val GreatTrainHeist = card("Great Train Heist") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2}{R} — Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n" +
+        "+ {2} — Creatures you control get +1/+0 and gain first strike until end of turn.\n" +
+        "+ {R} — Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Patterns.Group.untapGroup(GroupFilter.AllCreaturesYouControl)
+                        .then(
+                            ConditionalEffect(
+                                condition = Conditions.IsInPhase(Phase.COMBAT, yoursOnly = true),
+                                effect = AddCombatPhaseEffect
+                            )
+                        ),
+                    description = "+ {2}{R} — Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.",
+                    additionalManaCost = "{2}{R}"
+                ),
+                Mode(
+                    effect = Patterns.Group.modifyStatsForAll(1, 0, Filters.Group.creaturesYouControl)
+                        .then(Patterns.Group.grantKeywordToAll(Keyword.FIRST_STRIKE, Filters.Group.creaturesYouControl)),
+                    description = "+ {2} — Creatures you control get +1/+0 and gain first strike until end of turn.",
+                    additionalManaCost = "{2}"
+                ),
+                Mode(
+                    effect = CreateDelayedTriggerEffect(
+                        trigger = Triggers.dealsDamage(
+                            damageType = DamageType.Combat,
+                            recipient = RecipientFilter.AnyPlayer,
+                            sourceFilter = GameObjectFilter.Creature.youControl(),
+                        ),
+                        watchedRecipient = EffectTarget.ContextTarget(0),
+                        effect = Effects.CreateTreasure(1, tapped = true),
+                    ),
+                    targetRequirements = listOf(Targets.Opponent),
+                    description = "+ {R} — Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
+                    additionalManaCost = "{R}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg?1712860638"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "If it isn't your combat phase as the first mode resolves, you won't get an additional combat phase. If you cast Great Train Heist before your combat phase, you won't get an additional combat phase that turn.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MirageMesa.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MirageMesa.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Mirage Mesa
+ * Land — Desert
+ *
+ * This land enters tapped. As it enters, choose a color.
+ * {T}: Add one mana of the chosen color.
+ */
+val MirageMesa = card("Mirage Mesa") {
+    typeLine = "Land — Desert"
+    colorIdentity = ""
+    oracleText = "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    // {T}: Add one mana of the chosen color
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChosenColor()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Andrew Mar"
+        flavorText = "\"Out there, death and salvation may lie on either side of the same ridge of sand.\"\n—Ertha Jo, frontier mentor"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg?1712356348"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RuthlessLawbringer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RuthlessLawbringer.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ruthless Lawbringer
+ * {1}{W}{B}
+ * Creature — Vampire Assassin
+ * 3/2
+ *
+ * When this creature enters, you may sacrifice another creature. When you do,
+ * destroy target nonland permanent.
+ *
+ * "Sacrifice another creature" is a resolution-time choice, not a target: the
+ * player accepts the optional first, then chooses which creature (so declining
+ * never forces a commitment). The "When you do" reflexive trigger then targets a
+ * nonland permanent, chosen as that second ability goes on the stack.
+ */
+val RuthlessLawbringer = card("Ruthless Lawbringer") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Vampire Assassin"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may sacrifice another creature. When you do, destroy target nonland permanent."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Composite(listOf(
+                SelectTargetEffect(
+                    requirement = TargetObject(
+                        filter = TargetFilter.CreatureYouControl.other()
+                    ),
+                    storeAs = "creatureToSacrifice"
+                ),
+                Effects.SacrificeTarget(EffectTarget.PipelineTarget("creatureToSacrifice"))
+            )),
+            optional = true,
+            reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.NonlandPermanent),
+            descriptionOverride = "You may sacrifice another creature. When you do, destroy target nonland permanent."
+        )
+        description = "When this creature enters, you may sacrifice another creature. When you do, destroy target nonland permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Joshua Raphael"
+        flavorText = "There's only one law that truly matters to the Sterling Company: never stand in the way of profit."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg?1712356201"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5876,6 +5876,157 @@
     ]
 }
 
+// Great Train Heist
+{
+    "name": "Great Train Heist",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2}{R} — Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n+ {2} — Creatures you control get +1/+0 and gain first strike until end of turn.\n+ {R} — Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "TapUntap",
+                                    "target": "Self",
+                                    "tap": false
+                                }
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "IsInPhase",
+                                        "phases": [
+                                            "COMBAT"
+                                        ]
+                                    }
+                                },
+                                "then": "AddCombatPhase"
+                            }
+                        ]
+                    },
+                    "description": "+ {2}{R} — Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.",
+                    "additionalManaCost": "{2}{R}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "FIRST_STRIKE",
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "+ {2} — Creatures you control get +1/+0 and gain first strike until end of turn.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "CreateDelayedTrigger",
+                        "effect": {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure",
+                            "tapped": true
+                        },
+                        "trigger": {
+                            "event": {
+                                "type": "DealsDamageEvent",
+                                "damageType": "DamageCombat",
+                                "recipient": "AnyPlayer",
+                                "sourceFilter": "creature ctrl:you"
+                            }
+                        },
+                        "watchedRecipient": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetOpponent"
+                    ],
+                    "description": "+ {R} — Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
+                    "additionalManaCost": "{R}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "RARE",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg?1712860638",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You choose the modes as you cast the spell with spree. Once modes are chosen, they can't be changed."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If it isn't your combat phase as the first mode resolves, you won't get an additional combat phase. If you cast Great Train Heist before your combat phase, you won't get an additional combat phase that turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hardbristle Bandit
 {
     "name": "Hardbristle Bandit",
@@ -8570,6 +8721,41 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Mirage Mesa
+{
+    "name": "Mirage Mesa",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": "ManaColorSet.SourceChosenColor"
+                },
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "COLOR"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Andrew Mar",
+        "flavorText": "\"Out there, death and salvation may lie on either side of the same ridge of sand.\"\n—Ertha Jo, frontier mentor",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg?1712356348"
+    },
+    "colorIdentityOverride": []
 }
 
 // Mobile Homestead
@@ -12046,6 +12232,85 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Ruthless Lawbringer
+{
+    "name": "Ruthless Lawbringer",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Assassin",
+    "oracleText": "When this creature enters, you may sacrifice another creature. When you do, destroy target nonland permanent.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "storeAs": "creatureToSacrifice"
+                            },
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "creatureToSacrifice"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "nonland permanent"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice another creature. When you do, destroy target nonland permanent."
+                },
+                "descriptionOverride": "When this creature enters, you may sacrifice another creature. When you do, destroy target nonland permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "flavorText": "There's only one law that truly matters to the Sterling Company: never stand in the way of profit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg?1712356201"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1961,6 +1961,15 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject, condition: String? = null):
         val dsl: Dsl = when (rep.strField("_ReplacementActionWouldEnter")) {
             "EntersTapped" -> call("EntersTapped")
             "ChooseACreatureType" -> call("EntersWithChoice", arg("ChoiceType.CREATURE_TYPE"))
+            // "As ~ enters, choose a color." Only the unrestricted any-color choice (Mirage Mesa,
+            // Uncharted Haven) renders exactly; a constrained color pick scaffolds. Pairs with the
+            // `AddMana(ManaOfTheChosenColor)` -> `Effects.AddManaOfChosenColor()` mana ability.
+            "ChooseAColor" -> {
+                if ((rep["args"] as? JsonObject)?.strField("_ChoosableColor") != "AnyColor") {
+                    reasons.add("AsPermanentEnters"); return null
+                }
+                call("EntersWithChoice", arg("ChoiceType.COLOR"))
+            }
             "EntersWithACounter" -> {
                 // "~ enters with a [counter] on it" — a single fixed counter on this permanent. The
                 // self-scoped ±1/±1 counter renders as the default-filter EntersWithCounters; a keyword

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -65,6 +65,9 @@ internal fun manaProduceDsl(node: JsonElement?): Dsl? =
         null -> null
         "ManaProduceC" -> call("Effects.AddColorlessMana", arg("1"))
         "AnyManaColor" -> call("Effects.AddManaOfChoice")
+        // "{T}: Add one mana of the chosen color." — pairs with an `EntersWithChoice(ChoiceType.COLOR)`
+        // replacement (Mirage Mesa, Uncharted Haven). The chosen color was fixed when the land entered.
+        "ManaOfTheChosenColor" -> call("Effects.AddManaOfChosenColor")
         "And" -> manaAndDsl(node)  // {B}{B}{B} (Dark Ritual), {C}{C}{C} (Basalt Monolith), …
         else -> MANA_PRODUCE_COLOR[produce]?.let { call("Effects.AddMana", arg(it)) }
     }

--- a/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
@@ -11967,6 +11967,8 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 
 /**
@@ -11981,7 +11983,8 @@ val StoryCircle = card("Story Circle") {
     colorIdentity = "W"
     typeLine = "Enchantment"
     oracleText = "As this enchantment enters, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage."
-    // STRUCTURE needs human wiring: AsPermanentEnters
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+    // STRUCTURE needs human wiring: ChooseADamageSource
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "49"
@@ -13751,6 +13754,8 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 
 /**
@@ -13770,7 +13775,8 @@ val VoiceOfAll = card("Voice of All") {
     power = 2
     toughness = 2
     keywords(Keyword.FLYING)
-    // STRUCTURE needs human wiring: AsPermanentEnters
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+    // STRUCTURE needs human wiring: PermanentLayerEffect
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "56"

--- a/mtgish-tooling/src/test/resources/fixtures/chk.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/chk.emitted.golden.txt
@@ -9255,6 +9255,8 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 
 /**
@@ -9269,7 +9271,8 @@ val SwirlTheMists = card("Swirl the Mists") {
     colorIdentity = "U"
     typeLine = "Enchantment"
     oracleText = "As this enchantment enters, choose a color word.\nAll instances of color words in the text of spells and permanents are changed to the chosen color word."
-    // STRUCTURE needs human wiring: AsPermanentEnters
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+    // STRUCTURE needs human wiring: EachPermanentAndSpellEffect
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "94"

--- a/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
@@ -9466,6 +9466,8 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 
 /**
@@ -9481,6 +9483,8 @@ val RiptideReplicator = card("Riptide Replicator") {
     colorIdentity = ""
     typeLine = "Artifact"
     oracleText = "As this artifact enters, choose a color and a creature type.\nThis artifact enters with X charge counters on it.\n{4}, {T}: Create an X/X creature token of the chosen color and type, where X is the number of charge counters on this artifact."
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
     // STRUCTURE needs human wiring: AsPermanentEnters
     metadata {
         rarity = Rarity.RARE

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -40,6 +40,14 @@ data class DelayedTriggeredAbility(
      * matches this id.
      */
     val watchedEntityId: EntityId? = null,
+    /**
+     * For event-based delayed triggers: scopes the trigger to events whose *recipient*
+     * (the damaged/targeted entity) matches this id. Whereas [watchedEntityId] narrows by the
+     * event's source, this narrows by the event's recipient — e.g. "whenever a creature you
+     * control deals combat damage to *that player* this turn" (Great Train Heist). Baked from
+     * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.watchedRecipient].
+     */
+    val watchedRecipientId: EntityId? = null,
     /** For event-based delayed triggers: the expiry rule. */
     val expiry: DelayedTriggerExpiry? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -599,7 +599,7 @@ class TriggerDetector(
             for (delayed in eventBased) {
                 if (delayed.fireOnce && delayed.id in firedOnceIds) continue
                 val spec = delayed.trigger ?: continue
-                if (!matchesEventForWatchedEntity(spec, event, delayed.watchedEntityId, delayed.id, delayed.sourceId, delayed.controllerId, state)) continue
+                if (!matchesEventForWatchedEntity(spec, event, delayed.watchedEntityId, delayed.watchedRecipientId, delayed.id, delayed.sourceId, delayed.controllerId, state)) continue
                 if (delayed.fireOnce) firedOnceIds.add(delayed.id)
                 triggers.add(
                     PendingTrigger(
@@ -640,6 +640,7 @@ class TriggerDetector(
         spec: com.wingedsheep.sdk.scripting.TriggerSpec,
         event: EngineGameEvent,
         watchedEntityId: EntityId?,
+        watchedRecipientId: EntityId?,
         delayedId: String,
         sourceId: EntityId,
         controllerId: EntityId,
@@ -662,6 +663,9 @@ class TriggerDetector(
             is com.wingedsheep.sdk.scripting.EventPattern.DealsDamageEvent -> {
                 if (event !is com.wingedsheep.engine.core.DamageDealtEvent) return false
                 if (watchedEntityId != null && event.sourceId != watchedEntityId) return false
+                // Recipient-scoped ("…to *that player* this turn"): the damaged entity must be
+                // the baked recipient. The spec's recipient filter still applies on top.
+                if (watchedRecipientId != null && event.targetId != watchedRecipientId) return false
                 matcher.matchesDealsDamageTrigger(specEvent, event, state, controllerId)
             }
             // "When damage is prevented this way": fires only for this delayed trigger's own

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -67,6 +67,13 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         // entity id so matching later is cheap and doesn't need the original context.
         val watchedEntityId = effect.watchedTarget?.let { context.resolveTarget(it) }
 
+        // Recipient-scoped delayed triggers ("…deals combat damage to *that player* this turn"):
+        // resolve the chosen recipient (e.g. ContextTarget(0) for the targeted opponent) into a
+        // concrete entity id now, while the originating context still knows who it is.
+        val watchedRecipientId = effect.watchedRecipient?.let {
+            context.resolvePlayerTarget(it) ?: context.resolveTarget(it)
+        }
+
         // For step-based delayed triggers that restrict to a specific player's turn (e.g.
         // Nafs Asp's "at the beginning of their next draw step"): resolve the player target
         // now, while the trigger context still knows who it is, and bake the entity id in.
@@ -116,6 +123,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             controllerId = context.controllerId,
             trigger = resolvedTrigger,
             watchedEntityId = watchedEntityId,
+            watchedRecipientId = watchedRecipientId,
             expiry = if (effect.trigger != null) effect.expiry else null,
             fireOnce = effect.trigger != null && effect.fireOnce,
             notBeforeTurn = notBeforeTurn,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatTrainHeistTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatTrainHeistTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GreatTrainHeist
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.booleans.shouldBeTrue
+
+/**
+ * Great Train Heist — Spree instant ({R} + per-mode costs):
+ * + {2}{R} — Untap all creatures you control. If it's your combat phase, there is an
+ *            additional combat phase after this phase.
+ * + {2} — Creatures you control get +1/+0 and gain first strike until end of turn.
+ * + {R} — Choose target opponent. Whenever a creature you control deals combat damage to
+ *         that player this turn, create a tapped Treasure token.
+ *
+ * Mode 3 exercises the new recipient-scoped delayed trigger (`watchedRecipient`): the
+ * Treasure is created only on combat damage dealt to the *chosen* opponent by a creature the
+ * caster controls.
+ */
+class GreatTrainHeistTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + GreatTrainHeist + PredefinedTokens.Treasure)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun treasureCount(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).count { entityId ->
+            driver.state.getEntity(entityId)?.get<CardComponent>()?.name == "Treasure"
+        }
+
+    test("mode 3: a creature you control dealing combat damage to the chosen opponent makes a tapped Treasure") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val attacker = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        driver.removeSummoningSickness(attacker)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Mode 2 (index 2) only: base {R} + additional {R}.
+        driver.giveMana(me, Color.RED, 2)
+        val spell = driver.putCardInHand(me, "Great Train Heist")
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(2),
+                targets = listOf(ChosenTarget.Player(opp)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the spell -> registers the delayed trigger
+
+        driver.state.delayedTriggers.size shouldBe 1
+
+        // Swing with the Bears at the chosen opponent.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opp)
+        driver.bothPass() // end declare attackers
+        driver.bothPass() // end declare blockers (none)
+        // Resolve combat damage + the resulting delayed-trigger treasure.
+        repeat(8) { driver.bothPass() }
+
+        treasureCount(driver, me) shouldBe 1
+        // The Treasure entered tapped.
+        val treasure = driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).first { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == "Treasure"
+        }
+        driver.isTapped(treasure).shouldBeTrue()
+    }
+
+    test("mode 2: creatures you control get +1/+0 and gain first strike until end of turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Mode 1 (index 1): base {R} + additional {2}.
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveColorlessMana(me, 2)
+        val spell = driver.putCardInHand(me, "Great Train Heist")
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(1),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(bear) shouldBe 3
+        projected.hasKeyword(bear, Keyword.FIRST_STRIKE).shouldBeTrue()
+    }
+
+    test("mode 1: untaps your creatures and grants an additional combat phase during your combat") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val attacker = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(attacker)
+
+        // Attack so the creature is tapped and we are in the combat phase. After declaring
+        // attackers the active player still holds priority, so we can cast in response.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opp)
+        driver.isTapped(attacker).shouldBeTrue()
+
+        // Cast Great Train Heist mode 0 (index 0) during combat: {2}{R} + base {R}.
+        driver.giveMana(me, Color.RED, 2)
+        driver.giveColorlessMana(me, 2)
+        val spell = driver.putCardInHand(me, "Great Train Heist")
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = listOf(0),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Creatures you control untapped.
+        driver.isTapped(attacker) shouldBe false
+        // An additional combat phase is queued because it was cast during the caster's combat.
+        driver.state.getEntity(me)?.get<AdditionalCombatPhasesComponent>() shouldBe
+            AdditionalCombatPhasesComponent(1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessLawbringerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessLawbringerTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RuthlessLawbringer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Ruthless Lawbringer ({1}{W}{B}, 3/2 Vampire Assassin):
+ * "When this creature enters, you may sacrifice another creature. When you do,
+ *  destroy target nonland permanent."
+ *
+ * Composed as a [com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect]: the
+ * "sacrifice another creature" action is a resolution-time choice (SelectTargetEffect +
+ * SacrificeTarget), and the "When you do" reflexive destroy targets a nonland permanent,
+ * chosen as that second ability goes on the stack.
+ */
+class RuthlessLawbringerTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RuthlessLawbringer)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castLawbringer(driver: GameTestDriver, me: EntityId): EntityId {
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+        val card = driver.putCardInHand(me, "Ruthless Lawbringer")
+        driver.castSpell(me, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // resolve the enters trigger off the stack
+        return card
+    }
+
+    test("sacrificing another creature destroys a target nonland permanent") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val victim = driver.putCreatureOnBattlefield(opp, "Hill Giant")
+
+        castLawbringer(driver, me)
+
+        // "You may sacrifice another creature." — accept.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+
+        // Choose the fodder to sacrifice (SelectTargetEffect -> ChooseTargetsDecision).
+        driver.submitTargetSelection(me, listOf(fodder))
+
+        // The "When you do" reflexive trigger goes on the stack; pick the destroy target.
+        driver.submitTargetSelection(me, listOf(victim))
+        driver.bothPass() // resolve the reflexive destroy
+
+        driver.getGraveyard(me).contains(fodder) shouldBe true
+        driver.getGraveyard(opp).contains(victim) shouldBe true
+    }
+
+    test("declining the optional sacrifice destroys nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val victim = driver.putCreatureOnBattlefield(opp, "Hill Giant")
+
+        castLawbringer(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        // Nothing destroyed: the victim is still on the battlefield.
+        driver.getPermanents(opp).contains(victim) shouldBe true
+    }
+
+    test("the Lawbringer itself can't be the sacrificed creature (\"another\")") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // No other creatures: only the Lawbringer is on the battlefield, so the optional
+        // sacrifice has no legal target and the reflexive payoff must not fire.
+        castLawbringer(driver, me)
+
+        // With no "another creature" available, the may-sacrifice action is infeasible and is
+        // skipped entirely — no decision is presented.
+        driver.pendingDecision shouldBe null
+    }
+})


### PR DESCRIPTION
Three Outlaws of Thunder Junction cards, a reusable recipient-scoped delayed-trigger primitive, and two faithful mtgish-emitter additions.

## Cards

- **Mirage Mesa** (`Land — Desert`) — enters tapped, choose a color as it enters, `{T}`: add one mana of the chosen color. Built from the existing Uncharted Haven template (`EntersTapped` + `EntersWithChoice(ChoiceType.COLOR)` + `Effects.AddManaOfChosenColor()`), retyped as a Desert. No new mechanic.
- **Ruthless Lawbringer** (`{1}{W}{B}`, 3/2 Vampire Assassin) — "When this creature enters, you may sacrifice another creature. When you do, destroy target nonland permanent." Composed from `ReflexiveTriggerEffect`: the sacrifice is a resolution-time `SelectTargetEffect` (creature you control, source-excluded via `.other()`) + `SacrificeTarget`, and the **"When you do"** reflexive destroy targets a nonland permanent chosen as that second ability goes on the stack — the rules-correct timing, not "if you do".
- **Great Train Heist** (`{R}`, Spree instant) — modeled as a `ModalEffect` with per-mode `additionalManaCost` (`minChooseCount = 1`):
  - `+ {2}{R}` — untap all creatures you control; an additional combat phase if it's your combat phase (gated by `Conditions.IsInPhase(Phase.COMBAT)`).
  - `+ {2}` — creatures you control get +1/+0 and gain first strike until end of turn.
  - `+ {R}` — choose target opponent; whenever a creature you control deals combat damage to *that player* this turn, create a tapped Treasure.

## SDK / engine

- New `CreateDelayedTriggerEffect.watchedRecipient` (and `DelayedTriggeredAbility.watchedRecipientId`, baked in `CreateDelayedTriggerExecutor`, matched in `TriggerDetector`). It scopes a `DealsDamageEvent` delayed trigger by the damaged **recipient** — whereas the existing `watchedTarget` scopes by the damage **source**. This generalizes the recurring "...to that player this turn, ..." idiom (Great Train Heist's Treasure mode). The `TriggerSpec`'s `recipient`/`sourceFilter` still apply on top. Documented in `docs/card-sdk-language-reference.md`.

## mtgish-tooling

- Emitter now faithfully renders "As ~ enters, choose a color": `ChooseAColor[AnyColor]` → `EntersWithChoice(ChoiceType.COLOR)`, and `AddMana(ManaOfTheChosenColor)` → `Effects.AddManaOfChosenColor()`. **Mirage Mesa now emits a complete AUTO render** matching the hand-authored card. As a side benefit, Riptide Replicator / Story Circle / Swirl the Mists now pick up the color choice they previously dropped (still SCAFFOLD for unrelated reasons). POR regression gate stays **158/158, 0 mismatch**; `EmitterGolden` fixtures re-blessed (purely additive — only the new `EntersWithChoice(COLOR)` lines).
- **Ruthless Lawbringer** (`MayCost`-into-`If(CostWasPaid, ReflexiveTrigger)`) and **Great Train Heist** (Spree + conditional `If` + recipient-scoped delayed trigger) are intentionally **left at SCAFFOLD**. Both sit squarely in the documented "extra costs / cast-time conditionals / inherited choices" area the tooling's own CLAUDE/README says the emitter must decline rather than approximate. Forcing them would emit a lossy card, so per policy they stay SCAFFOLD with a passing hand-authored implementation as the ground truth.

## Tests

- New scenario tests `RuthlessLawbringerTest` (3 cases: sacrifice→destroy, decline, no-other-creature feasibility skip) and `GreatTrainHeistTest` (3 cases: recipient-scoped tapped Treasure on combat damage, team pump + first strike, untap + conditional extra combat) — all pass.
- Re-blessed `mtg-sets` `CardDefinitionSnapshotTest` golden (only the three new OTJ cards added) and `CardLintTest` passes. `mtgish-tooling` suite and rules-engine serialization tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)