### PR TITLE
Add Arid Archway, Shackle Slinger, This Town Ain't Big Enough (OTJ)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2651,6 +2651,15 @@ answer it and would silently return `false`.
   the dedicated check for "any target" effects with a player-only follow-up. Used by Sonic Shrieker
   ("If a player is dealt damage this way, they discard a card"); pair with
   `EffectTarget.ContextTarget(index)` to make that same player the subject of the follow-up.
+- `TargetIsTapped(targetIndex = 0)` — the context target resolves to a tapped battlefield permanent.
+  Non-permanent targets and permanents no longer on the battlefield return false. Branch on a target's
+  tapped state at resolution via `ConditionalEffect` — used by Shackle Slinger ("If it's tapped, put a
+  stun counter on it. Otherwise, tap it.").
+- `TargetIsSource(targetIndex = 0)` — the context target resolves to the ability's own source
+  permanent. Wrap in `Conditions.Not(...)` for "another"/"a different permanent" wordings — used by
+  Arid Archway ("If another Desert was returned this way, surveil 1": `All(TargetMatchesFilter(Desert
+  land), Not(TargetIsSource()))` checks the chosen land *before* the bounce, so returning the Archway
+  itself doesn't count).
 - `IfTargetTookExcessDamage(targetIndex = 0)` — true post-damage when the target creature's marked
   damage strictly exceeds its (projected) toughness. Chain after `Effects.DealDamage` in a composite
   so the marked-damage update applies before the condition reads it. Used by Orbital Plunge ("If

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -298,6 +298,22 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer(targetIndex)
 
     /**
+     * If the context target at [targetIndex] is a tapped battlefield permanent. Branch on a
+     * target's tapped state at resolution — e.g. Shackle Slinger's "If it's tapped, put a stun
+     * counter on it. Otherwise, tap it."
+     */
+    fun TargetIsTapped(targetIndex: Int = 0): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TargetIsTapped(targetIndex)
+
+    /**
+     * If the context target at [targetIndex] is this permanent (the ability's source). Wrap in
+     * [Not] for "another"/"a different permanent" wordings — e.g. Arid Archway's "If another
+     * Desert was returned this way".
+     */
+    fun TargetIsSource(targetIndex: Int = 0): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TargetIsSource(targetIndex)
+
+    /**
      * If the target shares a color with the most common color among all permanents
      * (or a color tied for most common). Used by Tsabo's Assassin.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -172,6 +172,40 @@ data class TargetIsPlayer(
 }
 
 /**
+ * Condition: "if [target] is tapped".
+ *
+ * Resolves the context target at [targetIndex] to a battlefield permanent and returns true when it
+ * is currently tapped. Non-permanent targets and permanents that have left the battlefield return
+ * false defensively. Pairs with a [com.wingedsheep.sdk.scripting.effects.ConditionalEffect] to branch
+ * on a target's tapped state at resolution time — e.g. Shackle Slinger's "choose target creature an
+ * opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it."
+ */
+@SerialName("TargetIsTapped")
+@Serializable
+data class TargetIsTapped(
+    val targetIndex: Int = 0
+) : Condition {
+    override val description: String = "if it's tapped"
+}
+
+/**
+ * Condition: "if [target] is this permanent (the source)".
+ *
+ * True when the context target at [targetIndex] resolves to the same entity as the ability's
+ * source. Wrap in [com.wingedsheep.sdk.dsl.Conditions.Not] for "if it's a different permanent" /
+ * "another" wordings — e.g. Arid Archway's "If another Desert was returned this way" pairs
+ * `Not(TargetIsSource())` with a Desert-land filter check so returning the Archway itself doesn't
+ * count. Non-permanent targets return false.
+ */
+@SerialName("TargetIsSource")
+@Serializable
+data class TargetIsSource(
+    val targetIndex: Int = 0
+) : Condition {
+    override val description: String = "if it's this permanent"
+}
+
+/**
  * Condition: "if excess damage was dealt this way" — true when the target creature's
  * marked damage now strictly exceeds its (projected) toughness.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AridArchway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AridArchway.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Arid Archway
+ * Land — Desert
+ *
+ * This land enters tapped.
+ * When this land enters, return a land you control to its owner's hand. If another Desert was
+ * returned this way, surveil 1.
+ * {T}: Add {C}{C}.
+ *
+ * "Return a land you control" is the controller's choice, modeled as a target constrained to their
+ * own lands (a self-bounce that cannot fizzle), like the Karoo bounce lands. "If another Desert
+ * was returned this way" is evaluated against the chosen land *before* the bounce (it leaves the
+ * battlefield, so its subtype can't be read afterward): surveil 1 fires only when the returned land
+ * is a Desert AND is not Arid Archway itself ([Conditions.Not] of [Conditions.TargetIsSource]).
+ */
+val AridArchway = card("Arid Archway") {
+    typeLine = "Land — Desert"
+    colorIdentity = ""
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, return a land you control to its owner's hand. If another Desert " +
+        "was returned this way, surveil 1. (Look at the top card of your library. You may put it " +
+        "into your graveyard.)\n" +
+        "{T}: Add {C}{C}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target(
+            "a land you control",
+            TargetPermanent(filter = TargetFilter.Land.youControl()),
+        )
+        // Evaluate the "another Desert" check while the land is still on the battlefield, then
+        // bounce + surveil (true branch) or just bounce (false branch).
+        effect = ConditionalEffect(
+            condition = Conditions.All(
+                Conditions.TargetMatchesFilter(GameObjectFilter.Land.withSubtype(Subtype.DESERT)),
+                Conditions.Not(Conditions.TargetIsSource()),
+            ),
+            effect = Effects.ReturnToHand(land).then(Patterns.Library.surveil(1)),
+            elseEffect = Effects.ReturnToHand(land),
+        )
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "252"
+        artist = "Raymond Bonilla"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg?1713223021"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShackleSlinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShackleSlinger.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Shackle Slinger
+ * {2}{U}
+ * Creature — Human Soldier
+ * 3/2
+ *
+ * Whenever you cast your second spell each turn, choose target creature an opponent controls. If
+ * it's tapped, put a stun counter on it. Otherwise, tap it.
+ *
+ * "Your second spell each turn" → [Triggers.NthSpellCast] with n = 2 scoped to [Player.You]. The
+ * stun-or-tap branch is a resolution-time read of the target's tapped state via
+ * [Conditions.TargetIsTapped]: tapped targets get a stun counter, untapped targets are tapped.
+ */
+val ShackleSlinger = card("Shackle Slinger") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever you cast your second spell each turn, choose target creature an opponent " +
+        "controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent " +
+        "with a stun counter would become untapped, remove one from it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = ConditionalEffect(
+            condition = Conditions.TargetIsTapped(),
+            effect = AddCountersEffect(counterType = Counters.STUN, count = 1, target = t),
+            elseEffect = Effects.Tap(t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Josh Hass"
+        flavorText = "Even when he missed the wrists, a pair of thundercuffs to the head got the job done."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg?1712355493"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThisTownAintBigEnough.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThisTownAintBigEnough.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+
+/**
+ * This Town Ain't Big Enough
+ * {4}{U}
+ * Instant
+ *
+ * This spell costs {3} less to cast if it targets a permanent you control.
+ * Return up to two target nonland permanents to their owners' hands.
+ *
+ * The cost reduction is a [SpellCostTarget.SelfCast] / [CostReductionSource.FixedIfAnyTargetMatches]
+ * pair: {3} comes off if any chosen target is a permanent you control. The bounce is up-to-two
+ * independent optional targets, returned in order.
+ */
+val ThisTownAintBigEnough = card("This Town Ain't Big Enough") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {3} less to cast if it targets a permanent you control.\n" +
+        "Return up to two target nonland permanents to their owners' hands."
+
+    spell {
+        // "Return up to two target nonland permanents" — one up-to-two target requirement; the bounce
+        // visits each chosen target, routing each permanent to its owner's hand.
+        target("target", TargetPermanent(optional = true, count = 2, filter = TargetFilter.NonlandPermanent))
+        effect = ForEachTargetEffect(listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND)))
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 3,
+                    filter = GameObjectFilter.Permanent.youControl(),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Andrew Mar"
+        flavorText = "\"All that fancy footwork, and you can't even dodge one silly little rope? " +
+            "Cryin' shame, that is.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg?1752091373"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -517,6 +517,150 @@
     ]
 }
 
+// Arid Archway
+{
+    "name": "Arid Archway",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "This land enters tapped.\nWhen this land enters, return a land you control to its owner's hand. If another Desert was returned this way, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}{C}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "All",
+                            "conditions": [
+                                {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "land Desert"
+                                },
+                                {
+                                    "type": "Not",
+                                    "condition": "TargetIsSource"
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "a land you control"
+                                },
+                                "destination": "Hand"
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeAs": "surveiled"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "surveiled",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "toGraveyard",
+                                        "storeRemainder": "toTop",
+                                        "selectedLabel": "Put in graveyard",
+                                        "remainderLabel": "Put on top"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "toGraveyard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "toTop",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Library",
+                                            "placement": "Top"
+                                        },
+                                        "order": "ControllerChooses"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "a land you control"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land ctrl:you"
+                    },
+                    "id": "a land you control"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Bonilla",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg?1713223021"
+    },
+    "colorIdentityOverride": []
+}
+
 // Armored Armadillo
 {
     "name": "Armored Armadillo",
@@ -12411,6 +12555,71 @@
     ]
 }
 
+// Shackle Slinger
+{
+    "name": "Shackle Slinger",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "TargetIsTapped"
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "stun",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "flavorText": "Even when he missed the wrists, a pair of thundercuffs to the head got the job done.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg?1712355493"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shepherd of the Clouds
 {
     "name": "Shepherd of the Clouds",
@@ -14349,6 +14558,63 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// This Town Ain't Big Enough
+{
+    "name": "This Town Ain't Big Enough",
+    "manaCost": "{4}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {3} less to cast if it targets a permanent you control.\nReturn up to two target nonland permanents to their owners' hands.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 3,
+                        "filter": "permanent ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "\"All that fancy footwork, and you can't even dodge one silly little rope? Cryin' shame, that is.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg?1752091373"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -36,6 +36,11 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("PutTopOfLibraryInGraveyard", "look-top pipeline -> MoveCollection (library->graveyard)", composes = listOf("MoveCollection", "MoveToZone"))
 
     composed("PutPermanentIntoItsOwnersHand", "bounce: MoveToZone / Gather-Select-MoveCollection pipeline", composes = listOf("MoveToZone"))
+    // "Return a <filter> you control to its owner's hand" — the controller CHOOSES the permanent (not a
+    // target); expressible as a self-bounce target constrained to the chooser's own permanents (the Karoo
+    // bounce-land idiom, Arid Archway). Capability only — the emitter scaffolds the "another Desert was
+    // returned this way" follow-up (see ZoneHandlers' `If` decline), so this is SCAFFOLD-tier in practice.
+    composed("PutAPermanentIntoItsOwnersHand", "chosen bounce: self-bounce target over the chooser's permanents -> MoveToZone", composes = listOf("MoveToZone"))
     composed("PutEachPermanentIntoItsOwnersHand", "EachPlayerReturnsPermanentToHand", composes = listOf("MoveCollection", "MoveToZone"))
     // "Return any number of [filter] to their owner's hand" (Rambling Possum) — Gather -> ChooseAnyNumber
     // -> MoveCollection (battlefield->hand routes to owner).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -213,6 +213,7 @@ internal fun EmitCtx.castEffectHandled(rule: JsonObject): Boolean {
         "AdditionalCastingCost" -> additionalCostLine(rule) != null
         "ReduceCastingCostIf" -> costReductionStaticLines(rule) != null
         "ReduceCastingCostIfItTargetsASpell" -> targetSpellCostReductionLines(rule) != null
+        "ReduceCastingCostIfItTargetsAPermanent" -> targetPermanentCostReductionLines(rule) != null
         "MayCastAsThoughItHadFlashForAdditionalCost" -> flashKickerLine(rule) != null
         else -> false
     }
@@ -245,6 +246,8 @@ internal fun EmitCtx.cardLevelCastEffectLines(card: JsonObject): List<String>? {
         if (reduction != null) { lines.addAll(reduction); continue }
         val targetReduction = targetSpellCostReductionLines(rule)
         if (targetReduction != null) { lines.addAll(targetReduction); continue }
+        val targetPermReduction = targetPermanentCostReductionLines(rule)
+        if (targetPermReduction != null) { lines.addAll(targetPermReduction); continue }
         val flash = flashKickerLine(rule)
         if (flash != null) { lines.add(flash); continue }
         if (!castEffectHandled(rule)) return null
@@ -311,6 +314,42 @@ private fun EmitCtx.targetSpellCostReductionLines(rule: JsonObject): List<String
         }
     }
     return abilities.flatMap { renderBlock(Block("staticAbility", listOf(Assign("ability", it))), "    ") }
+}
+
+/**
+ * `CastEffect(ReduceCastingCostIfItTargetsAPermanent([CostReduceGeneric N], <permanent filter>))` -> a
+ * `staticAbility { ability = ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfAnyTargetMatches(N,
+ * <filter>))) }` block. This Town Ain't Big Enough ("This spell costs {3} less to cast if it targets a
+ * permanent you control").
+ *
+ * Renders only a single bare generic reduction over a recoverable permanent filter (the controller
+ * "you control" clause is preserved as `.youControl()`). A colored/multi-symbol reduction, or an
+ * unrenderable filter, declines -> SCAFFOLD rather than misrender the gate.
+ */
+private fun EmitCtx.targetPermanentCostReductionLines(rule: JsonObject): List<String>? {
+    val node = rule["args"] as? JsonObject ?: return null
+    if (node.strField("_CastEffect") != "ReduceCastingCostIfItTargetsAPermanent") return null
+    val args = node["args"].asArr ?: return null
+    val symbols = (args.getOrNull(0) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
+    val amount = symbols[0]["args"].asInt() ?: return null
+    val filterNode = args.getOrNull(1) as? JsonObject ?: return null
+    // gameObjectFilterDsl already preserves the "you control" / "an opponent controls" controller clause
+    // (e.g. ControlledByAPlayer(You) -> GameObjectFilter.Permanent.youControl()); an unrenderable filter
+    // declines -> SCAFFOLD.
+    val filterDsl = gameObjectFilterDsl(filterNode) ?: return null
+    val ability = call(
+        "ModifySpellCost",
+        arg("target", Lit("SpellCostTarget.SelfCast")),
+        arg("modification", call(
+            "CostModification.ReduceGenericBy",
+            arg(call(
+                "CostReductionSource.FixedIfAnyTargetMatches",
+                arg("amount", "$amount"), arg("filter", Lit(filterDsl)),
+            )),
+        )),
+    )
+    return renderBlock(Block("staticAbility", listOf(Assign("ability", ability))), "    ")
 }
 
 /**
@@ -1404,6 +1443,20 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
         jsonContains(cond, "_Spells", "WasCastFromTheirHand")
     ) {
         return "Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))"
+    }
+    // "if it's tapped" — PermanentPassesFilter(Ref_TargetPermanent, IsTapped) over the bound target
+    // (Shackle Slinger's "If it's tapped, put a stun counter on it. Otherwise, tap it."). The subject
+    // must be the ability's first targeted permanent and the filter a bare IsTapped (no other clause);
+    // maps to Conditions.TargetIsTapped(). Any other subject/filter declines -> SCAFFOLD.
+    if (cond.strField("_Condition") == "PermanentPassesFilter") {
+        val condArgs = cond["args"].asArr
+        val subject = (condArgs?.getOrNull(0) as? JsonObject)?.strField("_Permanent")
+        val filt = condArgs?.getOrNull(1) as? JsonObject
+        if ((subject == "Ref_TargetPermanent" || subject == "Ref_TargetPermanent1") &&
+            filt?.strField("_Permanents") == "IsTapped" && filt.size == 1
+        ) {
+            return "Conditions.TargetIsTapped()"
+        }
     }
     // "this creature doesn't have a <counter> counter on it" — PermanentPassesFilter(ThisPermanent,
     // HasNoCountersOfType(<counter>)). Only the keyword/named counters we can name render; the source

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -82,6 +82,8 @@ import com.wingedsheep.sdk.scripting.conditions.YouSacrificedPermanentThisWay
 import com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget
 import com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness
 import com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer
+import com.wingedsheep.sdk.scripting.conditions.TargetIsTapped
+import com.wingedsheep.sdk.scripting.conditions.TargetIsSource
 import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
 import com.wingedsheep.sdk.scripting.conditions.ColorIsMostCommon
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
@@ -348,6 +350,8 @@ class ConditionEvaluator(
                 ifResolution { evaluateTriggeringEntityWasNotPutByThisSource(state, it) }
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }
             is TargetIsPlayer -> ifResolution { evaluateTargetIsPlayer(condition, it) }
+            is TargetIsTapped -> ifResolution { evaluateTargetIsTapped(state, condition, it) }
+            is TargetIsSource -> ifResolution { evaluateTargetIsSource(condition, it) }
             is TargetMarkedDamageExceedsToughness ->
                 ifResolution { evaluateTargetMarkedDamageExceedsToughness(state, condition, it) }
             is TargetSharesMostCommonColor -> ifResolution { evaluateTargetSharesMostCommonColor(state, condition, it) }
@@ -981,6 +985,40 @@ class ConditionEvaluator(
      * `Targets.Creature` + Composite they can't fire, but they keep this condition safe
      * if a future caller wraps it in a longer chain that crosses SBA or re-targets.
      */
+    /**
+     * "If the target is tapped": resolve the context target to a battlefield permanent and read its
+     * [TappedComponent]. Non-permanent targets and permanents no longer on the battlefield return
+     * false. Used by Shackle Slinger to branch between stunning a tapped target and tapping an
+     * untapped one.
+     */
+    private fun evaluateTargetIsTapped(
+        state: GameState,
+        condition: TargetIsTapped,
+        context: EffectContext
+    ): Boolean {
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
+        val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
+            ?.entityId ?: return false
+        if (entityId !in state.getBattlefield()) return false
+        return state.getEntity(entityId)?.has<TappedComponent>() == true
+    }
+
+    /**
+     * "If the target is this permanent (the source)": resolve the context target and compare its
+     * entity id to the ability's source. Non-permanent targets and a missing source return false.
+     * Wrapped in `Not` by Arid Archway to express "another" (a returned land that isn't itself).
+     */
+    private fun evaluateTargetIsSource(
+        condition: TargetIsSource,
+        context: EffectContext
+    ): Boolean {
+        val sourceId = context.sourceId ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
+        val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
+            ?.entityId ?: return false
+        return entityId == sourceId
+    }
+
     private fun evaluateTargetMarkedDamageExceedsToughness(
         state: GameState,
         condition: TargetMarkedDamageExceedsToughness,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AridArchwayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AridArchwayScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AridArchway
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Arid Archway (OTJ #252) — Land — Desert.
+ *
+ *   "This land enters tapped.
+ *    When this land enters, return a land you control to its owner's hand. If another Desert was
+ *    returned this way, surveil 1.
+ *    {T}: Add {C}{C}."
+ *
+ * Verifies: enters tapped; the ETB bounce always returns the chosen land; surveil 1 fires only when
+ * the returned land is a Desert OTHER than Arid Archway itself.
+ */
+class AridArchwayScenarioTest : FunSpec({
+
+    fun GameTestDriver.inHand(playerId: EntityId, name: String): Boolean =
+        getHand(playerId).any { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AridArchway))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("returning another Desert surveils 1; the land enters tapped") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val otherDesert = driver.putLandOnBattlefield(me, "Desert")
+        driver.putCardOnTopOfLibrary(me, "Island")
+
+        val archway = driver.putCardInHand(me, "Arid Archway")
+        driver.playLand(me, archway)
+
+        // Enters tapped.
+        driver.isTapped(archway) shouldBe true
+
+        // ETB trigger asks which land to return.
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(otherDesert))
+        driver.bothPass()
+
+        // The Desert was returned to hand.
+        driver.inHand(me, "Desert") shouldBe true
+        // Another Desert returned -> surveil 1 pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+    }
+
+    test("returning a non-Desert land does not surveil") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val island = driver.putLandOnBattlefield(me, "Island")
+
+        val archway = driver.putCardInHand(me, "Arid Archway")
+        driver.playLand(me, archway)
+
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(island))
+        driver.bothPass()
+
+        driver.inHand(me, "Island") shouldBe true
+        // Non-Desert returned -> no surveil; resolution completes.
+        driver.isPaused shouldBe false
+    }
+
+    test("returning Arid Archway itself does not surveil (not 'another' Desert)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val archway = driver.putCardInHand(me, "Arid Archway")
+        driver.playLand(me, archway)
+
+        // The only land you control is the Archway itself; return it.
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(archway))
+        driver.bothPass()
+
+        driver.inHand(me, "Arid Archway") shouldBe true
+        // Returned land is the source itself -> not "another" Desert -> no surveil.
+        driver.isPaused shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShackleSlingerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShackleSlingerScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ShackleSlinger
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Shackle Slinger (OTJ #65) — {2}{U} Creature — Human Soldier 3/2.
+ *
+ *   "Whenever you cast your second spell each turn, choose target creature an opponent controls.
+ *    If it's tapped, put a stun counter on it. Otherwise, tap it."
+ *
+ * Verifies: no trigger on the first spell; on the second spell, an untapped opposing creature is
+ * tapped (no stun counter); a tapped opposing creature gets a stun counter (stays tapped).
+ */
+class ShackleSlingerScenarioTest : FunSpec({
+
+    fun GameTestDriver.stunCount(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ShackleSlinger))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Lightning Bolt" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("second spell taps an untapped opposing creature; no stun counter") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Shackle Slinger")
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // First spell: no trigger.
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.bothPass()
+        driver.isTapped(bears) shouldBe false
+
+        // Second spell: trigger fires, targets the untapped Bears.
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        // Trigger asks for its target.
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(bears))
+        driver.bothPass()
+
+        // Untapped target -> tapped, no stun counter.
+        driver.isTapped(bears) shouldBe true
+        driver.stunCount(bears) shouldBe 0
+    }
+
+    test("second spell puts a stun counter on a tapped opposing creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Shackle Slinger")
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.tapPermanent(bears)
+
+        val bolt1 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt1, targets = listOf(opp))
+        driver.bothPass()
+
+        val bolt2 = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt2, targets = listOf(opp))
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(bears))
+        driver.bothPass()
+
+        // Already tapped -> stun counter; still tapped.
+        driver.stunCount(bears) shouldBe 1
+        driver.isTapped(bears) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThisTownAintBigEnoughScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThisTownAintBigEnoughScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ThisTownAintBigEnough
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * This Town Ain't Big Enough (OTJ #74) — {4}{U} Instant.
+ *
+ *   "This spell costs {3} less to cast if it targets a permanent you control.
+ *    Return up to two target nonland permanents to their owners' hands."
+ *
+ * Verifies: returns two targets to their owners' hands; the {3} reduction applies when a target is
+ * a permanent you control (castable with only {U} + {1} on the board).
+ */
+class ThisTownAintBigEnoughScenarioTest : FunSpec({
+
+    fun GameTestDriver.inHand(playerId: EntityId, name: String): Boolean =
+        getHand(playerId).any { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThisTownAintBigEnough))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("returns up to two nonland permanents to their owners' hands") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears1 = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val bears2 = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val card = driver.putCardInHand(me, "This Town Ain't Big Enough")
+        // Full cost {4}{U}; no own-permanent target here.
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 4)
+        driver.castSpell(me, card, targets = listOf(bears1, bears2))
+        driver.bothPass()
+
+        // Both creatures returned.
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(opp, com.wingedsheep.sdk.core.Zone.BATTLEFIELD))
+            .contains(bears1) shouldBe false
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(opp, com.wingedsheep.sdk.core.Zone.BATTLEFIELD))
+            .contains(bears2) shouldBe false
+        driver.inHand(opp, "Grizzly Bears") shouldBe true
+    }
+
+    test("costs {3} less when it targets a permanent you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val myBears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val oppBears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val card = driver.putCardInHand(me, "This Town Ain't Big Enough")
+        // Reduced cost: {4}{U} - {3} = {1}{U}. Provide exactly that.
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, card, targets = listOf(myBears, oppBears))
+        driver.bothPass()
+
+        // Spell resolved (was affordable at the reduced cost) and bounced both.
+        driver.inHand(me, "Grizzly Bears") shouldBe true
+        driver.inHand(opp, "Grizzly Bears") shouldBe true
+    }
+})


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards, with the SDK + mtgish-tooling support they need.

## Cards

- **Shackle Slinger** — `{2}{U}` Creature — Human Soldier 3/2. *Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it.* Second-spell trigger (`Triggers.NthSpellCast(2, Player.You)`) with a resolution-time stun-or-tap branch.
- **This Town Ain't Big Enough** — `{4}{U}` Instant. *This spell costs {3} less to cast if it targets a permanent you control. Return up to two target nonland permanents to their owners' hands.* Cost reduction via `ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfAnyTargetMatches(3, Permanent.youControl())))`; up-to-two bounce via `ForEachTargetEffect`.
- **Arid Archway** — Land — Desert. *Enters tapped. When it enters, return a land you control to its owner's hand. If another Desert was returned this way, surveil 1. {T}: Add {C}{C}.* Karoo-style self-bounce target + a conditional surveil gated on the returned land being a Desert other than the Archway itself.

## SDK

Two new general-purpose conditions (both `@Serializable`, evaluators added, SDK reference §12 updated):

- `Conditions.TargetIsTapped(targetIndex)` — resolves the context target to a battlefield permanent and reads its tapped state. Powers Shackle Slinger's stun-or-tap branch.
- `Conditions.TargetIsSource(targetIndex)` — true when the context target is the ability's own source. Wrapped in `Not(...)` for "another" wordings. Arid Archway's surveil gate is `All(TargetMatchesFilter(Land.withSubtype(DESERT)), Not(TargetIsSource()))`, evaluated before the bounce (the land leaves the battlefield, so its subtype can't be read afterward).

## mtgish-tooling

- **Shackle Slinger → AUTO**: taught the intervening-if renderer to map `PermanentPassesFilter(Ref_TargetPermanent, IsTapped)` → `Conditions.TargetIsTapped()`; the rest (NthSpellCast trigger, IfElse, stun counter, tap) already existed.
- **This Town → AUTO**: new `ReduceCastingCostIfItTargetsAPermanent` cast-effect handler renders the `{N}`-less-if-targets-a-permanent-you-control reduction; the body's `UptoNumberTargetPermanents` + `PutEachPermanentIntoItsOwnersHand` already rendered. The hand-authored card was aligned to the emitter's idiomatic tree so `coverage-verify` matches.
- **Arid Archway → SCAFFOLD (deliberate)**: its ETB is a *chosen* (non-target) `PutAPermanentIntoItsOwnersHand` plus an `APermanentWasPutIntoHandThisWay(Other(ThatEnteringPermanent), Desert)` follow-up. Faithfully auto-generating this would mean reifying a non-target chosen permanent as a target and special-casing the "another <type> was returned this way" condition — exactly the chosen/cast-time-value shape the tooling README says to decline rather than approximate. A bridge capability entry was added (so the probe scores it coverable) but the emitter declines to render the follow-up → SCAFFOLD.

## Verification

- 7 scenario tests (rules-engine) — pass.
- `EmitterGoldenTest` — green for every committed set (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE); no emitter drift.
- `coverage-verify POR` — GATE PASS, 158/158, 0 mismatches.
- OTJ `CardDefinitionSnapshotTest` reblessed (only the three new cards added); `CardLintTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)