### PR TITLE
Lower MAX_TOKENS_PER_EFFECT to 500 to fix CI slowdown

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameLimits.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameLimits.kt
@@ -39,7 +39,7 @@ object GameLimits {
      * and legal-action pass then scans, so this caps both the allocation burst and the resulting
      * per-step cost. Far above any real board; only a degenerate doubler stack reaches it.
      */
-    const val MAX_TOKENS_PER_EFFECT: Int = 10_000
+    const val MAX_TOKENS_PER_EFFECT: Int = 500
 
     /**
      * Maximum nesting/iteration depth of effect execution within a single resolution, enforced at


### PR DESCRIPTION
## Problem

The backend CI job suddenly jumped from ~6-7 min to ~14 min starting with PR #723 ("Number/token explosion safety net"). A single test was responsible: `NumberExplosionSafetyTest > "runaway token creation is capped at MAX_TOKENS_PER_EFFECT, not OOM"` took **434.6s**. The other three tests in the class are sub-second.

That test casts a card creating 50,000 tokens, clamped to `MAX_TOKENS_PER_EFFECT = 10,000`, and drives them through the full `GameTestDriver` stack. Because token creation/projection cost is roughly **O(N²)** over battlefield size, materializing 10k entities one-at-a-time took ~7 minutes.

## Fix

Lower `MAX_TOKENS_PER_EFFECT` from 10,000 → 500.

| | token test | class total |
|---|---|---|
| cap=10,000 | 434.6s | ~435s |
| **cap=500** | **11.3s** | **11.6s** |

A ~38× speedup from a 20× token reduction — the super-linear ratio confirms the quadratic scaling. Backend job should return to ~7 min.

500 is still far above any legitimate board, so the backstop's purpose (don't OOM / don't hang for minutes on a degenerate doubler combo) is unchanged — and now the cap actually **fails fast** instead of hanging for 7 minutes. Test assertions reference the constant symbolically, so they pass unchanged.

## Follow-up (not in this PR)

11s for 500 tokens is still ~22 ms/token — the O(N²) token-creation/projection cost is real, just no longer catastrophic. Worth a separate investigation if big-board performance matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)