### PR TITLE
Add One Last Job, Shifting Grift, The Key to the Vault (OTJ)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -280,10 +280,14 @@ power via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DR
     run once then `RepeatDynamicTimesEffect(amount = DynamicAmount.XValue, body = …)` for "X more times".
     → **Another Round** (implemented).
 
-15. **Targeted reanimate-attached for Auras/Equipment.** Only `ReturnSelfToBattlefieldAttached`
-    (source = self) exists. This mode targets a *separate* graveyard Aura/Equipment and attaches it to
-    a chosen creature on arrival — a targeted reanimate-attached effect.
-    → **One Last Job** (third Spree mode only; modes 1–2 buildable).
+15. **Targeted reanimate-attached for Auras/Equipment.** ✅ DONE —
+    `Effects.PutOntoBattlefieldAttachedToChosen(target, hostFilter = Creature.youControl())` puts a
+    targeted graveyard Aura/Equipment onto the battlefield attached to a host the controller chooses at
+    resolution (host is NOT a target). Works for both Auras and Equipment, intersects an Aura's enchant
+    legality, and (per ruling) lets an Equipment enter unattached / an Aura stay back when no legal host
+    exists. Pausing executor + `PutOntoBattlefieldAttachedToChosenContinuation` reuse the
+    MoveCollection attach helper.
+    → **One Last Job** (all three Spree modes) — implemented.
 
 16. **Inline "excess damage dealt this way" captured within one resolving spell.** ✅ DONE —
     `EntityNumericProperty.ExcessMarkedDamage` reads `max(0, marked − toughness)` of a context target

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -371,6 +371,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `PutOntoBattlefield(target, tapped?)` — put target on the battlefield.
 - `PutOntoBattlefieldUnderYourControl(target)` — under controller's control.
 - `PutOntoBattlefieldFaceDown(count, target?)` — enter face-down (2/2 morph shape).
+- `PutOntoBattlefieldAttachedToChosen(target, hostFilter?)` — put a targeted Aura or Equipment onto the
+  battlefield attached to a permanent the controller chooses at resolution (default host filter: a creature
+  you control). Works for both Auras and Equipment; the host is chosen, not targeted. If no legal host exists,
+  an Equipment enters unattached while an Aura can't enter (Rule 303.4g). (One Last Job.)
 - `ReturnSelfToBattlefieldAttached(target)` — return source attached to target (Aura recursion).
 - `ReturnSelfFromExileTransformed` — Craft resolution (CR 702.167a). Returns the source from exile to the
   battlefield as its back face, under its owner's control, and re-attaches the source's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2586,6 +2586,19 @@ object Effects {
         equipmentTarget, creatureTarget
     )
 
+    /**
+     * Put a targeted Aura or Equipment card onto the battlefield attached to a permanent the
+     * controller chooses at resolution (default: a creature you control). Works for both
+     * Auras and Equipment; the host is chosen, not targeted (One Last Job).
+     */
+    fun PutOntoBattlefieldAttachedToChosen(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        hostFilter: com.wingedsheep.sdk.scripting.GameObjectFilter =
+            com.wingedsheep.sdk.scripting.GameObjectFilter.Creature.youControl()
+    ): Effect = com.wingedsheep.sdk.scripting.effects.PutOntoBattlefieldAttachedToChosenEffect(
+        target, hostFilter
+    )
+
     // =========================================================================
     // Animate Effects
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.sdk.scripting.effects
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import kotlinx.serialization.SerialName
@@ -160,6 +161,35 @@ data class AttachTargetEquipmentToCreatureEffect(
     val creatureTarget: EffectTarget = EffectTarget.ContextTarget(1)
 ) : Effect {
     override val description: String = "Attach ${equipmentTarget.description} to ${creatureTarget.description}"
+}
+
+/**
+ * Put a targeted Aura or Equipment card onto the battlefield **attached to a permanent the
+ * effect's controller chooses** at resolution. The card is the [target] (e.g. a targeted
+ * Aura/Equipment in a graveyard); the host is chosen as the effect resolves and is therefore
+ * NOT a target — only the host filter constrains it ([hostFilter], default "a creature you
+ * control"). Models "Return target Aura or Equipment card from your graveyard to the
+ * battlefield attached to a creature you control" (One Last Job, Brass Squire-shaped attaches).
+ *
+ * Unlike the [com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect] aura auto-attach
+ * (Rule 303.4f), which is Aura-only and uses the Aura's own enchant target, this effect
+ * works for both Auras and Equipment and lets the card restrict the host. Per the One Last
+ * Job ruling, the Aura/Equipment must be legally attachable to the chosen host:
+ *  - If a legal host exists, the controller chooses one and the card enters attached to it.
+ *  - If no legal host exists, an Equipment enters the battlefield unattached, while an Aura
+ *    can't enter (it stays in its current zone — Rule 303.4g).
+ *
+ * @property target The Aura or Equipment card to put onto the battlefield (e.g. a graveyard target).
+ * @property hostFilter Which permanents are eligible hosts (default: a creature you control).
+ */
+@SerialName("PutOntoBattlefieldAttachedToChosen")
+@Serializable
+data class PutOntoBattlefieldAttachedToChosenEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0),
+    val hostFilter: GameObjectFilter = GameObjectFilter.Creature.youControl()
+) : Effect {
+    override val description: String =
+        "Put ${target.description} onto the battlefield attached to ${hostFilter.description}"
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OneLastJob.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OneLastJob.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * One Last Job
+ * {2}{W}
+ * Sorcery
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2} — Return target creature card from your graveyard to the battlefield.
+ * + {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.
+ * + {1} — Return target Aura or Equipment card from your graveyard to the battlefield
+ *         attached to a creature you control.
+ *
+ * Spree is a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`, per-mode
+ * `additionalManaCost`, and `allowRepeat = false` (CR 702.166 / 700.2). Every mode targets a
+ * card in your graveyard; chosen modes always resolve in printed order (so a creature returned
+ * by mode 1 can host an Aura/Equipment returned by mode 3).
+ *
+ *  - Modes 1 & 2 return the targeted card to the battlefield with [Effects.PutOntoBattlefield]
+ *    (the card is owned by you, so it enters under your control). Mode 2's target filter admits
+ *    a card with the Mount or Vehicle subtype, which need not be a creature card in the
+ *    graveyard.
+ *  - Mode 3 returns the targeted Aura/Equipment via
+ *    [Effects.PutOntoBattlefieldAttachedToChosen], which puts it onto the battlefield attached
+ *    to a creature you control chosen as the spell resolves (the host is NOT a target, per the
+ *    ruling). The effect works for both Auras and Equipment and enforces legal attachment: if
+ *    no creature you control can host it, an Equipment enters unattached while an Aura can't
+ *    return (Rule 303.4g) — matching the One Last Job rulings.
+ */
+val OneLastJob = card("One Last Job") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2} — Return target creature card from your graveyard to the battlefield.\n" +
+        "+ {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.\n" +
+        "+ {1} — Return target Aura or Equipment card from your graveyard to the battlefield " +
+        "attached to a creature you control."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                // + {2} — Return target creature card from your graveyard to the battlefield.
+                Mode(
+                    effect = Effects.PutOntoBattlefield(EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(
+                        TargetObject(
+                            filter = TargetFilter(
+                                GameObjectFilter.Creature.ownedByYou(),
+                                zone = Zone.GRAVEYARD
+                            )
+                        )
+                    ),
+                    description = "+ {2} — Return target creature card from your graveyard to the battlefield.",
+                    additionalManaCost = "{2}"
+                ),
+                // + {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.
+                Mode(
+                    effect = Effects.PutOntoBattlefield(EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(
+                        TargetObject(
+                            filter = TargetFilter(
+                                GameObjectFilter.Any.withAnySubtype("Mount", "Vehicle").ownedByYou(),
+                                zone = Zone.GRAVEYARD
+                            )
+                        )
+                    ),
+                    description = "+ {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.",
+                    additionalManaCost = "{1}"
+                ),
+                // + {1} — Return target Aura or Equipment card from your graveyard to the
+                //         battlefield attached to a creature you control.
+                Mode(
+                    effect = Effects.PutOntoBattlefieldAttachedToChosen(
+                        target = EffectTarget.ContextTarget(0),
+                        hostFilter = GameObjectFilter.Creature.youControl()
+                    ),
+                    targetRequirements = listOf(
+                        TargetObject(
+                            filter = TargetFilter(
+                                GameObjectFilter.Any.withAnySubtype("Aura", "Equipment").ownedByYou(),
+                                zone = Zone.GRAVEYARD
+                            )
+                        )
+                    ),
+                    description = "+ {1} — Return target Aura or Equipment card from your graveyard " +
+                        "to the battlefield attached to a creature you control.",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Caroline Gariba"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg?1712860542"
+
+        ruling("2024-04-12", "The creature that the Aura or Equipment card returned by the third mode will enter attached to isn't a target of that mode and is chosen as One Last Job resolves.")
+        ruling("2024-04-12", "The Aura or Equipment must be able to be legally attached to the creature you choose. You can't return an Aura card to the battlefield if there's nothing to enchant. However, if you control no creatures, you could return an Equipment card to the battlefield unattached to anything.")
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "No matter which modes you choose, you always follow the instructions in the order they are written.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShiftingGrift.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ShiftingGrift.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shifting Grift
+ * {U}{U}
+ * Sorcery
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2} — Exchange control of two target creatures.
+ * + {1} — Exchange control of two target artifacts.
+ * + {1} — Exchange control of two target enchantments.
+ *
+ * Spree is a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`, per-mode
+ * `additionalManaCost`, and `allowRepeat = false` (CR 702.166 / 700.2). Every mode targets
+ * two permanents of the listed type (any controller — you needn't control either) and
+ * resolves the swap via [Effects.ExchangeControl] over the mode-local `ContextTarget(0)` and
+ * `ContextTarget(1)` (same atom as Chromeshell Crab / Phyrexian Infiltrator). The control
+ * change lasts indefinitely (CR ruling) — `ExchangeControlEffect` installs a permanent
+ * control override, so it doesn't wear off at cleanup and survives the target later losing
+ * the permanent type.
+ *
+ * Per the spree rulings, each mode's two targets are independent target requirements, so a
+ * mode is selectable only if two legal targets of that type exist; if one target becomes
+ * illegal before resolution, that mode's exchange simply doesn't happen while other chosen
+ * modes still resolve.
+ */
+val ShiftingGrift = card("Shifting Grift") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2} — Exchange control of two target creatures.\n" +
+        "+ {1} — Exchange control of two target artifacts.\n" +
+        "+ {1} — Exchange control of two target enchantments."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                // + {2} — Exchange control of two target creatures.
+                Mode(
+                    effect = Effects.ExchangeControl(
+                        EffectTarget.ContextTarget(0),
+                        EffectTarget.ContextTarget(1)
+                    ),
+                    targetRequirements = listOf(Targets.Creature, Targets.Creature),
+                    description = "+ {2} — Exchange control of two target creatures.",
+                    additionalManaCost = "{2}"
+                ),
+                // + {1} — Exchange control of two target artifacts.
+                Mode(
+                    effect = Effects.ExchangeControl(
+                        EffectTarget.ContextTarget(0),
+                        EffectTarget.ContextTarget(1)
+                    ),
+                    targetRequirements = listOf(Targets.Artifact, Targets.Artifact),
+                    description = "+ {1} — Exchange control of two target artifacts.",
+                    additionalManaCost = "{1}"
+                ),
+                // + {1} — Exchange control of two target enchantments.
+                Mode(
+                    effect = Effects.ExchangeControl(
+                        EffectTarget.ContextTarget(0),
+                        EffectTarget.ContextTarget(1)
+                    ),
+                    targetRequirements = listOf(Targets.Enchantment, Targets.Enchantment),
+                    description = "+ {1} — Exchange control of two target enchantments.",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Nereida"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg?1712860608"
+
+        ruling("2024-04-12", "Gaining control of a permanent doesn't cause you to gain control of any Auras or Equipment attached to it.")
+        ruling("2024-04-12", "If one of the target permanents is an illegal target when Shifting Grift resolves, the exchange that permanent is involved in won't happen.")
+        ruling("2024-04-12", "The effects of Shifting Grift's modes last indefinitely. They don't wear off during the cleanup step, and they don't expire if one of the target permanents stops having that permanent type after Shifting Grift has resolved.")
+        ruling("2024-04-12", "You don't have to control any of the target permanents.")
+        ruling("2024-04-12", "If the same player controls both permanents involved in a single exchange when that exchange occurs, nothing happens to those permanents.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TheKeyToTheVault.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TheKeyToTheVault.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Key to the Vault
+ * {1}{U}
+ * Legendary Artifact — Equipment
+ *
+ * Whenever equipped creature deals combat damage to a player, look at that many cards
+ * from the top of your library. You may exile a nonland card from among them. Put the
+ * rest on the bottom of your library in a random order. You may cast the exiled card
+ * without paying its mana cost.
+ * Equip {2}{U}
+ *
+ * The trigger binds to the equipped creature ([TriggerBinding.ATTACHED]) and fires on a
+ * combat-damage-to-a-player event; `DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT)`
+ * captures "that many" (the amount of combat damage dealt). Modeled as the
+ * Sunbird's-Invocation / Goliath-Daydreamer pipeline of atomic primitives:
+ *
+ *   1. [GatherCardsEffect] over the top N of your library — `revealed = false` because the
+ *      card says "look at" (private), not "reveal".
+ *   2. [SelectFromCollectionEffect] `ChooseUpTo(1)` with a nonland eligibility filter
+ *      (`showAllCards = true` so lands are visible but unselectable); "you may exile".
+ *   3. [MoveCollectionEffect] the chosen card to exile (`storeMovedAs` re-captures the moved
+ *      entity), then the remainder to the bottom of the library in a random order.
+ *   4. [CastFromCollectionWithoutPayingCostEffect] over the exiled card — "you may cast
+ *      the exiled card without paying its mana cost", resolved during this ability so
+ *      card-type timing is ignored (per ruling). If the player exiles nothing, the
+ *      collections are empty and steps 3–4 are no-ops for them.
+ */
+val TheKeyToTheVault = card("The Key to the Vault") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Whenever equipped creature deals combat damage to a player, look at that " +
+        "many cards from the top of your library. You may exile a nonland card from among " +
+        "them. Put the rest on the bottom of your library in a random order. You may cast " +
+        "the exiled card without paying its mana cost.\nEquip {2}{U}"
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED
+        )
+        val damageDealt = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = damageDealt, player = Player.You),
+                    storeAs = "keyLooked",
+                    revealed = false
+                ),
+                SelectFromCollectionEffect(
+                    from = "keyLooked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Nonland,
+                    showAllCards = true,
+                    storeSelected = "keyChosen",
+                    storeRemainder = "keyToBottom",
+                    prompt = "You may exile a nonland card to cast for free.",
+                    selectedLabel = "Exile",
+                    remainderLabel = "Put on the bottom of your library"
+                ),
+                MoveCollectionEffect(
+                    from = "keyChosen",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.You),
+                    storeMovedAs = "keyExiled"
+                ),
+                MoveCollectionEffect(
+                    from = "keyToBottom",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                ),
+                CastFromCollectionWithoutPayingCostEffect(from = "keyExiled")
+            )
+        )
+    }
+
+    equipAbility("{2}{U}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg?1712355445"
+
+        ruling("2024-04-12", "You choose whether to cast the exiled card as The Key to the Vault's triggered ability resolves. If you do, you do so as part of the resolution of that ability. You can't wait to cast it later in the turn. Timing restrictions based on the card's types are ignored.")
+        ruling("2024-04-12", "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, those must be paid to cast the spell.")
+        ruling("2024-04-12", "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -9849,6 +9849,110 @@
     ]
 }
 
+// One Last Job
+{
+    "name": "One Last Job",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2} — Return target creature card from your graveyard to the battlefield.\n+ {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.\n+ {1} — Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Battlefield"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "description": "+ {2} — Return target creature card from your graveyard to the battlefield.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Battlefield"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "Mount|Vehicle own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": "PutOntoBattlefieldAttachedToChosen",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "Aura|Equipment own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Caroline Gariba",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg?1712860542",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The creature that the Aura or Equipment card returned by the third mode will enter attached to isn't a target of that mode and is chosen as One Last Job resolves."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The Aura or Equipment must be able to be legally attached to the creature you choose. You can't return an Aura card to the battlefield if there's nothing to enchant. However, if you control no creatures, you could return an Equipment card to the battlefield unattached to anything."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "No matter which modes you choose, you always follow the instructions in the order they are written."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ornery Tumblewagg
 {
     "name": "Ornery Tumblewagg",
@@ -13262,6 +13366,111 @@
     ]
 }
 
+// Shifting Grift
+{
+    "name": "Shifting Grift",
+    "manaCost": "{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2} — Exchange control of two target creatures.\n+ {1} — Exchange control of two target artifacts.\n+ {1} — Exchange control of two target enchantments.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "ExchangeControl",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {2} — Exchange control of two target creatures.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": "ExchangeControl",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            }
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Exchange control of two target artifacts.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": "ExchangeControl",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            }
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Exchange control of two target enchantments.",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Nereida",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg?1712860608",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Gaining control of a permanent doesn't cause you to gain control of any Auras or Equipment attached to it."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If one of the target permanents is an illegal target when Shifting Grift resolves, the exchange that permanent is involved in won't happen."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The effects of Shifting Grift's modes last indefinitely. They don't wear off during the cleanup step, and they don't expire if one of the target permanents stops having that permanent type after Shifting Grift has resolved."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You don't have to control any of the target permanents."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If the same player controls both permanents involved in a single exchange when that exchange occurs, nothing happens to those permanents."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shoot the Sheriff
 {
     "name": "Shoot the Sheriff",
@@ -15077,6 +15286,138 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// The Key to the Vault
+{
+    "name": "The Key to the Vault",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            "storeAs": "keyLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "keyLooked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "nonland",
+                            "storeSelected": "keyChosen",
+                            "storeRemainder": "keyToBottom",
+                            "prompt": "You may exile a nonland card to cast for free.",
+                            "selectedLabel": "Exile",
+                            "remainderLabel": "Put on the bottom of your library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "keyChosen",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "storeMovedAs": "keyExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "keyToBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        },
+                        {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "keyExiled"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{2}{U}",
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "RARE",
+        "artist": "Leon Tukker",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg?1712355445",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You choose whether to cast the exiled card as The Key to the Vault's triggered ability resolves. If you do, you do so as part of the resolution of that ability. You can't wait to cast it later in the turn. Timing restrictions based on the card's types are ignored."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, those must be paid to cast the spell."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -58,6 +58,9 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // (args[0] a self-ref) and declines anything else -> SCAFFOLD.
     effect("AttachPermanentToPermanent", "AttachEquipment", "self-attach an Equipment/Aura to a chosen permanent")
     effects("GainControlOfPermanent", "GainControlOfPermanentUntil", tag = "GainControl", note = UNIVERSAL)
+    // "Exchange control of two target permanents" (Shifting Grift, Chromeshell Crab) — the two-target
+    // ExchangeControlEffect, modeled as a pair of permanent Layer.CONTROL floating effects.
+    effect("ExchangeControl", "ExchangeControl", "exchange control of two target permanents")
     effect("RemoveCreatureFromCombat", "RemoveFromCombat", UNIVERSAL)
     // Ydwen Efreet's "remove from combat and creatures it solely blocked become unblocked" — the same
     // RemoveFromCombat effect (the emitter sets its unblockSoleBlockedAttackers flag).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -62,6 +62,10 @@ internal fun BridgeBuilder.zoneMovement() {
     // "Return the exiled card to the battlefield" — the delayed return half of exile-then-return
     // (Conciliator's Duelist). A plain MoveToZone back to the battlefield under its owner's control.
     composed("PutExiledCardOntoBattlefield", UNIVERSAL, composes = listOf("MoveToZone"))
+    // "You may cast the exiled card without paying its mana cost" (The Key to the Vault) — the
+    // mid-resolution CastFromCollectionWithoutPayingCostEffect over a card just exiled by the look
+    // pipeline (Sunbird's Invocation / Goliath Daydreamer shape).
+    composed("CastExiledCardWithoutPaying", "CastFromCollectionWithoutPayingCost over the exiled card", composes = listOf("CastFromCollectionWithoutPayingCost"))
     composed("ExileEachPermanent", UNIVERSAL, composes = listOf("MoveCollection", "MoveToZone"))
     composed("MillNumberCards", UNIVERSAL, composes = listOf("MoveCollection"))
     composed("MillCards", UNIVERSAL, composes = listOf("MoveCollection"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -780,6 +780,33 @@ private fun EmitCtx.youHaventCastASpellConditionDsl(cond: JsonObject?): String? 
  * The (target list, inner action list) of a mtgish `Targeted` action node, or null if it isn't a
  * Targeted envelope. Mirrors [extractEnvelope]'s Targeted unpacking for a single known node.
  */
+/**
+ * Strip a sibling-distinctness `Other(<ref>)` predicate from a target node's filter. mtgish models
+ * "two target creatures" as a first plain target plus a second whose filter is `And[Other(ref1),
+ * <same type>]` — the `Other` only enforces that the two chosen objects differ, which the engine does
+ * automatically (CR 115.1b). Drop the `Other` arm so the second target's filter renders to the same
+ * type filter as the first. Returns the original node when there's no such clause.
+ */
+private fun JsonObject.stripSiblingOther(): JsonObject {
+    val args = this["args"] as? JsonObject ?: return this
+    if (args.strField("_Permanents") != "And") return this
+    val arms = args["args"].asArr?.filterIsInstance<JsonObject>() ?: return this
+    val kept = arms.filterNot { it.strField("_Permanents") == "Other" }
+    if (kept.size == arms.size) return this // no Other arm
+    val newFilter: JsonElement = when (kept.size) {
+        0 -> return this // nothing left to filter on — keep original rather than widen to "any"
+        1 -> kept[0]
+        else -> buildJsonObject {
+            put("_Permanents", JsonPrimitive("And"))
+            put("args", JsonArray(kept))
+        }
+    }
+    return buildJsonObject {
+        this@stripSiblingOther.forEach { (k, v) -> if (k != "args") put(k, v) }
+        put("args", newFilter)
+    }
+}
+
 private fun targetedArms(node: JsonObject): Pair<List<JsonObject>?, List<JsonObject>>? {
     if (node.strField("_Actions") != "Targeted") return null
     val args = node["args"].asArr ?: return null
@@ -1051,14 +1078,50 @@ internal fun EmitCtx.spreeSpellBlock(rule: JsonObject): List<Stmt>? {
             }
             "Targeted" -> {
                 val (targets, actions) = targetedArms(actionsNode) ?: run { reasons.add("Spree"); return null }
-                if (targets == null || actions == null || targets.size != 1) { reasons.add("Spree"); return null }
-                val tnode = targetExpr(targets[0], actions)
-                    ?: run { reasons.add("target:${targets[0].strField("_Target")}"); return null }
-                // The targeted arm spends the modal target slot — bind the effect's target ref to it.
-                val effect = renderEffectList(actions, "EffectTarget.ContextTarget(0)") ?: return null
-                if (effect is Composite) { reasons.add("Spree"); return null }
-                modeArgs.add(arg("effect", effect))
-                modeArgs.add(arg("targetRequirements", call("listOf", arg(tnode))))
+                if (targets == null || actions == null || targets.isEmpty()) { reasons.add("Spree"); return null }
+                when (targets.size) {
+                    1 -> {
+                        val tnode = targetExpr(targets[0], actions)
+                            ?: run { reasons.add("target:${targets[0].strField("_Target")}"); return null }
+                        // The targeted arm spends the modal target slot — bind the effect's target ref to it.
+                        val effect = renderEffectList(actions, "EffectTarget.ContextTarget(0)") ?: return null
+                        if (effect is Composite) { reasons.add("Spree"); return null }
+                        modeArgs.add(arg("effect", effect))
+                        modeArgs.add(arg("targetRequirements", call("listOf", arg(tnode))))
+                    }
+                    2 -> {
+                        // A two-target mode (Shifting Grift: "exchange control of two target …"). Render
+                        // both target requirements and bind the per-kind refs (Ref_TargetPermanentN) to
+                        // the mode-local ContextTarget(0)/(1) so the effect resolves against them. Restore
+                        // the ref-var state afterwards so other modes/cards are unaffected.
+                        val tnodes = targets.map { t ->
+                            // "two target creatures" — the second slot carries an `Other(<sibling ref>)`
+                            // distinctness clause. Distinct targets are automatic (CR 115.1b: a spell
+                            // can't choose the same object for two of its targets), so strip the sibling
+                            // `Other` before rendering the filter rather than declining on it.
+                            val cleaned = t.stripSiblingOther()
+                            targetExpr(cleaned, actions) ?: run { reasons.add("target:${t.strField("_Target")}"); return null }
+                        }
+                        val kinds = targets.map { refKindForTarget(it) }
+                        if (kinds.any { it == null } || kinds.toSet().size != 1) { reasons.add("Spree"); return null }
+                        val kind = kinds.first()!!
+                        val ctxRefs = listOf("EffectTarget.ContextTarget(0)", "EffectTarget.ContextTarget(1)")
+                        val savedByKind = targetRefVarsByKind
+                        val savedVars = targetVars
+                        targetRefVarsByKind = mapOf(kind to ctxRefs)
+                        targetVars = ctxRefs
+                        val effect = try {
+                            renderEffectList(actions, ctxRefs.first())
+                        } finally {
+                            targetRefVarsByKind = savedByKind
+                            targetVars = savedVars
+                        } ?: return null
+                        if (effect is Composite) { reasons.add("Spree"); return null }
+                        modeArgs.add(arg("effect", effect))
+                        modeArgs.add(arg("targetRequirements", call("listOf", *tnodes.map { arg(it) }.toTypedArray())))
+                    }
+                    else -> { reasons.add("Spree"); return null }
+                }
             }
             else -> { reasons.add("Spree"); return null }
         }
@@ -1737,6 +1800,16 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         val binding = if (jsonContains(trig, "_Permanents", "Other")) "TriggerBinding.OTHER" else "TriggerBinding.ANY"
         val filter = gameObjectFilterDsl(trig) ?: return null
         return "Triggers.entersBattlefield(filter = $filter, binding = $binding)"
+    }
+
+    // "Whenever equipped creature deals combat damage to a player" — an Equipment/Aura combat-damage
+    // trigger bound to the host permanent (subject SinglePermanent(HostPermanent)). Maps to the
+    // ATTACHED binding (The Key to the Vault). Only the bare host subject to any player renders.
+    if (jsonContains(trig, "_Trigger", "WhenACreatureDealsCombatDamageToAPlayer") && isHost(trig) &&
+        jsonContains(trig, "_Players", "AnyPlayer")
+    ) {
+        return "Triggers.dealsDamage(DamageType.Combat, RecipientFilter.AnyPlayer, " +
+            "binding = TriggerBinding.ATTACHED)"
     }
 
     // "Whenever a [creature type] deals combat damage to a player, …" — non-self

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.tooling.coverage.bridge.Bridge
 import com.wingedsheep.tooling.coverage.bridge.MappingEntry
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.Raw
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.amountNode
@@ -136,6 +137,7 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     chooseTypeModifyStatsEffect(actions)?.let { return it }
     chooseCreatureTypeRevealTopEffect(actions)?.let { return it }
     impulseExileTopMayPlay(actions)?.let { return it }
+    lookExileCastFree(actions)?.let { return it }
     createValueXDealsDamageEffect(actions, tvar)?.let { return it }
     val rendered = mutableListOf<Dsl>()
     for (act in actions) {
@@ -856,6 +858,64 @@ internal fun EmitCtx.impulseExileTopMayPlay(actions: List<JsonObject>): Dsl? {
             Lit("GrantMayPlayFromExileEffect(\"exiledCard\", MayPlayExpiry.UntilEndOfNextTurn)")
         )
     )
+}
+
+/**
+ * `[LookAtTheTopNumberCardsOfLibrary(<count>, [MayExileACardOfType(nonland),
+ * PutTheRemainingCardsOnTheBottomOfLibraryInARandomOrder]), MayAction(CastExiledCardWithoutPaying(
+ * TheCardExiledThisWay))]` -> the "look at N, may exile a nonland, bottom the rest at random, then
+ * cast the exiled card for free" pipeline (The Key to the Vault). Spans two actions — the look (which
+ * names the exiled card collection) and the free cast — so it's recognised here as a whole action list
+ * rather than per-action.
+ *
+ * Renders the Sunbird's-Invocation pipeline: Gather(top N, private) -> SelectFromCollection(up to 1,
+ * nonland) -> MoveCollection(chosen -> exile, storeMovedAs) -> MoveCollection(rest -> library bottom,
+ * random) -> CastFromCollectionWithoutPayingCost(exiled). Only this exact two-action shape with a
+ * nonland exile filter and the random-bottom remainder renders; any other filter, remainder
+ * destination, or exiled-card rider declines (-> SCAFFOLD) rather than dropping a constraint.
+ */
+internal fun EmitCtx.lookExileCastFree(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val look = actions[0]
+    if (look.strField("_Action") != "LookAtTheTopNumberCardsOfLibrary") return null
+    val cast = actions[1]
+    // The free cast is wrapped in a `MayAction` envelope ("you may cast …").
+    val castInner = (cast["args"] as? JsonObject)?.takeIf { cast.strField("_Action") == "MayAction" } ?: return null
+    if (castInner.strField("_Action") != "CastExiledCardWithoutPaying") return null
+    if (!jsonContains(castInner["args"], "_CardInExile", "TheCardExiledThisWay")) return null
+
+    val lookArgs = look["args"].asArr ?: return null
+    val countExpr = render(dynamicAmountExpr(lookArgs.getOrNull(0)) ?: return null)
+    val subActions = lookArgs.getOrNull(1).asArr?.filterIsInstance<JsonObject>() ?: return null
+    // Exactly the may-exile-nonland + bottom-the-rest-at-random sub-actions, nothing else.
+    val exileNode = subActions.firstOrNull { it.strField("_LookAtTopOfLibraryAction") == "MayExileACardOfType" } ?: return null
+    val hasBottomRandom = subActions.any {
+        it.strField("_LookAtTopOfLibraryAction") == "PutTheRemainingCardsOnTheBottomOfLibraryInARandomOrder"
+    }
+    if (!hasBottomRandom || subActions.size != 2) return null
+    val exileFilter = exileNode["args"] as? JsonObject ?: return null
+    val filterExpr = when {
+        exileFilter.strField("_Cards") == "IsNonCardtype" && exileFilter.field("args").asStr() == "Land" -> "GameObjectFilter.Nonland"
+        else -> return null
+    }
+    return Composite(listOf(
+        Lit("GatherCardsEffect(source = CardSource.TopOfLibrary($countExpr), storeAs = \"looked\", revealed = false)"),
+        Raw(
+            "SelectFromCollectionEffect(\n" +
+                "                from = \"looked\",\n" +
+                "                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),\n" +
+                "                filter = $filterExpr,\n" +
+                "                showAllCards = true,\n" +
+                "                storeSelected = \"exiledChosen\",\n" +
+                "                storeRemainder = \"toBottom\",\n" +
+                "                selectedLabel = \"Exile\",\n" +
+                "                remainderLabel = \"Put on the bottom of your library\"\n" +
+                "            )",
+        ),
+        Lit("MoveCollectionEffect(from = \"exiledChosen\", destination = CardDestination.ToZone(Zone.EXILE), storeMovedAs = \"exiledCard\")"),
+        Lit("MoveCollectionEffect(from = \"toBottom\", destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom), order = CardOrder.Random)"),
+        Lit("CastFromCollectionWithoutPayingCostEffect(from = \"exiledCard\")"),
+    ))
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -738,6 +738,26 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         // widen the target to any artifact in the graveyard. Decline (-> SCAFFOLD) rather than drop it.
         if ("ManaValueIs" in blob) return null
         val types = targetTypes(args)
+        // "target Mount or Vehicle card" / "target Aura or Equipment card" from a graveyard (One Last
+        // Job modes 2 & 3): an `Or` of subtype clauses drawn from MORE THAN ONE type category
+        // (IsCreatureType Mount + IsArtifactType Vehicle; IsEnchantmentType Aura + IsArtifactType
+        // Equipment). The single-category `graveyardSubs` branch below only sees the creature subtypes
+        // and would silently drop the others, so handle the cross-category `Or` here as
+        // `GameObjectFilter.Any.withAnySubtype(…)`. Only the plain Or-of-subtypes shape (no IsCardtype,
+        // no mana-value cap) renders; anything else falls through.
+        run {
+            val anySubs = listOf("IsCreatureType", "IsArtifactType", "IsEnchantmentType", "IsLandType")
+                .flatMap { args.argWordsTagged(it) }
+            if (anySubs.size >= 2 && "\"Or\"" in blob && "IsCardtype" !in blob && "ManaValueIs" !in blob) {
+                // withAnySubtype takes vararg String (not Subtype), so emit quoted subtype names.
+                val subtypeArgs = anySubs.map { arg(Lit("\"${ktStr(it)}\"")) }.toTypedArray()
+                val base = Lit("GameObjectFilter.Any").dot("withAnySubtype", *subtypeArgs)
+                val filt = graveyardFilter(base, blob)
+                val parts = mutableListOf(arg("filter", filt))
+                if (ttype == "UptoOneTargetGraveyardCard") parts.add(0, arg("optional", "true"))
+                return Call("TargetObject", parts)
+            }
+        }
         // "target Spirit card from your graveyard" (Angel of Flight Alabaster): a creature-subtype
         // restriction, usually with an ownership clause. The bare CardInGraveyard constant used to
         // swallow this shape, silently dropping BOTH constraints (any card, any graveyard).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -166,6 +166,17 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         }
     }
 
+    on("ExchangeControl") { _, args, _ ->
+        // "Exchange control of two target permanents" (Shifting Grift). The IR carries two permanent
+        // refs (Ref_TargetPermanent1 / Ref_TargetPermanent2) — resolve each to its bound target. Both
+        // must resolve (the two-target context, e.g. a Spree mode), else decline -> SCAFFOLD.
+        val arr = args.asArr?.filterIsInstance<JsonObject>() ?: return@on null
+        if (arr.size != 2) return@on null
+        val t1 = refTargetFromRef(arr[0].strField("_Permanent"), null) ?: return@on null
+        val t2 = refTargetFromRef(arr[1].strField("_Permanent"), null) ?: return@on null
+        call("Effects.ExchangeControl", arg(Lit(t1)), arg(Lit(t2)))
+    }
+
     on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
         if (jsonContains(args, "_Permanent", "ThisPermanent")) Lit("SacrificeSelfEffect") else null
     }
@@ -397,6 +408,23 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
             // grab isn't expressible by either facade, so scaffold that pairing.
             val flagBlob = compact(args)
             val entersTapped = "EntersTapped" in flagBlob
+            // "…to the battlefield attached to a creature you control" (One Last Job mode 3): an
+            // EntersAttachedToAPermanent flag whose host filter is Creature + ControlledByAPlayer You.
+            // Render the PutOntoBattlefieldAttachedToChosen facade (host chosen at resolution, default
+            // filter "a creature you control"). Only that exact host shape renders; any other host
+            // (tapped pairing, a different filter) declines -> SCAFFOLD.
+            if ("EntersAttachedToAPermanent" in flagBlob) {
+                // The host filter must be exactly "a creature you control" (the facade's default host).
+                // A companion EntersUnderPlayersControl(You) flag is redundant here — attaching to a
+                // creature you control already enters the card under your control — so it's allowed; any
+                // OTHER control grant or a tapped pairing declines -> SCAFFOLD.
+                val attachesToOwnCreature = "\"Creature\"" in flagBlob &&
+                    "ControlledByAPlayer" in flagBlob && "\"You\"" in flagBlob
+                val controlOk = "EntersUnderPlayersControl" !in flagBlob || "\"You\"" in flagBlob
+                return@on if (attachesToOwnCreature && controlOk && !entersTapped)
+                    call("Effects.PutOntoBattlefieldAttachedToChosen", arg(Lit(tgt)))
+                else null
+            }
             return@on when {
                 "EntersUnderPlayersControl" !in flagBlob ->
                     if (entersTapped) call("Effects.PutOntoBattlefield", arg(Lit(tgt)), arg("tapped", "true"))

--- a/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
@@ -7987,7 +7987,7 @@ val NomadMythmaker = card("Nomad Mythmaker") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
         val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
-        effect = Effects.PutOntoBattlefieldUnderYourControl(t)
+        effect = Effects.PutOntoBattlefieldAttachedToChosen(t)
     }
     metadata {
         rarity = Rarity.RARE

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
@@ -192,6 +192,25 @@ data class MoveCollectionAuraTargetContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller chooses a host for a card put onto the battlefield attached to a
+ * chosen permanent (PutOntoBattlefieldAttachedToChosenEffect — One Last Job mode 3).
+ *
+ * The card ([cardId], an Aura or Equipment) is moved to the battlefield under [controllerId]'s
+ * control and attached to the chosen host. Reuses
+ * [com.wingedsheep.engine.handlers.effects.library.MoveCollectionExecutor.moveAuraToBattlefield],
+ * which is permanent-agnostic (works for both Auras and Equipment).
+ *
+ * @property cardId The Aura/Equipment card being put onto the battlefield
+ * @property controllerId The player putting it onto the battlefield (chooses the host)
+ */
+@Serializable
+data class PutOntoBattlefieldAttachedToChosenContinuation(
+    override val decisionId: String,
+    val cardId: EntityId,
+    val controllerId: EntityId
+) : ContinuationFrame
+
+/**
  * Resume after player reorders revealed cards to put on the bottom of their library.
  *
  * Used for effects like Erratic Explosion that reveal cards and then put them

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -225,6 +225,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CastModalModeSelectionContinuation::class)
         subclass(CastModalTargetSelectionContinuation::class)
         subclass(MoveCollectionAuraTargetContinuation::class)
+        subclass(PutOntoBattlefieldAttachedToChosenContinuation::class)
         subclass(ChainCopyAfterActionContinuation::class)
         subclass(ChainCopyDecisionContinuation::class)
         subclass(ChainCopyCostContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -37,6 +37,7 @@ class LibraryAndZoneContinuationResumer(
         resumer(ChoosePileContinuation::class, ::resumeChoosePile),
         resumer(SelectTargetPipelineContinuation::class, ::resumeSelectTargetPipeline),
         resumer(MoveCollectionAuraTargetContinuation::class, ::resumeMoveCollectionAuraTarget),
+        resumer(PutOntoBattlefieldAttachedToChosenContinuation::class, ::resumePutOntoBattlefieldAttachedToChosen),
         resumer(PutOnTopOrBottomContinuation::class, ::resumePutOnTopOrBottom),
         resumer(CascadeMayCastContinuation::class, ::resumeCascadeMayCast),
         resumer(CastFromCollectionTargetsContinuation::class, ::resumeCastFromCollectionTargets),
@@ -364,6 +365,45 @@ class LibraryAndZoneContinuationResumer(
         }
 
         return checkForMore(newState, moveEvents)
+    }
+
+    /**
+     * Resume after the controller chooses a host for a card put onto the battlefield attached to
+     * a chosen permanent (One Last Job mode 3). Moves the Aura/Equipment to the battlefield under
+     * the controller's control and attaches it to the chosen host, reusing the permanent-agnostic
+     * [com.wingedsheep.engine.handlers.effects.library.MoveCollectionExecutor.moveAuraToBattlefield].
+     */
+    fun resumePutOntoBattlefieldAttachedToChosen(
+        state: GameState,
+        continuation: PutOntoBattlefieldAttachedToChosenContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is TargetsResponse) {
+            return ExecutionResult.error(state, "Expected targets response for attach-host selection")
+        }
+
+        val hostIds = response.selectedTargets[0] ?: emptyList()
+        if (hostIds.isEmpty()) {
+            // No host chosen — leave the card where it is (mode does nothing).
+            return checkForMore(state, emptyList())
+        }
+        val hostId = hostIds.first()
+
+        // Host must still be on the battlefield.
+        if (!state.getBattlefield().contains(hostId)) {
+            return checkForMore(state, emptyList())
+        }
+
+        val executor = com.wingedsheep.engine.handlers.effects.library.MoveCollectionExecutor(
+            cardRegistry = services.cardRegistry,
+            targetFinder = services.targetFinder
+        )
+        val (newState, events) = executor.moveAuraToBattlefield(
+            state, continuation.cardId, hostId, continuation.controllerId
+        )
+
+        return checkForMore(newState, events)
     }
 
     fun resumeSelectFromCollection(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/PutOntoBattlefieldAttachedToChosenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/PutOntoBattlefieldAttachedToChosenExecutor.kt
@@ -1,0 +1,168 @@
+package com.wingedsheep.engine.handlers.effects.zones
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.PutOntoBattlefieldAttachedToChosenContinuation
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.effects.PutOntoBattlefieldAttachedToChosenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import java.util.UUID
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [PutOntoBattlefieldAttachedToChosenEffect].
+ *
+ * Puts a targeted Aura or Equipment card onto the battlefield attached to a host the
+ * controller chooses at resolution. Models "Return target Aura or Equipment card from your
+ * graveyard to the battlefield attached to a creature you control" (One Last Job mode 3).
+ *
+ * Flow:
+ *  1. Resolve the targeted card (the Aura/Equipment). If it isn't an Aura or Equipment, no-op.
+ *  2. Enumerate legal hosts: permanents matching the effect's [hostFilter]. For Auras the host
+ *     set is intersected with the Aura's own enchant legality ([CardScript.auraTarget], Rule
+ *     303.4f — targeting restrictions like hexproof/shroud are ignored), so the Aura can only
+ *     be put onto something it can legally enchant.
+ *  3. If a legal host exists, pause for the controller to choose one
+ *     ([ChooseTargetsDecision]) and resume via
+ *     [PutOntoBattlefieldAttachedToChosenContinuation] to move-and-attach.
+ *  4. If no legal host exists: an Equipment still enters the battlefield (unattached); an Aura
+ *     can't enter and stays in its current zone (Rule 303.4g). This matches the One Last Job
+ *     ruling exactly.
+ *
+ * The actual move-and-attach reuses [com.wingedsheep.engine.handlers.effects.library.MoveCollectionExecutor.moveAuraToBattlefield],
+ * which is permanent-agnostic (it wires controller, `AttachedToComponent`, the host's
+ * `AttachmentsComponent`, and the card's static/replacement effects) and therefore serves both
+ * Auras and Equipment.
+ */
+class PutOntoBattlefieldAttachedToChosenExecutor(
+    private val cardRegistry: CardRegistry,
+    private val targetFinder: TargetFinder
+) : EffectExecutor<PutOntoBattlefieldAttachedToChosenEffect> {
+
+    override val effectType: KClass<PutOntoBattlefieldAttachedToChosenEffect> =
+        PutOntoBattlefieldAttachedToChosenEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: PutOntoBattlefieldAttachedToChosenEffect,
+        context: EffectContext
+    ): EffectResult {
+        val cardId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state) // target gone — fizzles for this mode
+
+        val container = state.getEntity(cardId) ?: return EffectResult.success(state)
+        val cardComponent = container.get<CardComponent>()
+            ?: return EffectResult.success(state)
+
+        val isAura = cardComponent.typeLine.isAura
+        val isEquipment = cardComponent.typeLine.isEquipment
+        if (!isAura && !isEquipment) {
+            // Not an Aura or Equipment — nothing this mode can do.
+            return EffectResult.success(state)
+        }
+
+        val controllerId = context.controllerId
+
+        // Hosts that match the effect's host filter (e.g. "a creature you control").
+        val hostRequirement = TargetObject(filter = TargetFilter(baseFilter = effect.hostFilter))
+        var legalHosts = targetFinder.findLegalTargets(
+            state = state,
+            requirement = hostRequirement,
+            controllerId = controllerId,
+            sourceId = cardId,
+            ignoreTargetingRestrictions = true
+        )
+
+        // For an Aura, narrow to hosts it can legally enchant (Rule 303.4f).
+        if (isAura) {
+            val auraTarget = cardRegistry.getCard(cardComponent.cardDefinitionId)?.script?.auraTarget
+            if (auraTarget != null) {
+                val auraLegal = targetFinder.findLegalTargets(
+                    state = state,
+                    requirement = auraTarget,
+                    controllerId = controllerId,
+                    sourceId = cardId,
+                    ignoreTargetingRestrictions = true
+                ).toSet()
+                legalHosts = legalHosts.filter { it in auraLegal }
+            } else {
+                // No enchant target defined — the Aura can't be attached to anything.
+                legalHosts = emptyList()
+            }
+        }
+
+        if (legalHosts.isEmpty()) {
+            // No legal host. Equipment still enters the battlefield (unattached, Rule 301.5c);
+            // an Aura can't enter and stays in its current zone (Rule 303.4g).
+            return if (isEquipment) {
+                val fromZone = findCurrentZone(state, cardId)
+                    ?: return EffectResult.success(state)
+                val transition = ZoneTransitionService.moveToZone(
+                    state, cardId, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = controllerId),
+                    fromZone
+                )
+                EffectResult.success(transition.state, transition.events)
+            } else {
+                EffectResult.success(state)
+            }
+        }
+
+        // Pause for the controller to choose a host.
+        val decisionId = UUID.randomUUID().toString()
+        val cardName = cardComponent.name
+        val requirementInfo = TargetRequirementInfo(
+            index = 0,
+            description = effect.hostFilter.description,
+            minTargets = 1,
+            maxTargets = 1
+        )
+        val decision = ChooseTargetsDecision(
+            id = decisionId,
+            playerId = controllerId,
+            prompt = "Choose what $cardName attaches to",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                phase = DecisionPhase.RESOLUTION
+            ),
+            targetRequirements = listOf(requirementInfo),
+            legalTargets = mapOf(0 to legalHosts)
+        )
+
+        val continuation = PutOntoBattlefieldAttachedToChosenContinuation(
+            decisionId = decisionId,
+            cardId = cardId,
+            controllerId = controllerId
+        )
+
+        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+
+        return EffectResult(
+            state = stateWithContinuation,
+            events = emptyList(),
+            pendingDecision = decision
+        )
+    }
+
+    private fun findCurrentZone(state: GameState, entityId: com.wingedsheep.sdk.model.EntityId): ZoneKey? {
+        for ((zoneKey, entities) in state.zones) {
+            if (entityId in entities) return zoneKey
+        }
+        return null
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.handlers.effects.zones
 
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ExecutorModule
 import com.wingedsheep.engine.registry.CardRegistry
@@ -10,7 +11,8 @@ import com.wingedsheep.engine.registry.CardRegistry
  * adding or removing link bookkeeping.
  */
 class ZonesExecutors(
-    private val cardRegistry: CardRegistry
+    private val cardRegistry: CardRegistry,
+    private val targetFinder: TargetFinder = TargetFinder()
 ) : ExecutorModule {
     override fun executors(): List<EffectExecutor<*>> = listOf(
         MoveToZoneEffectExecutor(cardRegistry),
@@ -23,6 +25,7 @@ class ZonesExecutors(
         SacrificeTargetExecutor(),
         ReturnCreaturesPutInGraveyardThisTurnExecutor(),
         ReturnSelfToBattlefieldAttachedExecutor(cardRegistry),
+        PutOntoBattlefieldAttachedToChosenExecutor(cardRegistry, targetFinder),
         ExileOpponentsGraveyardsExecutor(),
         DestroyAllEquipmentOnTargetExecutor()
     )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjOneLastJobScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjOneLastJobScenarioTest.kt
@@ -1,0 +1,211 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.OneLastJob
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * One Last Job — {2}{W} Sorcery, Spree.
+ *
+ * + {2} — Return target creature card from your graveyard to the battlefield.
+ * + {1} — Return target Mount or Vehicle card from your graveyard to the battlefield.
+ * + {1} — Return target Aura or Equipment card from your graveyard to the battlefield attached
+ *         to a creature you control.
+ *
+ * Mode 3 exercises the new [Effects.PutOntoBattlefieldAttachedToChosen] effect: the host creature
+ * is chosen at resolution (not a target) and the Aura/Equipment enters attached to it.
+ */
+class OtjOneLastJobScenarioTest : FunSpec({
+
+    // A small Aura that buffs the enchanted creature, for the mode-3 attach path.
+    val testAura = card("Test Buff Aura") {
+        manaCost = "{W}"
+        typeLine = "Enchantment — Aura"
+        oracleText = "Enchant creature\nEnchanted creature gets +2/+2."
+        auraTarget = Targets.Creature
+        staticAbility { ability = ModifyStats(2, 2) }
+    }
+
+    // A small Equipment, for the mode-3 attach path.
+    val testEquip = card("Test Power Blade") {
+        manaCost = "{1}"
+        typeLine = "Artifact — Equipment"
+        oracleText = "Equipped creature gets +1/+0.\nEquip {1}"
+        staticAbility { ability = ModifyStats(1, 0) }
+        equipAbility("{1}")
+    }
+
+    // A Mount creature card, for mode 2 (Mount/Vehicle).
+    val testMount = card("Test Mustang") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Mount"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OneLastJob, testAura, testEquip, testMount))
+        return driver
+    }
+
+    test("mode + {2}: return target creature card from your graveyard to the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val courser = driver.putCardInGraveyard(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "One Last Job")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 4) // {2}{W} base + {2} for the mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(courser, me, Zone.GRAVEYARD)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Card(courser, me, Zone.GRAVEYARD))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(me, "Centaur Courser") shouldBe courser
+        driver.getGraveyard(me).contains(courser) shouldBe false
+    }
+
+    test("mode + {1}: return target Mount card from your graveyard to the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val mount = driver.putCardInGraveyard(me, "Test Mustang")
+
+        val spell = driver.putCardInHand(me, "One Last Job")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 3) // {2}{W} base + {1} for the mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(mount, me, Zone.GRAVEYARD)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Card(mount, me, Zone.GRAVEYARD))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(me, "Test Mustang") shouldBe mount
+    }
+
+    test("mode + {1}: return target Equipment attached to a chosen creature you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val host = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val equip = driver.putCardInGraveyard(me, "Test Power Blade")
+
+        val spell = driver.putCardInHand(me, "One Last Job")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 3) // {2}{W} base + {1} for the mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(equip, me, Zone.GRAVEYARD)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Card(equip, me, Zone.GRAVEYARD))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // The mode pauses for the controller to choose the host creature.
+        driver.isPaused shouldBe true
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(host))
+        driver.isPaused shouldBe false
+
+        // The Equipment is on the battlefield, attached to the chosen creature.
+        driver.findPermanent(me, "Test Power Blade") shouldBe equip
+        driver.state.getEntity(equip)?.get<AttachedToComponent>()?.targetId shouldBe host
+        driver.getGraveyard(me).contains(equip) shouldBe false
+    }
+
+    test("mode + {1}: return target Aura attached to a chosen creature you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val host = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val aura = driver.putCardInGraveyard(me, "Test Buff Aura")
+
+        val spell = driver.putCardInHand(me, "One Last Job")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(aura, me, Zone.GRAVEYARD)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Card(aura, me, Zone.GRAVEYARD))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(host))
+        driver.isPaused shouldBe false
+
+        // The Aura entered attached to the chosen creature.
+        driver.findPermanent(me, "Test Buff Aura") shouldBe aura
+        driver.state.getEntity(aura)?.get<AttachedToComponent>()?.targetId shouldBe host
+    }
+
+    test("Spree requires at least one mode: casting with no modes fails") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(me, "One Last Job")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                chosenModes = emptyList(),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjShiftingGriftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjShiftingGriftScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ShiftingGrift
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Shifting Grift — {U}{U} Sorcery, Spree.
+ *
+ * + {2} — Exchange control of two target creatures.
+ * + {1} — Exchange control of two target artifacts.
+ * + {1} — Exchange control of two target enchantments.
+ *
+ * Both permanents in each mode are targets; the swap lasts indefinitely (Effects.ExchangeControl).
+ */
+class OtjShiftingGriftScenarioTest : FunSpec({
+
+    // Simple permanents to swap control of.
+    val testArtifact = card("Test Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+    val testEnchantment = card("Test Charm") {
+        manaCost = "{1}"
+        typeLine = "Enchantment"
+        oracleText = ""
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ShiftingGrift, testArtifact, testEnchantment))
+        return driver
+    }
+
+    test("mode + {2}: exchange control of two target creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val mine = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val theirs = driver.putCreatureOnBattlefield(opp, "Savannah Lions")
+
+        val spell = driver.putCardInHand(me, "Shifting Grift")
+        driver.giveMana(me, Color.BLUE, 2) // {U}{U} base
+        driver.giveColorlessMana(me, 2)     // {2} for the mode
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs))
+                ),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Control is exchanged: I now control their Lions, they control my Courser.
+        driver.state.projectedState.getController(theirs) shouldBe me
+        driver.state.projectedState.getController(mine) shouldBe opp
+    }
+
+    test("mode + {1}: exchange control of two target artifacts") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val mine = driver.putPermanentOnBattlefield(me, "Test Trinket")
+        val theirs = driver.putPermanentOnBattlefield(opp, "Test Trinket")
+
+        val spell = driver.putCardInHand(me, "Shifting Grift")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs))
+                ),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.projectedState.getController(theirs) shouldBe me
+        driver.state.projectedState.getController(mine) shouldBe opp
+    }
+
+    test("two modes: exchange creatures and enchantments in one cast") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val myCreature = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val theirCreature = driver.putCreatureOnBattlefield(opp, "Savannah Lions")
+        val myEnchant = driver.putPermanentOnBattlefield(me, "Test Charm")
+        val theirEnchant = driver.putPermanentOnBattlefield(opp, "Test Charm")
+
+        val spell = driver.putCardInHand(me, "Shifting Grift")
+        driver.giveMana(me, Color.BLUE, 2) // {U}{U} base
+        driver.giveColorlessMana(me, 3)     // {2} (creatures) + {1} (enchantments)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(myCreature), ChosenTarget.Permanent(theirCreature),
+                    ChosenTarget.Permanent(myEnchant), ChosenTarget.Permanent(theirEnchant)
+                ),
+                chosenModes = listOf(0, 2),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(myCreature), ChosenTarget.Permanent(theirCreature)),
+                    listOf(ChosenTarget.Permanent(myEnchant), ChosenTarget.Permanent(theirEnchant))
+                ),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.projectedState.getController(theirCreature) shouldBe me
+        driver.state.projectedState.getController(myCreature) shouldBe opp
+        driver.state.projectedState.getController(theirEnchant) shouldBe me
+        driver.state.projectedState.getController(myEnchant) shouldBe opp
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjTheKeyToTheVaultScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjTheKeyToTheVaultScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TheKeyToTheVault
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The Key to the Vault — {1}{U} Legendary Artifact — Equipment.
+ *
+ * "Whenever equipped creature deals combat damage to a player, look at that many cards from the
+ * top of your library. You may exile a nonland card from among them. Put the rest on the bottom
+ * of your library in a random order. You may cast the exiled card without paying its mana cost.
+ * Equip {2}{U}"
+ */
+class OtjTheKeyToTheVaultScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + TheKeyToTheVault)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Equip the Key to [attacker], attack the opponent unblocked, and pass priority until the
+     * Key's combat-damage trigger pauses for the look/exile selection. Returns the look decision.
+     */
+    fun setupAndAttack(driver: GameTestDriver, me: EntityId, opp: EntityId): EntityId {
+        val attacker = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+        driver.removeSummoningSickness(attacker)
+        val key = driver.putPermanentOnBattlefield(me, "The Key to the Vault")
+
+        // Equip the Key onto the attacker (sorcery-speed, our main phase, empty stack).
+        val equipId = TheKeyToTheVault.activatedAbilities.first().id
+        driver.giveColorlessMana(me, 2)
+        driver.giveMana(me, Color.BLUE, 1) // {2}{U}
+        driver.submit(
+            ActivateAbility(me, key, equipId, targets = listOf(ChosenTarget.Permanent(attacker)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(key)?.get<AttachedToComponent>()?.targetId shouldBe attacker
+
+        // Move to our declare-attackers step and swing unblocked.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opp)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opp)
+
+        // Pass until the combat-damage trigger pauses for the look/exile choice.
+        var safety = 0
+        while (!driver.isPaused && safety++ < 30) driver.bothPass()
+        return attacker
+    }
+
+    test("combat damage triggers a look at N, exiles a nonland, and casts it for free") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // A castable nonland on top, so the exiled card has a legal free cast.
+        val lions = driver.putCardOnTopOfLibrary(me, "Savannah Lions")
+
+        setupAndAttack(driver, me, opp)
+
+        driver.isPaused shouldBe true
+        val look = driver.pendingDecision
+        look.shouldBeInstanceOf<SelectCardsDecision>()
+
+        // Exile Savannah Lions, then it is cast for free during the trigger's resolution.
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = (look as SelectCardsDecision).id, selectedCards = listOf(lions))
+        )
+        var safety = 0
+        while (driver.isPaused && safety++ < 10) driver.bothPass()
+        driver.bothPass()
+
+        // Savannah Lions was cast for free and is now on the battlefield.
+        driver.findPermanent(me, "Savannah Lions") shouldBe lions
+    }
+
+    test("the look trigger may decline to exile, leaving nothing cast") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val lions = driver.putCardOnTopOfLibrary(me, "Savannah Lions")
+
+        setupAndAttack(driver, me, opp)
+
+        driver.isPaused shouldBe true
+        val look = driver.pendingDecision
+        look.shouldBeInstanceOf<SelectCardsDecision>()
+
+        // Decline to exile anything.
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = (look as SelectCardsDecision).id, selectedCards = emptyList<EntityId>())
+        )
+        var safety = 0
+        while (driver.isPaused && safety++ < 10) driver.bothPass()
+        driver.bothPass()
+
+        // Nothing was cast and Savannah Lions was not exiled.
+        driver.findPermanent(me, "Savannah Lions") shouldBe null
+        driver.getExile(me).none {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Savannah Lions"
+        } shouldBe true
+    }
+})


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards (all canonical in OTJ) and teaches the mtgish generator to draft them.

## Cards

- **One Last Job** `{2}{W}` Sorcery, Spree — three modes reanimating graveyard cards. Mode 1: target creature. Mode 2: target Mount or Vehicle. Mode 3: target Aura or Equipment **attached to a creature you control** (host chosen at resolution, not targeted — per the rulings, an Equipment may enter unattached and an Aura can't return with no legal host).
- **Shifting Grift** `{U}{U}` Sorcery, Spree — three modes each exchanging control of two target permanents (creatures / artifacts / enchantments) via the existing two-target `Effects.ExchangeControl`. The control change lasts indefinitely.
- **The Key to the Vault** `{1}{U}` Legendary Artifact — Equipment — "whenever equipped creature deals combat damage to a player, look at that many cards… you may exile a nonland… cast it for free; bottom the rest at random." The Sunbird's-Invocation pipeline with an ATTACHED combat-damage trigger, plus `equip {2}{U}`.

## New SDK surface

`Effects.PutOntoBattlefieldAttachedToChosen(target, hostFilter = Creature.youControl())` — puts a targeted Aura/Equipment onto the battlefield attached to a host the controller chooses at resolution. Works for both Auras and Equipment, intersects an Aura's enchant legality, and honors the no-legal-host rulings. Backed by a pausing executor + `PutOntoBattlefieldAttachedToChosenContinuation` that reuse `MoveCollection`'s permanent-agnostic move-and-attach helper. Documented in `card-sdk-language-reference.md`; closes OTJ engine-gap #15.

## mtgish tooling

All three cards now render **AUTO**:
- Bridge capability entries: `ExchangeControl`, `CastExiledCardWithoutPaying`.
- Emitter: cross-category subtype-`Or` graveyard targets → `withAnySubtype`; `EntersAttachedToAPermanent(creature you control)` → `PutOntoBattlefieldAttachedToChosen` (also upgrades **Nomad Mythmaker** from a lossy under-your-control render to the faithful attach); two-target Spree modes (sibling-`Other` distinctness stripped) + `ExchangeControl` handler; the look → may-exile-nonland → bottom-random → cast-free trigger with ATTACHED combat-damage binding.

## Tests / gates

- New rules-engine scenario tests for all three cards (every mode/branch, attach edge cases, look/exile/cast-free flow) — all pass.
- `CardLintTest`, `EffectExecutorCoverageTest`, `CardDefinitionSnapshotTest` (OTJ.json re-blessed, +3 cards only) — pass.
- `EmitterGoldenTest` — all 9 sets pass (10E re-blessed for the Nomad Mythmaker fidelity improvement).
- `coverage-verify POR` — GATE PASS, 158/158, 0-mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)