### PR TITLE
Add Double Down, Rush of Dread, Luxurious Locomotive (OTJ)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -108,8 +108,10 @@ Tests: `CrewSaddleContributorsScenarioTest`.
 
 → Unblocks: Giant Beaver, Ornery Tumblewagg, Rambling Possum (saddlers get counters / bounce),
   The Gitrog Ravenous Ride & Calamity (consume the saddlers), **Luxurious Locomotive** (Treasure per
-  creature that crewed it this turn — note: dynamic-count Treasure creation is still Int-only; that
-  card additionally needs a dynamic `CreateTreasure` or a `CreateTokenEffect`-based Treasure).
+  creature that crewed it this turn — ✅ implemented: `Effects.CreateTreasure(count: DynamicAmount)`
+  already supports a dynamic count, and "Crew 1. Activate only once each turn." is now
+  `KeywordAbility.crew(1, onceEachTurn = true)`, enforced by the crew enumerator/handler via
+  `CrewSaddleContributorsComponent.crewActivations`). Tests: `OtjLuxuriousLocomotiveScenarioTest`.
 
 ### 3. `DynamicAmount` over spells cast this turn (filtered, per-player, exclude-self) — ✅ DONE
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -669,7 +669,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `SacrificeTargetEffect(target, sacrificedByItsController = false)` — sacrifice a specific permanent. By
   default only fires if the resolving player controls it; set `sacrificedByItsController = true` for
   "[that creature]'s controller sacrifices it" (e.g. The Ring's Ring-bearer ability).
-- `ForceSacrificeEffect(target, count)` — edict; target sacrifices N creatures.
+- `Effects.Sacrifice(filter, count, target)` / `ForceSacrificeEffect(target, count)` — edict; target
+  sacrifices N permanents matching the filter (target chooses). `count` accepts an `Int` or a
+  `DynamicAmount` — pass a `DynamicAmount` (via the `Effects.Sacrifice(filter, count: DynamicAmount, …)`
+  overload / `ForceSacrificeEffect.dynamicCount`) for "sacrifices half the creatures they control,
+  rounded up" (Rush of Dread): `Divide(AggregateBattlefield(Player.ContextPlayer(0), Creature), Fixed(2),
+  roundUp = true)`. The amount is evaluated at resolution against the resolving context, so a per-target
+  player reference counts the chosen player's permanents.
 - "Return a permanent you control [to its owner's hand]" is a pipeline composition, not an effect type:
   `GatherCards(BattlefieldMatching(filter, Player.You, excludeSelf?))` →
   `SelectFromCollection(ChooseExactly(1), useTargetingUI = true)` → `MoveCollection(→ HAND)` (the
@@ -2395,7 +2401,11 @@ composite abilities).
   `rampage()`). The second-spell-cast event is matched by `EventPattern.NthSpellCastEvent`; no new engine
   subsystem is involved. Example: `flurry { effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent), damageSource = EffectTarget.Self) }`.
 - `Afflict(n)` — defender loses N when this becomes blocked.
-- `Crew(n)` — tap N power worth to animate a Vehicle.
+- `Crew(n)` (`KeywordAbility.crew(n, onceEachTurn = false)` / `Numeric(Keyword.CREW, n, onceEachTurn)`) —
+  tap N power worth to animate a Vehicle. Pass `onceEachTurn = true` for "Crew N. Activate only once each
+  turn." (Luxurious Locomotive): the crew enumerator + handler then refuse a second crew activation in the
+  same turn (counted via `CrewSaddleContributorsComponent.crewActivations`, reset at end of turn). Vanilla
+  Crew is uncapped. `onceEachTurn` is omitted from compiled JSON when false (`encodeDefaults = false`).
 - `saddle(n)` (`KeywordAbility.saddle(n)`) — Saddle N (CR 702.171). A sorcery-speed activated
   ability whose cost is tapping any number of *other* untapped creatures you control with total
   power ≥ N; on resolution this permanent **becomes saddled** until end of turn. Reuses the same

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2179,6 +2179,15 @@ object Effects {
         ForceSacrificeEffect(filter, count, target)
 
     /**
+     * Force a player to sacrifice a [DynamicAmount] of permanents matching a filter — e.g.
+     * "sacrifices half the creatures they control, rounded up" (Rush of Dread). The amount is
+     * evaluated at resolution against the resolving context, so a per-target player reference
+     * (`Player.ContextPlayer(0)` / `Player.TargetOpponent`) counts the chosen player's permanents.
+     */
+    fun Sacrifice(filter: GameObjectFilter, count: DynamicAmount, target: EffectTarget = EffectTarget.PlayerRef(Player.TargetOpponent)): Effect =
+        ForceSacrificeEffect(filter = filter, target = target, dynamicCount = count)
+
+    /**
      * Sacrifice a specific permanent identified by target.
      * Used in delayed triggers where the exact permanent was determined at resolution time.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -147,11 +147,23 @@ sealed interface KeywordAbility {
      * - `Numeric(Keyword.ANNIHILATOR, 2)` — "Annihilator 2"
      * - `Numeric(Keyword.TOXIC, 1)`       — "Toxic 1"
      * - `Numeric(Keyword.CREW, 3)`        — "Crew 3"
+     *
+     * [onceEachTurn] models a per-turn activation cap on the keyword ability — currently only
+     * meaningful for Crew ("Crew 1. Activate only once each turn." — Luxurious Locomotive). It
+     * defaults to false and, with `encodeDefaults = false`, is omitted from the compiled JSON so
+     * existing numeric-keyword cards are unaffected.
      */
     @SerialName("Numeric")
     @Serializable
-    data class Numeric(override val keyword: Keyword, val n: Int) : KeywordAbility {
-        override val description: String = "${keyword.displayName} $n"
+    data class Numeric(
+        override val keyword: Keyword,
+        val n: Int,
+        val onceEachTurn: Boolean = false
+    ) : KeywordAbility {
+        override val description: String = buildString {
+            append("${keyword.displayName} $n")
+            if (onceEachTurn) append(". Activate only once each turn.")
+        }
     }
 
     /**
@@ -834,7 +846,8 @@ sealed interface KeywordAbility {
         fun rampage(n: Int): KeywordAbility = Numeric(Keyword.RAMPAGE, n)
         fun absorb(n: Int): KeywordAbility = Numeric(Keyword.ABSORB, n)
         fun afflict(n: Int): KeywordAbility = Numeric(Keyword.AFFLICT, n)
-        fun crew(n: Int): KeywordAbility = Numeric(Keyword.CREW, n)
+        fun crew(n: Int, onceEachTurn: Boolean = false): KeywordAbility =
+            Numeric(Keyword.CREW, n, onceEachTurn)
         fun saddle(n: Int): KeywordAbility = Numeric(Keyword.SADDLE, n)
         fun modular(n: Int): KeywordAbility = Numeric(Keyword.MODULAR, n)
         fun fading(n: Int): KeywordAbility = Numeric(Keyword.FADING, n)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
@@ -183,22 +183,39 @@ data class SacrificeTargetEffect(
 data class ForceSacrificeEffect(
     val filter: GameObjectFilter,
     val count: Int = 1,
-    val target: EffectTarget = EffectTarget.PlayerRef(Player.TargetOpponent)
+    val target: EffectTarget = EffectTarget.PlayerRef(Player.TargetOpponent),
+    /**
+     * When non-null, the number of permanents to sacrifice is evaluated at resolution from
+     * this [DynamicAmount] instead of the fixed [count] (e.g. Rush of Dread's "sacrifices half
+     * the creatures they control, rounded up" via `Divide(AggregateBattlefield(...), Fixed(2))`).
+     * The fixed [count] is kept as the fallback for the common edict ("a creature") case so
+     * existing cards and their compiled snapshots are untouched.
+     */
+    val dynamicCount: DynamicAmount? = null
 ) : Effect {
     override val description: String = buildString {
         append(target.description)
         append(" sacrifices ")
-        if (count == 1) {
-            append("a ")
+        if (dynamicCount != null) {
+            append(dynamicCount.description)
+            append(" ")
+            append(filter.description)
+            append("s")
         } else {
-            append("$count ")
+            if (count == 1) {
+                append("a ")
+            } else {
+                append("$count ")
+            }
+            append(filter.description)
+            if (count != 1) append("s")
         }
-        append(filter.description)
-        if (count != 1) append("s")
     }
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newFilter = filter.applyTextReplacement(replacer)
-        return if (newFilter !== filter) copy(filter = newFilter) else this
+        val newDynamicCount = dynamicCount?.applyTextReplacement(replacer)
+        return if (newFilter !== filter || newDynamicCount !== dynamicCount)
+            copy(filter = newFilter, dynamicCount = newDynamicCount) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DoubleDown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DoubleDown.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Double Down
+ * {3}{U}
+ * Enchantment
+ *
+ * Whenever you cast an outlaw spell, copy that spell. (Assassins, Mercenaries, Pirates,
+ * Rogues, and Warlocks are outlaws. Copies of permanent spells become tokens.)
+ *
+ * An "outlaw spell" is any spell with one or more of the outlaw creature types
+ * ([Subtype.OUTLAW_TYPES]); the trigger uses [GameObjectFilter.Any.withAnyOfSubtypes] so it
+ * fires for kindred/creature/any-card-type spells alike. The copy is made of the triggering
+ * spell itself ([EffectTarget.TriggeringEntity]) — reusing [Effects.CopyTargetSpell], the same
+ * idiom as Alania, Divergent Storm and Breeches, the Blastmaker. The copy is created on the
+ * stack (not "cast"), and a copy of a permanent spell becomes a token on resolution; both are
+ * handled by the standard copy executor.
+ */
+val DoubleDown = card("Double Down") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast an outlaw spell, copy that spell. (Assassins, Mercenaries, " +
+        "Pirates, Rogues, and Warlocks are outlaws. Copies of permanent spells become tokens.)"
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnyOfSubtypes(Subtype.OUTLAW_TYPES)
+        )
+        effect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)
+        description = "Whenever you cast an outlaw spell, copy that spell."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "44"
+        artist = "Javier Charro"
+        flavorText = "The best alibi is being in multiple places at the same time."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg?1712355404"
+
+        ruling("2024-04-12", "Double Down's ability and the copy it creates will resolve before the spell that caused it to trigger. They resolve even if that spell is countered.")
+        ruling("2024-04-12", "As a copy of a permanent spell resolves, it's put onto the battlefield as a token rather than putting a copy of the spell onto the battlefield.")
+        ruling("2024-04-12", "If a spell has the kindred card type and one of the outlaw creature types, Double Down will copy it.")
+        ruling("2024-04-12", "Double Down's ability doesn't trigger if an outlaw permanent is put onto the battlefield without being cast.")
+        ruling("2024-04-12", "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LuxuriousLocomotive.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LuxuriousLocomotive.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Luxurious Locomotive
+ * {5}
+ * Artifact — Vehicle
+ * 6/5
+ *
+ * Whenever this Vehicle attacks, create a Treasure token for each creature that crewed it
+ * this turn. (They're artifacts with "{T}, Sacrifice this token: Add one mana of any color.")
+ * Crew 1. Activate only once each turn. (Tap any number of creatures you control with total
+ * power 1 or more: This Vehicle becomes an artifact creature until end of turn.)
+ *
+ * The attack payoff reuses [DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn] (source-relative
+ * count off [com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent],
+ * which the crew handler records and which includes contributors that have since left — per the
+ * ruling). "Crew 1. Activate only once each turn." is `crew(1, onceEachTurn = true)`: the
+ * once-per-turn cap is enforced in the crew enumerator + handler via the component's crew-activation
+ * count (vanilla Crew is uncapped).
+ */
+val LuxuriousLocomotive = card("Luxurious Locomotive") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    power = 6
+    toughness = 5
+    oracleText = "Whenever this Vehicle attacks, create a Treasure token for each creature that " +
+        "crewed it this turn. (They're artifacts with \"{T}, Sacrifice this token: Add one mana " +
+        "of any color.\")\n" +
+        "Crew 1. Activate only once each turn. (Tap any number of creatures you control with total " +
+        "power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    // Whenever this Vehicle attacks, create a Treasure token for each creature that crewed it this turn.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateTreasure(count = DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn())
+    }
+
+    keywordAbility(KeywordAbility.crew(1, onceEachTurn = true))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg?1712356268"
+
+        ruling("2024-04-12", "You may tap more creatures than necessary to activate a crew ability.")
+        ruling("2024-04-12", "Once a player announces that they are activating a crew ability, no player may take other actions until the ability has been paid for.")
+        ruling("2024-04-12", "Luxurious Locomotive's triggered ability counts each creature that crewed it this turn, including creatures that are no longer on the battlefield as the ability resolves.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RushOfDread.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RushOfDread.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rush of Dread {1}{B}{B}
+ * Sorcery
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {1} — Target opponent sacrifices half the creatures they control of their choice, rounded up.
+ * + {2} — Target opponent discards half the cards in their hand, rounded up.
+ * + {2} — Target opponent loses half their life, rounded up.
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`,
+ * and per-mode `additionalManaCost` (CR 702.166): at least one mode must be chosen and no mode
+ * can be chosen more than once. Each mode targets an opponent independently
+ * ([Targets.Opponent] → the mode's `ContextTarget(0)`). "Half … rounded up" is
+ * `Divide(<count>, Fixed(2), roundUp = true)`, and the count is read off the *chosen* opponent
+ * via [Player.ContextPlayer]/[EffectTarget.ContextTarget] index 0:
+ * - creatures they control → `AggregateBattlefield(ContextPlayer(0), Creature)`
+ * - cards in their hand → `AggregateZone(ContextPlayer(0), HAND)`
+ * - their life → `LifeTotal(ContextPlayer(0))`.
+ */
+val RushOfDread = card("Rush of Dread") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {1} — Target opponent sacrifices half the creatures they control of their choice, rounded up.\n" +
+        "+ {2} — Target opponent discards half the cards in their hand, rounded up.\n" +
+        "+ {2} — Target opponent loses half their life, rounded up."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.Sacrifice(
+                        filter = GameObjectFilter.Creature,
+                        count = DynamicAmount.Divide(
+                            numerator = DynamicAmount.AggregateBattlefield(
+                                Player.ContextPlayer(0),
+                                GameObjectFilter.Creature
+                            ),
+                            denominator = DynamicAmount.Fixed(2),
+                            roundUp = true
+                        ),
+                        target = EffectTarget.ContextTarget(0)
+                    ),
+                    targetRequirements = listOf(Targets.Opponent),
+                    description = "+ {1} — Target opponent sacrifices half the creatures they " +
+                        "control of their choice, rounded up.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = Effects.Discard(
+                        count = DynamicAmount.Divide(
+                            numerator = DynamicAmount.AggregateZone(
+                                Player.ContextPlayer(0),
+                                Zone.HAND
+                            ),
+                            denominator = DynamicAmount.Fixed(2),
+                            roundUp = true
+                        ),
+                        target = EffectTarget.ContextTarget(0)
+                    ),
+                    targetRequirements = listOf(Targets.Opponent),
+                    description = "+ {2} — Target opponent discards half the cards in their hand, rounded up.",
+                    additionalManaCost = "{2}"
+                ),
+                Mode(
+                    effect = Effects.LoseLife(
+                        amount = DynamicAmount.Divide(
+                            numerator = DynamicAmount.LifeTotal(Player.ContextPlayer(0)),
+                            denominator = DynamicAmount.Fixed(2),
+                            roundUp = true
+                        ),
+                        target = EffectTarget.ContextTarget(0)
+                    ),
+                    targetRequirements = listOf(Targets.Opponent),
+                    description = "+ {2} — Target opponent loses half their life, rounded up.",
+                    additionalManaCost = "{2}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg?1712860603"
+
+        ruling("2024-04-12", "Like the effects of all modal spells, Rush of Dread's effects happen in order. If the first two modes target different opponents, the opponent targeted by the second mode will see what the first opponent sacrificed before choosing what to discard.")
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "If all targets for the chosen modes become illegal before a spell with spree resolves, the spell won't resolve. If at least one target is still legal, the spell resolves but has no effect on illegal targets.")
+        ruling("2024-04-12", "The mana value of a spell with spree is determined only by its mana cost. It doesn't matter which modes you choose or which additional costs you pay.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4190,6 +4190,76 @@
     ]
 }
 
+// Double Down
+{
+    "name": "Double Down",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast an outlaw spell, copy that spell. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Copies of permanent spells become tokens.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Assassin",
+                                    "Mercenary",
+                                    "Pirate",
+                                    "Rogue",
+                                    "Warlock"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CopyTargetSpell",
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Whenever you cast an outlaw spell, copy that spell."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "MYTHIC",
+        "artist": "Javier Charro",
+        "flavorText": "The best alibi is being in multiple places at the same time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg?1712355404",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Double Down's ability and the copy it creates will resolve before the spell that caused it to trigger. They resolve even if that spell is countered."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "As a copy of a permanent spell resolves, it's put onto the battlefield as a token rather than putting a copy of the spell onto the battlefield."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If a spell has the kindred card type and one of the outlaw creature types, Double Down will copy it."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Double Down's ability doesn't trigger if an outlaw permanent is put onto the battlefield without being cast."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Drover Grizzly
 {
     "name": "Drover Grizzly",
@@ -8584,6 +8654,63 @@
     ]
 }
 
+// Luxurious Locomotive
+{
+    "name": "Luxurious Locomotive",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever this Vehicle attacks, create a Treasure token for each creature that crewed it this turn. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")\nCrew 1. Activate only once each turn. (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1,
+            "onceEachTurn": true
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "dynamicCount": "CreaturesThatCrewedOrSaddledThisTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Leon Tukker",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg?1712356268",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You may tap more creatures than necessary to activate a crew ability."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Once a player announces that they are activating a crew ability, no player may take other actions until the ability has been paid for."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Luxurious Locomotive's triggered ability counts each creature that crewed it this turn, including creatures that are no longer on the battlefield as the ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Magda, the Hoardmaster
 {
     "name": "Magda, the Hoardmaster",
@@ -12534,6 +12661,174 @@
         "artist": "Josu Hernaiz",
         "flavorText": "\"Sneaking behind people? Pedestrian.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg?1712355656"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Rush of Dread
+{
+    "name": "Rush of Dread",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {1} — Target opponent sacrifices half the creatures they control of their choice, rounded up.\n+ {2} — Target opponent discards half the cards in their hand, rounded up.\n+ {2} — Target opponent loses half their life, rounded up.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "dynamicCount": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "AggregateBattlefield",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "filter": "creature"
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetOpponent"
+                    ],
+                    "description": "+ {1} — Target opponent sacrifices half the creatures they control of their choice, rounded up.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Divide",
+                                        "numerator": {
+                                            "type": "AggregateZone",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            },
+                                            "zone": "Hand"
+                                        },
+                                        "denominator": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        "TargetOpponent"
+                    ],
+                    "description": "+ {2} — Target opponent discards half the cards in their hand, rounded up.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "LifeTotal",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        "TargetOpponent"
+                    ],
+                    "description": "+ {2} — Target opponent loses half their life, rounded up.",
+                    "additionalManaCost": "{2}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg?1712860603",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Like the effects of all modal spells, Rush of Dread's effects happen in order. If the first two modes target different opponents, the opponent targeted by the second mode will see what the first opponent sacrificed before choosing what to discard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If all targets for the chosen modes become illegal before a spell with spree resolves, the spell won't resolve. If at least one target is still legal, the spell resolves but has no effect on illegal targets."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The mana value of a spell with spree is determined only by its mana cost. It doesn't matter which modes you choose or which additional costs you pay."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -55,6 +55,10 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     // Copy / retarget a spell or ability on the stack (Return the Favor). The unified copy effect
     // dispatches at resolution on the chosen stack-object kind (spell / activated / triggered ability).
     effect("CopySpellOrAbilityAndMayChooseNewTargets", "CopyTargetSpellOrAbility")
+    // "Copy that spell" — bare CopySpell(Trigger_ThatSpell) on a cast trigger (Double Down). Renders to
+    // CopyTargetSpell(EffectTarget.TriggeringEntity); only the triggering-spell subject is emitted (the
+    // "may choose new targets" variant stays a deliberate decline above — Breeches).
+    effect("CopySpell", "CopyTargetSpell")
     effect("ChangeTargetsOfSpellOrAbility", "ChangeTarget")
     effect("TakeAnExtraTurn", "TakeExtraTurn")
     effect("LoseTheGame", "LoseGame")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -22,6 +22,11 @@ internal fun BridgeBuilder.keywords() {
     // `keywordAbility(KeywordAbility.saddle(N))`; this `supported` entry only marks the capability as
     // covered (never blocking) so the probe doesn't report Saddle as a gap.
     supported("Saddle", "keyword ability: Saddle N -> keywordAbility(KeywordAbility.saddle(N)) (CR 702.171)")
+    // "Crew N. Activate only once each turn." (Luxurious Locomotive) — a PARAMETERIZED keyword ability
+    // like Saddle/Crew, so `supported` (not `keyword`) to avoid dropping the N. The emitter's
+    // `rname == "CrewOnceEachTurn"` branch renders `keywordAbility(KeywordAbility.crew(N, onceEachTurn = true))`;
+    // the engine enforces the once-per-turn cap in the crew enumerator/handler.
+    supported("CrewOnceEachTurn", "keyword ability: Crew N, activate only once each turn -> keywordAbility(KeywordAbility.crew(N, onceEachTurn = true))")
     // Firebending N (CR 702.189, Avatar: The Last Airbender) — a PARAMETERIZED keyword ability (the
     // N count rides in the rule's args as a nested _GameNumber:Integer, exactly like Saddle). Must be
     // `supported`, not `keyword`: a bare `keywords(Keyword.FIREBENDING)` would drop the N. The

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1840,6 +1840,9 @@ private fun castScope(players: JsonObject?): CastScope? = when (players?.strFiel
 private fun spellCastCategory(spells: JsonObject?): String? = when (spells?.strField("_Spells")) {
     "AnySpell" -> "any"
     "IsHistoric" -> "historic"
+    // "an outlaw spell" — a spell with one or more outlaw creature types (Double Down). Maps to the
+    // shared Subtype.OUTLAW_TYPES group via withAnyOfSubtypes.
+    "IsAnOutlaw" -> "outlaw"
     "IsCardtype" -> when (spells.field("args").asStr()) {
         "Creature" -> "creature"
         "Enchantment" -> "enchantment"
@@ -1863,6 +1866,7 @@ private fun categoryFilter(category: String): String? = when (category) {
     "enchantment" -> "GameObjectFilter.Enchantment"
     "instantOrSorcery" -> "GameObjectFilter.InstantOrSorcery"
     "historic" -> "GameObjectFilter.Historic"
+    "outlaw" -> "GameObjectFilter.Any.withAnyOfSubtypes(Subtype.OUTLAW_TYPES)"
     else -> null
 }
 
@@ -1908,6 +1912,7 @@ private fun castTriggerDsl(scope: CastScope, category: String, targetsMatching: 
             "enchantment" -> "Triggers.YouCastEnchantment"
             "instantOrSorcery" -> "Triggers.YouCastInstantOrSorcery"
             "historic" -> "Triggers.YouCastHistoric"
+            "outlaw" -> "Triggers.youCastSpell(spellFilter = ${categoryFilter("outlaw")})"
             else -> null
         }
         CastScope.ANY -> if (filter == null) "Triggers.AnyPlayerCastsSpell" else "Triggers.anyPlayerCasts($filter)"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -136,6 +136,17 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
     // targets for the copy." (Return the Favor mode 1). The four-way target is recovered by
     // `Targets.InstantSorcerySpellOrAbility`; the effect copies whichever stack-object kind was chosen.
     simple("CopySpellOrAbilityAndMayChooseNewTargets", dsl = "Effects.CopyTargetSpellOrAbility()")
+    // "Copy that spell" on a cast trigger — CopySpell(Trigger_ThatSpell) (Double Down). The copy is
+    // made of the triggering spell itself; copies of permanent spells become tokens (handled by the
+    // engine's copy executor). Only the triggering-spell subject renders; any other CopySpell subject
+    // (a chosen target, a stored spell) declines -> SCAFFOLD.
+    on("CopySpell") { node, _, _ ->
+        val subject = (node["args"] as? JsonObject)?.strField("_Spell")
+            ?: (node["args"].asArr?.firstOrNull() as? JsonObject)?.strField("_Spell")
+        if (subject == "Trigger_ThatSpell")
+            Lit("Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)")
+        else null
+    }
     // "Change the target of target spell or ability with a single target." (Return the Favor mode 2 /
     // Willbender). Pairs with `Targets.SpellOrAbilityWithSingleTarget`.
     simple("ChangeTargetsOfSpellOrAbility", dsl = "Effects.ChangeTarget()")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -375,6 +375,18 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // the flat type/subtype/controller filter below — emitting the aggregate without it would silently
         // over-count, so decline (-> SCAFFOLD) rather than misrender.
         if ("SharesACreatureTypeWithPermanent" in compact(node)) return null
+        // "for each creature that crewed it this turn" — a CrewedVehicleThisTurn predicate scoped to the
+        // source Vehicle (Luxurious Locomotive). This is a per-source set-tracker count, not a flat
+        // battlefield aggregate; the search filter below would silently drop the CrewedVehicleThisTurn
+        // clause and over-count every creature. Render the dedicated source-relative DynamicAmount instead
+        // (which retains contributors that have since left, matching the ruling). Only the source-Vehicle
+        // subject (Trigger_ThatCreature / ThisPermanent) is recognised; any other subject declines.
+        if ("CrewedVehicleThisTurn" in compact(node)) {
+            val subj = compact(node)
+            return if ("Trigger_ThatCreature" in subj || "ThisPermanent" in subj)
+                Lit("DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn")
+            else null
+        }
         val oracle = oracleText?.lowercase() ?: ""
         // The count filter is recovered by landSearchFilterExpr, which renders only type/subtype/color/land
         // shapes — it silently widens anything else (its `else` arm is GameObjectFilter.Any) and its

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -196,6 +196,12 @@ object Emitter {
                 rname == "FlashForCasters" -> block = ctx.conditionalFlashLines(rule)
                 rname == "Flashback" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.flashback", arg("\"$it\"")))))) }
                 rname == "Crew" -> block = rule["args"].asInt()?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.crew", arg("$it")))))) }
+                // "Crew N. Activate only once each turn." (Luxurious Locomotive) — CrewOnceEachTurn carries
+                // the crew power N. Renders `KeywordAbility.crew(N, onceEachTurn = true)`; the engine enforces
+                // the once-per-turn cap in the crew enumerator/handler.
+                rname == "CrewOnceEachTurn" -> block = rule["args"].asInt()?.let {
+                    listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.crew", arg("$it"), arg("onceEachTurn", "true"))))))
+                }
                 // Saddle N (CR 702.171) — a numeric keyword ability. mtgish shapes the count as a nested
                 // `_GameNumber: Integer` game number, so dig the integer out of the args (findInteger) rather
                 // than reading args directly as an Int. Renders `keywordAbility(KeywordAbility.saddle(N))`,

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -41,6 +41,15 @@ class EffectHandlerTest : StringSpec({
         effect("""{"_Action":"SomeActionWeDoNotModel"}""").shouldBeNull()
     }
 
+    "CopySpell(Trigger_ThatSpell) renders 'copy that spell' on a cast trigger (Double Down)" {
+        effect("""{"_Action":"CopySpell","args":{"_Spell":"Trigger_ThatSpell"}}""") shouldBe
+            "Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)"
+    }
+
+    "CopySpell with a non-triggering-spell subject declines (-> SCAFFOLD)" {
+        effect("""{"_Action":"CopySpell","args":{"_Spell":"Ref_TargetSpell"}}""").shouldBeNull()
+    }
+
     // --- SetPT layer effect ("target creature becomes a P/T until end of turn") -------------------
     fun layer(json: String, tvar: String?): String? = ctx.renderAction(obj(json), tvar)?.let(::render)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -69,6 +69,15 @@ class CrewVehicleHandler(
             .firstOrNull { it.keyword == Keyword.CREW }
             ?: return "This permanent doesn't have crew"
 
+        // "Crew N. Activate only once each turn." (Luxurious Locomotive): block a second crew
+        // activation this turn. Vanilla Crew (onceEachTurn = false) has no such cap.
+        if (crewAbility.onceEachTurn) {
+            val crewActivations = vehicleContainer.get<CrewSaddleContributorsComponent>()?.crewActivations ?: 0
+            if (crewActivations >= 1) {
+                return "This Vehicle's crew ability can only be activated once each turn"
+            }
+        }
+
         if (action.crewCreatures.isEmpty()) {
             return "Must select at least one creature to crew"
         }
@@ -141,8 +150,13 @@ class CrewVehicleHandler(
         // Record the crew so Vehicle payoffs can read "creatures that crewed it this turn"
         // (e.g. Luxurious Locomotive). Union across activations within the turn.
         currentState = currentState.updateEntity(action.vehicleId) { c ->
-            val existing = c.get<CrewSaddleContributorsComponent>()?.creatureIds ?: emptySet()
-            c.with(CrewSaddleContributorsComponent(existing + action.crewCreatures))
+            val existing = c.get<CrewSaddleContributorsComponent>()
+            c.with(
+                CrewSaddleContributorsComponent(
+                    creatureIds = (existing?.creatureIds ?: emptySet()) + action.crewCreatures,
+                    crewActivations = (existing?.crewActivations ?: 0) + 1
+                )
+            )
         }
 
         // Create the crew ability effect: Vehicle becomes an artifact creature

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -137,8 +137,13 @@ class SaddleMountHandler(
         // Record the saddlers so Mount payoffs can read "creatures that saddled it this turn".
         // Union across activations: saddle may be activated again even while already saddled.
         currentState = currentState.updateEntity(action.mountId) { c ->
-            val existing = c.get<CrewSaddleContributorsComponent>()?.creatureIds ?: emptySet()
-            c.with(CrewSaddleContributorsComponent(existing + action.saddleCreatures))
+            val existing = c.get<CrewSaddleContributorsComponent>()
+            c.with(
+                CrewSaddleContributorsComponent(
+                    creatureIds = (existing?.creatureIds ?: emptySet()) + action.saddleCreatures,
+                    crewActivations = existing?.crewActivations ?: 0
+                )
+            )
         }
 
         // Put the saddle ability on the stack: this permanent becomes saddled until end of turn.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ForceSacrificeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ForceSacrificeExecutor.kt
@@ -30,7 +30,9 @@ import kotlin.reflect.KClass
  * - The Eldest Reborn: "Each opponent sacrifices a creature or planeswalker."
  */
 class ForceSacrificeExecutor(
-    private val decisionHandler: DecisionHandler = DecisionHandler()
+    private val decisionHandler: DecisionHandler = DecisionHandler(),
+    private val dynamicAmountEvaluator: com.wingedsheep.engine.handlers.DynamicAmountEvaluator =
+        com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
 ) : EffectExecutor<ForceSacrificeEffect> {
 
     override val effectType: KClass<ForceSacrificeEffect> = ForceSacrificeEffect::class
@@ -45,7 +47,15 @@ class ForceSacrificeExecutor(
             return EffectResult.error(state, "No valid player for force sacrifice")
         }
 
-        return processPlayers(state, playerIds, effect.filter, effect.count, context.sourceId)
+        // A dynamic count ("sacrifices half the creatures they control, rounded up") is evaluated
+        // once at resolution; otherwise fall back to the fixed edict count. The amount is resolved
+        // against the same context so a per-target reference (e.g. Player.ContextPlayer / TargetOpponent)
+        // counts the chosen player's permanents.
+        val count = effect.dynamicCount
+            ?.let { dynamicAmountEvaluator.evaluate(state, it, context) }
+            ?: effect.count
+
+        return processPlayers(state, playerIds, effect.filter, count, context.sourceId)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CrewEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CrewEnumerator.kt
@@ -34,6 +34,15 @@ class CrewEnumerator : ActionEnumerator {
                 .filterIsInstance<KeywordAbility.Numeric>()
                 .firstOrNull { it.keyword == Keyword.CREW } ?: continue
 
+            // "Crew N. Activate only once each turn." — once it's already been crewed this turn,
+            // the crew action is no longer available (Luxurious Locomotive).
+            if (crewAbility.onceEachTurn) {
+                val crewActivations = container
+                    .get<com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent>()
+                    ?.crewActivations ?: 0
+                if (crewActivations >= 1) continue
+            }
+
             // Find all untapped creatures controlled by the player that can crew
             val validCrewCreatures = mutableListOf<TapForPowerCreatureData>()
             var totalAvailablePower = 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -116,7 +116,13 @@ data object SaddledComponent : Component
  */
 @Serializable
 data class CrewSaddleContributorsComponent(
-    val creatureIds: Set<EntityId>
+    val creatureIds: Set<EntityId>,
+    /**
+     * How many times the *crew* ability has been activated on this permanent this turn. Used to
+     * enforce a "Crew N. Activate only once each turn." cap (Luxurious Locomotive). Saddle
+     * activations don't increment it. Reset with the rest of the component at end of turn.
+     */
+    val crewActivations: Int = 0
 ) : Component
 
 /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjDoubleDownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjDoubleDownScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DoubleDown
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Double Down — {3}{U} Enchantment.
+ *
+ * Whenever you cast an outlaw spell, copy that spell.
+ *
+ * Verifies the cast-an-outlaw-spell trigger copies the spell (a creature copy resolves into a
+ * token, so the outlaw creature ends up on the battlefield twice) and that a non-outlaw spell is
+ * not copied.
+ */
+class OtjDoubleDownScenarioTest : FunSpec({
+
+    // Minimal outlaw creature spell (Rogue = an outlaw type).
+    val testOutlaw = card("Test Bandit") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Rogue"
+        power = 2
+        toughness = 2
+    }
+
+    // Minimal non-outlaw creature spell (Bear is not an outlaw type).
+    val testNonOutlaw = card("Test Bear") {
+        manaCost = "{1}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DoubleDown)
+        driver.registerCard(testOutlaw)
+        driver.registerCard(testNonOutlaw)
+        driver.initMirrorMatch(Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.countNamed(playerId: EntityId, name: String): Int =
+        getPermanents(playerId).count {
+            state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+
+    // Pass priority back and forth until the stack is empty (resolves the spell, the Double Down
+    // trigger, and the copy it creates).
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && pendingDecision == null && guard++ < 12) {
+            bothPass()
+        }
+    }
+
+    test("casting an outlaw creature spell copies it (resolves as a token)") {
+        val driver = newDriver()
+        val caster = driver.player1
+        driver.putPermanentOnBattlefield(caster, "Double Down")
+
+        val bandit = driver.putCardInHand(caster, "Test Bandit")
+        driver.giveColorlessMana(caster, 1)
+        driver.castSpell(caster, bandit).isSuccess shouldBe true
+
+        // Resolve the Double Down trigger (the copy → token) and the original spell.
+        driver.resolveStack()
+
+        // Original Bandit + its token copy = 2 on the battlefield.
+        driver.countNamed(caster, "Test Bandit") shouldBe 2
+    }
+
+    test("casting a non-outlaw creature spell does not copy it") {
+        val driver = newDriver()
+        val caster = driver.player1
+        driver.putPermanentOnBattlefield(caster, "Double Down")
+
+        val bear = driver.putCardInHand(caster, "Test Bear")
+        driver.giveColorlessMana(caster, 1)
+        driver.castSpell(caster, bear).isSuccess shouldBe true
+        driver.resolveStack()
+
+        driver.countNamed(caster, "Test Bear") shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjLuxuriousLocomotiveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjLuxuriousLocomotiveScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.mtg.sets.definitions.otj.cards.LuxuriousLocomotive
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Luxurious Locomotive — {5} Artifact — Vehicle, 6/5.
+ *
+ * - Whenever this Vehicle attacks, create a Treasure token for each creature that crewed it
+ *   this turn.
+ * - Crew 1. Activate only once each turn.
+ *
+ * Exercises the once-each-turn crew cap (new `crew(1, onceEachTurn = true)`) and the
+ * Treasure-per-crewer attack payoff.
+ */
+class OtjLuxuriousLocomotiveScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(LuxuriousLocomotive)
+        driver.registerCard(PredefinedTokens.Treasure)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.treasures(playerId: EntityId): Int =
+        getPermanents(playerId).count {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Treasure"
+        }
+
+    test("attacking creates a Treasure for each creature that crewed it this turn") {
+        val driver = newDriver()
+        val loco = driver.putPermanentOnBattlefield(driver.player1, "Luxurious Locomotive")
+        val bear1 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(loco)
+
+        driver.treasures(driver.player1) shouldBe 0
+
+        driver.submitSuccess(CrewVehicle(driver.player1, loco, listOf(bear1, bear2)))
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(loco), driver.player2)
+        driver.bothPass()
+
+        // Two creatures crewed it → two Treasure tokens.
+        driver.treasures(driver.player1) shouldBe 2
+    }
+
+    test("Crew can only be activated once each turn") {
+        val driver = newDriver()
+        val loco = driver.putPermanentOnBattlefield(driver.player1, "Luxurious Locomotive")
+        val bear1 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        // First crew succeeds.
+        driver.submitSuccess(CrewVehicle(driver.player1, loco, listOf(bear1)))
+        driver.bothPass()
+
+        // Second crew this turn is rejected by the once-each-turn cap, even with an untapped crewer.
+        driver.submitExpectFailure(CrewVehicle(driver.player1, loco, listOf(bear2)))
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRushOfDreadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OtjRushOfDreadScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RushOfDread
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rush of Dread — {1}{B}{B} Sorcery (Spree).
+ *
+ * + {1} — Target opponent sacrifices half the creatures they control of their choice, rounded up.
+ * + {2} — Target opponent discards half the cards in their hand, rounded up.
+ * + {2} — Target opponent loses half their life, rounded up.
+ *
+ * Exercises the new dynamic-count `ForceSacrificeEffect` ("half … rounded up") alongside the
+ * existing dynamic Discard / LoseLife, all gated by Spree's per-mode additional costs.
+ */
+class OtjRushOfDreadScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RushOfDread)
+        driver.initMirrorMatch(Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Mode 0: target opponent sacrifices half their creatures, rounded up") {
+        val driver = newDriver()
+        val caster = driver.player1
+        val foe = driver.player2
+
+        // Opponent controls 3 creatures → half rounded up = 2.
+        repeat(3) { driver.putCreatureOnBattlefield(foe, "Grizzly Bears") }
+
+        val spell = driver.putCardInHand(caster, "Rush of Dread")
+        driver.giveMana(caster, Color.BLACK, 2) // {B}{B}
+        driver.giveColorlessMana(caster, 2)      // {1} base + {1} mode 0
+        driver.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(foe)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(foe)))
+            )
+        )
+        driver.bothPass() // begin resolving → opponent's sacrifice decision
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        // Must sacrifice exactly 2 of the 3 creatures.
+        decision.minSelections shouldBe 2
+        driver.submitCardSelection(foe, decision.options.take(2))
+
+        driver.getCreatures(foe).size shouldBe 1
+    }
+
+    test("Mode 1: target opponent discards half their hand, rounded up") {
+        val driver = newDriver()
+        val caster = driver.player1
+        val foe = driver.player2
+
+        repeat(5) { driver.putCardInHand(foe, "Grizzly Bears") }
+        val handBefore = driver.getHandSize(foe)
+        val expectedDiscard = (handBefore + 1) / 2 // half, rounded up
+
+        val spell = driver.putCardInHand(caster, "Rush of Dread")
+        driver.giveMana(caster, Color.BLACK, 2)
+        driver.giveColorlessMana(caster, 3) // {1} base + {2} mode 1
+        driver.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(foe)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(foe)))
+            )
+        )
+        driver.bothPass() // begin resolving → opponent's discard decision
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        decision.minSelections shouldBe expectedDiscard
+        driver.submitCardSelection(foe, decision.options.take(expectedDiscard))
+
+        driver.getHandSize(foe) shouldBe handBefore - expectedDiscard
+    }
+
+    test("Mode 2: target opponent loses half their life, rounded up") {
+        val driver = newDriver()
+        val caster = driver.player1
+        val foe = driver.player2
+        driver.setLifeTotal(foe, 21) // half rounded up = 11
+
+        val spell = driver.putCardInHand(caster, "Rush of Dread")
+        driver.giveMana(caster, Color.BLACK, 2)
+        driver.giveColorlessMana(caster, 3) // {1} base + {2} mode 2
+        driver.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Player(foe)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(foe)))
+            )
+        )
+        driver.bothPass()
+
+        driver.getLifeTotal(foe) shouldBe 21 - 11
+    }
+})


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards via the `add-card` workflow, plus the small SDK/engine features two of them needed, and teaches the mtgish auto-gen tooling to draft them.

## Cards

- **Double Down** ({3}{U} Enchantment) — "Whenever you cast an outlaw spell, copy that spell." Reuses `Triggers.youCastSpell(outlaw filter)` + `Effects.CopyTargetSpell(EffectTarget.TriggeringEntity)` (the Alania / Breeches idiom). No new SDK surface.
- **Rush of Dread** ({1}{B}{B} Sorcery, Spree) — three modes making a target opponent sacrifice / discard / lose **half, rounded up**.
- **Luxurious Locomotive** ({5} Artifact — Vehicle, 6/5) — "Whenever this Vehicle attacks, create a Treasure for each creature that crewed it this turn. Crew 1. Activate only once each turn."

## Engine / SDK additions (designed for reuse, not one-offs)

- **Dynamic-count edict** — `ForceSacrificeEffect.dynamicCount: DynamicAmount?` + an `Effects.Sacrifice(filter, count: DynamicAmount, target)` overload, evaluated at resolution against the resolving context (so `Player.ContextPlayer(0)` counts the chosen opponent's permanents). The fixed-`Int` path is untouched, so existing edicts and their snapshots don't change. Rush of Dread's mode 1 composes `Divide(AggregateBattlefield(...), Fixed(2), roundUp = true)`; discard / lose-life already accept a `DynamicAmount`.
- **Crew "activate only once each turn"** — `onceEachTurn` flag on `KeywordAbility.crew` / `Numeric` (omitted from compiled JSON when false, so other Crew cards don't churn), enforced in the crew enumerator + handler via a per-turn `crewActivations` count on `CrewSaddleContributorsComponent`. Vanilla Crew stays uncapped. The "Treasure per creature that crewed it this turn" payoff reuses the existing `CrewSaddleContributorsComponent` tracker + dynamic `CreateTreasure`.

## mtgish auto-gen tooling

Double Down and Luxurious Locomotive now render at **AUTO** fidelity and match their hand-authored cards. Added: an "outlaw spell" cast-trigger category (`IsAnOutlaw` → `youCastSpell` + `Subtype.OUTLAW_TYPES`); a `CopySpell(Trigger_ThatSpell)` → `CopyTargetSpell(TriggeringEntity)` action handler; a source-relative `CrewedVehicleThisTurn` count → `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` (fixing a silent constraint-drop that had mis-rendered it as a flat battlefield aggregate); a `CrewOnceEachTurn` keyword → `crew(N, onceEachTurn = true)`; matching bridge entries + an `EffectHandlerTest` case. **Rush of Dread (Spree = per-mode additional costs) is left at SCAFFOLD**, per the module creator's note to decline value-selection / extra-cost shapes rather than mis-render. **POR stays 0-mismatch (158/158).**

## Tests

- New scenario tests (all green): `OtjDoubleDownScenarioTest`, `OtjRushOfDreadScenarioTest`, `OtjLuxuriousLocomotiveScenarioTest`.
- `CardDefinitionSnapshotTest` re-blessed (only the 3 new cards added; no unrelated drift). `CardLintTest`, the sacrifice/crew/saddle/edict regression set, and the full `:mtgish-tooling` test suite all pass.
- Docs: `card-sdk-language-reference.md` updated for the dynamic-count Sacrifice and the `onceEachTurn` Crew flag.

### Known pre-existing failure (not from this PR)
The full `:rules-engine` suite reports one failure: `NumberExplosionSafetyTest > "runaway token creation is capped …"` **times out** (897s, exceeding its 600s Kotest coroutine timeout). It is a pre-existing slow test (added in commit `038a5348e`, GameLimits safety net) that creates a "Create 50000 tokens" combo and projects 10000 capped tokens; its clamp logic passes (system-err shows the clamp firing) and it touches none of this PR's code (no Sacrifice / Crew / Treasure / token-creation changes). Reporting rather than fixing per repo collaboration rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)