### PR TITLE
Two-Headed Giant Phase 1: format config + team model

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Format.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Format.kt
@@ -69,6 +69,34 @@ sealed interface Format {
         val avatarCardName: String = "Momir Vig, Simic Visionary",
         val eligibleCreatureNames: List<String> = emptyList(),
     ) : Format
+
+    /**
+     * Two-Headed Giant — the 2v2 team variant (CR 810). Two teams of two players each; a team
+     * shares one life total and one pool of poison counters, takes a shared turn (CR 805), fights
+     * combined combat, and wins or loses together (CR 810.8a).
+     *
+     * Like [Commander] this is runtime config, not a code path: the engine reads it at game init
+     * to set the shared starting life and (via [com.wingedsheep.engine.core.GameConfig.teams]) to
+     * stamp team membership on the player entities.
+     *
+     * **Phasing note.** This Phase 1 type only carries the format config + drives team membership.
+     * The behaviours it *describes* — shared life total (CR 810.4 / 810.9), shared turns and
+     * priority (CR 805), combined combat (CR 805.10 / 810.7), and team win/loss (CR 810.8) — are
+     * implemented in later phases. Until then a 2HG game boots with the right teams and life values
+     * but otherwise runs the standard per-player rules.
+     *
+     * @property startingLife The team's shared starting life total. Regular two-player 2HG is 30
+     *   (CR 810.4). In Phase 1 (no shared pool yet) each player is initialized to this value.
+     * @property startingHandSize Cards drawn for each player's opening hand.
+     * @property poisonThreshold Poison counters at which a team loses the game (CR 810.8d). 2HG
+     *   raises the normal 10 to 15.
+     */
+    @Serializable
+    data class TwoHeadedGiant(
+        val startingLife: Int = 30,
+        val startingHandSize: Int = 7,
+        val poisonThreshold: Int = 15,
+    ) : Format
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -70,6 +70,18 @@ data class GameConfig(
     val attackMode: com.wingedsheep.sdk.core.AttackMode = com.wingedsheep.sdk.core.AttackMode.MULTIPLE,
 
     /**
+     * Team assignment for team variants (Two-Headed Giant — CR 810). Each entry is one team: a
+     * list of indices into [players]. When supplied, every listed player is stamped with a
+     * [com.wingedsheep.engine.state.components.identity.TeamComponent] carrying its team's index.
+     * The indices must partition [players] exactly — every player appears in exactly one team.
+     *
+     * Null (the default) means no teams: every player is its own team and no component is stamped,
+     * so Standard / Commander / FFA games are unaffected. Phase 1 only stamps membership; shared
+     * life, shared turns, and combined combat come in later phases.
+     */
+    val teams: List<List<Int>>? = null,
+
+    /**
      * Seed for the game's deterministic RNG (turn order, library shuffles, coin flips, every
      * "at random" choice). When null, the initializer draws a fresh seed from entropy so live
      * play stays random — but the chosen seed is always recorded on [InitializationResult.seed],
@@ -177,6 +189,9 @@ class GameInitializer(
         val formatStartingLife: Int? = when (val f = config.format) {
             is Format.Commander -> f.startingLife
             is Format.MomirBasic -> f.startingLife
+            // 2HG shares one 30-life total per team (CR 810.4). The shared pool arrives in a later
+            // phase; for now each player is initialized to the team's starting value.
+            is Format.TwoHeadedGiant -> f.startingLife
             else -> null
         }
 
@@ -207,6 +222,26 @@ class GameInitializer(
             )
 
             state = state.withEntity(playerId, playerContainer)
+        }
+
+        // 1b. Stamp team membership (Two-Headed Giant and other team variants — CR 810). Each entry
+        // in config.teams is a team of indices into config.players; the indices must partition the
+        // player list exactly. A player without a team entry is implicitly its own team (see
+        // GameState.teamOf), so non-team formats pass null here and stamp nothing.
+        config.teams?.let { teams ->
+            require(teams.flatten().sorted() == config.players.indices.toList()) {
+                "GameConfig.teams must partition all ${config.players.size} player indices exactly once, got: $teams"
+            }
+            teams.forEachIndexed { teamIndex, memberIndices ->
+                for (memberIndex in memberIndices) {
+                    val pid = playerIds[memberIndex]
+                    state = state.updateEntity(pid) { container ->
+                        container.with(
+                            com.wingedsheep.engine.state.components.identity.TeamComponent(teamIndex)
+                        )
+                    }
+                }
+            }
         }
 
         // 2. Set turn order

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -304,6 +304,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ControllerComponent::class)
         subclass(PlayerComponent::class)
         subclass(LifeTotalComponent::class)
+        subclass(TeamComponent::class)
         subclass(TokenComponent::class)
         subclass(FaceDownComponent::class)
         subclass(RevealedToComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -433,6 +433,69 @@ data class GameState(
     fun getOpponents(playerId: EntityId): List<EntityId> =
         activePlayers.filter { it != playerId }
 
+    // =========================================================================
+    // Teams (Two-Headed Giant and other team variants — CR 810)
+    //
+    // Team membership lives on the player entity as a
+    // [com.wingedsheep.engine.state.components.identity.TeamComponent]; these helpers are the
+    // single read surface for it. A player without that component is its own team, so every helper
+    // degrades to per-player behaviour in non-team formats — `teamOf(p) == [p]`,
+    // `teammatesOf(p) == []`, and `teams` is one singleton list per player. That is what keeps
+    // future team-aware turn/priority/combat/SBA code a no-op for ordinary games.
+    // =========================================================================
+
+    /**
+     * The game's teams, in turn order. Players sharing a `TeamComponent.teamIndex` are grouped into
+     * one list; a player without the component forms a singleton team. Teams appear in the order
+     * their first member appears in [turnOrder], and members keep turn order within a team. Includes
+     * players who have lost or left — filter with [teamActivePlayers] when liveness matters.
+     */
+    val teams: List<List<EntityId>>
+        get() {
+            val ordered = mutableListOf<MutableList<EntityId>>()
+            val byIndex = mutableMapOf<Int, MutableList<EntityId>>()
+            for (playerId in turnOrder) {
+                val idx = getEntity(playerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()?.teamIndex
+                if (idx == null) {
+                    ordered.add(mutableListOf(playerId))
+                } else {
+                    val team = byIndex.getOrPut(idx) { mutableListOf<EntityId>().also { ordered.add(it) } }
+                    team.add(playerId)
+                }
+            }
+            return ordered
+        }
+
+    /**
+     * Every player on [playerId]'s team, including [playerId] itself, in turn order. Returns just
+     * `[playerId]` when it has no [com.wingedsheep.engine.state.components.identity.TeamComponent]
+     * (its own team). Includes lost/left teammates.
+     */
+    fun teamOf(playerId: EntityId): List<EntityId> {
+        val idx = getEntity(playerId)
+            ?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()?.teamIndex
+            ?: return listOf(playerId)
+        return turnOrder.filter {
+            getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()?.teamIndex == idx
+        }
+    }
+
+    /**
+     * [playerId]'s teammates — its team minus itself, in turn order. Empty in non-team formats.
+     */
+    fun teammatesOf(playerId: EntityId): List<EntityId> =
+        teamOf(playerId).filter { it != playerId }
+
+    /**
+     * Members of [playerId]'s team still in the game (not lost/left), in turn order. The team-level
+     * analogue of [activePlayers].
+     */
+    fun teamActivePlayers(playerId: EntityId): List<EntityId> =
+        teamOf(playerId).filter {
+            getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
+        }
+
     /**
      * Returns the player who currently has *input authority* for [playerId] — that is,
      * who clicks the buttons and answers the decisions. Normally this is [playerId]

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/PlayerIdentityComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/PlayerIdentityComponents.kt
@@ -19,3 +19,17 @@ data class PlayerComponent(
 data class LifeTotalComponent(
     val life: Int
 ) : Component
+
+/**
+ * Team membership for a player entity (Two-Headed Giant and other team variants — CR 810).
+ *
+ * Players sharing a [teamIndex] are on the same team. The index is assigned at game init from
+ * [com.wingedsheep.engine.core.GameConfig.teams]. In non-team formats no player carries this
+ * component and every player is implicitly a team of one — see [com.wingedsheep.engine.state.GameState.teamOf]
+ * / [com.wingedsheep.engine.state.GameState.teams], so all team-aware helpers degrade to per-player
+ * behaviour with no change to existing games.
+ */
+@Serializable
+data class TeamComponent(
+    val teamIndex: Int
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSetupTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSetupTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.TeamComponent
+import com.wingedsheep.engine.state.components.player.LossReason
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 1: the format config + team model.
+ *
+ * Proves the foundation only (CR 810.1 / 810.4): a four-seat game boots into two teams of two,
+ * each player carries the right [TeamComponent], the team starts at 30 shared-format life, and the
+ * [com.wingedsheep.engine.state.GameState] team helpers group/iterate by team. Shared life, shared
+ * turns/priority, combined combat, and team win/loss are later phases and are *not* asserted here.
+ *
+ * Also pins the no-team degradation: in a Standard game every player is its own team with no
+ * component, so the team helpers behave per-player and existing games are unaffected.
+ */
+class TwoHeadedGiantSetupTest : FunSpec({
+
+    fun registry(): CardRegistry {
+        val r = CardRegistry()
+        r.register(TestCards.all)
+        return r
+    }
+
+    fun boot2hg(teams: List<List<Int>>? = listOf(listOf(0, 1), listOf(2, 3))) =
+        GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                teams = teams,
+                startingPlayerIndex = 0, // keep turnOrder == playerIds for deterministic assertions
+                skipMulligans = true,
+            )
+        )
+
+    test("a 2HG game boots into two teams of two at the shared 30-life starting value") {
+        val result = boot2hg()
+        val players = result.playerIds
+
+        (result.state.format is Format.TwoHeadedGiant) shouldBe true
+        players.size shouldBe 4
+
+        // CR 810.4 — each player starts at the team's 30 (shared pool itself is a later phase).
+        for (pid in players) {
+            result.state.getEntity(pid)!!.get<LifeTotalComponent>()!!.life shouldBe 30
+        }
+
+        // Team indices stamped per config.teams = [[0,1],[2,3]].
+        result.state.getEntity(players[0])!!.get<TeamComponent>()!!.teamIndex shouldBe 0
+        result.state.getEntity(players[1])!!.get<TeamComponent>()!!.teamIndex shouldBe 0
+        result.state.getEntity(players[2])!!.get<TeamComponent>()!!.teamIndex shouldBe 1
+        result.state.getEntity(players[3])!!.get<TeamComponent>()!!.teamIndex shouldBe 1
+    }
+
+    test("teams / teamOf / teammatesOf group players by their team in turn order") {
+        val result = boot2hg()
+        val players = result.playerIds
+        val state = result.state
+
+        state.teams shouldContainExactly listOf(
+            listOf(players[0], players[1]),
+            listOf(players[2], players[3]),
+        )
+        state.teamOf(players[0]) shouldContainExactly listOf(players[0], players[1])
+        state.teamOf(players[3]) shouldContainExactly listOf(players[2], players[3])
+        state.teammatesOf(players[0]) shouldContainExactly listOf(players[1])
+        state.teammatesOf(players[2]) shouldContainExactly listOf(players[3])
+    }
+
+    test("teams grouping preserves turn order even when teammates are not adjacent seats") {
+        // Cross-paired teams: seats 0 & 2 vs seats 1 & 3.
+        val result = boot2hg(teams = listOf(listOf(0, 2), listOf(1, 3)))
+        val players = result.playerIds
+
+        // Teams appear in the order their first member appears in turnOrder; members keep turn order.
+        result.state.teams shouldContainExactly listOf(
+            listOf(players[0], players[2]),
+            listOf(players[1], players[3]),
+        )
+        result.state.teamOf(players[2]) shouldContainExactly listOf(players[0], players[2])
+    }
+
+    test("teamActivePlayers excludes a teammate who has lost the game") {
+        val result = boot2hg()
+        val players = result.playerIds
+        val withLoss = result.state.updateEntity(players[1]) { c ->
+            c.with(PlayerLostComponent(LossReason.CONCESSION))
+        }
+
+        withLoss.teamActivePlayers(players[0]) shouldContainExactly listOf(players[0])
+        // teamOf still includes the lost teammate (it tracks membership, not liveness).
+        withLoss.teamOf(players[0]) shouldContainExactly listOf(players[0], players[1])
+    }
+
+    test("no-team games degrade to one singleton team per player") {
+        // Standard format, no teams config — the default for every existing game.
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        val players = result.playerIds
+        val state = result.state
+
+        for (pid in players) state.getEntity(pid)!!.get<TeamComponent>() shouldBe null
+        state.teams shouldContainExactly players.map { listOf(it) }
+        state.teamOf(players[0]) shouldContainExactly listOf(players[0])
+        state.teammatesOf(players[0]) shouldContainExactly emptyList()
+        state.teamActivePlayers(players[0]) shouldContainExactly listOf(players[0])
+    }
+
+    test("a teams config that does not partition every player exactly once is rejected") {
+        // Player index 3 is missing, and index 1 is duplicated.
+        shouldThrow<IllegalArgumentException> {
+            GameInitializer(registry()).initializeGame(
+                GameConfig(
+                    format = Format.TwoHeadedGiant(),
+                    players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                    teams = listOf(listOf(0, 1), listOf(1, 2)),
+                    skipMulligans = true,
+                )
+            )
+        }
+    }
+})


### PR DESCRIPTION
First phase of **Two-Headed Giant** (CR 810), building on the existing N-player multiplayer foundation (Multiplayer Phases 0–3). This PR adds *only* the format config and the team model that the rest of 2HG builds on — **no life/turn/combat behaviour changes yet**. A 2HG game boots with the right teams and 30-life starting value but otherwise runs the standard per-player rules.

## What's in this PR

- **`Format.TwoHeadedGiant`** — `startingLife = 30` (CR 810.4), `startingHandSize = 7`, `poisonThreshold = 15` (CR 810.8d). Documented as a phased type whose *described* behaviours (shared life CR 810.9, shared turns/priority CR 805, combined combat CR 805.10/810.7, team win/loss CR 810.8) land in later phases.
- **`TeamComponent(teamIndex)`** on player entities. `GameConfig.teams` partitions players into teams (a list of index-lists) and `GameInitializer` stamps the component, with a precondition that the indices partition every player exactly once.
- **`GameState` team helpers** — `teams`, `teamOf`, `teammatesOf`, `teamActivePlayers`. **Key design:** a player *without* a `TeamComponent` is its own team, so every helper degrades to per-player behaviour and non-team formats (Standard / Commander / FFA) are completely unaffected.
- **Format-driven starting life** — 2HG initializes each player to 30 (the shared team pool itself is Phase 2).

## Tests

`TwoHeadedGiantSetupTest` (rules-engine) covers:
- boots into two teams of two at 30 life with correct team indices
- `teams` / `teamOf` / `teammatesOf` group by team in turn order
- grouping preserves turn order with non-adjacent (cross-paired) teammates
- `teamActivePlayers` excludes a lost teammate while `teamOf` still reports membership
- no-team Standard game degrades to one singleton team per player, no component
- a `teams` config that doesn't partition players exactly once is rejected

All 6 pass; `rules-engine`, `game-server`, and `ai` compile clean.

## Roadmap (not in this PR)
2 — shared team life (resolver + team pool) · 3 — team win/loss SBAs · 4 — shared turns & priority · 5 — combined combat · 6 — server sessions/DTOs/lobby + hotseat · 7 — client UI · 8 (later) — team-aware AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)