### PR TITLE
Two-Headed Giant Phase 2: shared team life total

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -304,6 +304,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ControllerComponent::class)
         subclass(PlayerComponent::class)
         subclass(LifeTotalComponent::class)
+        subclass(TeamComponent::class)
         subclass(TokenComponent::class)
         subclass(FaceDownComponent::class)
         subclass(RevealedToComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -274,8 +274,8 @@ class ConditionEvaluator(
             // Existential over all players: some player has at most [threshold] life.
             // Reads each player's LifeTotalComponent from state.turnOrder.
             is APlayerLifeAtMost -> state.turnOrder.any { playerId ->
-                val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life
-                life != null && life <= condition.threshold
+                // CR 810.9a — read the team's shared total; existential so teams don't double-count.
+                state.lifeTotal(playerId) <= condition.threshold
             }
 
             // Board-derived only — no targets/triggering/kicker — so it works identically in

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -551,7 +551,8 @@ class CostHandler(
     ): Boolean = when (atom) {
         is CostAtom.Mana -> canPayManaCost(manaPool, atom.cost, abilityContext)
         is CostAtom.PayLife -> {
-            val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
+            // CR 810.9a — affordability uses the team's shared total in Two-Headed Giant.
+            val life = state.lifeTotal(controllerId)
             // CR 119.4 — a player may pay life only if their life total is >= the payment.
             // Paying down to exactly 0 is legal; the state-based action checker handles the loss.
             life >= atom.amount
@@ -802,7 +803,8 @@ class CostHandler(
                 is CostAtom.Discard ->
                     findMatchingCardsUnified(state, state.getZone(ZoneKey(controllerId, Zone.HAND)), atom.filter, controllerId).size >= atom.count
                 is CostAtom.PayLife -> {
-                    val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
+                    // CR 810.9a — affordability uses the team's shared total in Two-Headed Giant.
+                    val life = state.lifeTotal(controllerId)
                     // CR 119.4 — a player may pay life only if their life total is >= the payment.
                     life >= atom.amount
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -122,13 +122,14 @@ class DynamicAmountEvaluator(
             is DynamicAmount.ManaSpentOnX -> context.manaSpentOnXByColor[amount.color] ?: 0
 
             is DynamicAmount.YourLifeTotal -> {
-                state.getEntity(context.controllerId)?.get<LifeTotalComponent>()?.life ?: 0
+                // CR 810.9a — an individual player's life total reads the team's shared total.
+                state.lifeTotal(context.controllerId)
             }
 
             is DynamicAmount.LifeTotal -> {
                 val playerIds = resolveUnifiedPlayerIds(state, amount.player, context)
                 val playerId = playerIds.firstOrNull() ?: return 0
-                state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                state.lifeTotal(playerId)
             }
 
             is DynamicAmount.StartingLifeTotal -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -618,8 +618,7 @@ class CastSpellHandler(
                 state, action.playerId, action.targets
             )
             if (additionalLifeCost > 0) {
-                val currentLife = state.getEntity(action.playerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
                 if (currentLife < additionalLifeCost) {
                     return "Not enough life to pay additional life cost ($additionalLifeCost life required)"
                 }
@@ -1067,8 +1066,7 @@ class CastSpellHandler(
                         }
                     }
                     is CostAtom.PayLife -> {
-                        val currentLife = state.getEntity(action.playerId)
-                            ?.get<LifeTotalComponent>()?.life ?: 0
+                        val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
                         // CR 119.4 — you can't pay life unless you have at least that much
                         if (currentLife < atom.amount) {
                             return "Not enough life to pay ${atom.amount} life"
@@ -1301,8 +1299,7 @@ class CastSpellHandler(
                 }
                 is AdditionalCost.PayLifePerTarget -> {
                     val required = additionalCost.amountPerTarget * action.targets.size
-                    val currentLife = state.getEntity(action.playerId)
-                        ?.get<LifeTotalComponent>()?.life ?: 0
+                    val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
                     // CR 119.4 — you can't pay life unless you have at least that much
                     if (currentLife < required) {
                         return "Not enough life to pay $required life for ${action.targets.size} targets"
@@ -1592,12 +1589,9 @@ class CastSpellHandler(
                 else -> continue
             }
             if (lifeToPay == 0) continue
-            val playerEntity = currentState.getEntity(action.playerId)
-            val currentLife = playerEntity?.get<LifeTotalComponent>()?.life ?: 0
+            val currentLife = currentState.lifeTotal(action.playerId) // CR 810.9a — team's shared total
             val newLife = currentLife - lifeToPay
-            currentState = currentState.updateEntity(action.playerId) { c ->
-                c.with(LifeTotalComponent(newLife))
-            }
+            currentState = currentState.withLifeTotal(action.playerId, newLife)
             currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
             events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
         }
@@ -2072,12 +2066,9 @@ class CastSpellHandler(
 
         // Pay additional life cost (e.g., Festival of Embers graveyard casting)
         if (action.graveyardLifeCost > 0) {
-            val currentLife = currentState.getEntity(action.playerId)
-                ?.get<LifeTotalComponent>()?.life ?: 0
+            val currentLife = currentState.lifeTotal(action.playerId) // CR 810.9a — team's shared total
             val newLife = currentLife - action.graveyardLifeCost
-            currentState = currentState.updateEntity(action.playerId) { container ->
-                container.with(LifeTotalComponent(newLife))
-            }
+            currentState = currentState.withLifeTotal(action.playerId, newLife)
             events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.LIFE_LOSS))
             currentState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
         }
@@ -2090,12 +2081,9 @@ class CastSpellHandler(
                 currentState, action.playerId, action.targets
             )
             if (additionalLifeCost > 0) {
-                val currentLife = currentState.getEntity(action.playerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                val currentLife = currentState.lifeTotal(action.playerId) // CR 810.9a — team's shared total
                 val newLife = currentLife - additionalLifeCost
-                currentState = currentState.updateEntity(action.playerId) { container ->
-                    container.with(LifeTotalComponent(newLife))
-                }
+                currentState = currentState.withLifeTotal(action.playerId, newLife)
                 events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
                 currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -177,9 +177,11 @@ class ManaPaymentContinuationResumer(
 
         if (response.choice) {
             val playerId = continuation.payingPlayerId
-            val currentLife = state.getEntity(playerId)
-                ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life
-                ?: return ExecutionResult.error(state, "Paying player has no life total")
+            if (state.getEntity(playerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
+            ) return ExecutionResult.error(state, "Paying player has no life total")
+            // CR 810.9a — life paid as a cost comes out of the team's shared total.
+            val currentLife = state.lifeTotal(playerId)
 
             // If the player can't actually pay (e.g., life dropped between trigger and decision),
             // counter the spell. Players can pay life that takes them below 0.
@@ -199,11 +201,7 @@ class ManaPaymentContinuationResumer(
             }
 
             val newLife = currentLife - continuation.lifeCost
-            var newState = state.updateEntity(playerId) { container ->
-                container.with(
-                    com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife)
-                )
-            }
+            var newState = state.withLifeTotal(playerId, newLife)
             newState = com.wingedsheep.engine.handlers.effects.DamageUtils
                 .markLifeLostThisTurn(newState, playerId)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -780,13 +780,13 @@ class ModalAndCloneContinuationResumer(
 
         if (response.choice) {
             // Player chose to pay life
-            val currentLife = newState.getEntity(continuation.controllerId)
-                ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life
-                ?: return ExecutionResult.error(state, "Player has no life total")
+            if (newState.getEntity(continuation.controllerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
+            ) return ExecutionResult.error(state, "Player has no life total")
+            // CR 810.9a — life paid as a cost comes out of the team's shared total.
+            val currentLife = newState.lifeTotal(continuation.controllerId)
             val newLife = currentLife - continuation.lifeCost
-            newState = newState.updateEntity(continuation.controllerId) { container ->
-                container.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
-            }
+            newState = newState.withLifeTotal(continuation.controllerId, newLife)
             newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(
                 newState, continuation.controllerId
             )
@@ -851,13 +851,13 @@ class ModalAndCloneContinuationResumer(
 
         if (response.choice) {
             // Player chose to pay life
-            val currentLife = newState.getEntity(continuation.controllerId)
-                ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life
-                ?: return ExecutionResult.error(state, "Player has no life total")
+            if (newState.getEntity(continuation.controllerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
+            ) return ExecutionResult.error(state, "Player has no life total")
+            // CR 810.9a — life paid as a cost comes out of the team's shared total.
+            val currentLife = newState.lifeTotal(continuation.controllerId)
             val newLife = currentLife - continuation.lifeCost
-            newState = newState.updateEntity(continuation.controllerId) { container ->
-                container.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
-            }
+            newState = newState.withLifeTotal(continuation.controllerId, newLife)
             newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(
                 newState, continuation.controllerId
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -400,13 +400,11 @@ class SacrificeAndPayContinuationResumer(
         // Player chose to pay life
         val playerId = continuation.playerId
         val lifeToPay = continuation.requiredCount
-        val playerContainer = state.getEntity(playerId)
-        val currentLife = playerContainer?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+        // CR 810.9a — life paid as a cost comes out of the team's shared total.
+        val currentLife = state.lifeTotal(playerId)
         val newLife = currentLife - lifeToPay
 
-        var newState = state.updateEntity(playerId) {
-            it.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
-        }
+        var newState = state.withLifeTotal(playerId, newLife)
         newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(newState, playerId)
 
         val events = listOf(
@@ -626,12 +624,10 @@ class SacrificeAndPayContinuationResumer(
                 }
 
                 val lifeToPay = continuation.requiredCount
-                val currentLife = state.getEntity(playerId)
-                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                // CR 810.9a — life paid as a cost comes out of the team's shared total.
+                val currentLife = state.lifeTotal(playerId)
                 val newLife = currentLife - lifeToPay
-                var newState = state.updateEntity(playerId) {
-                    it.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
-                }
+                var newState = state.withLifeTotal(playerId, newLife)
                 newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(newState, playerId)
                 val events = mutableListOf<GameEvent>(
                     LifeChangedEvent(
@@ -728,8 +724,7 @@ class SacrificeAndPayContinuationResumer(
                 }
 
                 is CostAtom.PayLife -> {
-                    val life = state.getEntity(nextPlayerId)
-                        ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                    val life = state.lifeTotal(nextPlayerId) // CR 810.9a — team's shared total
                     if (life >= atom.amount) {
                         val decisionId = java.util.UUID.randomUUID().toString()
                         val prompt = "Pay ${atom.amount} life to prevent ${continuation.sourceName}'s effect?"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -209,14 +209,15 @@ object DamageUtils {
             // to lose that much life, so life-loss replacements (Bloodletter of Aclazotz)
             // modify the life total reduction here. Lifelink and other damage-based effects
             // below still see the unmodified `effectiveAmount`, matching the official ruling.
+            // CR 810.9 (Two-Headed Giant): damage happens to the player individually but the
+            // result applies to the team's shared life total, so read/write through the resolver.
+            val currentLife = newState.lifeTotal(targetId)
             var lifeLossAmount = applyStaticLifeLossModification(newState, targetId, effectiveAmount)
-            lifeLossAmount = applyLifeLossFloors(newState, targetId, lifeComponent.life, lifeLossAmount)
-            val newLife = lifeComponent.life - lifeLossAmount
-            newState = newState.updateEntity(targetId) { container ->
-                container.with(LifeTotalComponent(newLife))
-            }
+            lifeLossAmount = applyLifeLossFloors(newState, targetId, currentLife, lifeLossAmount)
+            val newLife = currentLife - lifeLossAmount
+            newState = newState.withLifeTotal(targetId, newLife)
             newState = trackDamageReceivedByPlayer(newState, targetId, effectiveAmount)
-            events.add(LifeChangedEvent(targetId, lifeComponent.life, newLife, LifeChangeReason.DAMAGE))
+            events.add(LifeChangedEvent(targetId, currentLife, newLife, LifeChangeReason.DAMAGE))
         } else if (projected.isPlaneswalker(targetId)) {
             // It's a planeswalker - remove loyalty counters equal to damage dealt
             val counters = newState.getEntity(targetId)?.get<CountersComponent>() ?: CountersComponent()
@@ -388,17 +389,17 @@ object DamageUtils {
         reason: LifeChangeReason,
         applyLifeLossModification: Boolean = false,
     ): Pair<GameState, LifeChangedEvent?> {
-        val currentLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life
-            ?: return state to null
+        // Presence guard stays per-player (every player carries a LifeTotalComponent); the value,
+        // however, is the team's shared total (CR 810.9a) — read/write via the resolver.
+        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) return state to null
+        val currentLife = state.lifeTotal(playerId)
         val lossAmount = if (applyLifeLossModification) {
             applyStaticLifeLossModification(state, playerId, amount)
         } else {
             amount
         }
         val newLife = currentLife - lossAmount
-        var newState = state.updateEntity(playerId) { container ->
-            container.with(LifeTotalComponent(newLife))
-        }
+        var newState = state.withLifeTotal(playerId, newLife)
         newState = markLifeLostThisTurn(newState, playerId)
         return newState to LifeChangedEvent(playerId, currentLife, newLife, reason)
     }
@@ -437,12 +438,11 @@ object DamageUtils {
             amount
         }
         if (gainAmount <= 0) return state to null
-        val currentLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life
-            ?: return state to null
+        // Presence guard stays per-player; the value is the team's shared total (CR 810.9a).
+        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) return state to null
+        val currentLife = state.lifeTotal(playerId)
         val newLife = currentLife + gainAmount
-        var newState = state.updateEntity(playerId) { container ->
-            container.with(LifeTotalComponent(newLife))
-        }
+        var newState = state.withLifeTotal(playerId, newLife)
         newState = markLifeGainedThisTurn(newState, playerId, gainAmount)
         return newState to LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.LIFE_GAIN)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -375,7 +375,7 @@ class GatedEffectExecutor(
                 )
             }
             is PayLifeEffect -> {
-                val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                 life >= cost.amount
             }
             is CompositeEffect -> cost.effects.all { canAfford(state, playerId, it, context) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/EachPlayerDiscardsOrLoseLifeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/EachPlayerDiscardsOrLoseLifeExecutor.kt
@@ -184,13 +184,13 @@ class EachPlayerDiscardsOrLoseLifeExecutor(
 
             for ((playerId, discardedCreatureCard) in discardedCreature) {
                 if (!discardedCreatureCard) {
-                    val currentLife = currentState.getEntity(playerId)
-                        ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life
-                        ?: continue
+                    if (currentState.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
+                    ) continue
+                    // CR 810.9a — life loss applies to the team's shared total.
+                    val currentLife = currentState.lifeTotal(playerId)
                     val newLife = currentLife - lifeLoss
-                    currentState = currentState.updateEntity(playerId) { container ->
-                        container.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
-                    }
+                    currentState = currentState.withLifeTotal(playerId, newLife)
                     events.add(
                         com.wingedsheep.engine.core.LifeChangedEvent(
                             playerId, currentLife, newLife,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeAndPowerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeAndPowerExecutor.kt
@@ -47,9 +47,12 @@ class ExchangeLifeAndPowerExecutor : EffectExecutor<ExchangeLifeAndPowerEffect> 
 
         val controllerId = context.controllerId
 
-        // Read both values before making any changes (simultaneous exchange)
-        val currentLife = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life
-            ?: return EffectResult.success(state)
+        // Read both values before making any changes (simultaneous exchange).
+        // CR 810.9a — the player's life total is the team's shared total in Two-Headed Giant.
+        if (state.getEntity(controllerId)?.get<LifeTotalComponent>() == null) {
+            return EffectResult.success(state)
+        }
+        val currentLife = state.lifeTotal(controllerId)
 
         val projected = state.projectedState
         val currentPower = projected.getPower(creatureId)
@@ -73,9 +76,7 @@ class ExchangeLifeAndPowerExecutor : EffectExecutor<ExchangeLifeAndPowerEffect> 
         val lifeSideBlocked = currentPower > currentLife &&
             DamageUtils.isLifeGainPrevented(newState, controllerId)
         if (currentPower != currentLife && !lifeSideBlocked) {
-            newState = newState.updateEntity(controllerId) { container ->
-                container.with(LifeTotalComponent(currentPower))
-            }
+            newState = newState.withLifeTotal(controllerId, currentPower)
 
             val reason = if (currentPower > currentLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
             events.add(LifeChangedEvent(controllerId, currentLife, currentPower, reason))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/OwnerGainsLifeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/OwnerGainsLifeExecutor.kt
@@ -39,8 +39,8 @@ class OwnerGainsLifeExecutor : EffectExecutor<OwnerGainsLifeEffect> {
             ?: targetContainer?.get<CardComponent>()?.ownerId
             ?: return EffectResult.success(state) // Can't determine owner, effect fizzles
 
-        // Owner must have a life total
-        if (state.getEntity(ownerId)?.get<LifeTotalComponent>()?.life == null) {
+        // Owner must have a life total (presence check; the value is the team's shared total).
+        if (state.getEntity(ownerId)?.get<LifeTotalComponent>() == null) {
             return EffectResult.error(state, "Owner has no life total")
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayLifeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayLifeEffectExecutor.kt
@@ -27,13 +27,14 @@ class PayLifeEffectExecutor : EffectExecutor<PayLifeEffect> {
     ): EffectResult {
         val playerId = context.controllerId
 
-        val currentLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life
-            ?: return EffectResult.error(state, "Player not found for life payment")
+        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) {
+            return EffectResult.error(state, "Player not found for life payment")
+        }
+        // CR 810.9a — life paid as a cost comes out of the team's shared total.
+        val currentLife = state.lifeTotal(playerId)
 
         val newLife = currentLife - effect.amount
-        val newState = state.updateEntity(playerId) { container ->
-            container.with(LifeTotalComponent(newLife))
-        }
+        val newState = state.withLifeTotal(playerId, newLife)
 
         val events = listOf<EngineGameEvent>(
             LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/SetLifeTotalExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/SetLifeTotalExecutor.kt
@@ -40,8 +40,9 @@ class SetLifeTotalExecutor(
         val events = mutableListOf<EngineGameEvent>()
 
         for (playerId in playerIds) {
-            val currentLife = newState.getEntity(playerId)?.get<LifeTotalComponent>()?.life
-                ?: continue
+            if (newState.getEntity(playerId)?.get<LifeTotalComponent>() == null) continue
+            // CR 810.9c — setting a player's life adjusts the team's shared total by the gain/loss.
+            val currentLife = newState.lifeTotal(playerId)
 
             val newLife = amountEvaluator.evaluate(newState, effect.amount, context)
 
@@ -53,9 +54,7 @@ class SetLifeTotalExecutor(
             }
 
             if (newLife != currentLife) {
-                newState = newState.updateEntity(playerId) { container ->
-                    container.with(LifeTotalComponent(newLife))
-                }
+                newState = newState.withLifeTotal(playerId, newLife)
 
                 val reason = if (newLife > currentLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
                 events.add(LifeChangedEvent(playerId, currentLife, newLife, reason))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
@@ -102,7 +102,7 @@ class GainControlByMostExecutor : EffectExecutor<GainControlByMostEffect> {
     private fun metricValue(state: GameState, metric: PlayerRankMetric, playerId: EntityId): Int =
         when (metric) {
             is PlayerRankMetric.LifeTotal ->
-                state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                state.lifeTotal(playerId) // CR 810.9a — team's shared total
             is PlayerRankMetric.CreaturesOfSubtype ->
                 // Projected state so type-changing effects (a permanent animated/typeshifted
                 // into the subtype) and stolen control are counted correctly.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -123,7 +123,7 @@ class AnyPlayerMayPayExecutor(
             }
             // CR 119.4: a player may pay life only if their life total is at least the amount.
             is CostAtom.PayLife -> {
-                val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                 life >= atom.amount
             }
             else -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/OpenLifeBidExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/OpenLifeBidExecutor.kt
@@ -85,7 +85,7 @@ object OpenLifeBidLogic {
     private val decisionHandler = DecisionHandler()
 
     private fun lifeOf(state: GameState, playerId: EntityId): Int =
-        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        state.lifeTotal(playerId) // CR 810.9a — team's shared total
 
     /**
      * Ask [bidderToAsk] whether to top the current [highBid], or resolve the auction if they

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -365,9 +365,9 @@ class PayOrSufferExecutor(
         sourceName: String,
         controllerId: EntityId
     ): EffectResult {
-        // Check if player has enough life to pay (must have more than the cost)
-        val playerContainer = state.getEntity(controllerId)
-        val playerLife = playerContainer?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+        // Check if player has enough life to pay (must have more than the cost).
+        // CR 810.9a — affordability uses the team's shared total in Two-Headed Giant.
+        val playerLife = state.lifeTotal(controllerId)
 
         // If player doesn't have enough life to pay and survive, execute suffer effect
         if (playerLife <= cost.amount) {
@@ -649,7 +649,7 @@ class PayOrSufferExecutor(
                 is CostAtom.Discard -> findValidCardsInHand(state, playerId, atom.filter).size >= atom.count
                 is CostAtom.Sacrifice -> findValidPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
                 is CostAtom.PayLife -> {
-                    val life = state.getEntity(playerId)?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                    val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                     life > atom.amount
                 }
                 is CostAtom.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, atom.cost)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -280,7 +280,7 @@ class WardCounterEffectExecutor(
         payingPlayerId: EntityId,
         lifeCost: Int
     ): EffectResult {
-        val currentLife = state.getEntity(payingPlayerId)?.get<LifeTotalComponent>()?.life ?: 0
+        val currentLife = state.lifeTotal(payingPlayerId) // CR 810.9a — team's shared total
         if (currentLife < lifeCost) {
             // Can't pay — counter immediately.
             return counterSpellOrAbility(state, spellEntityId, container)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1637,8 +1637,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
                 // Check life affordability (only when there is a life cost)
                 if (lifeCost > 0) {
-                    val currentLife = state.getEntity(playerId)
-                        ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                    val currentLife = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                     if (currentLife < lifeCost) continue
                 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -1715,7 +1715,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             // affordability gate so "discard a card or pay 3 life" modes don't
                             // surface a Pay-3-Life action when the caster has fewer than 3 life
                             // (Bitter Triumph). Validation in CastSpellHandler still backstops.
-                            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                            val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                             if (life < atom.amount) canPayAdditionalCosts = false
                         }
                         else -> {}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -577,7 +577,7 @@ class CostEnumerationUtils(
             else -> false
         }
         if (hasPayXLife) {
-            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
             maxX = minOf(maxX, life.coerceAtLeast(0))
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -439,7 +439,7 @@ internal class CombatDamageManager(
             val isPlayer = container.get<LifeTotalComponent>() != null && container.get<CardComponent>() == null
             when {
                 isPlayer -> ResolutionDefender(defenderId, ResolutionTargetKind.PLAYER, "Player",
-                    container.get<LifeTotalComponent>()?.life)
+                    state.lifeTotal(defenderId)) // CR 810.9a — team's shared total
                 projected.isPlaneswalker(defenderId) -> ResolutionDefender(defenderId, ResolutionTargetKind.PLANESWALKER,
                     container.get<CardComponent>()?.name ?: "Planeswalker",
                     container.get<CountersComponent>()?.getCount(CounterType.LOYALTY))
@@ -857,13 +857,13 @@ internal class CombatDamageManager(
         // player to lose that much life, so life-loss replacements (Bloodletter of
         // Aclazotz) modify the life total reduction here. Lifelink and tracking still
         // see the unmodified `effectiveAmount`.
-        val currentLife = newState.getEntity(targetId)?.get<LifeTotalComponent>()?.life ?: return newState
+        if (newState.getEntity(targetId)?.get<LifeTotalComponent>() == null) return newState
+        // CR 810.9 — combat damage applies to the team's shared life total.
+        val currentLife = newState.lifeTotal(targetId)
         var lifeLossAmount = DamageUtils.applyStaticLifeLossModification(newState, targetId, effectiveAmount)
         lifeLossAmount = DamageUtils.applyLifeLossFloors(newState, targetId, currentLife, lifeLossAmount)
         val newLife = currentLife - lifeLossAmount
-        newState = newState.updateEntity(targetId) { container ->
-            container.with(LifeTotalComponent(newLife))
-        }
+        newState = newState.withLifeTotal(targetId, newLife)
         newState = DamageUtils.trackDamageReceivedByPlayer(newState, targetId, effectiveAmount)
 
         // Track combat damage: source dealt damage + dealt combat damage to player
@@ -1001,11 +1001,10 @@ internal class CombatDamageManager(
         val isPlaneswalker = !isPlayer && projected.isPlaneswalker(targetId)
 
         if (isPlayer) {
-            val currentLife = targetContainer.get<LifeTotalComponent>()?.life ?: return newState
+            // CR 810.9 — applies to the team's shared total (isPlayer already guards presence).
+            val currentLife = newState.lifeTotal(targetId)
             val newLife = currentLife - amount
-            newState = newState.updateEntity(targetId) { container ->
-                container.with(LifeTotalComponent(newLife))
-            }
+            newState = newState.withLifeTotal(targetId, newLife)
             newState = DamageUtils.trackDamageReceivedByPlayer(newState, targetId, amount)
             // Track combat damage: source dealt damage + dealt combat damage to player
             if (sourceId in newState.getBattlefield()) {
@@ -1156,11 +1155,11 @@ internal class CombatDamageManager(
         val attackerController = projected.getController(sourceId) ?: return state
         if (attackerController == targetPlayerId) return state
 
-        val attackerControllerLife = state.getEntity(attackerController)?.get<LifeTotalComponent>()?.life ?: return state
+        if (state.getEntity(attackerController)?.get<LifeTotalComponent>() == null) return state
+        // CR 810.9 — applies to the attacking player's team's shared total.
+        val attackerControllerLife = state.lifeTotal(attackerController)
         val newLife = attackerControllerLife - originalAmount
-        var newState = state.updateEntity(attackerController) { container ->
-            container.with(LifeTotalComponent(newLife))
-        }
+        var newState = state.withLifeTotal(attackerController, newLife)
         newState = DamageUtils.trackDamageReceivedByPlayer(newState, attackerController, originalAmount)
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Creature"
         events.add(DamageDealtEvent(sourceId, attackerController, originalAmount, true,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -483,7 +483,7 @@ class CostPaymentService(private val services: EngineServices) {
         }
 
         private fun life(state: GameState, playerId: EntityId): Int =
-            state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            state.lifeTotal(playerId) // CR 810.9a — team's shared total in Two-Headed Giant
 
         fun cardsInHand(state: GameState, playerId: EntityId, filter: GameObjectFilter): List<EntityId> {
             val context = PredicateContext(controllerId = playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -31,8 +31,11 @@ class PlayerLifeLossCheck : StateBasedActionCheck {
             if (container.has<PlayerLostComponent>()) continue
             if (playerCantLoseGame(state, playerId)) continue
 
-            val lifeComponent = container.get<LifeTotalComponent>() ?: continue
-            if (lifeComponent.life <= 0) {
+            // Presence guard stays per-player; the value is the team's shared total (CR 810.9c).
+            // Reading through the resolver means every member of a 0-life team is marked in this
+            // same pass — the principled single team-loss check is Phase 3.
+            if (container.get<LifeTotalComponent>() == null) continue
+            if (state.lifeTotal(playerId) <= 0) {
                 newState = newState.updateEntity(playerId) { c ->
                     c.with(PlayerLostComponent(LossReason.LIFE_ZERO))
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -430,8 +430,13 @@ data class GameState(
      * specific opponent must say which one (a chosen target, an iteration, or the
      * per-creature defending player — CR 802.2a).
      */
-    fun getOpponents(playerId: EntityId): List<EntityId> =
-        activePlayers.filter { it != playerId }
+    fun getOpponents(playerId: EntityId): List<EntityId> {
+        // CR 810: an opponent is a player on an opposing team, so exclude the player's whole team
+        // (themselves and any teammates), not just themselves. In a non-team game a player is its
+        // own team, so this is identical to "everyone but me".
+        val ownTeam = teamOf(playerId).toHashSet()
+        return activePlayers.filter { it !in ownTeam }
+    }
 
     // =========================================================================
     // Teams (Two-Headed Giant and other team variants — CR 810)
@@ -495,6 +500,56 @@ data class GameState(
         teamOf(playerId).filter {
             getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
         }
+
+    // =========================================================================
+    // Shared life total (Two-Headed Giant — CR 810.4 / 810.9)
+    //
+    // A team has ONE life total (CR 810.4); "if a cost or effect needs an individual player's life
+    // total, it uses the team's life total instead" (CR 810.9a). We model this by storing the single
+    // [LifeTotalComponent] for a team on a stable *canonical owner* — the first member of the team in
+    // turn order ([teamLifeOwnerOf]) — and resolving every life read/write to that owner.
+    //
+    // Every player still carries a [LifeTotalComponent] so player-detection (`has<LifeTotalComponent>`)
+    // and entity shape are unchanged; only the canonical owner's value is authoritative. A
+    // non-canonical teammate's component value is never read — all reads go through [lifeTotal] and
+    // all writes through [withLifeTotal] / [adjustLife], which target the owner. In a non-team game a
+    // player is its own team, so the owner is the player itself and these helpers are a pure pass-through.
+    // =========================================================================
+
+    /**
+     * The entity that holds [playerId]'s team's authoritative [LifeTotalComponent] — the first
+     * member of [teamOf] (stable across the game; team membership and turn order never change). For
+     * a player with no team this is the player itself.
+     */
+    fun teamLifeOwnerOf(playerId: EntityId): EntityId = teamOf(playerId).firstOrNull() ?: playerId
+
+    /**
+     * [playerId]'s life total — the team's shared total in a team game (CR 810.9a), the player's own
+     * total otherwise. Returns 0 if the owner somehow has no [LifeTotalComponent] (should not happen
+     * for a real player).
+     */
+    fun lifeTotal(playerId: EntityId): Int =
+        getEntity(teamLifeOwnerOf(playerId))
+            ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+
+    /**
+     * Set [playerId]'s (team's) life total to [newLife], writing the canonical owner's component.
+     * Low-level — callers still emit the appropriate `LifeChangedEvent` (attributed to the
+     * individual player per CR 810.9) and run any prevention/replacement before computing [newLife].
+     */
+    fun withLifeTotal(playerId: EntityId, newLife: Int): GameState =
+        updateEntity(teamLifeOwnerOf(playerId)) { container ->
+            container.with(
+                com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife)
+            )
+        }
+
+    /**
+     * Convenience: adjust [playerId]'s (team's) life by [delta] (negative to lose), returning the new
+     * state. Equivalent to `withLifeTotal(playerId, lifeTotal(playerId) + delta)`.
+     */
+    fun adjustLife(playerId: EntityId, delta: Int): GameState =
+        withLifeTotal(playerId, lifeTotal(playerId) + delta)
 
     /**
      * Returns the player who currently has *input authority* for [playerId] — that is,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1534,7 +1534,8 @@ class ClientStateTransformer(
     ): ClientPlayer {
         val container = state.getEntity(playerId)
         val playerComponent = container?.get<PlayerComponent>()
-        val lifeTotalComponent = container?.get<LifeTotalComponent>()
+        // CR 810.9a — a player's displayed life is the team's shared total in Two-Headed Giant.
+        val displayedLife = if (container?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else null
         val landDropsComponent = container?.get<LandDropsComponent>()
         val manaPoolComponent = container?.get<ManaPoolComponent>()
 
@@ -1589,7 +1590,7 @@ class ClientStateTransformer(
         return ClientPlayer(
             playerId = playerId,
             name = playerComponent?.name ?: "Unknown",
-            life = lifeTotalComponent?.life ?: 20,
+            life = displayedLife ?: 20,
             poisonCounters = container?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0,
             handSize = handSize,
             librarySize = librarySize,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.hygiene
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import java.io.File
+
+/**
+ * Guards the Two-Headed Giant shared-life invariant (CR 810.9a): an individual player's life total
+ * is the team's shared total, so every life *value* read and write must go through the
+ * [com.wingedsheep.engine.state.GameState] resolver (`lifeTotal` / `withLifeTotal` / `adjustLife`),
+ * never directly off a player's `LifeTotalComponent`. A raw `LifeTotalComponent(...)` write or a
+ * `.get<LifeTotalComponent>()?.life` read on a non-canonical teammate would silently desync a team.
+ *
+ * Presence checks (`get<LifeTotalComponent>() != null` / `== null`, used to detect "is this a
+ * player") are fine — every player still carries the component — so this guard only flags the
+ * `.life` value accessor and the `LifeTotalComponent(...)` constructor.
+ *
+ * If this fails: replace the read with `state.lifeTotal(playerId)` and the write with
+ * `state.withLifeTotal(playerId, newLife)` (or `state.adjustLife(playerId, delta)`).
+ */
+class LifeTotalReadsThroughResolverTest : FunSpec({
+
+    test("life value reads/writes go through the GameState resolver, not raw LifeTotalComponent") {
+        val valueRead = Regex("""LifeTotalComponent>\(\)[?!.]*\.life""")
+        val construct = Regex("""\bLifeTotalComponent\s*\(""")
+
+        val offenders = sourceRoot().walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                val relative = file.absolutePath.replace('\\', '/')
+                    .substringAfter("src/main/kotlin/")
+                if (relative in ALLOWED_FILES) return@flatMap emptySequence<String>()
+                file.readLines().withIndex().mapNotNull { (idx, line) ->
+                    if (valueRead.containsMatchIn(line) || construct.containsMatchIn(line)) {
+                        "$relative:${idx + 1}: ${line.trim()}"
+                    } else null
+                }.asSequence()
+            }
+            .toList()
+
+        offenders.shouldBeEmpty()
+    }
+}) {
+    companion object {
+        /**
+         * Files that legitimately touch the raw component. Each is the authoritative read/write
+         * surface the resolver itself routes through — they must not be "fixed" to call the
+         * resolver (that would be infinite recursion or a chicken-and-egg at init).
+         */
+        private val ALLOWED_FILES = setOf(
+            // The resolver itself + team-life ownership helpers read/write the canonical component.
+            "com/wingedsheep/engine/state/GameState.kt",
+            // Game setup stamps the initial LifeTotalComponent on every player entity.
+            "com/wingedsheep/engine/core/GameInitializer.kt",
+            // The component's own declaration.
+            "com/wingedsheep/engine/state/components/identity/PlayerIdentityComponents.kt",
+        )
+
+        private fun sourceRoot(): File =
+            listOf(File("src/main/kotlin"), File("rules-engine/src/main/kotlin"))
+                .firstOrNull { it.isDirectory }
+                ?: error("Could not locate rules-engine/src/main/kotlin from ${File(".").absolutePath}")
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.life.GainLifeExecutor
+import com.wingedsheep.engine.handlers.effects.life.LoseLifeExecutor
+import com.wingedsheep.engine.handlers.effects.life.SetLifeTotalExecutor
+import com.wingedsheep.engine.mechanics.sba.player.PlayerLifeLossCheck
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.SetLifeTotalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 2: shared team life total (CR 810.4 / 810.9).
+ *
+ * A team has one life total. Damage, life loss, and life gain happen to a player individually but
+ * apply to the team's shared total (CR 810.9); a cost or effect that reads an individual player's
+ * life uses the team's total (CR 810.9a). We verify the resolver + every routed read/write site:
+ * both teammates report the same total, changes to either move the one shared pool, "each opponent"
+ * drains a whole opposing team, and a 0-life team's members are all marked lost.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order.
+ */
+class TwoHeadedGiantSharedLifeTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().also { it.register(TestCards.all) }
+
+    /** Boot a 2HG game; returns state + the four player ids (p0,p1 = team 0; p2,p3 = team 1). */
+    fun boot(): Pair<GameState, List<EntityId>> {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    fun ctx(controller: EntityId) = EffectContext(sourceId = null, controllerId = controller)
+
+    test("both teammates report the same shared life total, starting at 30") {
+        val (state, p) = boot()
+        state.lifeTotal(p[0]) shouldBe 30
+        state.lifeTotal(p[1]) shouldBe 30
+        state.lifeTotal(p[2]) shouldBe 30
+        state.lifeTotal(p[3]) shouldBe 30
+        // The canonical owner of each team is its first member.
+        state.teamLifeOwnerOf(p[1]) shouldBe p[0]
+        state.teamLifeOwnerOf(p[3]) shouldBe p[2]
+    }
+
+    test("life loss by one teammate moves the single shared pool both teammates read") {
+        val (state, p) = boot()
+        val (after, _) = DamageUtils.loseLife(state, p[1], 5, LifeChangeReason.LIFE_LOSS)
+
+        after.lifeTotal(p[0]) shouldBe 25
+        after.lifeTotal(p[1]) shouldBe 25
+        // The other team is untouched.
+        after.lifeTotal(p[2]) shouldBe 30
+        // Only the canonical owner's raw component changed; the teammate's is never read.
+        after.getEntity(p[0])!!.get<LifeTotalComponent>()!!.life shouldBe 25
+    }
+
+    test("life gain by one teammate raises the shared total") {
+        val (state, p) = boot()
+        val (after, _) = DamageUtils.gainLife(state, p[1], 4)
+        after.lifeTotal(p[0]) shouldBe 34
+        after.lifeTotal(p[1]) shouldBe 34
+    }
+
+    test("damage to a teammate reduces the shared team total") {
+        val (state, p) = boot()
+        val result = DamageUtils.dealDamageToTarget(state, p[0], 6, sourceId = null)
+        result.state.lifeTotal(p[0]) shouldBe 24
+        result.state.lifeTotal(p[1]) shouldBe 24
+        result.state.lifeTotal(p[2]) shouldBe 30
+    }
+
+    test("an EachOpponent loss drains BOTH players of the opposing team from one shared pool") {
+        val (state, p) = boot()
+        // Controller is p0 (team 0); EachOpponent = p2 and p3 (team 1). Each loses 3 → team 1
+        // shares one pool, so the two individual 3-life losses stack to a 6-life drop.
+        val effect = LoseLifeEffect(
+            amount = DynamicAmount.Fixed(3),
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+        val result = LoseLifeExecutor().execute(state, effect, ctx(p[0]))
+
+        result.state.lifeTotal(p[0]) shouldBe 30 // controller's team untouched
+        result.state.lifeTotal(p[2]) shouldBe 24 // 30 - 3 - 3
+        result.state.lifeTotal(p[3]) shouldBe 24
+    }
+
+    test("an EachOpponent gain via GainLife also resolves per-opposing-player onto their shared pool") {
+        val (state, p) = boot()
+        val effect = GainLifeEffect(
+            amount = DynamicAmount.Fixed(2),
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+        val result = GainLifeExecutor().execute(state, effect, ctx(p[0]))
+        result.state.lifeTotal(p[2]) shouldBe 34 // 30 + 2 + 2
+        result.state.lifeTotal(p[0]) shouldBe 30
+    }
+
+    test("SetLifeTotal sets the team's shared total (CR 810.9c)") {
+        val (state, p) = boot()
+        val effect = SetLifeTotalEffect(
+            amount = DynamicAmount.Fixed(10),
+            target = EffectTarget.PlayerRef(Player.You)
+        )
+        val result = SetLifeTotalExecutor().execute(state, effect, ctx(p[3]))
+        result.state.lifeTotal(p[2]) shouldBe 10
+        result.state.lifeTotal(p[3]) shouldBe 10
+        result.state.lifeTotal(p[0]) shouldBe 30
+    }
+
+    test("adjustLife / withLifeTotal resolver helpers target the team pool") {
+        val (state, p) = boot()
+        state.adjustLife(p[1], -7).lifeTotal(p[0]) shouldBe 23
+        state.withLifeTotal(p[3], 5).lifeTotal(p[2]) shouldBe 5
+    }
+
+    test("when a team's shared total hits 0, both teammates are marked lost in one SBA pass") {
+        val (state, p) = boot()
+        // Drop team 0 to exactly 0 via a single teammate's loss.
+        val (zeroed, _) = DamageUtils.loseLife(state, p[0], 30, LifeChangeReason.LIFE_LOSS)
+        zeroed.lifeTotal(p[1]) shouldBe 0
+
+        val result = PlayerLifeLossCheck().check(zeroed)
+        result.newState.getEntity(p[0])!!.has<PlayerLostComponent>() shouldBe true
+        result.newState.getEntity(p[1])!!.has<PlayerLostComponent>() shouldBe true
+        // The opposing team is unaffected.
+        result.newState.getEntity(p[2])!!.has<PlayerLostComponent>() shouldBe false
+    }
+
+    test("a non-team game is a pure pass-through: lifeTotal equals the player's own life") {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                players = (1..2).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        val p = result.playerIds
+        val state = result.state
+        state.teamLifeOwnerOf(p[0]) shouldBe p[0]
+        val (after, _) = DamageUtils.loseLife(state, p[0], 4, LifeChangeReason.LIFE_LOSS)
+        after.lifeTotal(p[0]) shouldBe 16
+        after.lifeTotal(p[1]) shouldBe 20 // opponent untouched — they are their own team
+        after.getEntity(p[0])!!.get<LifeTotalComponent>()!!.life shouldBe 16
+    }
+})


### PR DESCRIPTION
Phase 2 of **Two-Headed Giant** (CR 810): a team shares **one life total**. Builds on the Phase 1 team model (#751) — **this PR is based on `feat/2hg-phase1-team-model`, not `main`**; retarget to `main` once #751 merges.

## Rules (CR 810)
- 810.4 — a team has one shared life total (regular 2HG starts at 30).
- 810.9 / 810.9a — damage, life loss, and life gain happen to a player *individually* but apply to the team's shared total; any cost/effect reading an individual player's life uses the team's total.
- "Each opponent" means players on an *opposing* team (excludes your teammate).

## Design — resolver + canonical owner (no mirroring)
Each team's single authoritative `LifeTotalComponent` lives on a stable **canonical owner** (the first team member). A `GameState` resolver routes every life read/write to it:

- `lifeTotal(p)` · `withLifeTotal(p, n)` · `adjustLife(p, d)` · `teamLifeOwnerOf(p)`

A player with no team is its own owner → **non-team games are a pure pass-through** (byte-identical behaviour). Every player keeps a `LifeTotalComponent`, so player-detection (`has<LifeTotalComponent>`) and entity shape are unchanged; only `.life` *value* reads/writes are routed.

## Migrated (~35 sites)
`DamageUtils` (loseLife/gainLife/dealDamageToTarget) · `CombatDamageManager` (combat damage, lifelink, redirect) · every PayLife affordability + payment path (`CostHandler`, `CostPaymentService`, `CastSpellEnumerator`, `CastFromZoneEnumerator`, `CostEnumerationUtils`, the three continuation resumers, `PayOrSuffer`, `AnyPlayerMayPay`, `Ward`) · `SetLifeTotal` / `PayLife` / `ExchangeLifeAndPower` executors · `YourLifeTotal` / `LifeTotal` dynamic amounts · `APlayerLifeAtMost` · `GainControlByMost` · `OpenLifeBid` · `EachPlayerDiscardsOrLoseLife` · the `ClientStateTransformer` life DTO (shows the team total).

`getOpponents` is now team-aware; `PlayerLifeLossCheck` reads the shared total so a 0-life team's members are all marked lost in one SBA pass (the principled single team-loss check is **Phase 3**).

## Tests
- `TwoHeadedGiantSharedLifeTest` — shared damage/gain/loss across teammates, each-opponent drains a whole opposing team from one pool, set-life, life payment, 0-life team wipe, and non-team pass-through.
- `LifeTotalReadsThroughResolverTest` — hygiene guard that fails the build if any future code reads/writes raw life outside the resolver (allowlist: the resolver, `GameInitializer`, the component declaration).
- Full `rules-engine` and `game-server` suites green.

## Deferred (by design)
AI life evaluation still reads per-player life (Phase 8 — AI doesn't play 2HG yet). Exotic CR 810.9 clauses (810.9b simultaneous-pay cap, 810.9d set-each-to-N picks one member, 810.9e no teammate exchange, 810.9g/h team-wide can't-gain/can't-lose) are noted for a later sub-phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)