### PR TITLE
Add Guardian Beast to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 70 / 78
+**Implemented:** 73 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -40,7 +40,7 @@
 - [x] Cuombajj Witches
 - [x] El-Hajjâj
 - [x] Erg Raiders
-- [ ] Guardian Beast
+- [x] Guardian Beast
 - [x] Hasran Ogress
 - [x] Junún Efreet
 - [x] Juzám Djinn
@@ -55,7 +55,7 @@
 - [x] Desert Nomads
 - [x] Hurr Jackal
 - [x] Kird Ape
-- [ ] Magnetic Mountain
+- [x] Magnetic Mountain
 - [x] Mijae Djinn
 - [x] Rukh Egg
 - [x] Ydwen Efreet
@@ -65,7 +65,7 @@
 - [x] Erhnam Djinn
 - [x] Ghazbán Ogre
 - [x] Ifh-Bíff Efreet
-- [ ] Metamorphosis
+- [x] Metamorphosis
 - [x] Nafs Asp
 - [x] Sandstorm
 - [x] Singing Tree

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1314,6 +1314,8 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.withColor(c)` / `.withAnyColor(c…)` / `.notColor(c)` — fixed-color predicates (`CardPredicate.HasColor`/`NotColor`).
 - `.nonartifact()` — appends `CardPredicate.IsNonartifact` ("nonartifact creature", the Terror template);
   the type-negation analogue of `.notColor(c)` / `.notSubtype(s)`.
+- `.notCreature()` — appends `CardPredicate.Not(CardPredicate.IsCreature)` ("noncreature artifact",
+  e.g. `GameObjectFilter.Artifact.notCreature().youControl()` — Guardian Beast).
 - `.withChosenColor()` — `CardPredicate.HasChosenColor`: matches the color chosen during the current
   effect's resolution (read from `EffectContext.chosenColor`, set by `Effects.ChooseColorThen`). Use with
   `AggregateBattlefield(Player.Each, …)` for "for each permanent of that color" (Coalition Dragon cycle).
@@ -2065,6 +2067,14 @@ staticAbility {
   `AbilityFlag.CANT_BE_SACRIFICED` flag, honored by the sacrifice executor — a sacrifice that can't
   happen simply no-ops). Wrap in `ConditionalStaticAbility` for time-restricted forms, e.g. Zurgo,
   Thunder's Decree: `ConditionalStaticAbility(CantBeSacrificed(GroupFilter(Token.youControl().withSubtype("Warrior"))), IsInStep(listOf(Step.END)))`.
+- `GrantKeyword(AbilityFlag.CANT_BE_ENCHANTED.name, filter)` — matching permanents can't be enchanted
+  (CR 303.4): an Aura can't legally target them. Honored in `TargetValidator` at Aura-cast/activation
+  target legality (only the targeting step — effects that move/attach an Aura without targeting are not
+  covered). (Guardian Beast)
+- `GrantKeyword(AbilityFlag.CANT_GAIN_CONTROL.name, filter)` — other players can't gain control of
+  matching permanents. Honored in the control-change executors (`GainControl`, `GainControlByMost`,
+  `ExchangeControl` — an exchange where either side can't be gained control of fails entirely); the
+  controller keeping their own permanent is an unaffected no-op. (Guardian Beast)
 - `CantBlockCreaturesWithGreaterPower(filter = source())` — blocker-side evasion (Spitfire Handler): this
   creature can't block creatures whose projected power exceeds its own.
 - `CantBeBlockedByCreaturesWithLessPower(filter = source())` — attacker-side dual (Formation Breaker): this

--- a/manual-scenarios/cards/g/guardian-beast.json
+++ b/manual-scenarios/cards/g/guardian-beast.json
@@ -1,0 +1,44 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Guardian Beast"},
+      {"name": "Pyramids"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Naturalize", "Steal Artifact"],
+    "battlefield": [
+      {"name": "Aladdin"},
+      {"name": "Icy Manipulator"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Island", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/AbilityFlag.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/AbilityFlag.kt
@@ -26,5 +26,18 @@ enum class AbilityFlag(val displayName: String) {
     CANT_RECEIVE_COUNTERS("Can't have counters put on it"),
 
     // ── Sacrifice restriction flags ─────────────────────────────
-    CANT_BE_SACRIFICED("Can't be sacrificed")
+    CANT_BE_SACRIFICED("Can't be sacrificed"),
+
+    // ── Aura / control restriction flags ────────────────────────
+    /**
+     * Auras can't be put onto this permanent (CR 303.4). Enforced at Aura-cast target legality
+     * in TargetValidator. Granted by effects like Guardian Beast.
+     */
+    CANT_BE_ENCHANTED("Can't be enchanted"),
+
+    /**
+     * Other players can't gain control of this permanent. Enforced in the control-change executors
+     * (gain / exchange / by-most). Granted by effects like Guardian Beast.
+     */
+    CANT_GAIN_CONTROL("Can't be gained control of")
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -208,6 +208,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.IsNonartifact
     )
 
+    /** Exclude creatures ("noncreature artifact", e.g. Guardian Beast). */
+    fun notCreature() = copy(
+        cardPredicates = cardPredicates + CardPredicate.Not(CardPredicate.IsCreature)
+    )
+
     /**
      * Restrict to spells/abilities on the stack that target at least one object matching
      * [subfilter]. Used for "an instant or sorcery spell that targets a creature" (Repartee —

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/GuardianBeast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/GuardianBeast.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Guardian Beast
+ * {3}{B}
+ * Creature — Beast
+ * 2/4
+ * As long as this creature is untapped, noncreature artifacts you control can't be enchanted,
+ * they have indestructible, and other players can't gain control of them. This effect doesn't
+ * remove Auras already attached to those artifacts.
+ *
+ * Three conditional static abilities, each gated on [Conditions.SourceIsUntapped] and scoped to
+ * noncreature artifacts you control, grant a continuous property via the layer system:
+ *  - INDESTRUCTIBLE (existing keyword).
+ *  - CANT_BE_ENCHANTED — a granted restriction enforced at Aura-cast target legality (TargetValidator).
+ *  - CANT_GAIN_CONTROL — enforced in the control-change executors (gain / exchange / by-most).
+ * Because the grants only apply while Guardian Beast is untapped, Auras already attached when it
+ * was untapped are not removed (the static doesn't detach anything) — matching the reminder text.
+ */
+val GuardianBeast = card("Guardian Beast") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 4
+    oracleText = "As long as this creature is untapped, noncreature artifacts you control can't be " +
+        "enchanted, they have indestructible, and other players can't gain control of them. This " +
+        "effect doesn't remove Auras already attached to those artifacts."
+
+    val noncreatureArtifactsYouControl =
+        GroupFilter(GameObjectFilter.Artifact.notCreature().youControl())
+
+    staticAbility {
+        condition = Conditions.SourceIsUntapped
+        ability = GrantKeyword(Keyword.INDESTRUCTIBLE, noncreatureArtifactsYouControl)
+    }
+    staticAbility {
+        condition = Conditions.SourceIsUntapped
+        ability = GrantKeyword(AbilityFlag.CANT_BE_ENCHANTED.name, noncreatureArtifactsYouControl)
+    }
+    staticAbility {
+        condition = Conditions.SourceIsUntapped
+        ability = GrantKeyword(AbilityFlag.CANT_GAIN_CONTROL.name, noncreatureArtifactsYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "26"
+        artist = "Ken Meyer, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg?1562923479"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -1706,6 +1706,103 @@
     ]
 }
 
+// Guardian Beast
+{
+    "name": "Guardian Beast",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "As long as this creature is untapped, noncreature artifacts you control can't be enchanted, they have indestructible, and other players can't gain control of them. This effect doesn't remove Auras already attached to those artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsArtifact",
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsCreature"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "untapped"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_ENCHANTED",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsArtifact",
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsCreature"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "untapped"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_GAIN_CONTROL",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsArtifact",
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsCreature"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "untapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "RARE",
+        "artist": "Ken Meyer, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg?1562923479"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hasran Ogress
 {
     "name": "Hasran Ogress",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.ExchangeControlEffect
 import kotlin.reflect.KClass
@@ -59,6 +60,15 @@ class ExchangeControlExecutor : EffectExecutor<ExchangeControlEffect> {
 
         // If both creatures already have the same controller, no-op
         if (controller1 == controller2) return EffectResult.success(state)
+
+        // "Other players can't gain control of it" (Guardian Beast): an exchange would hand each
+        // permanent to a different player, so if either side can't be gained control of, the whole
+        // exchange fails to happen.
+        if (state.projectedState.hasKeyword(target1Id, AbilityFlag.CANT_GAIN_CONTROL) ||
+            state.projectedState.hasKeyword(target2Id, AbilityFlag.CANT_GAIN_CONTROL)
+        ) {
+            return EffectResult.success(state)
+        }
 
         // Capture the base timestamp before threading state so that +1 is stable
         val baseTimestamp = state.timestamp

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComp
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.GainControlByMostEffect
@@ -66,6 +67,12 @@ class GainControlByMostExecutor : EffectExecutor<GainControlByMostEffect> {
         val currentControllerId = state.projectedState.getController(targetId)
             ?: targetContainer.get<ControllerComponent>()?.playerId
         if (currentControllerId == newControllerId) return EffectResult.success(state)
+
+        // "Other players can't gain control of it" (Guardian Beast): a different player can't take
+        // control of the permanent.
+        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_GAIN_CONTROL)) {
+            return EffectResult.success(state)
+        }
 
         // Remove any previous Layer.CONTROL floating effects from the same source on the same target.
         val filteredEffects = state.floatingEffects.filter { floating ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.scripting.effects.GainControlEffect
 import kotlin.reflect.KClass
 
@@ -38,6 +39,14 @@ class GainControlExecutor : EffectExecutor<GainControlEffect> {
 
         val cardComponent = targetContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Target is not a card")
+
+        // "Other players can't gain control of it" (Guardian Beast): a different player can't take
+        // control. The controller keeping control of their own permanent is a no-op anyway.
+        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_GAIN_CONTROL) &&
+            state.projectedState.getController(targetId) != context.controllerId
+        ) {
+            return EffectResult.success(state)
+        }
 
         val newControllerId = context.controllerId
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
@@ -200,8 +201,39 @@ class TargetValidator {
         val protectionFromSupertypeError = checkProtectionFromSupertype(state, target, sourceId)
         if (protectionFromSupertypeError != null) return protectionFromSupertypeError
 
+        // "Can't be enchanted" (CR 303.4): an Aura can't legally target a permanent with the
+        // CANT_BE_ENCHANTED restriction (Guardian Beast). Only applies when the source is an Aura.
+        val cantBeEnchantedError = checkCantBeEnchanted(state, target, sourceId)
+        if (cantBeEnchantedError != null) return cantBeEnchantedError
+
         // Check protection from color and creature subtype (Rule 702.16)
         return checkProtection(state, target, sourceColors, sourceSubtypes)
+    }
+
+    /**
+     * Reject an Aura targeting a permanent that can't be enchanted (CR 303.4). No-op for
+     * non-Aura sources and for non-permanent targets.
+     *
+     * Scope note: this only guards Aura *targeting* at cast/activation time, which covers the
+     * common case (casting an Aura, or an ability that targets with an Aura on the stack). It does
+     * NOT cover effects that move/attach an existing Aura without targeting (e.g. "attach target
+     * Aura to ~", reanimate-an-Aura-attached). A card needing full coverage of the non-targeted
+     * attachment cases (CR 303.4i for entering attached, CR 303.4j for re-attaching an on-battlefield
+     * Aura) must also check [AbilityFlag.CANT_BE_ENCHANTED] at the attachment step.
+     */
+    private fun checkCantBeEnchanted(
+        state: GameState,
+        target: ChosenTarget,
+        sourceId: EntityId?
+    ): String? {
+        val sourceIsAura = sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.typeLine?.isAura }
+            ?: false
+        if (!sourceIsAura) return null
+        val targetId = (target as? ChosenTarget.Permanent)?.entityId ?: return null
+        return if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_BE_ENCHANTED)) {
+            "That permanent can't be enchanted"
+        } else null
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianBeastScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianBeastScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.GainControlByMostEffect
+import com.wingedsheep.sdk.scripting.effects.PlayerRankMetric
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Guardian Beast (Arabian Nights, {3}{B} 2/4 Beast).
+ *
+ * "As long as this creature is untapped, noncreature artifacts you control can't be enchanted,
+ * they have indestructible, and other players can't gain control of them."
+ *
+ * Covers all three granted properties (indestructible, can't-be-enchanted, can't-gain-control)
+ * and that they switch off when Guardian Beast is tapped.
+ */
+class GuardianBeastScenarioTest : FunSpec({
+
+    // A vanilla noncreature artifact to protect.
+    val testRelic = card("Test Relic") {
+        manaCost = "{0}"
+        typeLine = "Artifact"
+    }
+    val smashRelic = CardDefinition.sorcery(
+        name = "Smash Relic",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = "Destroy target artifact.",
+        script = CardScript.spell(Effects.Destroy(EffectTarget.ContextTarget(0)), Targets.Artifact),
+    )
+    val seizeRelic = CardDefinition.sorcery(
+        name = "Seize Relic",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = "Gain control of target artifact.",
+        script = CardScript.spell(Effects.GainControl(EffectTarget.ContextTarget(0)), Targets.Artifact),
+    )
+    // Exchange control of two target artifacts (exercises ExchangeControlExecutor).
+    val swapRelics = CardDefinition.sorcery(
+        name = "Swap Relics",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = "Exchange control of two target artifacts.",
+        script = CardScript.spell(
+            Effects.ExchangeControl(EffectTarget.ContextTarget(0), EffectTarget.ContextTarget(1)),
+            Targets.Artifact,
+            Targets.Artifact,
+        ),
+    )
+    // The player with the most life gains control of target artifact (exercises GainControlByMostExecutor).
+    val richestTakesRelic = CardDefinition.sorcery(
+        name = "Richest Takes Relic",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = "The player with the most life gains control of target artifact.",
+        script = CardScript.spell(
+            GainControlByMostEffect(PlayerRankMetric.LifeTotal, EffectTarget.ContextTarget(0)),
+            Targets.Artifact,
+        ),
+    )
+    // An Aura that enchants artifacts.
+    val relicChains = card("Relic Chains") {
+        manaCost = "{1}"
+        typeLine = "Enchantment — Aura"
+        oracleText = "Enchant artifact"
+        auraTarget = Targets.Artifact
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all +
+                listOf(testRelic, smashRelic, seizeRelic, swapRelics, richestTakesRelic, relicChains),
+        )
+        return driver
+    }
+
+    test("noncreature artifacts you control are indestructible while Guardian Beast is untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beast = driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val relic = driver.putPermanentOnBattlefield(you, "Test Relic")
+
+        // Untapped Guardian Beast: a "destroy target artifact" spell fails to destroy the relic.
+        val smash1 = driver.putCardInHand(you, "Smash Relic")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(you, smash1, listOf(ChosenTarget.Permanent(relic)))
+        driver.bothPass()
+        driver.findPermanent(you, "Test Relic") shouldNotBe null
+
+        // Tap Guardian Beast — the relic loses indestructible and is destroyed.
+        driver.tapPermanent(beast)
+        val smash2 = driver.putCardInHand(you, "Smash Relic")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(you, smash2, listOf(ChosenTarget.Permanent(relic)))
+        driver.bothPass()
+        driver.findPermanent(you, "Test Relic") shouldBe null
+    }
+
+    test("other players can't gain control of your noncreature artifacts while Guardian Beast is untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val beast = driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val relic = driver.putPermanentOnBattlefield(you, "Test Relic")
+
+        // Advance to the opponent's turn so they can cast a sorcery-speed steal.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        if (driver.activePlayer != opponent) {
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+
+        val seize = driver.putCardInHand(opponent, "Seize Relic")
+        driver.giveMana(opponent, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(opponent, seize, listOf(ChosenTarget.Permanent(relic)))
+        driver.bothPass()
+
+        // Guardian Beast untapped → control didn't change.
+        driver.state.getEntity(relic)?.get<ControllerComponent>()?.playerId shouldBe you
+        driver.state.projectedState.getController(relic) shouldBe you
+        beast shouldNotBe null
+    }
+
+    test("noncreature artifacts you control can't be enchanted while Guardian Beast is untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val relic = driver.putPermanentOnBattlefield(you, "Test Relic")
+
+        // Casting an Aura targeting the protected relic is illegal.
+        val aura = driver.putCardInHand(you, "Relic Chains")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        val result = driver.castSpellWithTargets(you, aura, listOf(ChosenTarget.Permanent(relic)))
+        result.error shouldNotBe null
+    }
+
+    test("an exchange-control effect can't swap away a protected artifact (the whole exchange fails)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val yourRelic = driver.putPermanentOnBattlefield(you, "Test Relic")
+        val theirRelic = driver.putPermanentOnBattlefield(opponent, "Test Relic")
+
+        // Opponent casts an exchange targeting your protected relic and their own.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        if (driver.activePlayer != opponent) {
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+        val swap = driver.putCardInHand(opponent, "Swap Relics")
+        driver.giveMana(opponent, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(
+            opponent,
+            swap,
+            listOf(ChosenTarget.Permanent(yourRelic), ChosenTarget.Permanent(theirRelic)),
+        )
+        driver.bothPass()
+
+        // The whole exchange fails: neither permanent changed hands.
+        driver.state.projectedState.getController(yourRelic) shouldBe you
+        driver.state.projectedState.getController(theirRelic) shouldBe opponent
+    }
+
+    test("a 'most life' control effect can't take a protected artifact") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val relic = driver.putPermanentOnBattlefield(you, "Test Relic")
+
+        // Make the opponent the unique most-life player, then resolve "most life gains control".
+        driver.setLifeTotal(opponent, 30)
+        val grab = driver.putCardInHand(you, "Richest Takes Relic")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(you, grab, listOf(ChosenTarget.Permanent(relic)))
+        driver.bothPass()
+
+        // Opponent would otherwise gain control; Guardian Beast prevents it.
+        driver.state.projectedState.getController(relic) shouldBe you
+    }
+
+    test("Auras already attached are not removed when Guardian Beast becomes untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beast = driver.putCreatureOnBattlefield(you, "Guardian Beast")
+        val relic = driver.putPermanentOnBattlefield(you, "Test Relic")
+
+        // While Guardian Beast is tapped the relic can be enchanted, so attach an Aura.
+        driver.tapPermanent(beast)
+        val aura = driver.putCardInHand(you, "Relic Chains")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        driver.castSpellWithTargets(you, aura, listOf(ChosenTarget.Permanent(relic)))
+        driver.bothPass()
+        val auraId = driver.findPermanent(you, "Relic Chains")
+        driver.state.getEntity(auraId!!)?.get<AttachedToComponent>()?.targetId shouldBe relic
+
+        // Untapping Guardian Beast re-enables "can't be enchanted" but must NOT detach the Aura.
+        driver.untapPermanent(beast)
+        driver.state.getEntity(auraId)?.get<AttachedToComponent>()?.targetId shouldBe relic
+    }
+})


### PR DESCRIPTION
Depends on https://github.com/wingedsheep/argentum-engine/pull/746

{3}{B} 2/4 Beast. As long as it's untapped, noncreature artifacts you
control can't be enchanted, have indestructible, and can't be gained
control of by other players.

Modeled as three SourceIsUntapped-gated GrantKeyword statics over a
noncreature-artifacts-you-control filter, composing existing primitives
rather than adding a bespoke ability. Introduces two non-displayed
restriction flags on AbilityFlag and a notCreature() filter helper:

- CANT_BE_ENCHANTED — enforced at Aura-cast target legality in
  TargetValidator (CR 303.4); guards targeting only, not non-targeted
  Aura attach/move.
- CANT_GAIN_CONTROL — enforced in the gain / by-most / exchange control
  executors (an exchange fails entirely if either side can't be gained).

Scenario test covers all three properties, the tap-state toggle, the
exchange and by-most branches, and that already-attached Auras are not
removed. Updates the SDK reference and the ARN snapshot.