### PR TITLE
Fix Moonshadow triggering on tokens put into the graveyard

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1448,8 +1448,14 @@ class TriggerDetector(
         entityId: EntityId,
         filter: GameObjectFilter
     ): Boolean {
+        // Tokens aren't cards (CR 111.6), so a token put into a graveyard never satisfies a
+        // "one or more [permanent] cards are put into your graveyard" trigger — even though it
+        // momentarily occupies the graveyard zone before CR 704.5s/111.7 sweeps it away (which
+        // is also why it can still be present here at trigger-detection time).
+        val entity = state.getEntity(entityId) ?: return false
+        if (entity.has<TokenComponent>()) return false
         if (filter == GameObjectFilter.Any) return true
-        val cardComponent = state.getEntity(entityId)?.get<CardComponent>() ?: return false
+        val cardComponent = entity.get<CardComponent>() ?: return false
         return filter.cardPredicates.all { predicate ->
             when (predicate) {
                 is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonshadowTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonshadowTest.kt
@@ -377,4 +377,50 @@ class MoonshadowTest : FunSpec({
 
         triggers.none { it.sourceId == moon } shouldBe true
     }
+
+    test("creature token dying to your graveyard does not trigger Moonshadow (tokens aren't cards)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Mountain" to 20),
+            startingLife = 20
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+
+        val moon = driver.putCreatureOnBattlefield(activePlayer, "Moonshadow")
+        addMinusOneMinusOne(driver, moon, 6)
+
+        // A creature *token* (not a card) dying to the graveyard. CR 111.6: a token isn't a card,
+        // so Moonshadow's "one or more permanent cards are put into your graveyard" must not fire.
+        // CR 111.7: the token still occupies the graveyard at trigger-detection time (it ceases to
+        // exist via a later state-based action), which is exactly what previously mismatched.
+        val token = driver.putCreatureOnBattlefield(activePlayer, "Savannah Lions")
+        driver.replaceState(
+            driver.state.updateEntity(token) { it.with(com.wingedsheep.engine.state.components.identity.TokenComponent) }
+        )
+
+        val battlefieldZone = com.wingedsheep.engine.state.ZoneKey(activePlayer, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)
+        val graveyardZone = com.wingedsheep.engine.state.ZoneKey(activePlayer, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
+        driver.replaceState(
+            driver.state.removeFromZone(battlefieldZone, token).addToZone(graveyardZone, token)
+        )
+
+        val events = listOf(
+            com.wingedsheep.engine.core.ZoneChangeEvent(
+                entityId = token,
+                entityName = "Savannah Lions",
+                fromZone = com.wingedsheep.sdk.core.Zone.BATTLEFIELD,
+                toZone = com.wingedsheep.sdk.core.Zone.GRAVEYARD,
+                ownerId = activePlayer,
+                lastKnownWasToken = true
+            )
+        )
+
+        val detector = com.wingedsheep.engine.event.TriggerDetector(driver.cardRegistry)
+        val triggers = detector.detectTriggers(driver.state, events)
+
+        triggers.none { it.sourceId == moon } shouldBe true
+        getMinusOneMinusOne(driver, moon) shouldBe 6
+    }
 })


### PR DESCRIPTION
## Problem

Goblin tokens dying to the graveyard incorrectly triggered **Moonshadow** ("Whenever one or more permanent **cards** are put into your graveyard from anywhere ... remove a -1/-1 counter").

Tokens aren't cards (**CR 111.6**), so they must never satisfy a "cards put into your graveyard" trigger. The bug surfaced because a dead token still occupies the graveyard zone at trigger-detection time — it only ceases to exist via a *later* state-based action (**CR 111.7**) — and a token in the graveyard still carries a permanent type line, so it matched `GameObjectFilter.Permanent`.

## Fix

`TriggerDetector.cardMatchesGraveyardBatchFilter` (the shared matcher behind both the `CardsPutIntoYourGraveyard` and `CardsLeftYourGraveyard` batching trigger families) now excludes any entity with a `TokenComponent` up front. This also corrects the `GameObjectFilter.Any` short-circuit, which previously matched tokens for any "cards put into your graveyard" trigger.

## Test

Added a `MoonshadowTest` case: a token-marked creature moved to the graveyard produces no trigger and leaves the -1/-1 counter count unchanged. All 9 cases in the suite pass.

No SDK surface changed.