### PR TITLE
Show Omen/Adventure cast face on the stack, not the permanent face

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -995,8 +995,20 @@ class ClientStateTransformer(
             ?.flatMap { it.subtypes }?.toSet()
             ?.takeIf { it.isNotEmpty() }
 
+        // A spell cast as a non-permanent secondary face (an Omen, an Adventure, or a split half) is
+        // — while it sits on the stack — that face, not the card's default permanent characteristics.
+        // Per [com.wingedsheep.sdk.model.CardLayout.OMEN]: "from every zone other than the stack the
+        // card is just the Dragon"; on the stack it's the Omen spell (e.g. Petty Revenge). Without
+        // this, casting the Omen showed the Dragon's name/type/text/P-T on the stack. We only swap in
+        // spell faces (instant/sorcery) — a modal-DFC permanent back keeps its own handling.
+        val castFace = if (zoneKey.zoneType == Zone.STACK) {
+            spellOnStack?.faceIndex
+                ?.let { cardDef?.cardFaces?.getOrNull(it) }
+                ?.takeIf { !it.typeLine.isPermanent }
+        } else null
+
         // Build type line string from TypeLine, using projected types/subtypes if available
-        val typeLine = cardComponent.typeLine
+        val typeLine = castFace?.typeLine ?: cardComponent.typeLine
         val projectedSubtypes = projectedValues?.subtypes?.toList()
         val displaySubtypes = projectedSubtypes ?: typeLine.subtypes.map { it.value }
         // When the projected subtypes contain every creature type — either via CHANGELING
@@ -1068,16 +1080,17 @@ class ClientStateTransformer(
 
         return ClientCard(
             id = entityId,
-            name = cardComponent.name,
-            manaCost = cardComponent.manaCost.toString(),
-            manaValue = cardComponent.manaCost.cmc,
+            name = castFace?.name ?: cardComponent.name,
+            manaCost = (castFace?.manaCost ?: cardComponent.manaCost).toString(),
+            manaValue = (castFace?.manaCost ?: cardComponent.manaCost).cmc,
             typeLine = typeLineString,
             cardTypes = displayCardTypes.map { it.name }.toSet(),
             subtypes = displaySubtypes.toSet(),
-            colors = colors,
-            oracleText = cardComponent.oracleText,
-            power = power,
-            toughness = toughness,
+            colors = if (castFace != null) castFace.manaCost.colors else colors,
+            oracleText = castFace?.oracleText ?: cardComponent.oracleText,
+            // A non-permanent cast face (Omen/Adventure/split half) has no power/toughness.
+            power = if (castFace != null) null else power,
+            toughness = if (castFace != null) null else toughness,
             basePower = cardComponent.baseStats?.basePower,
             baseToughness = cardComponent.baseStats?.baseToughness,
             damage = damage,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenStackDisplayTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenStackDisplayTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain as stringShouldContain
+
+/**
+ * An Omen card (Tarkir: Dragonstorm) is "just the Dragon" in every zone except the stack. When its
+ * Omen face is cast, the spell sitting on the stack must be presented to the client as the *Omen*
+ * (e.g. Petty Revenge — a Sorcery), not as the Dragon creature. Regression for the bug where casting
+ * the Omen showed the creature's name/type/oracle-text/P-T on the stack, so the cast spell appeared
+ * to vanish into the Dragon and then (correctly) shuffle into the library.
+ */
+class OmenStackDisplayTest : ScenarioTestBase() {
+
+    private val transformer = com.wingedsheep.engine.view.ClientStateTransformer(cardRegistry)
+    private val p1 = EntityId.of("player-1")
+
+    init {
+        test("Omen face on the stack is shown as the Omen spell, not the Dragon") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Disruptive Stormbrood")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardInLibrary(1, "Swamp")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val cardId = game.state.getHand(p1).first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Disruptive Stormbrood"
+            }
+            game.execute(CastSpell(p1, cardId, listOf(ChosenTarget.Permanent(bears)), faceIndex = 0)).error shouldBe null
+
+            val stackId = game.state.stack.first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Disruptive Stormbrood"
+            }
+            val card = transformer.transform(game.state, p1).cards[stackId]!!
+
+            withClue("name should be the Omen, not the Dragon") { card.name shouldBe "Petty Revenge" }
+            withClue("type line should be the Omen sorcery") { card.typeLine.stringShouldContain("Sorcery") }
+            withClue("Omen face is a sorcery — no P/T") {
+                card.power.shouldBeNull()
+                card.toughness.shouldBeNull()
+            }
+            withClue("cast face cost {1}{B} is black") { card.colors shouldContain com.wingedsheep.sdk.core.Color.BLACK }
+            withClue("oracle text is the Omen's effect") {
+                card.oracleText.stringShouldContain("Destroy target creature")
+            }
+        }
+
+        test("creature face on the stack is still shown as the Dragon") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Disruptive Stormbrood")
+                .withLandsOnBattlefield(1, "Forest", 5)
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Disruptive Stormbrood").error shouldBe null
+            val stackId = game.state.stack.first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Disruptive Stormbrood"
+            }
+            val card = transformer.transform(game.state, p1).cards[stackId]!!
+
+            withClue("creature face keeps the Dragon characteristics") {
+                card.name shouldBe "Disruptive Stormbrood"
+                card.typeLine.stringShouldContain("Creature")
+                card.power shouldBe 3
+                card.toughness shouldBe 3
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The bug

> When casting Disruptive Stormbrood as a spell (the **Petty Revenge** Omen face) it completely disappears without appearing on the stack.

## What was actually happening

I reproduced the cast against the live server (vs-human, both faces) and traced every layer. The **mechanics were already correct**: the Omen spell goes on the stack, the opponent gets priority when they can respond, it destroys its target, and the card shuffles into the owner's library on resolution (correct Omen behavior).

The defect was in **display**: `ClientStateTransformer` always rendered a spell on the stack with the *card's* default (permanent) characteristics. So casting **Petty Revenge** ({1}{B} Sorcery — "Destroy target creature with power 3 or less") showed the **{4}{G} 3/3 Dragon** on the stack instead — name, type line, oracle text, power/toughness and color all the creature's. Dumped directly from the server while the Omen sat on the stack:

```
name:     "Disruptive Stormbrood"     (expected "Petty Revenge")
typeLine: "Creature — Dragon"         (expected "Sorcery — Omen")
power/toughness: 3/3                   (expected none)
oracleText: "Flying\nWhen this creature enters…"  (expected "Destroy target creature…")
```

Because the Omen then correctly shuffles itself away on resolution, the spell you cast looked like it turned into the Dragon and vanished, rather than appearing on the stack as the spell you cast.

## The fix

A spell cast as a **non-permanent secondary face** (Omen, Adventure, or a split half) *is*, while on the stack, that face. Per `CardLayout.OMEN`: *"from every zone other than the stack the card is just the Dragon"* — on the stack it's the Omen. The transformer now uses the cast face's name, mana cost, type line, oracle text and color (and no P/T) for the stack object.

Permanent secondary faces (modal-DFC backs, Room halves) are left to their existing handling via the `!typeLine.isPermanent` guard, so Rooms/MDFCs are unaffected.

## Tests

- New `OmenStackDisplayTest`: Omen face on the stack reads as the Omen spell; creature face still reads as the Dragon.
- Full `:rules-engine` suite passes, including the existing Omen, split (Invasion), Room, Adventure (Feral Deathgorger) and modal stack-visibility tests. `:game-server` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)