### PR TITLE
Use the official Momir Vig avatar art for the card image

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/custom/MomirVigSimicVisionary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/custom/MomirVigSimicVisionary.kt
@@ -36,4 +36,10 @@ val MomirVigSimicVisionary = card("Momir Vig, Simic Visionary") {
         restrictions = listOf(ActivationRestriction.OncePerTurn)
         activateFromZone = Zone.COMMAND
     }
+
+    // Vanguard avatars aren't in any Scryfall set we generate URLs for, so point directly at the
+    // official avatar art (used wherever the card renders — command zone and on the stack).
+    metadata {
+        imageUri = "https://cards.scryfall.io/large/front/3/8/3831df29-83d4-48d6-a3d6-a5fbd5ddf30d.jpg?1562908207"
+    }
 }


### PR DESCRIPTION
## What

Sets the Momir Vig, Simic Visionary Vanguard avatar's card image to the official avatar art so it renders correctly wherever the card appears — in the command zone and **on the stack** when its ability is activated.

```kotlin
metadata {
    imageUri = "https://cards.scryfall.io/large/front/3/8/3831df29-83d4-48d6-a3d6-a5fbd5ddf30d.jpg?1562908207"
}
```

## Why

The avatar is a custom card that isn't part of any Scryfall set we generate image URLs for, so it previously rendered without art. `getCardImageUrl` returns `metadata.imageUri` directly when present, so pointing it at the official image fixes every render path.

## Note on scope

The **Momir Basic custom-format feature itself** (lobby Format-dropdown entry, `{X}` avatar cost + 24 life, all-sets creature pool, and AI support for the avatar's X-cost ability) already landed on `main` as commit `2217bc763` — it reached main through this shared clone's auto-sync rather than a reviewed PR. This PR is the follow-up image fix only; its diff is a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)