### PR TITLE
Two-Headed Giant Phase 3: team win/loss

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1061,17 +1061,22 @@ class GameSession(
             return GameOverReason.DRAW
         }
 
-        // Find the losing player (the one who is not the winner)
-        val loserId = state.turnOrder.find { it != state.winnerId }
-        val lossComponent = loserId?.let { state.getEntity(it)?.get<PlayerLostComponent>() }
+        // Find why the losing side lost. In Two-Headed Giant a whole team is defeated, so prefer a
+        // meaningful cause over the propagated TEAM_DEFEATED marker (CR 810.8a) — mirrors the
+        // engine's GameEndCheck reason derivation. (Team-aware winner display is Phase 6.)
+        val lostReasons = state.turnOrder
+            .mapNotNull { state.getEntity(it)?.get<PlayerLostComponent>()?.reason }
+        val reason = lostReasons.firstOrNull { it != LossReason.TEAM_DEFEATED }
+            ?: lostReasons.firstOrNull()
 
-        return when (lossComponent?.reason) {
+        return when (reason) {
             LossReason.LIFE_ZERO -> GameOverReason.LIFE_ZERO
             LossReason.EMPTY_LIBRARY -> GameOverReason.DECK_OUT
             LossReason.POISON_COUNTERS -> GameOverReason.POISON_COUNTERS
             LossReason.CONCESSION -> GameOverReason.CONCESSION
             LossReason.CARD_EFFECT -> GameOverReason.CARD_EFFECT
             LossReason.COMMANDER_DAMAGE -> GameOverReason.COMMANDER_DAMAGE
+            LossReason.TEAM_DEFEATED -> GameOverReason.CARD_EFFECT
             null -> GameOverReason.LIFE_ZERO // Fallback
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -881,6 +881,8 @@ enum class GameEndReason {
     DRAW,
     /** Commander format: 21+ combat damage from a single commander (CR 903.10a). */
     COMMANDER_DAMAGE,
+    /** Two-Headed Giant: a player lost with their team (CR 810.8a). */
+    TEAM_DEFEATED,
     /** Rule 104.4c — SBAs never stabilized, treated as an unbreakable infinite loop. */
     INFINITE_LOOP,
     UNKNOWN

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/WinGameExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/WinGameExecutor.kt
@@ -6,8 +6,6 @@ import com.wingedsheep.engine.core.PlayerLostEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.LossReason
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.sdk.scripting.effects.WinGameEffect
@@ -33,7 +31,11 @@ class WinGameExecutor : EffectExecutor<WinGameEffect> {
         val winnerId = context.resolvePlayerTarget(effect.target)
             ?: return EffectResult.error(state, "No target player for WinGameEffect")
 
-        val opponentIds = state.turnOrder.filter { it != winnerId }
+        // CR 810.8a — "if either player on a team wins, the entire team wins": only players on
+        // opposing teams lose, never the winner's teammate. getOpponents is team-aware (excludes the
+        // winner's whole team); in a non-team game it is every other player as before. The defeated
+        // opponents' own teammates are then marked by TeamLossPropagationCheck.
+        val opponentIds = state.getOpponents(winnerId)
         if (opponentIds.isEmpty()) return EffectResult.success(state)
 
         var newState = state
@@ -42,13 +44,8 @@ class WinGameExecutor : EffectExecutor<WinGameEffect> {
         for (opponentId in opponentIds) {
             val container = newState.getEntity(opponentId) ?: continue
             if (container.has<PlayerLostComponent>()) continue
-
-            val cantLose = newState.getBattlefield().any { entityId ->
-                val c = newState.getEntity(entityId) ?: return@any false
-                c.has<GrantsCantLoseGameComponent>() &&
-                    c.get<ControllerComponent>()?.playerId == opponentId
-            }
-            if (cantLose) continue
+            // CR 810.8a — a can't-lose grant controlled by any teammate protects the whole team.
+            if (com.wingedsheep.engine.mechanics.sba.player.playerCantLoseGame(newState, opponentId)) continue
 
             newState = newState.updateEntity(opponentId) { c ->
                 c.with(PlayerLostComponent(LossReason.CARD_EFFECT))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -20,6 +20,7 @@ object SbaOrder {
     const val COMMANDER_ZONE_CHOICE = 950   // 903.9a (Commander format)
     const val TOKENS_IN_WRONG_ZONES = 1000  // 704.5s
     const val PHANTOM_CARD_COPIES = 1050    // 707.10a
+    const val TEAM_LOSS_PROPAGATION = 8500  // 810.8a (Two-Headed Giant: a team loses together)
     const val LEAVE_GAME = 9000             // 800.4a–c (multiplayer: process a player who has left)
     const val GAME_END = 9999
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/game/GameEndCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/game/GameEndCheck.kt
@@ -19,29 +19,22 @@ class GameEndCheck : StateBasedActionCheck {
     override fun check(state: GameState): ExecutionResult {
         if (state.gameOver) return ExecutionResult.success(state)
 
-        val activePlayers = state.turnOrder.filter { playerId ->
-            val container = state.getEntity(playerId) ?: return@filter false
-            !container.has<PlayerLostComponent>()
-        }
+        // CR 104.2a / 810.8a — the game ends when one *team* remains. In a non-team game every
+        // player is a team of one, so [activeTeams] mirrors the surviving players and this is the
+        // ordinary "one player left" check.
+        val activeTeams = state.activeTeams
 
-        if (activePlayers.size == 1) {
-            val winner = activePlayers.first()
-            val losingPlayer = state.turnOrder.find { it != winner }
-            val lossComponent = losingPlayer?.let { state.getEntity(it)?.get<PlayerLostComponent>() }
-            val reason = when (lossComponent?.reason) {
-                LossReason.LIFE_ZERO -> GameEndReason.LIFE_ZERO
-                LossReason.POISON_COUNTERS -> GameEndReason.POISON_COUNTERS
-                LossReason.EMPTY_LIBRARY -> GameEndReason.DECK_EMPTY
-                LossReason.CONCESSION -> GameEndReason.CONCESSION
-                LossReason.CARD_EFFECT -> GameEndReason.CARD_EFFECT
-                LossReason.COMMANDER_DAMAGE -> GameEndReason.COMMANDER_DAMAGE
-                null -> GameEndReason.UNKNOWN
-            }
+        if (activeTeams.size == 1) {
+            // The whole surviving team wins (CR 810.8a). winnerId records a representative — the
+            // first surviving member; both members are winners (neither carries PlayerLostComponent).
+            val winningTeam = activeTeams.first()
+            val winner = winningTeam.first { state.getEntity(it)?.has<PlayerLostComponent>() != true }
+            val reason = losingReason(state)
             return ExecutionResult.success(
                 state.copy(gameOver = true, winnerId = winner),
                 listOf(GameEndedEvent(winner, reason))
             )
-        } else if (activePlayers.isEmpty()) {
+        } else if (activeTeams.isEmpty()) {
             return ExecutionResult.success(
                 state.copy(gameOver = true, winnerId = null),
                 listOf(GameEndedEvent(null, GameEndReason.DRAW))
@@ -49,5 +42,27 @@ class GameEndCheck : StateBasedActionCheck {
         }
 
         return ExecutionResult.success(state)
+    }
+
+    /**
+     * The game-end reason, drawn from a defeated player. Prefers a *meaningful* cause over the
+     * propagated [LossReason.TEAM_DEFEATED] (CR 810.8a), so a team that lost because a member decked
+     * out / hit lethal life reports that cause rather than "team defeated".
+     */
+    private fun losingReason(state: GameState): GameEndReason {
+        val lostReasons = state.turnOrder
+            .mapNotNull { state.getEntity(it)?.get<PlayerLostComponent>()?.reason }
+        val reason = lostReasons.firstOrNull { it != LossReason.TEAM_DEFEATED }
+            ?: lostReasons.firstOrNull()
+        return when (reason) {
+            LossReason.LIFE_ZERO -> GameEndReason.LIFE_ZERO
+            LossReason.POISON_COUNTERS -> GameEndReason.POISON_COUNTERS
+            LossReason.EMPTY_LIBRARY -> GameEndReason.DECK_EMPTY
+            LossReason.CONCESSION -> GameEndReason.CONCESSION
+            LossReason.CARD_EFFECT -> GameEndReason.CARD_EFFECT
+            LossReason.COMMANDER_DAMAGE -> GameEndReason.COMMANDER_DAMAGE
+            LossReason.TEAM_DEFEATED -> GameEndReason.TEAM_DEFEATED
+            null -> GameEndReason.UNKNOWN
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameCheck.kt
@@ -28,11 +28,12 @@ class PlayerLeavesGameCheck : StateBasedActionCheck {
     override fun check(state: GameState): ExecutionResult {
         if (state.gameOver) return ExecutionResult.success(state)
 
-        // When a loss leaves one or zero players standing, the game is ending — the
-        // game-end SBA settles it and there is nothing to keep playing for, so we don't
-        // tear down the loser's board. Leave-the-game processing only matters when the pod
-        // continues, which keeps a two-player game's end-state byte-identical to before.
-        if (state.activePlayers.size <= 1) return ExecutionResult.success(state)
+        // When a loss leaves one or zero *teams* standing, the game is ending — the game-end SBA
+        // settles it and there is nothing to keep playing for, so we don't tear down the losers'
+        // boards. Leave-the-game processing only matters when the pod continues. In a non-team
+        // game [activeTeams] mirrors the surviving players, keeping a two-player game's end-state
+        // byte-identical to before; in 2HG it stops a wiped team's board being torn down mid-end.
+        if (state.activeTeams.size <= 1) return ExecutionResult.success(state)
 
         val leaver = state.turnOrder.firstOrNull { id ->
             val container = state.getEntity(id) ?: return@firstOrNull false
@@ -54,5 +55,6 @@ internal fun LossReason?.toGameEndReason(): GameEndReason = when (this) {
     LossReason.CONCESSION -> GameEndReason.CONCESSION
     LossReason.CARD_EFFECT -> GameEndReason.CARD_EFFECT
     LossReason.COMMANDER_DAMAGE -> GameEndReason.COMMANDER_DAMAGE
+    LossReason.TEAM_DEFEATED -> GameEndReason.TEAM_DEFEATED
     null -> GameEndReason.UNKNOWN
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -48,9 +48,13 @@ class PlayerLifeLossCheck : StateBasedActionCheck {
 }
 
 internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
+    // CR 810.8a — "if an effect says a player can't lose the game, that player's team can't lose":
+    // a can't-lose grant controlled by any teammate protects the whole team. In a non-team game the
+    // team is just [playerId], so this is the ordinary single-player check.
+    val team = state.teamOf(playerId).toHashSet()
     return state.getBattlefield().any { entityId ->
         val container = state.getEntity(entityId) ?: return@any false
         container.has<GrantsCantLoseGameComponent>() &&
-            container.get<ControllerComponent>()?.playerId == playerId
+            container.get<ControllerComponent>()?.playerId in team
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerSbaModule.kt
@@ -8,6 +8,7 @@ class PlayerSbaModule : StateBasedActionModule {
         PlayerLifeLossCheck(),
         CommanderDamageLossCheck(),
         PoisonLossCheck(),
+        TeamLossPropagationCheck(),
         PlayerLeavesGameCheck()
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PoisonLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PoisonLossCheck.kt
@@ -6,30 +6,33 @@ import com.wingedsheep.engine.core.PlayerLostEvent
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.player.LossReason
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
-import com.wingedsheep.sdk.core.CounterType
 
 /**
- * 704.5b - A player with 10 or more poison counters loses the game.
+ * 704.5c - A player with 10 or more poison counters loses the game.
+ *
+ * In Two-Headed Giant the threshold is 15 and poison is pooled by the team (CR 810.8d / 810.10): a
+ * team loses when its members' combined poison reaches 15. Both values come from the format, so
+ * non-2HG games keep the plain per-player 10.
  */
 class PoisonLossCheck : StateBasedActionCheck {
-    override val name = "704.5b Poison Loss"
+    override val name = "704.5c Poison Loss"
     override val order = SbaOrder.POISON_LOSS
 
     override fun check(state: GameState): ExecutionResult {
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
 
+        val threshold = (state.format as? com.wingedsheep.sdk.core.Format.TwoHeadedGiant)?.poisonThreshold ?: 10
+
         for (playerId in state.turnOrder) {
             val container = state.getEntity(playerId) ?: continue
             if (container.has<PlayerLostComponent>()) continue
             if (playerCantLoseGame(state, playerId)) continue
 
-            val counters = container.get<CountersComponent>() ?: continue
-            val poisonCount = counters.getCount(CounterType.POISON)
-            if (poisonCount >= 10) {
+            // CR 810.10a — an individual player's poison count uses the team's pooled total.
+            if (state.teamPoison(playerId) >= threshold) {
                 newState = newState.updateEntity(playerId) { c ->
                     c.with(PlayerLostComponent(LossReason.POISON_COUNTERS))
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/TeamLossPropagationCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/TeamLossPropagationCheck.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.mechanics.sba.player
+
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEndReason
+import com.wingedsheep.engine.core.PlayerLostEvent
+import com.wingedsheep.engine.mechanics.sba.SbaOrder
+import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.LossReason
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+
+/**
+ * CR 810.8a (Two-Headed Giant) — players win and lose only as a team: if either player on a team
+ * loses the game, the team loses. This propagation marks every still-in teammate of any lost player
+ * as having lost too ([LossReason.TEAM_DEFEATED]).
+ *
+ * It runs after the individual loss checks (life, commander damage, poison) and after concession,
+ * so the *cause* (e.g. one player decking out, taking lethal commander damage, or conceding —
+ * CR 810.8b) is recorded on the originating player, and this check spreads the loss to the rest of
+ * the team. The SBA loop re-runs until stable, so a loss recorded by any earlier check in the same
+ * settle is propagated before [com.wingedsheep.engine.mechanics.sba.game.GameEndCheck] decides the
+ * game.
+ *
+ * In a non-team game every player is a team of one, so this never marks anyone — existing games are
+ * unaffected.
+ */
+class TeamLossPropagationCheck : StateBasedActionCheck {
+    override val name = "810.8a Team Loss Propagation"
+    override val order = SbaOrder.TEAM_LOSS_PROPAGATION
+
+    override fun check(state: GameState): ExecutionResult {
+        var newState = state
+        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+
+        for (playerId in state.turnOrder) {
+            val lostTeammate = state.getEntity(playerId)?.has<PlayerLostComponent>() == true
+            if (!lostTeammate) continue
+
+            // This player is out — every teammate still in the game goes down with the team.
+            for (teammate in state.teammatesOf(playerId)) {
+                if (newState.getEntity(teammate)?.has<PlayerLostComponent>() == true) continue
+                newState = newState.updateEntity(teammate) { c ->
+                    c.with(PlayerLostComponent(LossReason.TEAM_DEFEATED))
+                }
+                events.add(PlayerLostEvent(teammate, GameEndReason.TEAM_DEFEATED))
+            }
+        }
+
+        return ExecutionResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -501,6 +501,28 @@ data class GameState(
             getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
         }
 
+    /**
+     * Teams with at least one player still in the game (not lost/left), in turn order. The
+     * team-level analogue of [activePlayers] — the game ends when only one of these remains
+     * (CR 810.8a). In a non-team game each player is its own team, so this mirrors [activePlayers].
+     */
+    val activeTeams: List<List<EntityId>>
+        get() = teams.filter { team ->
+            team.any { getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true }
+        }
+
+    /**
+     * The shared poison-counter total for [playerId]'s team (CR 810.10 — poison counters are placed
+     * on players individually but pooled by the team). Summed across all team members. For a player
+     * with no team this is just that player's own poison count.
+     */
+    fun teamPoison(playerId: EntityId): Int =
+        teamOf(playerId).sumOf { member ->
+            getEntity(member)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
+                ?.getCount(com.wingedsheep.sdk.core.CounterType.POISON) ?: 0
+        }
+
     // =========================================================================
     // Shared life total (Two-Headed Giant — CR 810.4 / 810.9)
     //

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -351,6 +351,8 @@ enum class LossReason {
     CARD_EFFECT,
     /** Commander format: 21+ combat damage from a single commander (CR 903.10a). */
     COMMANDER_DAMAGE,
+    /** Two-Headed Giant: this player's team lost, so they lose with it (CR 810.8a). */
+    TEAM_DEFEATED,
 }
 
 /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.Concede
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameEndReason
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.actions.special.ConcedeHandler
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.player.WinGameExecutor
+import com.wingedsheep.engine.mechanics.StateBasedActionChecker
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.player.LossReason
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.WinGameEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 3: team win/loss (CR 810.8).
+ *
+ * Players win and lose only as a team (810.8a): if either teammate loses, the team loses; a
+ * conceding player's team loses (810.8b); a team at 0 life (810.8c) or 15 poison (810.8d) loses.
+ * A can't-lose grant on either teammate protects the whole team (810.8a). The game ends when only
+ * one team remains, and that whole team wins.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order.
+ */
+class TwoHeadedGiantTeamLossTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().also { it.register(TestCards.all) }
+
+    fun checker() = StateBasedActionChecker(cardRegistry = registry())
+
+    fun boot(format: Format = Format.TwoHeadedGiant(), playerCount: Int = 4): Pair<GameState, List<EntityId>> {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = format,
+                players = (1..playerCount).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                teams = if (format is Format.TwoHeadedGiant) listOf(listOf(0, 1), listOf(2, 3)) else null,
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    fun lost(state: GameState, p: EntityId) = state.getEntity(p)!!.has<PlayerLostComponent>()
+
+    test("a team at 0 shared life loses; the opposing team wins together (CR 810.8a/c)") {
+        val (state, p) = boot()
+        val zeroed = DamageUtils.loseLife(state, p[0], 30, LifeChangeReason.LIFE_LOSS).first
+
+        val result = checker().checkAndApply(zeroed)
+        val s = result.newState
+
+        // Both members of team 0 are out; both members of team 1 survive.
+        lost(s, p[0]) shouldBe true
+        lost(s, p[1]) shouldBe true
+        lost(s, p[2]) shouldBe false
+        lost(s, p[3]) shouldBe false
+
+        s.gameOver shouldBe true
+        (s.winnerId in listOf(p[2], p[3])) shouldBe true
+    }
+
+    test("conceding makes the whole team lose (CR 810.8b)") {
+        val (state, p) = boot()
+        val result = ConcedeHandler(checker()).execute(state, Concede(p[2]))
+        val s = result.newState
+
+        // p2 conceded; teammate p3 goes down with the team; team 0 wins.
+        s.getEntity(p[2])!!.get<PlayerLostComponent>()!!.reason shouldBe LossReason.CONCESSION
+        s.getEntity(p[3])!!.get<PlayerLostComponent>()!!.reason shouldBe LossReason.TEAM_DEFEATED
+        lost(s, p[0]) shouldBe false
+        lost(s, p[1]) shouldBe false
+        s.gameOver shouldBe true
+        (s.winnerId in listOf(p[0], p[1])) shouldBe true
+    }
+
+    test("one teammate decking out loses the team, and the game-end reason is the real cause") {
+        val (state, p) = boot()
+        // Simulate the empty-library SBA having marked p1 (deck-out is recorded per-player).
+        val marked = state.updateEntity(p[1]) { it.with(PlayerLostComponent(LossReason.EMPTY_LIBRARY)) }
+
+        val result = checker().checkAndApply(marked)
+        val s = result.newState
+
+        lost(s, p[0]) shouldBe true // teammate goes down too
+        s.getEntity(p[0])!!.get<PlayerLostComponent>()!!.reason shouldBe LossReason.TEAM_DEFEATED
+        s.gameOver shouldBe true
+        // The end reason reports the real cause (deck-out), not the propagated TEAM_DEFEATED.
+        result.events.filterIsInstance<com.wingedsheep.engine.core.GameEndedEvent>()
+            .single().reason shouldBe GameEndReason.DECK_EMPTY
+    }
+
+    test("poison is pooled by the team and the team loses at 15, not 10 (CR 810.8d / 810.10)") {
+        val (state, p) = boot()
+        // 8 + 7 = 15 across the team → loss. (Either alone is below the 2HG threshold.)
+        val poisoned = state
+            .updateEntity(p[2]) { it.with(CountersComponent(mapOf(CounterType.POISON to 8))) }
+            .updateEntity(p[3]) { it.with(CountersComponent(mapOf(CounterType.POISON to 7))) }
+
+        val s = checker().checkAndApply(poisoned).newState
+        lost(s, p[2]) shouldBe true
+        lost(s, p[3]) shouldBe true
+        s.gameOver shouldBe true
+        (s.winnerId in listOf(p[0], p[1])) shouldBe true
+    }
+
+    test("a team with 10 combined poison does NOT lose under the 15 threshold") {
+        val (state, p) = boot()
+        val poisoned = state
+            .updateEntity(p[2]) { it.with(CountersComponent(mapOf(CounterType.POISON to 5))) }
+            .updateEntity(p[3]) { it.with(CountersComponent(mapOf(CounterType.POISON to 5))) }
+
+        val s = checker().checkAndApply(poisoned).newState
+        lost(s, p[2]) shouldBe false
+        s.gameOver shouldBe false
+    }
+
+    test("a can't-lose grant on either teammate protects the whole team (CR 810.8a)") {
+        val (state, p) = boot()
+        // Put a "can't lose the game" permanent under p1's control (teammate of p0).
+        val (permId, withId) = state.newEntity()
+        val protectedState = withId
+            .withEntity(
+                permId,
+                ComponentContainer.of(ControllerComponent(p[1]), GrantsCantLoseGameComponent)
+            )
+            .addToZone(ZoneKey(p[1], Zone.BATTLEFIELD), permId)
+        // Now drop team 0 to 0 life.
+        val zeroed = DamageUtils.loseLife(protectedState, p[0], 30, LifeChangeReason.LIFE_LOSS).first
+
+        val s = checker().checkAndApply(zeroed).newState
+        // The team is protected — neither teammate is marked, game continues.
+        lost(s, p[0]) shouldBe false
+        lost(s, p[1]) shouldBe false
+        s.gameOver shouldBe false
+    }
+
+    test("'you win the game' wins for your whole team and defeats only opposing teams (CR 810.8a)") {
+        val (state, p) = boot()
+        val result = WinGameExecutor().execute(
+            state, WinGameEffect(), EffectContext(sourceId = null, controllerId = p[0])
+        )
+        val s = checker().checkAndApply(result.state).newState
+
+        lost(s, p[0]) shouldBe false // winner
+        lost(s, p[1]) shouldBe false // winner's teammate is NOT defeated
+        lost(s, p[2]) shouldBe true  // opposing team loses
+        lost(s, p[3]) shouldBe true
+        s.gameOver shouldBe true
+        (s.winnerId in listOf(p[0], p[1])) shouldBe true
+    }
+
+    test("the game does not end while both teams still have a player standing") {
+        val (state, p) = boot()
+        // No one has lost: two active teams, the game continues.
+        state.activeTeams.size shouldBe 2
+        val s = checker().checkAndApply(state).newState
+        s.gameOver shouldBe false
+
+        // A single non-lethal loss on one team wipes that whole team (810.8a), so the only way to
+        // still have two teams standing is to have no team fully out — which is the case above.
+        // Knock out just one player of team 1 and confirm the team-loss is what ends the game.
+        val partial = state.updateEntity(p[2]) { it.with(PlayerLostComponent(LossReason.LIFE_ZERO)) }
+        val s2 = checker().checkAndApply(partial).newState
+        s2.activeTeams.size shouldBe 1
+        s2.gameOver shouldBe true
+    }
+
+    test("non-team game is unchanged: a player at 0 loses alone and poison threshold stays 10") {
+        val (state, p) = boot(format = Format.Standard, playerCount = 2)
+        val zeroed = DamageUtils.loseLife(state, p[0], 20, LifeChangeReason.LIFE_LOSS).first
+        val s = checker().checkAndApply(zeroed).newState
+        lost(s, p[0]) shouldBe true
+        s.gameOver shouldBe true
+        s.winnerId shouldBe p[1]
+
+        val (state2, q) = boot(format = Format.Standard, playerCount = 2)
+        val poisoned = state2.updateEntity(q[0]) { it.with(CountersComponent(mapOf(CounterType.POISON to 10))) }
+        lost(checker().checkAndApply(poisoned).newState, q[0]) shouldBe true
+    }
+})


### PR DESCRIPTION
Phase 3 of **Two-Headed Giant** (CR 810.8): players win and lose only as a **team**. Builds on Phases 1 (#751) & 2 (#752) — **based on `feat/2hg-phase2-shared-life`**; retarget down the stack as each merges.

## Rules (CR 810.8 / 810.10)
- **810.8a** — if either teammate loses, the team loses; if either wins, the team wins; a "can't lose" grant on either teammate protects the whole team.
- **810.8b** — a conceding player's team loses.
- **810.8c / 810.8d** — a team loses at 0 shared life, or at 15 pooled poison counters.
- **810.10** — poison is placed on players individually but pooled by the team.

## Changes
- **`TeamLossPropagationCheck`** (new SBA, order 8500, after the per-player loss checks): marks every still-in teammate of any lost player lost with the new `LossReason.TEAM_DEFEATED` / `GameEndReason.TEAM_DEFEATED`. This is the principled mechanism behind 810.8a — the per-player checks record the *cause*, and this spreads the loss. Non-team games never trigger it (everyone is a team of one).
- **`GameEndCheck` is team-aware**: the game ends when one **team** remains, and that whole team wins (`winnerId` records a representative; both members survive). Its end reason prefers the real cause over the propagated `TEAM_DEFEATED`.
- **`PlayerLeavesGameCheck`** gates board-teardown on `activeTeams` (not `activePlayers`), so a wiped team's board isn't torn down mid-end.
- **`PoisonLossCheck`** reads the threshold from the format (15 for 2HG, else 10) and uses team-pooled poison (new `GameState.teamPoison`).
- **`playerCantLoseGame`** is team-aware (810.8a): a grant on any teammate protects all of them. Replaces the duplicate inline check in `WinGameExecutor`.
- **`WinGameExecutor`** uses team-aware `getOpponents` (spares the winner's teammate) — "if either player wins, the team wins."
- New `GameState.activeTeams`; `GameSession.gameOverReason` prefers the real cause across the losing team.

## Tests
`TwoHeadedGiantTeamLossTest` — 0-life team wipe + opposing team wins, concede→team loss, deck-out propagation with the real end reason surfaced, 15-poison pooled loss, 10-poison survives the 2HG threshold, can't-lose team protection, "you win" spares your teammate and defeats opposing teams, the game continues while both teams stand, and a non-team regression (player loses alone at 0, poison stays 10). Full `rules-engine` + `game-server` suites green.

## Deferred (by design)
Team-aware *winner display* (a single `winnerId` represents the team; the client groups by team) is Phase 6/7. Exotic CR 810.9 life clauses remain noted for a later sub-phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)