### PR TITLE
Two-Headed Giant Phase 4: shared team turns

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -44,13 +44,18 @@ class BeginningPhaseManager(
     fun performUntapStep(state: GameState): ExecutionResult {
         val activePlayer = state.activePlayerId
             ?: return ExecutionResult.error(state, "No active player")
+        // CR 805.4 — in a shared team turn both teammates untap (and phase in / lose summoning
+        // sickness) together. In a non-team game the active team is just the active player.
+        val activeTeam = state.teamActivePlayers(activePlayer).toHashSet()
 
         val events = mutableListOf<GameEvent>()
         var newState = state
 
-        // Phase in permanents that phased out under the active player's control
+        // Phase in permanents that phased out under each active-team member's control
         // (Rule 702.26e: this happens during the untap step, before untapping).
-        newState = phaseInPermanents(newState, activePlayer, events)
+        for (member in activeTeam) {
+            newState = phaseInPermanents(newState, member, events)
+        }
 
         // Check if the player has a SkipUntapComponent
         val skipUntap = newState.getEntity(activePlayer)?.get<SkipUntapComponent>()
@@ -59,9 +64,9 @@ class BeginningPhaseManager(
         // Recomputed from newState so just-phased-in permanents are visible.
         val projected = newState.projectedState
 
-        // Find all tapped permanents controlled by the active player
+        // Find all tapped permanents controlled by the active team (CR 805.4)
         val permanentsToUntap = newState.entities.filter { (entityId, container) ->
-            projected.getController(entityId) == activePlayer &&
+            projected.getController(entityId) in activeTeam &&
                 container.has<TappedComponent>()
         }.keys.filter { entityId ->
             // If there's a skip untap component, check if this permanent should be skipped
@@ -143,7 +148,7 @@ class BeginningPhaseManager(
         // or UntapFilteredDuringOtherUntapSteps (e.g., Ivorytusk Fortress)
         val projectedForSeedborn = newState.projectedState
         for (playerId in newState.turnOrder) {
-            if (playerId == activePlayer) continue
+            if (playerId in activeTeam) continue // active team already untapped above (CR 805.4)
 
             var untapAll = false
             val filteredUntapFilters = mutableListOf<GameObjectFilter>()
@@ -194,10 +199,11 @@ class BeginningPhaseManager(
         // Remove WhileSourceTapped floating effects whose source is no longer tapped
         newState = cleanupPhaseManager.cleanupWhileSourceTappedEffects(newState)
 
-        // Remove summoning sickness from all creatures the player controls (using projected state)
+        // Remove summoning sickness from all creatures the active team controls (CR 805.4 — both
+        // teammates' creatures lose summoning sickness on the team's turn; projected state).
         val projectedAfterUntap = newState.projectedState
         val creaturesToRefresh = newState.entities.filter { (entityId, container) ->
-            projectedAfterUntap.getController(entityId) == activePlayer &&
+            projectedAfterUntap.getController(entityId) in activeTeam &&
                 container.has<SummoningSicknessComponent>()
         }.keys
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
@@ -67,54 +67,80 @@ class DrawPhaseManager(
             drawStepStartDrawCountByPlayer = stateIn.drawStepStartDrawCountByPlayer + (activePlayer to drawnSoFar)
         )
 
-        // CR 103.8a: in a two-player game the player who plays first skips the draw step
-        // of their first turn. CR 103.8c: in all other multiplayer games, no player skips
-        // the first draw. So the skip is gated on the table having exactly two players.
-        val isFirstTurnFirstPlayer = state.turnNumber == 1 &&
+        // CR 103.8a / 810.6: the player (or team) that goes first skips the draw step of its first
+        // turn; CR 103.8c — no one skips in a 3+/4-player free-for-all. With non-team games modeled
+        // as singleton teams, "exactly two teams" captures both cases: a 2-player game and a 2-team
+        // Two-Headed Giant game skip the starting side's first draw, while a 3/4-player FFA does not.
+        val isFirstTurnFirstTeam = state.turnNumber == 1 &&
             activePlayer == state.turnOrder.first() &&
-            state.turnOrder.size == 2
-        if (isFirstTurnFirstPlayer) {
+            state.teams.size == 2
+        if (isFirstTurnFirstTeam) {
             return ExecutionResult.success(
                 state.withPriority(activePlayer),
                 listOf(StepChangedEvent(Step.DRAW))
             )
         }
 
-        // Skip the draw if a "skip your next draw step" marker is present (e.g., Elfhame
-        // Sanctuary). Consume the marker so it only skips one draw step.
-        if (state.getEntity(activePlayer)?.has<SkipDrawStepComponent>() == true) {
-            val consumed = state.updateEntity(activePlayer) { it.without<SkipDrawStepComponent>() }
+        // CR 805.4b — each player on the active team draws during the team's draw step. Draw the
+        // teammates first (a team draws in any order it likes, 805.6a), then the active player last
+        // so its prompt-on-draw pause stays the final action of the step. Deck-out marks the loss in
+        // the returned state, so accumulating each draw's state/events is enough. (Prompt-on-draw for
+        // a teammate's own draw is a rare deferred nuance — teammate draws skip that prompt.) In a
+        // non-team game there are no teammates and this loop is a no-op.
+        var s = state
+        val teammateEvents = mutableListOf<GameEvent>()
+        for (teammate in state.teamActivePlayers(activePlayer)) {
+            if (teammate == activePlayer) continue
+            if (s.getEntity(teammate)?.has<SkipDrawStepComponent>() == true) {
+                s = s.updateEntity(teammate) { it.without<SkipDrawStepComponent>() }
+                continue
+            }
+            val teammateDrawCount = dispatcher.applyDrawAmountModifier(s, teammate, 1)
+            if (teammateDrawCount <= 0) continue
+            val r = drawCards(s, teammate, teammateDrawCount)
+            if (r.isPaused) {
+                return ExecutionResult.paused(r.newState, r.pendingDecision!!, teammateEvents + r.events)
+            }
+            s = r.newState
+            teammateEvents.addAll(r.events)
+        }
+
+        // Skip the active player's draw if a "skip your next draw step" marker is present (e.g.,
+        // Elfhame Sanctuary). Consume the marker so it only skips one draw step.
+        if (s.getEntity(activePlayer)?.has<SkipDrawStepComponent>() == true) {
+            val consumed = s.updateEntity(activePlayer) { it.without<SkipDrawStepComponent>() }
             return ExecutionResult.success(
                 consumed.withPriority(activePlayer),
-                listOf(StepChangedEvent(Step.DRAW))
+                teammateEvents + StepChangedEvent(Step.DRAW)
             )
         }
 
         // Apply ModifyDrawAmount replacements once at the draw-step's announcement
         // site (CR 121.2a) — e.g., Quantum Riddler's "draw that many cards plus one
         // instead" turns this step's draw of 1 into 2 while its restriction holds.
-        val drawCount = dispatcher.applyDrawAmountModifier(state, activePlayer, 1)
+        val drawCount = dispatcher.applyDrawAmountModifier(s, activePlayer, 1)
         if (drawCount <= 0) {
             return ExecutionResult.success(
-                state.withPriority(activePlayer),
-                listOf(StepChangedEvent(Step.DRAW))
+                s.withPriority(activePlayer),
+                teammateEvents + StepChangedEvent(Step.DRAW)
             )
         }
 
         // Ask "prompt on draw" abilities (e.g., Words of Wind) once up-front.
         // The draw loop runs with skipPromptOnDraw=true to avoid asking again.
-        val promptResult = checkPromptOnDraw(state, activePlayer, drawCount, isDrawStep = true)
+        val promptResult = checkPromptOnDraw(s, activePlayer, drawCount, isDrawStep = true)
         if (promptResult != null) {
-            return promptResult
+            return if (teammateEvents.isEmpty()) promptResult
+            else ExecutionResult.paused(promptResult.newState, promptResult.pendingDecision!!, teammateEvents + promptResult.events)
         }
 
-        val drawResult = drawCards(state, activePlayer, drawCount)
+        val drawResult = drawCards(s, activePlayer, drawCount)
         if (!drawResult.isSuccess) {
             return drawResult
         }
 
         val newState = drawResult.newState.withPriority(activePlayer)
-        return ExecutionResult.success(newState, drawResult.events + StepChangedEvent(Step.DRAW))
+        return ExecutionResult.success(newState, teammateEvents + drawResult.events + StepChangedEvent(Step.DRAW))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -126,13 +126,16 @@ class TurnManager(
             }
         }
 
-        // Increment the active player's turn-taken counter. CR 500.11 / 614.10a
-        // make a skipped turn "proceed past as though it didn't exist", so a
-        // skipped turn should not count — the increment lives here, downstream of
-        // the SkipNextTurn consumption path that decides whether a turn runs at all.
-        newState = newState.updateEntity(playerId) { container ->
-            val prev = container.get<PlayerTurnsTakenComponent>() ?: PlayerTurnsTakenComponent()
-            container.with(prev.increment())
+        // Increment the turn-taken counter for every player on the active team. CR 500.11 / 614.10a
+        // make a skipped turn "proceed past as though it didn't exist", so a skipped turn should not
+        // count — the increment lives here, downstream of the SkipNextTurn consumption path. In a
+        // shared team turn (CR 805.4) both teammates are taking the turn, so both counters advance;
+        // in a non-team game this is just the active player.
+        for (member in newState.teamActivePlayers(playerId)) {
+            newState = newState.updateEntity(member) { container ->
+                val prev = container.get<PlayerTurnsTakenComponent>() ?: PlayerTurnsTakenComponent()
+                container.with(prev.increment())
+            }
         }
 
         // Activate MustAttackPlayerComponent if present (Taunt effect)
@@ -447,19 +450,22 @@ class TurnManager(
         val currentPlayer = state.activePlayerId
             ?: return ExecutionResult.error(state, "No active player")
 
-        // Get next player
-        var nextPlayer = state.getNextPlayer(currentPlayer)
-
         // Clean up end-of-turn effects
         var cleanedState = cleanupPhaseManager.cleanupEndOfTurn(state)
 
-        // Check if the next player should skip their turn (e.g., Last Chance effect)
-        val nextPlayerEntity = cleanedState.getEntity(nextPlayer)
-        if (nextPlayerEntity?.has<SkipNextTurnComponent>() == true) {
-            cleanedState = cleanedState.updateEntity(nextPlayer) { container ->
-                container.without<SkipNextTurnComponent>()
+        // The turn passes to the next *team* (CR 805.4) — both teammates share one turn, so we
+        // advance past the whole active team, not to a teammate. In a non-team game getNextTeam is
+        // identical to getNextPlayer.
+        var nextPlayer = cleanedState.getNextTeam(currentPlayer)
+
+        // Team-wide skip (CR 805.8): if any member of the next team has a skip marker, the whole
+        // team skips its turn. Clear the marker from every member and move on to the team after.
+        val nextTeam = cleanedState.teamOf(nextPlayer)
+        if (nextTeam.any { cleanedState.getEntity(it)?.has<SkipNextTurnComponent>() == true }) {
+            for (member in nextTeam) {
+                cleanedState = cleanedState.updateEntity(member) { it.without<SkipNextTurnComponent>() }
             }
-            nextPlayer = cleanedState.getNextPlayer(nextPlayer)
+            nextPlayer = cleanedState.getNextTeam(nextPlayer)
         }
 
         // Start the new turn (sets step to UNTAP with no priority)
@@ -521,7 +527,7 @@ class TurnManager(
     fun canPlaySorcerySpeed(state: GameState, playerId: EntityId): Boolean {
         return state.step.allowsSorcerySpeed &&
             state.priorityPlayerId == playerId &&
-            state.activePlayerId == playerId &&
+            state.isActiveTurnFor(playerId) && // CR 805.5a — either teammate may act on the team's turn
             state.stack.isEmpty()
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -360,7 +360,7 @@ class TriggerDetector(
         for (entry in index.getEntitiesForCategory(TriggerCategory.STEP)) {
             for (ability in entry.abilities) {
                 if (ability.activeZone != Zone.BATTLEFIELD) continue
-                if (matcher.matchesStepTrigger(ability.trigger, step, entry.controllerId, activePlayerId)) {
+                if (matcher.matchesStepTrigger(ability.trigger, step, entry.controllerId, state)) {
                     triggers.add(
                         PendingTrigger(
                             ability = ability,
@@ -384,7 +384,7 @@ class TriggerDetector(
                     if (ability.activeZone != Zone.BATTLEFIELD) continue
                     val trigger = ability.trigger as? EventPattern.StepEvent ?: continue
                     if (step != trigger.step) continue
-                    if (matcher.matchesPlayerForStep(trigger.player, enchantedController, activePlayerId)) {
+                    if (matcher.matchesPlayerForStep(trigger.player, enchantedController, state)) {
                         triggers.add(
                             PendingTrigger(
                                 ability = ability,
@@ -413,7 +413,7 @@ class TriggerDetector(
                     val ownerId = cardComponent.ownerId
                         ?: container.get<OwnerComponent>()?.playerId
                         ?: continue
-                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, activePlayerId)) {
+                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, state)) {
                         triggers.add(
                             PendingTrigger(
                                 ability = ability,
@@ -441,7 +441,7 @@ class TriggerDetector(
                     val ownerId = cardComponent.ownerId
                         ?: container.get<OwnerComponent>()?.playerId
                         ?: continue
-                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, activePlayerId)) {
+                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, state)) {
                         triggers.add(
                             PendingTrigger(
                                 ability = ability,
@@ -460,7 +460,7 @@ class TriggerDetector(
         // (e.g., Dimensional Breach creates a permanent global upkeep trigger)
         for (global in state.globalGrantedTriggeredAbilities) {
             val ability = global.ability
-            if (matcher.matchesStepTrigger(ability.trigger, step, global.controllerId, activePlayerId)) {
+            if (matcher.matchesStepTrigger(ability.trigger, step, global.controllerId, state)) {
                 triggers.add(
                     PendingTrigger(
                         ability = ability,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1070,18 +1070,26 @@ class TriggerMatcher(
         trigger: EventPattern,
         step: Step,
         controllerId: EntityId,
-        activePlayerId: EntityId
+        state: GameState
     ): Boolean {
         if (trigger !is EventPattern.StepEvent) return false
         if (step != trigger.step) return false
-        return matchesPlayerForStep(trigger.player, controllerId, activePlayerId)
+        return matchesPlayerForStep(trigger.player, controllerId, state)
     }
 
-    fun matchesPlayerForStep(player: Player, controllerId: EntityId, activePlayerId: EntityId): Boolean {
+    /**
+     * Whether a step trigger owned by [controllerId] fires this step. "Your" step is the *team's*
+     * step in Two-Headed Giant (CR 805.4d): every member of the active team sees their own "at the
+     * beginning of your upkeep/draw/end step" trigger fire, and a nonactive player's "each opponent's
+     * step" trigger fires while the opposing team is active. In a non-team game this reduces to the
+     * ordinary active-player comparison. (The 805.4d per-opponent *multiplicity* nuance — firing once
+     * per opposing teammate — is not yet modelled; the trigger fires once.)
+     */
+    fun matchesPlayerForStep(player: Player, controllerId: EntityId, state: GameState): Boolean {
         return when (player) {
-            Player.You -> controllerId == activePlayerId
+            Player.You -> state.isActiveTurnFor(controllerId)
             Player.Each -> true
-            Player.EachOpponent -> controllerId != activePlayerId
+            Player.EachOpponent -> !state.isActiveTurnFor(controllerId)
             else -> true
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -170,13 +170,16 @@ class ConditionEvaluator(
             is Compare -> evaluateCompareCtx(state, condition, ctx)
             is Exists -> evaluateExistsCtx(state, condition, ctx)
 
-            is IsYourTurn -> ctx.controllerId?.let { state.activePlayerId == it } ?: false
-            is IsNotYourTurn -> ctx.controllerId?.let { state.activePlayerId != it } ?: false
+            // CR 805 — "your turn" is the active team's turn for every member of that team.
+            is IsYourTurn -> ctx.controllerId?.let { state.isActiveTurnFor(it) } ?: false
+            is IsNotYourTurn -> ctx.controllerId?.let { !state.isActiveTurnFor(it) } ?: false
 
             // Board-derived (current step + active player), so it works identically at resolution
             // and under projection — used as a ConditionalStaticAbility gate (Zurgo's end step).
             is IsInStep -> {
-                if (condition.yoursOnly && state.activePlayerId != ctx.controllerId) false
+                val cid = ctx.controllerId
+                val notYourTurn = cid == null || !state.isActiveTurnFor(cid)
+                if (condition.yoursOnly && notYourTurn) false
                 else state.step in condition.steps
             }
 
@@ -811,7 +814,7 @@ class ConditionEvaluator(
     }
 
     private fun evaluateIsInPhase(state: GameState, condition: IsInPhase, context: EffectContext): Boolean {
-        if (condition.yoursOnly && state.activePlayerId != context.controllerId) return false
+        if (condition.yoursOnly && !state.isActiveTurnFor(context.controllerId)) return false
         return state.phase in condition.phases
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1615,7 +1615,8 @@ class ActivateAbilityHandler(
         return when (restriction) {
             is ActivationRestriction.AnyPlayerMay -> null // Not a restriction; handled in validate()
             is ActivationRestriction.OnlyDuringYourTurn -> {
-                if (state.activePlayerId != playerId) "This ability can only be activated during your turn"
+                // CR 805.5a — "your turn" is the active team's turn in Two-Headed Giant.
+                if (!state.isActiveTurnFor(playerId)) "This ability can only be activated during your turn"
                 else null
             }
             is ActivationRestriction.BeforeStep -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -59,7 +59,7 @@ class PlotCardHandler(
             return "You don't have priority"
         }
         if (!state.step.isMainPhase || state.stack.isNotEmpty() ||
-            state.activePlayerId != action.playerId) {
+            !state.isActiveTurnFor(action.playerId)) {
             return "Plot can only be activated during your main phase while the stack is empty"
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -47,7 +47,7 @@ class SaddleMountHandler(
 
         // "Activate only as a sorcery" (CR 702.171a)
         if (!state.step.isMainPhase || state.stack.isNotEmpty() ||
-            state.activePlayerId != action.playerId
+            !state.isActiveTurnFor(action.playerId)
         ) {
             return "Saddle can only be activated during your main phase while the stack is empty"
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -55,7 +55,8 @@ class PlayLandHandler(
     override val actionType: KClass<PlayLand> = PlayLand::class
 
     override fun validate(state: GameState, action: PlayLand): String? {
-        if (state.activePlayerId != action.playerId) {
+        if (!state.isActiveTurnFor(action.playerId)) {
+            // CR 805.4c — each player on the active team may play a land on the team's turn.
             return "You can only play lands on your turn"
         }
         if (!state.step.isMainPhase) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
@@ -50,7 +50,7 @@ class UnlockRoomDoorHandler(
         if (state.priorityPlayerId != action.playerId) {
             return "You don't have priority"
         }
-        if (state.activePlayerId != action.playerId) {
+        if (!state.isActiveTurnFor(action.playerId)) {
             return "You can only unlock doors during your own turn"
         }
         if (!state.step.isMainPhase) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -163,7 +163,7 @@ class CastZoneResolver(
         if (!cardComponent.typeLine.isPermanent) return false
 
         // Only works on controller's turn
-        if (state.activePlayerId != playerId) return false
+        if (!state.isActiveTurnFor(playerId)) return false
 
         // Find a Muldrotha-like permanent with available permission for any of this card's types
         val permanentTypes = cardComponent.typeLine.cardTypes.filter { it.isPermanent }
@@ -194,7 +194,7 @@ class CastZoneResolver(
             val permDef = cardRegistry.getCard(permCard.cardDefinitionId) ?: continue
             for (sa in permDef.script.staticAbilities) {
                 if (sa !is MayCastFromGraveyard) continue
-                if (sa.duringYourTurnOnly && state.activePlayerId != playerId) continue
+                if (sa.duringYourTurnOnly && !state.isActiveTurnFor(playerId)) continue
                 if (predicateEvaluator.matches(
                         state, state.projectedState, cardId, sa.filter,
                         PredicateContext(controllerId = playerId)
@@ -475,7 +475,7 @@ class CastZoneResolver(
                 .filterIsInstance<GrantMayCastFromLinkedExile>()
                 .firstOrNull() ?: continue
 
-            if (grantAbility.duringYourTurnOnly && state.activePlayerId != playerId) continue
+            if (grantAbility.duringYourTurnOnly && !state.isActiveTurnFor(playerId)) continue
 
             if (grantAbility.ownedByYou && cardComponent.ownerId != playerId) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -69,9 +69,10 @@ class EnumerationContext(
         manaSolver.findAvailableManaSources(state, playerId)
     }
 
-    // Timing flags
+    // Timing flags. CR 805.5a — on a shared team turn either teammate may take sorcery-speed
+    // actions, so this is gated on the active *team*, not the single active player.
     val canPlaySorcerySpeed: Boolean by lazy {
-        state.step.isMainPhase && state.stack.isEmpty() && state.activePlayerId == playerId
+        state.step.isMainPhase && state.stack.isEmpty() && state.isActiveTurnFor(playerId)
     }
 
     // Land drop availability (accounts for static ability bonuses like GrantAdditionalLandDrop)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -592,7 +592,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 .firstOrNull() ?: continue
 
             // Timing restriction — e.g. Dawnhand Dissident's "during your turn"
-            if (grantAbility.duringYourTurnOnly && state.activePlayerId != playerId) continue
+            if (grantAbility.duringYourTurnOnly && !state.isActiveTurnFor(playerId)) continue
 
             // Once-per-turn restriction (Maralen, Fae Ascendant) — skip the granter entirely
             // once it's already been used this turn.
@@ -940,7 +940,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
         val playerId = context.playerId
 
         // Only the active player can use Muldrotha-style permissions
-        if (state.activePlayerId != playerId) return
+        if (!state.isActiveTurnFor(playerId)) return
 
         val graveyardCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
         for (cardId in graveyardCards) {
@@ -1471,7 +1471,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
         if (!playerEntity.has<MayCastCreaturesFromGraveyardWithForageComponent>()) return
 
         // Only the active player can cast creature spells (sorcery timing)
-        if (state.activePlayerId != playerId) return
+        if (!state.isActiveTurnFor(playerId)) return
 
         val graveyardCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
 
@@ -1608,7 +1608,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
         // Check timing restrictions
         for (permission in permissions) {
-            if (permission.duringYourTurnOnly && state.activePlayerId != playerId) continue
+            if (permission.duringYourTurnOnly && !state.isActiveTurnFor(playerId)) continue
             val lifeCost = permission.lifeCost
             val lifeSuffix = if (lifeCost > 0) " (pay $lifeCost life)" else ""
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -59,7 +59,7 @@ class CastPermissionUtils(
     ): Boolean {
         return when (restriction) {
             is ActivationRestriction.AnyPlayerMay -> true
-            is ActivationRestriction.OnlyDuringYourTurn -> state.activePlayerId == playerId
+            is ActivationRestriction.OnlyDuringYourTurn -> state.isActiveTurnFor(playerId)
             is ActivationRestriction.BeforeStep -> state.step.ordinal < restriction.step.ordinal
             is ActivationRestriction.DuringPhase -> state.phase == restriction.phase
             is ActivationRestriction.DuringStep -> state.step == restriction.step

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1256,7 +1256,7 @@ class ManaSolver(
         restriction: ActivationRestriction
     ): Boolean = when (restriction) {
         is ActivationRestriction.AnyPlayerMay -> true
-        is ActivationRestriction.OnlyDuringYourTurn -> state.activePlayerId == playerId
+        is ActivationRestriction.OnlyDuringYourTurn -> state.isActiveTurnFor(playerId)
         is ActivationRestriction.BeforeStep -> state.step.ordinal < restriction.step.ordinal
         is ActivationRestriction.DuringPhase -> state.phase == restriction.phase
         is ActivationRestriction.DuringStep -> state.step == restriction.step

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -524,6 +524,49 @@ data class GameState(
         }
 
     // =========================================================================
+    // Shared team turns (Two-Headed Giant — CR 805 / 810.2)
+    //
+    // A team takes ONE turn together (CR 805.4): both members untap and draw (805.4b), each may
+    // play a land (805.4c), and either may take sorcery-speed actions while it is the team's turn
+    // (805.5a — a player may act when their team has priority). The engine keeps a single
+    // [activePlayerId] (CR 805.9 — "active player" is one specific player), but turn *ownership* —
+    // "is it this player's turn?" — is a team question answered by [isActiveTurnFor]. Priority still
+    // cycles per player, so each teammate gets their own window and the phase advances only once
+    // everyone has passed; that already yields the shared-turn outcome.
+    // =========================================================================
+
+    /**
+     * True when it is [playerId]'s team's turn — i.e. [playerId] is on the active team. The
+     * team-aware replacement for `activePlayerId == playerId` at every turn-ownership / sorcery-speed
+     * gate. In a non-team game the active team is just the active player, so this reduces to equality.
+     */
+    fun isActiveTurnFor(playerId: EntityId): Boolean {
+        val active = activePlayerId ?: return false
+        return teamOf(active).contains(playerId)
+    }
+
+    /**
+     * The representative (first still-in member) of the team that takes its turn after [afterPlayer]'s
+     * team — the team-level analogue of [getNextPlayer]. Fully-eliminated teams are skipped. For a
+     * player with no team this is identical to [getNextPlayer]. Used by turn advancement so the turn
+     * passes to the next *team*, not to a teammate who shares the same turn (CR 805.4).
+     */
+    fun getNextTeam(afterPlayer: EntityId): EntityId {
+        val teamsList = teams
+        if (teamsList.isEmpty()) return afterPlayer
+        val curIdx = teamsList.indexOfFirst { afterPlayer in it }
+        val n = teamsList.size
+        for (step in 1..n) {
+            val team = teamsList[((curIdx + step) % n + n) % n]
+            val rep = team.firstOrNull {
+                getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
+            }
+            if (rep != null) return rep
+        }
+        return afterPlayer
+    }
+
+    // =========================================================================
     // Shared life total (Two-Headed Giant — CR 810.4 / 810.9)
     //
     // A team has ONE life total (CR 810.4); "if a cost or effect needs an individual player's life

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedTurnTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 4: shared team turns (CR 805 / 810.6).
+ *
+ * A team takes ONE turn together: both members untap and draw (805.4b), each may play a land
+ * (805.4c) and act at sorcery speed on the team's turn (805.5a), the turn passes team-by-team
+ * (805.4), and the starting team skips its first draw (810.6). Priority still cycles per player —
+ * that already gives each teammate a window — so this verifies turn *structure* and the
+ * turn-ownership gates, not the priority machinery.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order: p0,p1 = team 0 (starting);
+ * p2,p3 = team 1.
+ */
+class TwoHeadedGiantSharedTurnTest : FunSpec({
+
+    val forest = "Forest"
+
+    fun registry(): CardRegistry = CardRegistry().also { it.register(TestCards.all) }
+
+    fun boot(): Triple<GameState, List<EntityId>, ActionProcessor> {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of(forest to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return Triple(result.state, result.playerIds, ActionProcessor(registry()))
+    }
+
+    fun handSize(state: GameState, p: EntityId) = state.getZone(ZoneKey(p, Zone.HAND)).size
+
+    /** Pass priority (answering any discard decision) until [predicate] holds or the cap is hit. */
+    fun drive(start: GameState, proc: ActionProcessor, cap: Int = 400, predicate: (GameState) -> Boolean): GameState {
+        var state = start
+        var n = 0
+        while (!predicate(state)) {
+            check(++n < cap) { "drive never reached target (step=${state.step}, active=${state.activePlayerId})" }
+            val pending = state.pendingDecision
+            if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                val resp = com.wingedsheep.engine.core.CardsSelectedResponse(pending.id, pending.options.take(pending.minSelections))
+                state = proc.process(state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, resp)).result.newState
+                continue
+            }
+            val prio = state.priorityPlayerId ?: break
+            state = proc.process(state, PassPriority(prio)).result.newState
+        }
+        return state
+    }
+
+    test("isActiveTurnFor / getNextTeam know the team, not the individual") {
+        val (state, p, _) = boot()
+        state.isActiveTurnFor(p[0]) shouldBe true
+        state.isActiveTurnFor(p[1]) shouldBe true  // teammate of the active player
+        state.isActiveTurnFor(p[2]) shouldBe false
+        // The turn after team 0 belongs to team 1 (its first member), not to the teammate p1.
+        state.getNextTeam(p[0]) shouldBe p[2]
+        state.getNextTeam(p[2]) shouldBe p[0]
+    }
+
+    test("the starting team skips its first draw, but BOTH teammates draw on the next team's turn (CR 810.6 / 805.4b)") {
+        val (state, p, proc) = boot()
+        val openingP0 = handSize(state, p[0])
+        val openingP1 = handSize(state, p[1])
+        val openingP2 = handSize(state, p[2])
+        val openingP3 = handSize(state, p[3])
+
+        // Drive into team 1's precombat main (their full beginning phase has happened).
+        val atTeam1Main = drive(state, proc) {
+            it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN
+        }
+
+        // Starting team (0) skipped the first draw entirely — neither member ever drew on turn 1
+        // (hands only shrink, never grew; here they never played, so stay at opening size).
+        handSize(atTeam1Main, p[0]) shouldBe openingP0
+        handSize(atTeam1Main, p[1]) shouldBe openingP1
+        // Team 1 drew on their turn — BOTH members drew exactly one card (805.4b), no first-team skip.
+        handSize(atTeam1Main, p[2]) shouldBe openingP2 + 1
+        handSize(atTeam1Main, p[3]) shouldBe openingP3 + 1
+    }
+
+    test("the turn passes to the next TEAM, and both teammates' turn counters advance") {
+        val (state, p, proc) = boot()
+        // Team 0 starts; turn counter is 1 for both starting-team members at the game's first turn.
+        state.getEntity(p[0])!!.get<PlayerTurnsTakenComponent>()!!.count shouldBe 1
+
+        val atTeam1 = drive(state, proc) { it.activePlayerId == p[2] }
+        // The active player advanced to team 1's representative (p2), NOT to p0's teammate p1.
+        atTeam1.activePlayerId shouldBe p[2]
+        // Both team-1 members took the turn together (805.4): both counters incremented to 1.
+        atTeam1.getEntity(p[2])!!.get<PlayerTurnsTakenComponent>()!!.count shouldBe 1
+        atTeam1.getEntity(p[3])!!.get<PlayerTurnsTakenComponent>()!!.count shouldBe 1
+    }
+
+    test("the non-active teammate may play a land on the team's turn (CR 805.4c / 805.5a)") {
+        val (state, p, proc) = boot()
+        // Reach team 0's precombat main with the teammate (p1) holding priority: pass once from p0.
+        var s = drive(state, proc) { it.activePlayerId == p[0] && it.step == Step.PRECOMBAT_MAIN && it.priorityPlayerId == p[0] }
+        s = proc.process(s, PassPriority(p[0])).result.newState
+        s.priorityPlayerId shouldBe p[1] // priority cycled to the teammate
+
+        val forestInHand = s.getZone(ZoneKey(p[1], Zone.HAND)).first()
+        val landsBefore = s.getZone(ZoneKey(p[1], Zone.BATTLEFIELD)).size
+        val result = proc.process(s, PlayLand(p[1], forestInHand))
+        result.result.isSuccess shouldBe true
+        // The teammate's land resolved onto the battlefield even though they are not the active player.
+        result.result.newState.getZone(ZoneKey(p[1], Zone.BATTLEFIELD)).size shouldBe landsBefore + 1
+    }
+})


### PR DESCRIPTION
Phase 4 of **Two-Headed Giant** (CR 805 / 810.6): a team takes **one turn together**. Builds on Phases 1–3 (#751/#752/#757) — **based on `feat/2hg-phase3-team-winloss`**; retarget down the stack as each merges.

## Rules (CR 805 / 810.6)
- **805.4** — each *team* takes a turn (not each player); **805.4b** both members draw; **805.4c** each may play a land.
- **805.5a** — a player may take sorcery-speed actions while it is **their team's** turn.
- **810.6** — the starting team skips its first draw. **805.8** — extra turns / skips are team-wide.

## Design — keep per-player priority, make turn *ownership* a team question
Priority still cycles per player: each teammate already gets a window, so the phase only advances once everyone passes — that is exactly the shared-turn outcome, with no change to the priority state machine. A single `activePlayerId` stays (CR 805.9 — "active player" is one specific player), but **"is it your turn?"** becomes `GameState.isActiveTurnFor(p)` (your team is active), and every turn-ownership / sorcery-speed gate routes through it so the non-active teammate can act.

## Changes
- **`GameState`**: `isActiveTurnFor`, `getNextTeam` (turn advances to the next *team*).
- **`TurnManager`**: `endTurn` advances to the next team and skips a whole team (805.8); both teammates' turn counters increment.
- **`BeginningPhaseManager`**: both active-team members untap, phase in, and lose summoning sickness.
- **`DrawPhaseManager`**: both members draw; the first-draw skip unifies to "exactly two teams" — covers a 2-player game *and* 2HG, never a 3/4-player FFA.
- **Timing gates** routed through `isActiveTurnFor`: `canPlaySorcerySpeed` (EnumerationContext + TurnManager), `PlayLand`, `ActivateAbility`/`Plot`/`Saddle`/`UnlockRoom`/`Mana` "only during your turn", cast-from-zone `duringYourTurnOnly`, the `IsYourTurn`/`IsNotYourTurn`/`IsInStep`/`IsInPhase` conditions, and **step-trigger ownership** (`TriggerMatcher.matchesPlayerForStep` — each active-team member's "your upkeep/draw/end step" fires).
- `TakeExtraTurn` already composes with team-aware `getOpponents` + the team-wide `endTurn` skip.

## Tests
`TwoHeadedGiantSharedTurnTest` — `isActiveTurnFor`/`getNextTeam`; the starting team skips its first draw while **both** members of the next team draw; the turn passes team→team with both counters advancing; and the **non-active teammate plays a land on the team's turn**. Full `rules-engine` suite green; `game-server` + `ai` compile.

## Deferred (by design)
Combined combat → **Phase 5**. The CR 805.4d per-opponent step-trigger *multiplicity* nuance (an opponent's "each opponent's step" trigger firing once per opposing teammate) — fires once for now. Turn-order adjacency enforcement (CR 805.1) → lobby seating, Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)