### PR TITLE
Two-Headed Giant Phase 5: combined combat

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
@@ -25,7 +25,9 @@ class DeclareAttackersHandler(
     override val actionType: KClass<DeclareAttackers> = DeclareAttackers::class
 
     override fun validate(state: GameState, action: DeclareAttackers): String? {
-        if (state.activePlayerId != action.playerId) {
+        // CR 805.10a/b — the whole active team is the attacking team, so either teammate may make
+        // the team's one combined attack declaration.
+        if (!state.isActiveTurnFor(action.playerId)) {
             return "You can only declare attackers on your turn"
         }
         if (state.step != Step.DECLARE_ATTACKERS) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
@@ -26,7 +26,8 @@ class DeclareBlockersHandler(
     override val actionType: KClass<DeclareBlockers> = DeclareBlockers::class
 
     override fun validate(state: GameState, action: DeclareBlockers): String? {
-        if (state.activePlayerId == action.playerId) {
+        // CR 805.10a — the active team is the attacking team; no member of it blocks.
+        if (state.isActiveTurnFor(action.playerId)) {
             return "You cannot declare blockers on your turn"
         }
         if (state.step != Step.DECLARE_BLOCKERS) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CombatEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CombatEnumerator.kt
@@ -28,12 +28,12 @@ class CombatEnumerator : ActionEnumerator {
     fun isCombatDeclarationStep(context: EnumerationContext): Boolean {
         val state = context.state
         val playerId = context.playerId
-        if (state.step == Step.DECLARE_ATTACKERS && state.activePlayerId == playerId) {
+        if (state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(playerId)) {
             val attackersAlreadyDeclared = state.getEntity(playerId)
                 ?.get<AttackersDeclaredThisCombatComponent>() != null
             if (!attackersAlreadyDeclared) return true
         }
-        if (state.step == Step.DECLARE_BLOCKERS && state.activePlayerId != playerId) {
+        if (state.step == Step.DECLARE_BLOCKERS && !state.isActiveTurnFor(playerId)) {
             val blockersAlreadyDeclared = state.getEntity(playerId)
                 ?.get<BlockersDeclaredThisCombatComponent>() != null
             if (!blockersAlreadyDeclared &&
@@ -50,7 +50,7 @@ class CombatEnumerator : ActionEnumerator {
         val playerId = context.playerId
 
         // Declare attackers
-        if (state.step == Step.DECLARE_ATTACKERS && state.activePlayerId == playerId) {
+        if (state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(playerId)) {
             val attackersAlreadyDeclared = state.getEntity(playerId)
                 ?.get<AttackersDeclaredThisCombatComponent>() != null
             if (!attackersAlreadyDeclared) {
@@ -78,7 +78,7 @@ class CombatEnumerator : ActionEnumerator {
         }
 
         // Declare blockers — offered only to a defending player (one being attacked).
-        if (state.step == Step.DECLARE_BLOCKERS && state.activePlayerId != playerId &&
+        if (state.step == Step.DECLARE_BLOCKERS && !state.isActiveTurnFor(playerId) &&
             com.wingedsheep.engine.mechanics.combat.CombatDefenders.isDefendingPlayer(state, playerId)
         ) {
             val blockersAlreadyDeclared = state.getEntity(playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -67,7 +67,10 @@ internal class AttackPhaseManager(
     ): ExecutionResult {
         // Validate each attacker
         val projected = state.projectedState
-        val opponents = state.turnOrder.filter { it != attackingPlayer }
+        // CR 805.10a/b — a creature attacks the opposing team; never a teammate. Exclude the whole
+        // attacking team from legal player targets (in a non-team game this is just the attacker).
+        val attackingTeam = state.teamOf(attackingPlayer)
+        val opponents = state.turnOrder.filter { it !in attackingTeam }
 
         // Validate band declarations (CR 702.22c).
         val bandValidation = validateBands(state, attackers, bands, projected)
@@ -81,7 +84,7 @@ internal class AttackPhaseManager(
             }
             // Validate defender is either an opponent player or a planeswalker controlled by an opponent
             if (defenderId !in opponents) {
-                if (!projected.isPlaneswalker(defenderId) || projected.getController(defenderId) in listOf(attackingPlayer)) {
+                if (!projected.isPlaneswalker(defenderId) || projected.getController(defenderId) in attackingTeam) {
                     return ExecutionResult.error(state, "Invalid attack target: must be an opponent or their planeswalker")
                 }
                 if (defenderId !in state.getBattlefield()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -335,14 +335,15 @@ internal class BlockPhaseManager(
 
         // Check each attacker
         for (attackerId in attackerIds) {
-            // CR 509.1b: a creature can only block an attacker that is attacking its
-            // controller (or a planeswalker/battle its controller protects). In a
-            // multiplayer combat this stops a player from blocking an attack aimed at
-            // someone else.
+            // CR 509.1b / 805.10d: a creature can only block an attacker that is attacking its
+            // controller (or a planeswalker/battle its controller protects). In Two-Headed Giant
+            // the defending team blocks as one, so a creature may block an attacker aimed at any
+            // member of its team (teamActivePlayers is a singleton in a non-team game, preserving
+            // the plain multiplayer rule).
             val attacking = state.getEntity(attackerId)?.get<AttackingComponent>()
                 ?: return "${cardComponent.name} can't block: ${attackerId.value} isn't attacking"
             val attackedDefender = CombatDefenders.defendingPlayerOf(state, attacking.defenderId)
-            if (attackedDefender != blockingPlayer) {
+            if (attackedDefender !in state.teamActivePlayers(blockingPlayer)) {
                 return "${cardComponent.name} can't block a creature attacking another player"
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDefenders.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDefenders.kt
@@ -26,12 +26,16 @@ object CombatDefenders {
             state.getEntity(defenderId)?.get<ControllerComponent>()?.playerId ?: defenderId
         }
 
-    /** Every distinct player who has at least one creature attacking them or their
-     *  planeswalkers in the current combat. */
+    /** Every distinct defending player in the current combat: anyone who has a creature attacking
+     *  them (or their planeswalkers/battles) — and, in Two-Headed Giant, their whole team (CR
+     *  805.10a: every member of the nonactive team is a defending player, so an un-attacked teammate
+     *  may still declare blockers to protect the team). In a non-team game `teamOf` is a singleton,
+     *  so this is unchanged. */
     fun defendingPlayers(state: GameState): Set<EntityId> =
         state.getBattlefield()
             .mapNotNull { state.getEntity(it)?.get<AttackingComponent>()?.defenderId }
             .map { defendingPlayerOf(state, it) }
+            .flatMap { state.teamOf(it) }
             .toSet()
 
     /** True if [playerId] is a defending player in the current combat. */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -41,8 +41,10 @@ class MustBeCreatureAttackRule : AttackRestrictionRule {
  */
 class ControlledByAttackerRule : AttackRestrictionRule {
     override fun check(ctx: AttackCheckContext): String? {
+        // CR 805.10b — the attacking team's combined attack may include creatures controlled by any
+        // active-team member, so accept control by any teammate (not just the declaring player).
         val controller = ctx.projected.getController(ctx.attackerId)
-        if (controller != ctx.attackingPlayer) {
+        if (controller == null || controller !in ctx.state.teamOf(ctx.attackingPlayer)) {
             val name = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
             return "You don't control $name"
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.mechanics.combat.CombatDefenders
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 5: combined combat (CR 805.10).
+ *
+ * The active team is the attacking team and the nonactive team the defending team (805.10a). The
+ * active team makes one combined attack whose creatures may be controlled by either teammate, each
+ * aimed at an opposing-team player (805.10b); a creature never attacks a teammate. The defending
+ * team makes one combined block in which a creature controlled by either defender may block any
+ * attacker aimed at any member of that team (805.10d). Damage applies to the shared team total.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order: p0,p1 = team 0 (active);
+ * p2,p3 = team 1 (defending).
+ */
+class TwoHeadedGiantCombatTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Combat Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun registry() = CardRegistry().also { it.register(bear) }
+
+    fun init2hg(): Pair<GameState, List<EntityId>> {
+        val deck = Deck(cards = List(40) { bear.name })
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", deck) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    /** Put a 2/2 bear on [owner]'s battlefield (untapped, not summoning sick). If [attacking] is
+     *  set, it enters already declared as an attacker against that defender. */
+    fun GameState.withBear(owner: EntityId, attacking: EntityId? = null): Pair<GameState, EntityId> {
+        val id = EntityId.generate()
+        var container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = bear.name,
+                name = bear.name,
+                manaCost = bear.manaCost,
+                typeLine = bear.typeLine,
+                baseStats = bear.creatureStats,
+                ownerId = owner
+            ),
+            OwnerComponent(owner),
+            ControllerComponent(owner)
+        )
+        if (attacking != null) container = container.with(AttackingComponent(defenderId = attacking))
+        val next = withEntity(id, container).addToZone(ZoneKey(owner, Zone.BATTLEFIELD), id)
+        return next to id
+    }
+
+    test("a creature attacks the opposing team, never a teammate (CR 805.10b)") {
+        val (base, p) = init2hg()
+        val (s1, atk) = base.withBear(p[0])
+        val state = s1.copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT).withPriority(p[0])
+        val proc = ActionProcessor(registry())
+
+        // Attacking the teammate (p1) is illegal.
+        proc.process(state, DeclareAttackers(p[0], mapOf(atk to p[1]))).result.isSuccess.shouldBeFalse()
+        // Attacking an opposing-team player (p2) is legal.
+        proc.process(state, DeclareAttackers(p[0], mapOf(atk to p[2]))).result.isSuccess.shouldBeTrue()
+    }
+
+    test("the combined attack may include creatures controlled by BOTH active-team members (CR 805.10b)") {
+        val (base, p) = init2hg()
+        val (s1, atk0) = base.withBear(p[0])
+        val (s2, atk1) = s1.withBear(p[1]) // the teammate's creature
+        val state = s2.copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT).withPriority(p[0])
+        val proc = ActionProcessor(registry())
+
+        // The active player declares one combined attack including the teammate's creature.
+        val result = proc.process(
+            state, DeclareAttackers(p[0], mapOf(atk0 to p[2], atk1 to p[3]))
+        ).result
+        result.isSuccess.shouldBeTrue()
+        result.newState.getEntity(atk1)!!.get<AttackingComponent>()!!.defenderId shouldBe p[3]
+    }
+
+    test("the whole nonactive team defends — even an un-attacked teammate is a defending player (CR 805.10a)") {
+        val (base, p) = init2hg()
+        val (state, _) = base.withBear(p[0], attacking = p[2]) // p0 attacks p2 only
+        // Both members of team 1 are defending players, including the un-attacked p3.
+        CombatDefenders.defendingPlayers(state) shouldBe setOf(p[2], p[3])
+        CombatDefenders.isDefendingPlayer(state, p[3]).shouldBeTrue()
+        // Nobody on the attacking team is a defender.
+        CombatDefenders.isDefendingPlayer(state, p[1]).shouldBeFalse()
+    }
+
+    test("a defending creature may block an attacker aimed at its TEAMMATE (CR 805.10d)") {
+        val (base, p) = init2hg()
+        val (s1, atk) = base.withBear(p[0], attacking = p[2]) // p0's attacker aimed at p2
+        val (s2, blkP3) = s1.withBear(p[3])                   // blocker controlled by p3 (p2's teammate)
+        var state = s2.updateEntity(p[0]) { it.with(AttackersDeclaredThisCombatComponent) }
+        state = state.copy(step = Step.DECLARE_BLOCKERS, phase = Phase.COMBAT).withPriority(p[3])
+        val proc = ActionProcessor(registry())
+
+        // p3 blocks an attacker that is attacking p2 — legal in 2HG (would be illegal in FFA, 509.1b).
+        val result = proc.process(state, DeclareBlockers(p[3], mapOf(blkP3 to listOf(atk)))).result
+        result.isSuccess.shouldBeTrue()
+    }
+
+    test("a member of the attacking team cannot declare blockers (CR 805.10a)") {
+        val (base, p) = init2hg()
+        val (s1, atk) = base.withBear(p[0], attacking = p[2]) // team 0 (active) attacks p2
+        val (s2, blkP1) = s1.withBear(p[1])                   // p1 is on the active (attacking) team
+        var state = s2.updateEntity(p[0]) { it.with(AttackersDeclaredThisCombatComponent) }
+        state = state.copy(step = Step.DECLARE_BLOCKERS, phase = Phase.COMBAT).withPriority(p[1])
+        val proc = ActionProcessor(registry())
+
+        // p1 is on the attacking team, so it may not block (the active team never blocks).
+        proc.process(state, DeclareBlockers(p[1], mapOf(blkP1 to listOf(atk)))).result.isSuccess.shouldBeFalse()
+    }
+})


### PR DESCRIPTION
Phase 5 of **Two-Headed Giant** (CR 805.10): the active team attacks as one, the defending team blocks as one. Builds on Phases 1–4 (#751/#752/#757/#759) — **based on `feat/2hg-phase4-shared-turns`**; retarget down the stack as each merges.

## Rules (CR 805.10)
- **805.10a** — the active team is the *attacking team*; the nonactive team is the *defending team*, and **every** member of it is a defending player.
- **805.10b** — one combined attack; its creatures may be controlled by **either** active-team member, each aimed at an opposing-team player (never a teammate).
- **805.10d** — one combined block; a creature controlled by **either** defender may block **any** attacker aimed at **any** member of that team.

## Changes (all degrade to plain multiplayer in a non-team game — `teamOf` is a singleton)
- `DeclareAttackersHandler` / `DeclareBlockersHandler` gates use `isActiveTurnFor` — either active-team member may declare the attack; no active-team member blocks.
- `ControlledByAttackerRule` accepts an attacker controlled by **any** active-team member (combined attack).
- `AttackPhaseManager` excludes the **whole** attacking team from legal player/planeswalker targets.
- **`CombatDefenders.defendingPlayers` expands to the whole defending team** — an un-attacked teammate is still a defending player who may block (the key 805.10a seam).
- `BlockPhaseManager`'s CR 509.1b check allows blocking an attacker aimed at **any member of the blocker's team**.
- `CombatEnumerator` attacker/blocker gates use `isActiveTurnFor`.

Block-step sequencing and `PassPriorityHandler` need **no** changes — they compose via the now-team-aware `defendingPlayers`/`isDefendingPlayer` (both defenders declare, then the step advances). Combat damage already lands on the shared team life total (Phase 2).

## Tests
`TwoHeadedGiantCombatTest` — can't attack a teammate; combined attack including both members' creatures; the whole nonactive team defends (incl. an un-attacked teammate); **a defender blocks an attacker aimed at its teammate**; an attacking-team member can't block. Full `rules-engine` suite green; `game-server` + `ai` compile.

## Deferred (by design)
Team-aware `getValidAttackers`/`getValidBlockers` enumeration **hints** (UI only) → Phase 7. The 805.10f/g damage-assignment-order team choices use the existing per-creature flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)