### PR TITLE
Stop the AI mulliganing every Momir Basic opening hand

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.view.ClientGameState
 import com.wingedsheep.engine.view.LegalActionInfo
+import com.wingedsheep.sdk.core.Format
 import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
 
@@ -78,6 +79,13 @@ class EngineAiPlayerController(
     }
 
     override fun decideMulligan(mulliganMessage: MulliganInfo): Boolean {
+        // Momir Basic: every deck is 60 basic lands and the avatar's only cost is generic {X}, so
+        // every opening hand is interchangeable — a mulligan can only shrink the hand (the London
+        // mulligan bottoms a card each time) without ever improving it. Always keep. Without this,
+        // the generic "6-7 lands is a flood → mulligan" heuristic below mulligans every all-lands
+        // Momir hand down to the forced keep at mulliganCount >= 2, leaving the AI on a 5-card hand.
+        if (gameStateProvider()?.format is Format.MomirBasic) return true
+
         val handSize = mulliganMessage.hand.size
         val mulliganCount = mulliganMessage.mulliganCount
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/EngineAiMomirMulliganTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/EngineAiMomirMulliganTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.ai.llm.CardSummary
+import com.wingedsheep.ai.llm.MulliganInfo
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+
+/**
+ * Momir Basic decks are 60 basic lands and the avatar's only cost is generic {X}, so every opening
+ * hand is interchangeable — a mulligan can only shrink the hand without improving it. The engine
+ * AI's generic "6-7 lands is a flood → mulligan" heuristic would otherwise mulligan every all-lands
+ * Momir hand down to the forced keep at mulliganCount >= 2, leaving the AI on a 5-card hand every
+ * game. These tests pin that the format short-circuit keeps, while the flood heuristic is untouched
+ * outside Momir.
+ */
+class EngineAiMomirMulliganTest : ScenarioTestBase() {
+
+    // The avatar + pool creatures live outside MtgSetCatalog, so build the registry the way the
+    // other engine-AI tests do (TestCards bundles the avatar + basics).
+    private val aiRegistry: CardRegistry = CardRegistry().apply {
+        register(TestCards.all)
+        register(PredefinedTokens.allTokens)
+    }
+
+    /** A fresh opening hand of seven basic lands — the only kind of hand a Momir deck can produce. */
+    private fun sevenBasicLandHand(): MulliganInfo {
+        val ids = (1..7).map { EntityId.of("land-$it") }
+        val cards = ids.associateWith { CardSummary(name = "Forest", typeLine = "Basic Land — Forest") }
+        return MulliganInfo(hand = ids, mulliganCount = 0, cardsToPutOnBottom = 0, cards = cards)
+    }
+
+    init {
+        test("engine AI keeps an all-lands opening hand in Momir Basic") {
+            val game = scenario().withPlayers().withFormat(Format.MomirBasic()).build()
+            val controller = EngineAiPlayerController(aiRegistry, game.player1Id) { game.state }
+
+            controller.decideMulligan(sevenBasicLandHand()) shouldBe true
+        }
+
+        test("engine AI still mulligans a 7-land flood outside Momir Basic") {
+            // Standard format: a seven-land opener is a genuine flood, so the heuristic mulligans.
+            val game = scenario().withPlayers().build()
+            val controller = EngineAiPlayerController(aiRegistry, game.player1Id) { game.state }
+
+            controller.decideMulligan(sevenBasicLandHand()) shouldBe false
+        }
+    }
+}


### PR DESCRIPTION
## Problem

In Momir Basic the AI opponent mulligans **every** opening hand and starts on a 5-card hand.

Momir Basic decks are 60 basic lands and the Vanguard avatar's only cost is generic `{X}`, so every opening hand is interchangeable — a mulligan can only shrink the hand (the London mulligan bottoms a card each time) without ever improving it.

The engine AI's `decideMulligan` keeps only when `landCount in 2..5`. A Momir opener is always 7 basic lands (`landCount = 7`), so it falls through to `MULLIGAN` every time, then force-keeps at `mulliganCount >= 2` — leaving the AI on a 5-card all-lands hand each game.

## Fix

Short-circuit `EngineAiPlayerController.decideMulligan` to always keep when `gameStateProvider()?.format is Format.MomirBasic`. The decision is read from the real `GameState` the controller already has access to, so no protocol/DTO changes are needed.

The generic flood heuristic is untouched for every other format.

### Scope note
The LLM controller asks the model directly and isn't covered here; it's a dev-only path (requires an API key) and its failure fallback already routes to the now-fixed engine AI. The reported default path is the engine AI.

## Test

`EngineAiMomirMulliganTest`:
- engine AI **keeps** an all-lands opening hand in Momir Basic
- engine AI **still mulligans** a 7-land flood outside Momir Basic (heuristic intact)

Both pass; existing `MomirBasicAiTest` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)