### PR TITLE
Make custom formats a distinct either/or choice in the Quick Game lobby

### DIFF
--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1099,6 +1099,135 @@
   font-weight: 700;
 }
 
+/* =========================================================================
+ * Custom formats (Momir Basic, …)
+ * Elevated out of the constructed-format dropdown into their own section so a
+ * non-deckbuilding game mode reads as something distinct from a deck-pool
+ * restriction. Each mode is a selectable card with an icon + one-line pitch.
+ * ========================================================================= */
+/* One either/or group: constructed dropdown on top, "or" divider, custom-mode cards below. */
+.formatSelector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.formatSelector:last-child {
+  border-bottom: none;
+}
+
+.formatSelectorTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* While a custom format is active the constructed dropdown is inert — dim it so only one side reads as live. */
+.formatDropdownInactive {
+  opacity: 0.45;
+}
+
+/* "— or pick a custom format —": makes the constructed/custom choice read as mutually exclusive. */
+.formatOrDivider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 2px 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-disabled);
+}
+
+.formatOrDivider::before,
+.formatOrDivider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+
+.customFormatCards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.customFormatCard {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1 1 240px;
+  min-width: 220px;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  background: linear-gradient(135deg, rgba(111, 211, 192, 0.06), transparent 72%);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s, transform 0.1s;
+}
+
+.customFormatCard:hover:not(:disabled) {
+  border-color: var(--accent-teal, #6fd3c0);
+  transform: translateY(-1px);
+}
+
+.customFormatCard:disabled {
+  cursor: default;
+}
+
+.customFormatCardActive {
+  border-color: var(--accent-teal, #6fd3c0);
+  background: linear-gradient(135deg, rgba(111, 211, 192, 0.2), rgba(111, 211, 192, 0.04));
+  box-shadow: 0 0 0 1px rgba(111, 211, 192, 0.4), 0 4px 16px rgba(111, 211, 192, 0.14);
+}
+
+.customFormatIcon {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  background-color: var(--accent-teal, #6fd3c0);
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  opacity: 0.9;
+}
+
+.customFormatText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.customFormatName {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.customFormatCheck {
+  font-size: var(--font-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  color: var(--accent-teal, #6fd3c0);
+}
+
+.customFormatDesc {
+  font-size: var(--font-xs);
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
 .settingsButtons {
   display: flex;
   gap: var(--space-1);

--- a/web-client/src/components/ui/QuickGameLobbyOverlay.tsx
+++ b/web-client/src/components/ui/QuickGameLobbyOverlay.tsx
@@ -190,13 +190,13 @@ export function QuickGameLobbyOverlay() {
                 </button>
               </div>
             </div>
-            <FormatRow isMomir={isMomir} format={lobby.format ?? null} isHost={isHost} onChange={setFormat} />
+            <FormatSelector isMomir={isMomir} format={lobby.format ?? null} isHost={isHost} onChange={setFormat} />
           </div>
         )}
 
         {lobby.vsAi && (
           <div className={styles.settingsPanel}>
-            <FormatRow isMomir={isMomir} format={lobby.format ?? null} isHost={isHost} onChange={setFormat} />
+            <FormatSelector isMomir={isMomir} format={lobby.format ?? null} isHost={isHost} onChange={setFormat} />
           </div>
         )}
 
@@ -259,16 +259,40 @@ export function QuickGameLobbyOverlay() {
   )
 }
 
-/** Sentinel dropdown value for the Momir Basic custom format (not a real {@link DeckFormat}). */
+/** Sentinel key for the Momir Basic custom format (not a real {@link DeckFormat}). */
 const MOMIR_FORMAT_VALUE = 'MOMIR'
 
 /**
- * Lobby format selector. Constructed deck-formats restrict submitted decks; the "Custom formats"
- * group holds non-deckbuilding modes — currently just Momir Basic, which flips the lobby into the
- * Vanguard format (fixed 60 basics, avatar in the command zone, creatures rolled from all sets).
- * Host-only; the opponent sees it read-only.
+ * Non-deckbuilding game modes, surfaced as their own elevated section (see {@link CustomFormatSection})
+ * rather than buried among constructed formats in the dropdown. Currently just Momir Basic — fixed
+ * 60-basic decks, the avatar in the command zone, creatures rolled from every set.
+ *
+ * NOTE: the lobby's format channel is `(format, momirBasic)` where `momirBasic` is Momir-specific.
+ * Adding a second custom mode here means widening that contract (e.g. a custom-format key) so this
+ * section can tell the modes apart — today the toggle simply maps to the `momirBasic` flag.
  */
-function FormatRow({
+const CUSTOM_FORMATS: ReadonlyArray<{ key: string; name: string; desc: string; icon: string }> = [
+  {
+    key: MOMIR_FORMAT_VALUE,
+    name: 'Momir Basic',
+    desc: 'No deckbuilding — everyone runs 60 basics. Discard a card and pay {X} to flip a random creature with mana value X.',
+    icon: momirVigUrl,
+  },
+]
+
+/**
+ * Lobby format picker — a single either/or choice, not two stacked settings.
+ *
+ * The top row restricts submitted decks to a *constructed* format ("No restriction" = anything);
+ * below an explicit "or" divider, the *custom* (non-deckbuilding) modes appear as selectable cards.
+ * The two are mutually exclusive server-side, so we make that visible: while a custom mode is
+ * active the constructed dropdown is disabled (and reads "No restriction", since the server clears
+ * `format`), and selecting a constructed format leaves every custom card unselected. Exactly one
+ * side is ever live. Toggle a custom card off to return to no restriction and re-enable the dropdown.
+ *
+ * Host-only; the opponent sees both halves read-only.
+ */
+function FormatSelector({
   isMomir,
   format,
   isHost,
@@ -279,33 +303,76 @@ function FormatRow({
   isHost: boolean
   onChange: (format: DeckFormat | null, momirBasic: boolean) => void
 }) {
-  const value = isMomir ? MOMIR_FORMAT_VALUE : (format ?? '')
+  const dropdownValue = isMomir ? '' : (format ?? '')
+  const dropdownDisabled = !isHost || isMomir
   return (
-    <div className={styles.settingsRow}>
-      <span className={styles.settingsLabel}>Format</span>
-      <select
-        value={value}
-        onChange={(e) => {
-          if (!isHost) return
-          const v = e.target.value
-          if (v === MOMIR_FORMAT_VALUE) onChange(null, true)
-          else onChange(v ? (v as DeckFormat) : null, false)
-        }}
-        disabled={!isHost}
-        title={isHost ? 'Restrict decks to a constructed format, or pick a custom format. None = no restriction.' : 'Only the host can change the format'}
-        className={styles.settingsButton}
-        style={{ minWidth: 160 }}
-      >
-        <option value="">No restriction</option>
-        <optgroup label="Custom formats">
-          <option value={MOMIR_FORMAT_VALUE}>Momir Basic</option>
-        </optgroup>
-        <optgroup label="Constructed">
-          {FORMAT_OPTIONS.map((f) => (
-            <option key={f.value} value={f.value}>{f.label}</option>
-          ))}
-        </optgroup>
-      </select>
+    <div className={styles.formatSelector}>
+      <div className={styles.formatSelectorTop}>
+        <span className={styles.settingsLabel}>Format</span>
+        <select
+          value={dropdownValue}
+          onChange={(e) => {
+            if (!isHost) return
+            const v = e.target.value
+            onChange(v ? (v as DeckFormat) : null, false)
+          }}
+          disabled={dropdownDisabled}
+          title={
+            isMomir
+              ? 'A custom format is active — turn it off below to restrict by a constructed format.'
+              : isHost
+                ? 'Restrict submitted decks to a constructed format. None = no restriction.'
+                : 'Only the host can change the format'
+          }
+          className={`${styles.settingsButton} ${isMomir ? styles.formatDropdownInactive : ''}`}
+          style={{ minWidth: 160 }}
+        >
+          <option value="">No restriction</option>
+          <optgroup label="Constructed">
+            {FORMAT_OPTIONS.map((f) => (
+              <option key={f.value} value={f.value}>{f.label}</option>
+            ))}
+          </optgroup>
+        </select>
+      </div>
+
+      <div className={styles.formatOrDivider}>or pick a custom format</div>
+
+      <div className={styles.customFormatCards}>
+        {CUSTOM_FORMATS.map((cf) => {
+          // With a single Momir-only contract, "active" == the Momir flag.
+          const active = cf.key === MOMIR_FORMAT_VALUE && isMomir
+          return (
+            <button
+              key={cf.key}
+              type="button"
+              disabled={!isHost}
+              aria-pressed={active}
+              onClick={() => {
+                if (!isHost) return
+                // Toggle: re-clicking the active mode drops back to no restriction.
+                onChange(null, !active)
+              }}
+              className={`${styles.customFormatCard} ${active ? styles.customFormatCardActive : ''}`}
+              title={isHost ? '' : 'Only the host can change the format'}
+              data-testid={`custom-format-${cf.key.toLowerCase()}`}
+            >
+              <span
+                aria-hidden
+                className={styles.customFormatIcon}
+                style={{ WebkitMaskImage: `url(${cf.icon})`, maskImage: `url(${cf.icon})` }}
+              />
+              <span className={styles.customFormatText}>
+                <span className={styles.customFormatName}>
+                  {cf.name}
+                  {active && <span className={styles.customFormatCheck}>✓ Selected</span>}
+                </span>
+                <span className={styles.customFormatDesc}>{cf.desc}</span>
+              </span>
+            </button>
+          )
+        })}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

In the Quick Game lobby, Momir Basic was buried as a single `<option>` inside the Format dropdown's `Custom formats` optgroup. A non-deckbuilding game mode looked identical to a constructed deck restriction, and (after a first pass that elevated it into its own section) showing the dropdown and the custom cards side-by-side read as though you could combine a custom format *with* a constructed format.

## Change

Merged both controls into one `FormatSelector` that frames the choice as **mutually exclusive**:

- Constructed-format dropdown on top ("No restriction" or Standard/Modern/…).
- An explicit **"— or pick a custom format —"** divider.
- Custom modes as selectable cards (avatar icon + one-line pitch, teal "✓ Selected" glow).

Mutual exclusivity is now visible: while a custom format is active the constructed dropdown is **disabled and dimmed**, so exactly one side is ever live. Toggling the custom card off re-enables the dropdown.

Custom modes now live in a `CUSTOM_FORMATS` data array for easy extension (currently just Momir Basic).

No backend changes — the existing `(format, momirBasic)` lobby channel already enforced mutual exclusivity server-side.

## Files

- `web-client/src/components/ui/QuickGameLobbyOverlay.tsx` — `FormatRow` + `CustomFormatSection` collapsed into one `FormatSelector`.
- `web-client/src/components/ui/GameUI.module.css` — new `.formatSelector` / `.formatSelectorTop` / `.formatOrDivider` / `.formatDropdownInactive` + custom-card styles.

## Verification

`npm run typecheck` passes; drove the running stack with Playwright through the lobby and confirmed both states (dropdown active + cards unselected; dropdown dimmed/disabled + Momir card selected) round-trip correctly over the WebSocket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)