### PR TITLE
Two-Headed Giant Phase 6: server sessions, masking & lobby

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/QuickGameController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/QuickGameController.kt
@@ -48,7 +48,8 @@ class QuickGameController(
                 PublicQuickGameDTO(
                     lobbyId = lobby.lobbyId,
                     playerCount = lobby.players.count { !it.isAi },
-                    maxPlayers = QuickGameLobby.MAX_PLAYERS,
+                    // Reflects the lobby's actual seat count: 4 for Two-Headed Giant, else 2.
+                    maxPlayers = lobby.maxPlayers,
                     setCode = lobby.setCode ?: host?.setCode,
                     hostName = host?.playerName,
                     format = lobby.format?.name

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -159,6 +159,16 @@ class QuickGameLobbyHandler(
             sender.sendError(session, ErrorCode.INVALID_ACTION, "AI opponent is not enabled on this server")
             return
         }
+        // Two-Headed Giant is four human seats; the built-in AI is not team-aware yet (Phase 8),
+        // and 2HG (a rules format) is orthogonal to Momir Basic.
+        if (message.twoHeadedGiant && message.vsAi) {
+            sender.sendError(session, ErrorCode.INVALID_ACTION, "Two-Headed Giant does not support AI opponents yet")
+            return
+        }
+        if (message.twoHeadedGiant && message.momirBasic) {
+            sender.sendError(session, ErrorCode.INVALID_ACTION, "Two-Headed Giant and Momir Basic cannot be combined")
+            return
+        }
 
         val lobby = QuickGameLobby(
             vsAi = message.vsAi,
@@ -168,6 +178,7 @@ class QuickGameLobbyHandler(
             // Momir Basic has no deck-construction restriction; the two flags are mutually exclusive.
             format = if (message.momirBasic) null else message.format,
             momirBasic = message.momirBasic,
+            twoHeadedGiant = message.twoHeadedGiant,
         )
         lobby.players += QuickGameLobbyPlayer(
             playerId = playerSession.playerId,
@@ -380,12 +391,20 @@ class QuickGameLobbyHandler(
             useHandSmoother = gameProperties.handSmoother.enabled,
             debugMode = gameProperties.debugMode,
             printingRegistry = printingRegistry,
+            // Four seats for Two-Headed Giant (CR 810), two otherwise.
+            maxPlayers = lobby.maxPlayers,
         )
         // Commander-shape formats (Commander / Brawl / Standard Brawl) run on the engine's 1v1
         // Commander rules. Other formats fall through to Standard. Brawl-specific tweaks
         // (60 cards, alternative life total) are Phase 4 territory — Phase 1 covers Commander.
         if (lobby.format?.isCommanderShape == true) {
             gameSession.engineFormat = com.wingedsheep.sdk.core.Format.Commander()
+        }
+        // Two-Headed Giant: run under the team format and forward the seat→team partition. The
+        // engine stamps TeamComponent and sets up shared life / turns / combat (Phases 1–5).
+        if (lobby.twoHeadedGiant) {
+            gameSession.engineFormat = com.wingedsheep.sdk.core.Format.TwoHeadedGiant()
+            gameSession.teams = lobby.teamAssignment()
         }
         // Each player can pick their own set for a Random pool. For a vs-AI lobby the AI mirrors
         // the (single) human's set so both sides play the same set. Resolve that set ONCE here —
@@ -503,12 +522,14 @@ class QuickGameLobbyHandler(
             lobbyId = lobby.lobbyId,
             vsAi = lobby.vsAi,
             setCode = lobby.setCode,
-            players = lobby.players.map { it.toView(lobby) },
+            players = lobby.players.mapIndexed { i, p -> p.toView(lobby, i) },
             youPlayerId = playerId,
             canStart = lobby.allReady(),
             isPublic = lobby.isPublic,
             format = lobby.format,
             momirBasic = lobby.momirBasic,
+            twoHeadedGiant = lobby.twoHeadedGiant,
+            maxPlayers = lobby.maxPlayers,
         )
         sender.send(session, msg)
     }
@@ -535,12 +556,14 @@ class QuickGameLobbyHandler(
                 lobbyId = lobby.lobbyId,
                 vsAi = lobby.vsAi,
                 setCode = lobby.setCode,
-                players = lobby.players.map { it.toView(lobby) },
+                players = lobby.players.mapIndexed { i, p -> p.toView(lobby, i) },
                 youPlayerId = player.playerId,
                 canStart = lobby.allReady(),
                 isPublic = lobby.isPublic,
                 format = lobby.format,
                 momirBasic = lobby.momirBasic,
+                twoHeadedGiant = lobby.twoHeadedGiant,
+                maxPlayers = lobby.maxPlayers,
             )
             sender.send(ws, msg)
         }
@@ -573,7 +596,7 @@ class QuickGameLobbyHandler(
         }
     }
 
-    private fun QuickGameLobbyPlayer.toView(lobby: QuickGameLobby): ServerMessage.QuickGameLobbyPlayerView {
+    private fun QuickGameLobbyPlayer.toView(lobby: QuickGameLobby, seatIndex: Int): ServerMessage.QuickGameLobbyPlayerView {
         val total = deckList?.values?.sum() ?: 0
         // Momir Basic has no deckbuilding: every seat plays the fixed 60 basics, so it always counts
         // as "deck selected" and shows a fixed label rather than the deck-picker states.
@@ -591,7 +614,8 @@ class QuickGameLobbyHandler(
             deckSelected = lobby.momirBasic || deckList != null,
             deckCardCount = if (lobby.momirBasic) MomirBasicSetup.COPIES_PER_BASIC * MomirBasicSetup.BASIC_LAND_NAMES.size else total,
             deckLabel = label,
-            setCode = setCode
+            setCode = setCode,
+            teamIndex = lobby.teamIndexOf(seatIndex),
         )
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
@@ -41,21 +41,43 @@ class QuickGameLobby(
      * scopes the random creature pool. Fixed at creation. Mutually exclusive with [format].
      */
     val momirBasic: Boolean = false,
+    /**
+     * When true this is a Two-Headed Giant lobby (CR 810): four seats forming two teams of two
+     * (join order 0+1 vs 2+3), played under [com.wingedsheep.sdk.core.Format.TwoHeadedGiant].
+     * Fixed at creation. Human-only (the built-in AI is not team-aware yet — Phase 8).
+     */
+    val twoHeadedGiant: Boolean = false,
 ) {
     val players: MutableList<QuickGameLobbyPlayer> = mutableListOf()
 
     @Volatile
     var started: Boolean = false
 
-    val isFull: Boolean get() = players.size >= MAX_PLAYERS
+    /** Seats this lobby fills before it can start: 4 for Two-Headed Giant, else the default 2. */
+    val maxPlayers: Int get() = if (twoHeadedGiant) TWO_HEADED_GIANT_PLAYERS else MAX_PLAYERS
+
+    val isFull: Boolean get() = players.size >= maxPlayers
 
     fun findPlayer(playerId: EntityId): QuickGameLobbyPlayer? =
         players.firstOrNull { it.playerId == playerId }
 
-    fun allReady(): Boolean = players.size == MAX_PLAYERS && players.all { it.ready }
+    fun allReady(): Boolean = players.size == maxPlayers && players.all { it.ready }
+
+    /**
+     * The team partition for [Format.TwoHeadedGiant], as seat indices into join order: seats 0+1
+     * are team 0, seats 2+3 team 1. Null in a non-2HG lobby (each player plays alone). Forwarded
+     * to [com.wingedsheep.gameserver.session.GameSession.teams] → `GameConfig.teams`.
+     */
+    fun teamAssignment(): List<List<Int>>? =
+        if (twoHeadedGiant) listOf(listOf(0, 1), listOf(2, 3)) else null
+
+    /** The team index of the seat at [seatIndex] (join order), or null in a non-2HG lobby. */
+    fun teamIndexOf(seatIndex: Int): Int? =
+        teamAssignment()?.indexOfFirst { seatIndex in it }?.takeIf { it >= 0 }
 
     companion object {
         const val MAX_PLAYERS = 2
+        const val TWO_HEADED_GIANT_PLAYERS = 4
 
         // Use the same UUID format as TournamentLobby so the join-code UX is consistent
         // across both flows (shared invite-box copy interaction).

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -448,6 +448,13 @@ sealed interface ClientMessage {
          * creature pool. Mutually exclusive with [format] (the constructed-legality restriction).
          */
         val momirBasic: Boolean = false,
+        /**
+         * When true the lobby plays Two-Headed Giant (CR 810): four seats, two teams of two
+         * (seats 0+1 vs 2+3 in join order), shared life / turns / combat. Human-only — the
+         * built-in AI is not team-aware yet (Phase 8), so [vsAi] must be false. Mutually
+         * exclusive with [momirBasic].
+         */
+        val twoHeadedGiant: Boolean = false,
     ) : ClientMessage
 
     /** Join an existing quick-game lobby by its short code. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -68,6 +68,14 @@ sealed interface ServerMessage {
         /** True for the recipient's own seat. Always false in spectator/replay rosters. */
         val isYou: Boolean = false,
         val isAi: Boolean = false,
+        /**
+         * Team membership for team variants (Two-Headed Giant — CR 810). Seats sharing a
+         * [teamIndex] are teammates (shared life, shared turns, combined combat). Null in
+         * non-team games (every seat plays alone), so the 2-player / Free-for-All clients
+         * are unaffected; the 2HG client groups and colors the rail by this index and treats
+         * the recipient's same-team, non-[isYou] seat as the ally.
+         */
+        val teamIndex: Int? = null,
     )
 
     /**
@@ -1054,6 +1062,10 @@ sealed interface ServerMessage {
         val format: com.wingedsheep.sdk.core.DeckFormat? = null,
         /** True for a Momir Basic lobby: fixed 60-basic decks, no deckbuilding, [setCode] scopes the creature pool. */
         val momirBasic: Boolean = false,
+        /** True for a Two-Headed Giant lobby (CR 810): four seats, two teams (see [QuickGameLobbyPlayerView.teamIndex]). */
+        val twoHeadedGiant: Boolean = false,
+        /** How many seats this lobby fills before it can start: 4 for Two-Headed Giant, else 2. */
+        val maxPlayers: Int = 2,
     ) : ServerMessage
 
     /**
@@ -1072,7 +1084,13 @@ sealed interface ServerMessage {
         /** "random" if the player chose to defer to the server's random sealed pool. */
         val deckLabel: String,
         /** Per-player set choice for Random pools; null = "any set". */
-        val setCode: String? = null
+        val setCode: String? = null,
+        /**
+         * Team membership in a Two-Headed Giant lobby (CR 810): seats sharing a [teamIndex] are
+         * teammates. Derived from the seat's join order (0+1 = team 0, 2+3 = team 1). Null in a
+         * non-2HG lobby, so the existing 2-player overlay is unaffected.
+         */
+        val teamIndex: Int? = null,
     )
 
     /** The lobby has been closed (host left, AI failed to spin up, etc.). */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -111,6 +111,12 @@ class ScenarioBuilderService(
         if (seats.size > 2 && request.effectiveMode != ScenarioMode.SELF) {
             errors += "Pods of more than two seats only support SELF (hotseat) mode."
         }
+        request.teams?.let { teams ->
+            val flat = teams.flatten().sorted()
+            if (flat != seats.indices.toList()) {
+                errors += "teams must partition all ${seats.size} seat indices exactly once (got $flat)."
+            }
+        }
         seats.forEachIndexed { i, (_, config) -> checkPlayer("player${i + 1}", config) }
 
         if (enforceLimits && total > MAX_TOTAL_CARDS) {
@@ -133,6 +139,7 @@ class ScenarioBuilderService(
         }
         request.activePlayer?.let { builder.withActivePlayer(it) }
         request.priorityPlayer?.let { builder.withPriorityPlayer(it) }
+        request.teams?.let { builder.withTeams(it) }
 
         val (state, playerIds) = builder.build()
         return ScenarioBuildResult(state, playerIds)
@@ -388,6 +395,26 @@ class ScenarioBuilderService(
         fun withPriorityPlayer(playerNumber: Int): ScenarioBuilder {
             val playerId = playerFor(playerNumber)
             state = state.copy(priorityPlayerId = playerId)
+            return this
+        }
+
+        /**
+         * Stamp team membership (Two-Headed Giant — CR 810). [teams] entries are lists of 0-based
+         * seat indices; each becomes a team via [TeamComponent]. Also switches the game to
+         * [Format.TwoHeadedGiant] — the only team format today — so shared life, the 15-poison
+         * threshold, and team win/loss read the right rules. Mirrors GameInitializer's stamping for
+         * the freshly-built (lobby/quick-game) path.
+         */
+        fun withTeams(teams: List<List<Int>>): ScenarioBuilder {
+            teams.forEachIndexed { teamIndex, memberIndices ->
+                for (memberIndex in memberIndices) {
+                    val pid = playerIds[memberIndex]
+                    state = state.updateEntity(pid) { container ->
+                        container.with(TeamComponent(teamIndex))
+                    }
+                }
+            }
+            state = state.copy(format = com.wingedsheep.sdk.core.Format.TwoHeadedGiant())
             return this
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
@@ -42,6 +42,15 @@ data class ScenarioRequest(
      * stay two-seat.
      */
     val players: List<ScenarioSeat>? = null,
+    /**
+     * Team assignment for team variants (Two-Headed Giant — CR 810). Each entry is one team:
+     * a list of seat indices into [players] (0-based, turn order). When supplied the seats are
+     * stamped into teams (shared life, shared turns, combined combat) and the game runs under
+     * [com.wingedsheep.sdk.core.Format.TwoHeadedGiant], making a 2HG hotseat bootable for manual
+     * testing before the lobby UI lands. Null = each player plays alone (unchanged). The indices
+     * must partition every seat exactly once. Use with [ScenarioMode.SELF] (single-client hotseat).
+     */
+    val teams: List<List<Int>>? = null,
     val phase: Phase? = null,
     val step: Step? = null,
     val activePlayer: Int? = null,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -141,6 +141,16 @@ class GameSession(
     @Volatile
     var attackMode: com.wingedsheep.sdk.core.AttackMode = com.wingedsheep.sdk.core.AttackMode.MULTIPLE
 
+    /**
+     * Team partitioning for team variants (Two-Headed Giant — CR 810), as lists of seat indices
+     * into the join/turn order; each entry is one team. Set by the lobby / scenario handler before
+     * [startGame] and forwarded to [GameConfig.teams], which stamps [TeamComponent] on each player.
+     * Null = no teams (every seat plays alone), so 2-player / Free-for-All games are unchanged.
+     * Stored on the session for the same reasons as [engineFormat].
+     */
+    @Volatile
+    var teams: List<List<Int>>? = null
+
     /** Player info for persistence (playerId -> (playerName, token)) */
     private val playerPersistenceInfo = mutableMapOf<EntityId, PlayerPersistenceInfo>()
 
@@ -277,10 +287,15 @@ class GameSession(
 
     /**
      * Get every other seated player's ID (all opponents of [playerId]). In a 2-player game this
-     * is a single-element list. Order follows seating/turn order.
+     * is a single-element list. Order follows seating/turn order. In Two-Headed Giant (CR 810)
+     * a teammate is not an opponent, so the player's whole team is excluded; the engine's
+     * [GameState.teamOf] is the single source of truth, and degrades to a singleton in non-team
+     * games so this is unchanged there. Before the game has started (no state yet) every other
+     * seat is treated as an opponent.
      */
     fun getOpponentIds(playerId: EntityId): List<EntityId> {
-        return players.keys.filter { it != playerId }
+        val team = gameState?.teamOf(playerId)?.toHashSet() ?: setOf(playerId)
+        return players.keys.filter { it !in team }
     }
 
     /**
@@ -326,12 +341,16 @@ class GameSession(
     fun getPlayerNames(): List<String> = getPlayers().map { it.playerName }
 
     /**
-     * Current life totals in seat order, for spectator display.
+     * Current life totals in seat order, for spectator display. Routed through
+     * [GameState.lifeTotal] so a Two-Headed Giant team's shared total (CR 810.9a) shows the
+     * same value for both teammates; in non-team games this is the player's own total.
      */
     fun getLifeTotals(): List<Int> {
         val state = gameState ?: return emptyList()
         return getPlayers().map { player ->
-            state.getEntity(player.playerId)?.get<LifeTotalComponent>()?.life ?: 20
+            if (state.getEntity(player.playerId)?.get<LifeTotalComponent>() != null) {
+                state.lifeTotal(player.playerId)
+            } else 20
         }
     }
 
@@ -341,7 +360,8 @@ class GameSession(
      * when given, flags that recipient's own seat ([PlayerSeatInfo.isYou]); spectators pass null.
      */
     fun seatInfos(viewerId: EntityId? = null): List<ServerMessage.PlayerSeatInfo> {
-        val turnOrder = gameState?.turnOrder
+        val state = gameState
+        val turnOrder = state?.turnOrder
         val seated = getPlayers()
         return seated.mapIndexed { joinIndex, player ->
             val seatIndex = turnOrder?.indexOf(player.playerId)?.takeIf { it >= 0 } ?: joinIndex
@@ -351,6 +371,10 @@ class GameSession(
                 seatIndex = seatIndex,
                 isYou = viewerId != null && player.playerId == viewerId,
                 isAi = playerPersistenceInfo[player.playerId]?.isAi == true,
+                // Team membership for Two-Headed Giant (CR 810); null in non-team games.
+                teamIndex = state?.getEntity(player.playerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()
+                    ?.teamIndex,
             )
         }.sortedBy { it.seatIndex }
     }
@@ -383,6 +407,9 @@ class GameSession(
             useHandSmoother = useHandSmoother,
             format = engineFormat,
             attackMode = attackMode,
+            // Team partitioning for Two-Headed Giant (CR 810); null for non-team games. The seat
+            // indices line up with playerConfigs, which preserves the join/turn order of `players`.
+            teams = teams,
         )
 
         val result = gameInitializer.initializeGame(config)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantLobbyTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantLobbyTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — Phase 6 lobby plumbing. A [QuickGameLobby] flagged [QuickGameLobby.twoHeadedGiant]
+ * is a four-seat, two-team staging area; a normal lobby stays two-seat. This pins the seat-count and
+ * team-partition math the handler relies on to thread `GameSession.teams` and the 2HG format.
+ */
+class TwoHeadedGiantLobbyTest : FunSpec({
+
+    fun lobby(twoHeadedGiant: Boolean) =
+        QuickGameLobby(vsAi = false, setCode = null, twoHeadedGiant = twoHeadedGiant)
+
+    fun seat(n: Int) = QuickGameLobbyPlayer(EntityId.of("p$n"), "Player$n", ready = true)
+
+    test("a 2HG lobby seats four players in two teams of two") {
+        val l = lobby(twoHeadedGiant = true)
+        l.maxPlayers shouldBe 4
+        l.teamAssignment() shouldBe listOf(listOf(0, 1), listOf(2, 3))
+        l.teamIndexOf(0) shouldBe 0
+        l.teamIndexOf(1) shouldBe 0
+        l.teamIndexOf(2) shouldBe 1
+        l.teamIndexOf(3) shouldBe 1
+    }
+
+    test("a 2HG lobby is full and ready only with all four seats filled and ready") {
+        val l = lobby(twoHeadedGiant = true)
+        l.players += seat(1)
+        l.players += seat(2)
+        l.isFull shouldBe false
+        l.allReady() shouldBe false
+
+        l.players += seat(3)
+        l.players += seat(4)
+        l.isFull shouldBe true
+        l.allReady() shouldBe true
+
+        // One seat not ready blocks the start.
+        l.players[3] = l.players[3].copy(ready = false)
+        l.allReady() shouldBe false
+    }
+
+    test("a normal lobby is unchanged: two seats, no teams") {
+        val l = lobby(twoHeadedGiant = false)
+        l.maxPlayers shouldBe 2
+        l.teamAssignment() shouldBe null
+        l.teamIndexOf(0) shouldBe null
+
+        l.players += seat(1)
+        l.isFull shouldBe false
+        l.players += seat(2)
+        l.isFull shouldBe true
+        l.allReady() shouldBe true
+    }
+})

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenario/TwoHeadedGiantScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenario/TwoHeadedGiantScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.gameserver.scenario
+
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.TeamComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Two-Headed Giant — Phase 6 hotseat path. A scenario request may carry a [ScenarioRequest.teams]
+ * partition; [ScenarioBuilderService] then stamps the engine team model (TeamComponent + the 2HG
+ * format) so a single-client hotseat can drive a faithful 2HG game for manual testing before the
+ * lobby UI lands. Teams are seats 0+1 vs 2+3.
+ */
+class TwoHeadedGiantScenarioTest : ScenarioTestBase() {
+
+    private val service get() = ScenarioBuilderService(cardRegistry)
+
+    private fun fourSeat(teams: List<List<Int>>? = listOf(listOf(0, 1), listOf(2, 3))) =
+        ScenarioRequest(
+            players = listOf(
+                ScenarioSeat("A1", PlayerConfig(lifeTotal = 30)),
+                ScenarioSeat("A2", PlayerConfig(lifeTotal = 20)),
+                ScenarioSeat("B1", PlayerConfig(lifeTotal = 30)),
+                ScenarioSeat("B2", PlayerConfig(lifeTotal = 20)),
+            ),
+            teams = teams,
+            mode = ScenarioMode.SELF,
+        )
+
+    init {
+        test("teams partition stamps TeamComponent on every seat and runs under the 2HG format") {
+            val build = service.buildScenario(fourSeat())
+            val s = build.state
+
+            s.format.shouldBeInstanceOf<Format.TwoHeadedGiant>()
+            build.playerIds.map {
+                s.getEntity(it)?.get<TeamComponent>()?.teamIndex
+            } shouldContainExactly listOf(0, 0, 1, 1)
+        }
+
+        test("life resolves to the shared team total: a teammate reads the canonical owner") {
+            val build = service.buildScenario(fourSeat())
+            val s = build.state
+            val a1 = EntityId.of("player-1") // team 0 canonical owner (life 30)
+            val a2 = EntityId.of("player-2") // team 0 teammate, own raw component 20
+
+            // The teammate's own raw component is 20, but the shared total reads the canonical owner.
+            s.getEntity(a2)?.get<LifeTotalComponent>()?.life shouldBe 20
+            s.lifeTotal(a1) shouldBe 30
+            s.lifeTotal(a2) shouldBe 30
+        }
+
+        test("without teams the scenario is unchanged: no TeamComponent, default format") {
+            val build = service.buildScenario(fourSeat(teams = null))
+            val s = build.state
+            build.playerIds.forEach { s.getEntity(it)?.get<TeamComponent>() shouldBe null }
+            s.format.shouldBeInstanceOf<Format.Standard>()
+        }
+
+        test("validate accepts a well-formed 4-seat 2HG hotseat request") {
+            service.validate(fourSeat(), enforceLimits = true) shouldHaveSize 0
+        }
+
+        test("validate rejects a teams list that does not partition every seat") {
+            // Seat 3 is missing and seat 1 is doubled — not a clean partition of [0,1,2,3].
+            val errors = service.validate(fourSeat(teams = listOf(listOf(0, 1), listOf(1, 2))), enforceLimits = true)
+            errors.any { it.contains("partition") } shouldBe true
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * Two-Headed Giant — Phase 6: the server session/DTO/masking layer must surface the engine's team
+ * model (Phases 1–5) without disturbing the 2-player / Free-for-All paths. These tests drive a real
+ * 4-seat [GameSession] under [Format.TwoHeadedGiant] (no WebSocket plumbing) and assert the
+ * team-aware seat roster, opponent list, shared life resolution, and teammate hand visibility — and
+ * that a non-team game is the unchanged degenerate case of the same code path.
+ *
+ * Teams are seats 0+1 (team 0) vs 2+3 (team 1) in join/turn order.
+ */
+class TwoHeadedGiantSessionTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    /** A started 4-seat Two-Headed Giant session (40-Forest decks), with player ids player-1..4. */
+    private fun started2hg(): Pair<GameSession, List<EntityId>> {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 4)
+        session.engineFormat = Format.TwoHeadedGiant()
+        session.teams = listOf(listOf(0, 1), listOf(2, 3))
+        val ids = (1..4).map { EntityId.of("player-$it") }
+        ids.forEachIndexed { i, id ->
+            session.addPlayer(PlayerSession(mockWs("ws$i"), id, "Player${i + 1}"), mapOf("Forest" to 40))
+        }
+        session.startGame()
+        return session to ids
+    }
+
+    init {
+        test("seat roster carries each seat's team index, with teammates in adjacent seats (CR 805.1)") {
+            val (session, ids) = started2hg()
+
+            val roster = session.seatInfos(viewerId = ids[0]).sortedBy { it.seatIndex }
+            roster.forEach { it.teamIndex shouldNotBe null }
+            roster.single { it.isYou }.playerId shouldBe ids[0].value
+
+            // The two members of each team occupy consecutive seats — the seating precondition
+            // for shared team turns (CR 805.1). Which team is seated first is randomized (805.3).
+            roster.groupBy { it.teamIndex }.values.forEach { members ->
+                members shouldHaveSize 2
+                (members.maxOf { it.seatIndex } - members.minOf { it.seatIndex }) shouldBe 1
+            }
+
+            // Team membership follows the config partition (seats 0+1 vs 2+3), independent of seating.
+            val teamOf = roster.associate { it.playerId to it.teamIndex }
+            teamOf[ids[0].value] shouldBe teamOf[ids[1].value]
+            teamOf[ids[2].value] shouldBe teamOf[ids[3].value]
+            (teamOf[ids[0].value] == teamOf[ids[2].value]) shouldBe false
+        }
+
+        test("a teammate is not an opponent (CR 810): getOpponentIds returns only the other team") {
+            val (session, ids) = started2hg()
+
+            // p0's opponents are the other team (p2, p3) — never the teammate p1.
+            session.getOpponentIds(ids[0]) shouldContainExactlyInAnyOrder listOf(ids[2], ids[3])
+            session.getOpponentIds(ids[2]) shouldContainExactlyInAnyOrder listOf(ids[0], ids[1])
+        }
+
+        test("life totals are the shared team total for both teammates, not each raw component") {
+            val (session, ids) = started2hg()
+
+            // Drive team 0's shared total to 25 (resolver writes the canonical owner = first member),
+            // then corrupt the teammate's own raw component to a different value. getLifeTotals must
+            // report the team total (25) for BOTH teammates — proving it routes through the resolver,
+            // not the raw LifeTotalComponent. Team 1 is untouched (30 from the 2HG starting life).
+            var s = session.getStateForTesting()!!
+            s = s.withLifeTotal(ids[0], 25)
+            s = s.updateEntity(ids[1]) { it.with(LifeTotalComponent(99)) }
+            session.injectStateForDevScenario(s)
+            ids.forEachIndexed { i, id ->
+                session.addPlayer(PlayerSession(mockWs("ws$i"), id, "Player${i + 1}"), mapOf("Forest" to 40))
+            }
+
+            session.getLifeTotals() shouldContainExactly listOf(25, 25, 30, 30)
+        }
+
+        test("a player sees their teammate's hand but not an opponent's (CR 810.2)") {
+            val (session, ids) = started2hg()
+            val viewer = ids[0]
+            val teammate = ids[1]
+
+            val update = session.createStateUpdate(viewer, emptyList()) as ServerMessage.StateUpdate
+            val handZones = update.state.zones.filter { it.zoneId.zoneType == Zone.HAND }
+
+            val ownHand = handZones.single { it.zoneId.ownerId == viewer }
+            val teammateHand = handZones.single { it.zoneId.ownerId == teammate }
+            val opponentHands = handZones.filter { it.zoneId.ownerId in listOf(ids[2], ids[3]) }
+
+            // Own hand and the teammate's hand are both fully visible with their cards populated.
+            ownHand.isVisible shouldBe true
+            teammateHand.isVisible shouldBe true
+            teammateHand.cardIds.size shouldBe teammateHand.size
+            teammateHand.cardIds.size shouldBe ownHand.cardIds.size
+
+            // Opponents' hands keep their count but hide their contents.
+            opponentHands.forEach {
+                it.isVisible shouldBe false
+                it.cardIds.size shouldBe 0
+            }
+        }
+
+        test("non-team game is unchanged: no team index, every other seat is an opponent") {
+            // No teams / Standard format — the degenerate case of the same code path.
+            val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+            val ids = (1..2).map { EntityId.of("solo-$it") }
+            ids.forEachIndexed { i, id ->
+                session.addPlayer(PlayerSession(mockWs("s$i"), id, "P${i + 1}"), mapOf("Forest" to 40))
+            }
+            session.startGame()
+
+            session.seatInfos(viewerId = ids[0]).forEach { it.teamIndex shouldBe null }
+            session.getOpponentIds(ids[0]) shouldContainExactly listOf(ids[1])
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -244,8 +244,25 @@ class GameInitializer(
             }
         }
 
-        // 2. Set turn order
-        val shuffledOrder = if (config.startingPlayerIndex != null) {
+        // 2. Set turn order. In a team game with shared team turns (CR 805.1) the members of each
+        // team must sit in adjacent seats, so the order is built team-by-team — teammates are never
+        // interleaved; only the order *between* teams is chosen or randomized (CR 805.3, which team
+        // goes first). [config.startingPlayerIndex] selects the starting team (the team containing
+        // that player). Non-team games shuffle individual players exactly as before.
+        val teams = config.teams
+        val shuffledOrder: List<EntityId> = if (teams != null) {
+            val teamMemberIds = teams.map { members -> members.map { playerIds[it] } }
+            val startTeam = config.startingPlayerIndex
+                ?.let { sp -> teams.indexOfFirst { sp in it }.takeIf { it >= 0 } }
+            val orderedTeams = if (startTeam != null) {
+                teamMemberIds.subList(startTeam, teamMemberIds.size) + teamMemberIds.subList(0, startTeam)
+            } else {
+                val (shuffled, shuffledState) = state.nextRandom { shuffle(teamMemberIds) }
+                state = shuffledState
+                shuffled
+            }
+            orderedTeams.flatten()
+        } else if (config.startingPlayerIndex != null) {
             val idx = config.startingPlayerIndex
             playerIds.subList(idx, playerIds.size) + playerIds.subList(0, idx)
         } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -385,8 +385,13 @@ class ClientStateTransformer(
             // affected player sees of their own hand. Spectators never gain visibility.
             // A non-spectator viewer also sees an opponent's hand while they control a
             // permanent that makes their opponents play with hands revealed (Seer's Vision).
+            // In Two-Headed Giant (CR 810.2b) teammates share strategy openly, so a player
+            // always sees their teammate's hand; [teammatesOf] is empty in non-team games, so
+            // this clause is inert for 2-player / Free-for-All. (Library stays hidden — teams
+            // share life and turns, not card knowledge of each other's library order.)
             Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
                 (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
+                (!isSpectator && state.teammatesOf(viewingPlayerId).contains(zoneKey.ownerId)) ||
                 (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
                     revealsOpponentHandsTo(state, viewingPlayerId))
             Zone.BATTLEFIELD,


### PR DESCRIPTION
Phase 6 of Two-Headed Giant (CR 810). Stacked on #760 (Phase 5); retarget to `main` as the stack merges. This is the **server/session/protocol** layer — it surfaces the engine team model (Phases 1–5) so a 2HG game can be set up, masked, and started. The 2-player and Free-for-All paths stay byte-identical (every team helper degrades to per-player when there's no `TeamComponent`).

## What's in this phase

**Protocol & DTOs**
- `PlayerSeatInfo.teamIndex` (null in non-team games), populated in `GameSession.seatInfos()` from `TeamComponent`; carried by `GameStarted`.
- `QuickGameLobbyState` / `QuickGameLobbyPlayerView` carry `twoHeadedGiant` / `maxPlayers` / per-seat `teamIndex`; the public-listing DTO reports the lobby's real seat count.

**Session**
- `getOpponentIds` is team-aware — a teammate is not an opponent (CR 810) — via `GameState.teamOf`.
- `getLifeTotals` routes through `GameState.lifeTotal`, so a team's shared total (CR 810.9a) shows the same value for both teammates.
- New `GameSession.teams` field forwarded to `GameConfig.teams` in `startGame()`.

**Masking**
- `ClientStateTransformer` grants a player visibility of their **teammate's hand** (CR 810.5 — "teammates may review each other's hands"); the library stays hidden. `teammatesOf()` is empty in non-team games, so the new clause is inert for 1v1/FFA.

**Turn order (CR 805.1)**
- `GameInitializer` builds team games **team-by-team** so teammates sit in **adjacent seats** — the precondition for shared team turns. Only the order *between* teams is randomized/chosen (CR 805.3). Non-team games shuffle individuals exactly as before.

**Hotseat**
- `ScenarioRequest.teams` stamps `TeamComponent` + the 2HG format, making a **2HG hotseat bootable** for manual testing before the lobby UI lands; `validate()` checks the partition.

**Lobby (server-side only)**
- `QuickGameLobby` gains a `twoHeadedGiant` flag → four seats in two teams (join order 0+1 vs 2+3); the handler threads the format and team partition into the session. Human-only — the built-in AI is not team-aware yet (Phase 8). The lobby **overlay/UI is Phase 7**; this PR is the server plumbing it builds on.

## Tests
- `TwoHeadedGiantSessionTest` — seat roster + teammate adjacency (CR 805.1), team-aware opponents, shared life total routing, teammate hand visibility, non-team game unchanged.
- `TwoHeadedGiantScenarioTest` — hotseat `teams` stamps team model + 2HG format, shared-life resolution, partition validation.
- `TwoHeadedGiantLobbyTest` — seat-count / team-partition math.
- Full `rules-engine` and `game-server` suites green; `ai` compiles.

## Scope notes
- New protocol fields are additive with defaults (`@Serializable`), so existing clients are unaffected; no new `Component` (so no serialization-registration change). No card-SDK surface added, so `card-sdk-language-reference.md` is unchanged.
- **Remaining:** Phase 7 (client UI — team-grouped rail, one shared life orb, ally board, lobby team-picker overlay), Phase 8 (team-aware AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)