### PR TITLE
Fire "becomes tapped" only on an untapped→tapped transition

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
@@ -36,19 +36,20 @@ class TapUntapCollectionExecutor : EffectExecutor<TapUntapCollectionEffect> {
         for (entityId in entityIds) {
             val container = currentState.getEntity(entityId) ?: continue
             val cardName = container.get<CardComponent>()?.name ?: "Permanent"
+            val alreadyTapped = container.has<TappedComponent>()
 
-            currentState = currentState.updateEntity(entityId) { c ->
-                if (effect.tap) {
-                    c.with(TappedComponent)
-                } else {
-                    c.without<TappedComponent>()
-                }
+            if (effect.tap) {
+                // Only untapped permanents can be tapped (CR 701.21a); tapping an
+                // already-tapped permanent is a no-op that emits no TappedEvent, so
+                // "becomes tapped" triggers don't fire on a non-transition (CR 603.2f).
+                if (alreadyTapped) continue
+                currentState = currentState.updateEntity(entityId) { it.with(TappedComponent) }
+                events.add(TappedEvent(entityId, cardName))
+            } else {
+                if (!alreadyTapped) continue
+                currentState = currentState.updateEntity(entityId) { it.without<TappedComponent>() }
+                events.add(UntappedEvent(entityId, cardName))
             }
-
-            events.add(
-                if (effect.tap) TappedEvent(entityId, cardName)
-                else UntappedEvent(entityId, cardName)
-            )
         }
 
         return EffectResult.success(currentState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
@@ -37,6 +37,13 @@ class TapUntapExecutor : EffectExecutor<TapUntapEffect> {
             return EffectResult.success(newState, listOfNotNull(event))
         }
 
+        // Only untapped permanents can be tapped (CR 701.21a). Tapping an
+        // already-tapped permanent is a no-op and must emit no TappedEvent,
+        // or "becomes tapped" triggers would fire on a non-transition (CR 603.2f).
+        if (state.getEntity(targetId)?.has<TappedComponent>() == true) {
+            return EffectResult.success(state)
+        }
+
         val newState = state.updateEntity(targetId) { it.with(TappedComponent) }
         return EffectResult.success(newState, listOf(TappedEvent(targetId, cardName)))
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChampionsOfTheShoalTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChampionsOfTheShoalTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Champions of the Shoal (ECL #46).
+ *
+ * Champions of the Shoal {3}{U}
+ * Creature — Merfolk Soldier 4/6
+ * Whenever this creature enters or becomes tapped, tap up to one target
+ * creature and put a stun counter on it.
+ *
+ * "Becomes tapped" only fires on an untapped -> tapped transition (CR 603.2f):
+ * tapping an already-tapped permanent does nothing (CR 701.21a) and must not
+ * re-fire the trigger. This regression test pins both directions.
+ */
+class ChampionsOfTheShoalTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun stunCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    test("becomes-tapped trigger fires when Champions of the Shoal is tapped while untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val champions = driver.putCreatureOnBattlefield(active, "Champions of the Shoal")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // Tap Champions with a real tap effect: an untapped -> tapped transition.
+        val chill = driver.putCardInHand(active, "Crippling Chill")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpell(active, chill, targets = listOf(champions))
+        driver.bothPass() // resolve Crippling Chill -> taps Champions -> queues becomes-tapped trigger
+
+        driver.isTapped(champions) shouldBe true
+
+        // The becomes-tapped trigger is on the stack; choose its "up to one target creature".
+        val chooseTargets = driver.pendingDecision
+        (chooseTargets is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(active, listOf(victim))
+        driver.bothPass() // resolve the trigger
+
+        driver.isTapped(victim) shouldBe true
+        stunCounters(driver, victim) shouldBe 1
+    }
+
+    test("becomes-tapped trigger does NOT fire when Champions of the Shoal is already tapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val champions = driver.putCreatureOnBattlefield(active, "Champions of the Shoal")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // Put Champions into a tapped state directly (no TappedEvent, so no trigger yet).
+        driver.tapPermanent(champions)
+        driver.isTapped(champions) shouldBe true
+
+        // Tap the already-tapped Champions again with a real tap effect.
+        val chill = driver.putCardInHand(active, "Crippling Chill")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpell(active, chill, targets = listOf(champions))
+        driver.bothPass() // resolve Crippling Chill
+
+        // No untapped -> tapped transition => no becomes-tapped trigger => no target decision,
+        // and the victim is untouched.
+        driver.pendingDecision.shouldBeNull()
+        driver.isTapped(victim) shouldBe false
+        stunCounters(driver, victim) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Bug

Champions of the Shoal — *"Whenever this creature enters or becomes tapped, tap up to one target creature and put a stun counter on it."* — re-fired its **becomes tapped** trigger when an effect tapped the creature while it was **already tapped**. Any card with a `Triggers.BecomesTapped` trigger (e.g. Chrome Companion) was affected.

Per the Comprehensive Rules:
- **701.21a** — *"Only untapped permanents can be tapped."* Tapping an already-tapped permanent does nothing.
- **603.2f** — a *"becomes tapped"* trigger fires only when a permanent's status *changes* from untapped to tapped.

## Root cause

Both tap effect executors emitted `TappedEvent` unconditionally, regardless of the permanent's prior state, so the trigger matcher saw a (spurious) tap event:

- `TapUntapExecutor` (`tap target …`)
- `TapUntapCollectionExecutor` (`tap each …`)

## Fix

- `TapUntapExecutor` no-ops (no state change, no event) when the target already has `TappedComponent`.
- `TapUntapCollectionExecutor` skips already-tapped entities on the tap branch — and, symmetrically, already-untapped entities on the untap branch — so no spurious `Tapped`/`Untapped` event is emitted.

This mirrors the pattern already used in `CostPaymentService.tapSelected`.

## Tests

New `ChampionsOfTheShoalTest` pins both directions:
- trigger **fires** when the creature is tapped from untapped (victim gains a stun counter);
- trigger **does not fire** when it's tapped while already tapped (no target decision, victim untouched).

Full `:rules-engine` suite is green; existing tap/stun/untap/combat tests (Chrome Companion, Stun Counter, Uncontrolled Infestation, Untap Each Target) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)