### PR TITLE
Make targeting/selection banners draggable

### DIFF
--- a/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
+++ b/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
@@ -5,6 +5,7 @@ import type { EntityId, ChooseTargetsDecision } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { DecisionCardPreview } from './DecisionComponents'
+import { DraggableBanner } from './DraggableBanner'
 import styles from './DecisionUI.module.css'
 
 /**
@@ -106,7 +107,7 @@ export function BattlefieldTargetingUI({
   const promptText = targetReq?.description ?? decision.prompt
 
   return (
-    <div className={styles.sideBannerSelection}>
+    <DraggableBanner className={styles.sideBannerSelection}>
       {sourceImageUrl && (
         <img
           src={sourceImageUrl}
@@ -155,6 +156,6 @@ export function BattlefieldTargetingUI({
           </button>
         )}
       </div>
-    </div>
+    </DraggableBanner>
   )
 }

--- a/web-client/src/components/decisions/DecisionUI.module.css
+++ b/web-client/src/components/decisions/DecisionUI.module.css
@@ -82,6 +82,33 @@
   box-shadow: 0 4px 24px var(--color-target-shadow);
 }
 
+/* Drag handle for movable banners (lets the player pull the prompt off the
+ * opponent's board on small screens). pointer-events: auto so the handle stays
+ * grabbable even inside .sideBannerTarget, which is otherwise click-through. */
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: var(--space-1) 0;
+  margin: calc(var(--space-2) * -1) 0 calc(var(--space-1) * -1);
+  cursor: grab;
+  touch-action: none;
+  pointer-events: auto;
+}
+
+.dragHandleGrip {
+  width: 36px;
+  height: 4px;
+  border-radius: var(--radius-full, 9999px);
+  background-color: var(--color-target);
+  opacity: 0.6;
+}
+
+.dragHandle:hover .dragHandleGrip {
+  opacity: 0.9;
+}
+
 /* =========================================================================
  * Banner Card Image (source card shown in targeting banner)
  * ========================================================================= */

--- a/web-client/src/components/decisions/DraggableBanner.tsx
+++ b/web-client/src/components/decisions/DraggableBanner.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+import { useDraggable } from '@/hooks/useDraggable.ts'
+import styles from './DecisionUI.module.css'
+
+/**
+ * Side banner that the player can drag out of the way (e.g. when the targeting
+ * prompt covers the opponent's board on a small screen). Renders a grab handle at
+ * the top; the banner keeps its CSS-default position until the handle is dragged.
+ */
+export function DraggableBanner({
+  className,
+  children,
+}: {
+  className: string | undefined
+  children: ReactNode
+}) {
+  const { ref, handleProps, style, isDragging } = useDraggable()
+
+  return (
+    <div ref={ref} className={className} style={style}>
+      <div
+        className={styles.dragHandle}
+        style={isDragging ? { cursor: 'grabbing' } : undefined}
+        aria-label="Drag to move"
+        {...handleProps}
+      >
+        <span className={styles.dragHandleGrip} />
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/web-client/src/components/decisions/PlayerTargetingUI.tsx
+++ b/web-client/src/components/decisions/PlayerTargetingUI.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '@/store/gameStore.ts'
 import type { ChooseTargetsDecision } from '@/types'
+import { DraggableBanner } from './DraggableBanner'
 import styles from './DecisionUI.module.css'
 
 /**
@@ -18,7 +19,7 @@ export function PlayerTargetingUI({
   }
 
   return (
-    <div className={styles.sideBannerTarget}>
+    <DraggableBanner className={styles.sideBannerTarget}>
       <div className={styles.bannerTitle}>
         Choose Target
       </div>
@@ -35,6 +36,6 @@ export function PlayerTargetingUI({
           </button>
         </div>
       )}
-    </div>
+    </DraggableBanner>
   )
 }

--- a/web-client/src/hooks/useDraggable.ts
+++ b/web-client/src/hooks/useDraggable.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, useState } from 'react'
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
+
+interface DraggableResult {
+  /** Attach to the element that should move. */
+  ref: (node: HTMLElement | null) => void
+  /** Spread onto the drag handle (the grab area). */
+  handleProps: { onPointerDown: (e: ReactPointerEvent) => void }
+  /** Inline style to apply to the element — empty until the user drags it. */
+  style: CSSProperties
+  isDragging: boolean
+}
+
+/**
+ * Pointer-based drag for a floating element (mouse + touch via Pointer Events).
+ *
+ * The element keeps its CSS-defined position until the user grabs the handle; on
+ * first drag we measure its current viewport rect and switch to explicit
+ * `left`/`top` (clearing `right`/`transform` so CSS anchoring doesn't fight us),
+ * then track the pointer and clamp the element inside the viewport.
+ *
+ * Built for the targeting/selection side banners, which are `position: fixed` and
+ * can otherwise sit on top of the opponent's board on small screens (mobile) with
+ * no way to move them out of the way.
+ */
+export function useDraggable(): DraggableResult {
+  const elementRef = useRef<HTMLElement | null>(null)
+  const dragOffset = useRef<{ x: number; y: number } | null>(null)
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    elementRef.current = node
+  }, [])
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    const offset = dragOffset.current
+    const el = elementRef.current
+    if (!offset || !el) return
+    const margin = 4
+    const maxLeft = window.innerWidth - el.offsetWidth - margin
+    const maxTop = window.innerHeight - el.offsetHeight - margin
+    const left = Math.max(margin, Math.min(e.clientX - offset.x, maxLeft))
+    const top = Math.max(margin, Math.min(e.clientY - offset.y, maxTop))
+    setPos({ left, top })
+  }, [])
+
+  const onPointerUp = useCallback(() => {
+    dragOffset.current = null
+    setIsDragging(false)
+    window.removeEventListener('pointermove', onPointerMove)
+    window.removeEventListener('pointerup', onPointerUp)
+  }, [onPointerMove])
+
+  const onPointerDown = useCallback((e: ReactPointerEvent) => {
+    const el = elementRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    dragOffset.current = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    setPos({ left: rect.left, top: rect.top })
+    setIsDragging(true)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    e.preventDefault()
+  }, [onPointerMove, onPointerUp])
+
+  const style: CSSProperties = pos
+    ? { left: pos.left, top: pos.top, right: 'auto', transform: 'none' }
+    : {}
+
+  return { ref, handleProps: { onPointerDown }, style, isDragging }
+}


### PR DESCRIPTION
## Problem

Some effects require choosing a target via the **"Choose Target"** side banner
(`BattlefieldTargetingUI` / `PlayerTargetingUI`). That banner is `position: fixed`
pinned to the right edge of the viewport. On a phone, it sits **on top of the
opponent's board** — hiding the exact permanents/players the effect needs you to
target — with no way to move it aside. The targeting becomes impossible.

## Change

- **`useDraggable` hook** (`web-client/src/hooks/useDraggable.ts`) — pointer-based
  drag supporting both mouse and touch via Pointer Events. The element keeps its
  CSS-default position until grabbed; on first drag it measures the current rect and
  switches to explicit `left`/`top` (clearing `right`/`transform`), tracking the
  pointer and clamping inside the viewport.
- **`DraggableBanner` wrapper** (`web-client/src/components/decisions/DraggableBanner.tsx`)
  — renders a grab-handle bar at the top of the banner and wires up the hook. Shared
  by both targeting banners.
- Wrapped `BattlefieldTargetingUI` and `PlayerTargetingUI`'s banners with it.
- Handle CSS uses `pointer-events: auto` + `touch-action: none` so it stays grabbable
  even inside the otherwise click-through `.sideBannerTarget`, and touch-drag doesn't
  scroll the page.

Now the player can drag the prompt off the board to see and tap their target.

## Scope / safety

Frontend-only, additive. No game logic, no server changes. The banner's default
appearance/position is unchanged aside from a small grip handle at the top; behaviour
only differs once the user actively drags it.

## Note on screenshots

The change is an **interaction** (drag the banner) plus a small grip affordance; a
static screenshot can't demonstrate the drag, and capturing a live targeting prompt
requires driving a full game into a targeting decision. Happy to add a capture if a
reviewer wants the grip-handle shot.

## Verification

- `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)