### PR TITLE
Add Random/Manual team toggle to Two-Headed Giant lobby (default random)

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -325,6 +325,14 @@ sealed, or premade), then one N-player game".
   `GameConfig.attackMode` → `GameState.attackMode`; the legal-action enumerator filters
   `validAttackTargets` and the engine rejects an out-of-seat declaration. Ignored in `TOURNAMENT`
   mode and in any two-player game (all three modes permit the sole opponent).
+- **Two-Headed Giant teams (CR 810).** When `gameMode` is `TWO_HEADED_GIANT`, the same two messages
+  carry an optional `randomTeams` (default **`true`**) and `teamAssignments` (playerId → team index
+  `0`/`1`, full map), both echoed by `LobbySettings`. `randomTeams = true` shuffles the four seats
+  into two teams of two at game start, re-rolled each game; `false` uses the host's
+  `teamAssignments`. At start the server resolves the partition (`TwoHeadedGiantTeams.partition`):
+  random, or the manual map balanced into even teams, falling back to seat-order pairing if the
+  manual assignment can't form two pairs of two. The result flows to `GameSession.teams` →
+  `GameConfig.teams`. Ignored outside `TWO_HEADED_GIANT`.
 - **Free mulligan.** A game that begins with more than two players (any FFA pod) uses the CR 800.6
   multiplayer mulligan: a player's *first* mulligan is free — it bottoms 0 cards and doesn't count
   toward the mulligan limit. This is engine-internal; the existing `MulliganDecision.cardsToPutOnBottom`

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -87,13 +87,19 @@ class FreeForAllHandler(
         // CR 802 / 803 — the lobby's chosen attack rule applies to this multiplayer game.
         gameSession.attackMode = lobby.attackMode
 
-        // Two-Headed Giant (CR 810): run under the team format and assign the four seats to two
-        // teams of two. Team indices reference the add-player order below; GameInitializer seats
-        // teammates adjacently (CR 805.1). GameSession.teams flows into GameConfig.teams, which
-        // stamps a TeamComponent on each seat — the engine then shares life/turns/combat per team.
+        // Two-Headed Giant (CR 810): run under the team format and split the four seats into two
+        // teams of two — random by default (re-rolled each game), or the host's manual assignment.
+        // Team indices reference the add-player order below (same order used for the partition);
+        // GameInitializer seats teammates adjacently (CR 805.1). GameSession.teams flows into
+        // GameConfig.teams, which stamps a TeamComponent on each seat — the engine then shares
+        // life/turns/combat per team.
         if (lobby.isTwoHeadedGiant) {
             gameSession.engineFormat = com.wingedsheep.sdk.core.Format.TwoHeadedGiant()
-            gameSession.teams = listOf(listOf(0, 1), listOf(2, 3))
+            gameSession.teams = com.wingedsheep.gameserver.lobby.TwoHeadedGiantTeams.partition(
+                orderedPlayerIds = playerStates.map { it.identity.playerId },
+                randomTeams = lobby.randomTeams,
+                manualAssignment = lobby.teamAssignments,
+            )
         }
 
         for (playerState in playerStates) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -2033,6 +2033,14 @@ class LobbyHandler(
                 .onSuccess { lobby.attackMode = it }
         }
 
+        // Two-Headed Giant team setup (CR 810). Stored regardless of mode; only consumed when a 2HG
+        // game starts. randomTeams=true re-rolls teams each game; when false the host's
+        // teamAssignments (playerId -> team) are used, balanced/falling back if incomplete.
+        message.randomTeams?.let { lobby.randomTeams = it }
+        message.teamAssignments?.let { assignments ->
+            lobby.setTeamAssignments(assignments.mapKeys { com.wingedsheep.sdk.model.EntityId(it.key) })
+        }
+
         // Manual boosterCount override (apply after format change)
         // Grid draft uses fixed booster counts based on player count — no manual override.
         // Premade decks doesn't use boosters at all — ignore.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -298,6 +298,12 @@ class TournamentLobby(
      * bracket (whose matches are always two-player). Defaults to [AttackMode.MULTIPLE].
      */
     var attackMode: com.wingedsheep.sdk.core.AttackMode = com.wingedsheep.sdk.core.AttackMode.MULTIPLE,
+    /**
+     * Two-Headed Giant only (CR 810): when true (the default) the four seats are split into two
+     * random teams of two at game start, re-rolled each game. When false the host sets the teams
+     * by hand via [teamAssignments]. Ignored outside [gameMode] == TWO_HEADED_GIANT.
+     */
+    var randomTeams: Boolean = true,
 ) {
 
     /**
@@ -357,6 +363,23 @@ class TournamentLobby(
 
     /** Players indexed by player ID */
     val players = ConcurrentHashMap<EntityId, LobbyPlayerState>()
+
+    /**
+     * Two-Headed Giant manual team assignment: playerId -> team index (0 or 1). Only consulted when
+     * [randomTeams] is false. Keyed by player id (not seat) so it survives reordering, reconnects,
+     * and a player leaving/rejoining. Players missing here are balanced into the open team at game
+     * start (see [TwoHeadedGiantTeams.partition]).
+     */
+    @Volatile
+    var teamAssignments: Map<EntityId, Int> = emptyMap()
+        private set
+
+    /** Replace the manual 2HG team assignment, keeping only current players and valid team indices. */
+    fun setTeamAssignments(assignments: Map<EntityId, Int>) {
+        teamAssignments = assignments.filter { (id, team) ->
+            id in players.keys && team in 0 until TwoHeadedGiantTeams.TEAM_COUNT
+        }
+    }
 
     /** Tournament-level spectators (non-participants watching standings/matches) */
     val spectators = ConcurrentHashMap<EntityId, PlayerIdentity>()
@@ -1509,6 +1532,8 @@ class TournamentLobby(
                 aiAssistEnabled = aiAssistEnabled,
                 gameMode = gameMode.name,
                 attackMode = attackMode.name,
+                randomTeams = randomTeams,
+                teamAssignments = teamAssignments.mapKeys { it.key.value },
             ),
             isHost = isHost(forPlayerId)
         )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantTeams.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantTeams.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.sdk.model.EntityId
+import kotlin.random.Random
+
+/**
+ * Computes the Two-Headed Giant team partition (CR 810) for a four-seat pod.
+ *
+ * Teams are expressed as seat indices into [orderedPlayerIds] — the exact order in which the caller
+ * will seat the players — so the result drops straight into
+ * [com.wingedsheep.gameserver.session.GameSession.teams]. The engine's [GameInitializer] later
+ * reorders seats so teammates sit adjacently (CR 805.1), so the pairs here need not be adjacent
+ * indices.
+ *
+ * Two modes:
+ *  - [randomTeams] = true (the lobby default): the seats are shuffled and split into even teams.
+ *    Re-rolled on every call, so a "play again" pod gets fresh teams each game.
+ *  - [randomTeams] = false: each player's team comes from [manualAssignment] (playerId -> team
+ *    index). Players with no entry are slotted into whichever team still has room, so a partial
+ *    assignment is usable. An assignment that can't yield even teams (e.g. three players forced onto
+ *    one team) falls back to seat-order pairing so a malformed manual setup can never wedge the
+ *    start of a game.
+ */
+object TwoHeadedGiantTeams {
+    /** Two-Headed Giant is always two teams (CR 810.1). */
+    const val TEAM_COUNT = 2
+
+    fun partition(
+        orderedPlayerIds: List<EntityId>,
+        randomTeams: Boolean,
+        manualAssignment: Map<EntityId, Int>,
+        random: Random = Random.Default,
+    ): List<List<Int>> {
+        val seats = orderedPlayerIds.indices.toList()
+        val teamSize = seats.size / TEAM_COUNT
+
+        if (randomTeams) {
+            return seats.shuffled(random).chunked(teamSize).take(TEAM_COUNT).map { it.sorted() }
+        }
+
+        val teams = List(TEAM_COUNT) { mutableListOf<Int>() }
+        for (seat in seats) {
+            val team = manualAssignment[orderedPlayerIds[seat]] ?: continue
+            if (team in 0 until TEAM_COUNT) teams[team].add(seat)
+        }
+        // Slot any unassigned seats into a team that still has room (keeps partial setups usable).
+        val assigned = teams.flatten().toSet()
+        for (seat in seats) {
+            if (seat in assigned) continue
+            (teams.firstOrNull { it.size < teamSize } ?: teams[0]).add(seat)
+        }
+        return if (teams.all { it.size == teamSize }) {
+            teams.map { it.sorted() }
+        } else {
+            // Malformed manual assignment (e.g. 3 vs 1): fall back to deterministic seat-order pairing.
+            seats.chunked(teamSize).take(TEAM_COUNT).map { it.sorted() }
+        }
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
@@ -65,6 +65,8 @@ fun TournamentLobby.toPersistent(): PersistentTournamentLobby {
         aiAssistEnabled = aiAssistEnabled,
         gameMode = gameMode.name,
         attackMode = attackMode.name,
+        randomTeams = randomTeams,
+        teamAssignments = teamAssignments.mapKeys { it.key.value },
         ffaGameSessionId = ffaGameSessionId,
         ffaGamesPlayed = ffaGamesPlayed
     )
@@ -105,7 +107,8 @@ fun restoreTournamentLobby(
         gameMode = runCatching { LobbyGameMode.valueOf(persistent.gameMode) }
             .getOrDefault(LobbyGameMode.TOURNAMENT),
         attackMode = runCatching { com.wingedsheep.sdk.core.AttackMode.valueOf(persistent.attackMode) }
-            .getOrDefault(com.wingedsheep.sdk.core.AttackMode.MULTIPLE)
+            .getOrDefault(com.wingedsheep.sdk.core.AttackMode.MULTIPLE),
+        randomTeams = persistent.randomTeams
     )
     // FFA in-flight state (last standings are deliberately not persisted — after a restart the
     // pod simply readies up for the next game).
@@ -153,6 +156,9 @@ fun restoreTournamentLobby(
         )
         lobby.players[playerId] = playerState
     }
+
+    // 2HG manual team assignment — restored after players so the validity filter keeps current ids.
+    lobby.setTeamAssignments(persistent.teamAssignments.mapKeys { EntityId(it.key) })
 
     // Restore state via internal method
     lobby.restoreFromPersistence(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
@@ -38,6 +38,10 @@ data class PersistentTournamentLobby(
     val gameMode: String = "TOURNAMENT",
     /** FFA attack rule: AttackMode enum name ("MULTIPLE" / "LEFT" / "RIGHT"). */
     val attackMode: String = "MULTIPLE",
+    /** 2HG: true = random teams each game, false = host-set teams via [teamAssignments]. */
+    val randomTeams: Boolean = true,
+    /** 2HG manual team assignment: playerId -> team index (0 or 1). Empty when unset/random. */
+    val teamAssignments: Map<String, Int> = emptyMap(),
     /** FFA mode: session id of the game currently in progress, or null between games. */
     val ffaGameSessionId: String? = null,
     /** FFA mode: completed games in this lobby's play-again loop. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -266,6 +266,13 @@ sealed interface ClientMessage {
         val gameMode: String? = null,
         /** Free-for-All attack rule (CR 802/803): "MULTIPLE", "LEFT", or "RIGHT". Null = unchanged. */
         val attackMode: String? = null,
+        /** Two-Headed Giant: true = random teams each game, false = host-set teams. Null = unchanged. */
+        val randomTeams: Boolean? = null,
+        /**
+         * Two-Headed Giant manual team assignment: playerId -> team index (0 or 1). The full map is
+         * sent each time (not a delta). Null leaves the current assignment unchanged.
+         */
+        val teamAssignments: Map<String, Int>? = null,
     ) : ClientMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -461,6 +461,16 @@ sealed interface ServerMessage {
         val gameMode: String = "TOURNAMENT",
         /** Free-for-All attack rule (CR 802/803): "MULTIPLE", "LEFT", or "RIGHT". Ignored in tournament mode. */
         val attackMode: String = "MULTIPLE",
+        /**
+         * Two-Headed Giant only (CR 810): true = random teams each game (the default); false = host
+         * sets the teams via [teamAssignments]. Ignored outside Two-Headed Giant mode.
+         */
+        val randomTeams: Boolean = true,
+        /**
+         * Two-Headed Giant manual team assignment: playerId -> team index (0 or 1). Only meaningful
+         * when [randomTeams] is false. Empty = unset (host hasn't picked teams yet).
+         */
+        val teamAssignments: Map<String, Int> = emptyMap(),
     )
 
     /**

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantTeamsTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TwoHeadedGiantTeamsTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+/**
+ * Two-Headed Giant team partition (CR 810). [TwoHeadedGiantTeams.partition] is the single source of
+ * truth FreeForAllHandler uses to fill `GameSession.teams`: random by default, or the host's manual
+ * playerId -> team assignment with a safe fallback for malformed setups.
+ */
+class TwoHeadedGiantTeamsTest : FunSpec({
+
+    val ids = (0..3).map { EntityId.of("p$it") }
+
+    fun flatten(teams: List<List<Int>>) = teams.flatten().sorted()
+
+    test("random teams cover all four seats as two disjoint pairs") {
+        // A fixed seed keeps the assertion deterministic without pinning a specific shuffle order.
+        val teams = TwoHeadedGiantTeams.partition(ids, randomTeams = true, manualAssignment = emptyMap(), random = Random(42))
+        teams.size shouldBe 2
+        teams.forEach { it.size shouldBe 2 }
+        flatten(teams) shouldBe listOf(0, 1, 2, 3)
+    }
+
+    test("manual assignment places each player on the chosen team") {
+        val assignment = mapOf(ids[0] to 1, ids[1] to 1, ids[2] to 0, ids[3] to 0)
+        val teams = TwoHeadedGiantTeams.partition(ids, randomTeams = false, manualAssignment = assignment)
+        teams[0] shouldContainExactlyInAnyOrder listOf(2, 3)
+        teams[1] shouldContainExactlyInAnyOrder listOf(0, 1)
+    }
+
+    test("a partial manual assignment balances the rest into the open team") {
+        val teams = TwoHeadedGiantTeams.partition(ids, randomTeams = false, manualAssignment = mapOf(ids[0] to 0))
+        teams.forEach { it.size shouldBe 2 }
+        teams[0] shouldBe listOf(0, 1)
+        teams[1] shouldBe listOf(2, 3)
+    }
+
+    test("a malformed assignment (three on one team) falls back to seat-order pairing") {
+        val assignment = mapOf(ids[0] to 0, ids[1] to 0, ids[2] to 0)
+        val teams = TwoHeadedGiantTeams.partition(ids, randomTeams = false, manualAssignment = assignment)
+        teams shouldBe listOf(listOf(0, 1), listOf(2, 3))
+    }
+
+    test("an out-of-range team index is ignored, then balanced") {
+        val teams = TwoHeadedGiantTeams.partition(ids, randomTeams = false, manualAssignment = mapOf(ids[0] to 7))
+        teams.forEach { it.size shouldBe 2 }
+        flatten(teams) shouldBe listOf(0, 1, 2, 3)
+    }
+})

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -756,6 +756,23 @@ function LobbyOverlay({
   // Two-Headed Giant (CR 810): the pod mode that runs two teams of two off the same draft/sealed
   // build. Exactly four players; combat/attack rules are fixed (no per-creature attack picker).
   const is2hg = lobbyState.settings.gameMode === 'TWO_HEADED_GIANT'
+  // 2HG team setup: random by default, or host-assigned (playerId -> team, defaulting to join order).
+  const randomTeams = lobbyState.settings.randomTeams ?? true
+  const teamAssignments = lobbyState.settings.teamAssignments ?? {}
+  const playerTeam = (playerId: string, index: number): number =>
+    teamAssignments[playerId] ?? Math.floor(index / 2)
+  // Manual teams must be an even 2v2 to play as intended (the server otherwise re-balances).
+  const manualTeamsBalanced = lobbyState.players.length === 4 &&
+    [0, 1].every(t => lobbyState.players.filter((p, i) => playerTeam(p.playerId, i) === t).length === 2)
+  // Move one player to the other team, sending the full explicit assignment for all four seats.
+  const togglePlayerTeam = (playerId: string, index: number) => {
+    const flipped = playerTeam(playerId, index) === 0 ? 1 : 0
+    const next: Record<string, number> = {}
+    lobbyState.players.forEach((p, i) => {
+      next[p.playerId] = p.playerId === playerId ? flipped : playerTeam(p.playerId, i)
+    })
+    updateLobbySettings({ teamAssignments: next })
+  }
   // "Draft-shape" — anything that hands packs around at pick time. Commander Draft fits the
   // shape (same per-pick UI / timer / pack-passing) so it inherits Draft-only settings.
   const isAnyDraft = isDraft || isWinston || isGridDraft || isCommanderDraft
@@ -933,12 +950,43 @@ function LobbyOverlay({
                 )}
                 {is2hg && (
                   <div className={styles.variantCaption}>
-                    Four players in two teams of two (seats 1+2 vs 3+4). Each team shares one 30-life
-                    total, takes turns together, and attacks and blocks as one. Last team standing wins.
+                    Four players in two teams of two. Each team shares one 30-life total, takes turns
+                    together, and attacks and blocks as one. Last team standing wins.
                   </div>
                 )}
               </div>
             </div>
+            {/* Two-Headed Giant team setup (CR 810): random teams each game, or host-picked teams. */}
+            {is2hg && (
+              <div className={styles.settingsRow}>
+                <span className={styles.settingsLabel}>Teams</span>
+                <div className={styles.variantGroup}>
+                  <div className={styles.settingsButtons}>
+                    <button
+                      onClick={() => updateLobbySettings({ randomTeams: true })}
+                      className={`${styles.settingsButton} ${randomTeams ? styles.settingsButtonActive : ''}`}
+                      title="Shuffle the four players into two teams of two when the game starts (re-rolled each game)"
+                    >
+                      Random
+                    </button>
+                    <button
+                      onClick={() => updateLobbySettings({ randomTeams: false })}
+                      className={`${styles.settingsButton} ${!randomTeams ? styles.settingsButtonActive : ''}`}
+                      title="Set the teams by hand — click each player's team chip below"
+                    >
+                      Choose teams
+                    </button>
+                  </div>
+                  <div className={styles.variantCaption}>
+                    {randomTeams
+                      ? 'Teams are randomised at game start, fresh every game.'
+                      : manualTeamsBalanced
+                        ? 'Click a player’s team chip below to move them between teams.'
+                        : 'Click each player’s team chip below — each team needs exactly two players.'}
+                  </div>
+                </div>
+              </div>
+            )}
             {/* Free-for-All attack rule (CR 802/803) — only relevant once 3+ players share one table */}
             {isFfa && (
               <div className={styles.settingsRow}>
@@ -1420,26 +1468,50 @@ function LobbyOverlay({
                 <span className={styles.playerName}>
                   {player.playerName}
                 </span>
-                {/* Two-Headed Giant team chip — seats fill the two teams in join order (1+2, 3+4). */}
-                {is2hg && (() => {
-                  const team = Math.floor(i / 2)
+                {/* Two-Headed Giant team chip. Random mode: a neutral chip (teams decided at game
+                    start). Manual mode: the assigned team, clickable for the host to reassign. */}
+                {is2hg && randomTeams && (
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 800,
+                      letterSpacing: '0.05em',
+                      textTransform: 'uppercase',
+                      color: 'rgba(226, 232, 240, 0.7)',
+                      border: '1px solid rgba(148, 163, 184, 0.45)',
+                      background: 'rgba(148, 163, 184, 0.12)',
+                      borderRadius: 4,
+                      padding: '1px 6px',
+                    }}
+                  >
+                    Random
+                  </span>
+                )}
+                {is2hg && !randomTeams && (() => {
+                  const team = playerTeam(player.playerId, i)
                   const c = teamColor(team)
-                  return (
-                    <span
-                      style={{
-                        fontSize: 10,
-                        fontWeight: 800,
-                        letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                        color: c.bright,
-                        border: `1px solid ${c.base}`,
-                        background: c.soft,
-                        borderRadius: 4,
-                        padding: '1px 6px',
-                      }}
+                  const chipStyle = {
+                    fontSize: 10,
+                    fontWeight: 800,
+                    letterSpacing: '0.05em',
+                    textTransform: 'uppercase' as const,
+                    color: c.bright,
+                    border: `1px solid ${c.base}`,
+                    background: c.soft,
+                    borderRadius: 4,
+                    padding: '1px 6px',
+                  }
+                  const hostCanEdit = isWaiting && lobbyState.isHost
+                  return hostCanEdit ? (
+                    <button
+                      onClick={() => togglePlayerTeam(player.playerId, i)}
+                      style={{ ...chipStyle, cursor: 'pointer' }}
+                      title="Click to move this player to the other team"
                     >
                       Team {team + 1}
-                    </span>
+                    </button>
+                  ) : (
+                    <span style={chipStyle}>Team {team + 1}</span>
                   )
                 })()}
                 {player.isHost && (

--- a/web-client/src/store/slices/handlers/lobbyHandlers.ts
+++ b/web-client/src/store/slices/handlers/lobbyHandlers.ts
@@ -22,7 +22,7 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
           lobbyId: msg.lobbyId,
           state: 'WAITING_FOR_PLAYERS',
           players: [],
-          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false, bannedCardNames: [], aiAssistEnabled: false, gameMode: 'TOURNAMENT', attackMode: 'MULTIPLE' },
+          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false, bannedCardNames: [], aiAssistEnabled: false, gameMode: 'TOURNAMENT', attackMode: 'MULTIPLE', randomTeams: true, teamAssignments: {} },
           isHost: true,
           draftState: null,
           winstonDraftState: null,

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -38,7 +38,7 @@ export interface LobbySliceActions {
   startLobby: () => void
   leaveLobby: () => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number> }) => void
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   readyForNextRound: () => void

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -849,7 +849,7 @@ export type GameStore = {
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number> }) => void
   /** Disconnected tournament players: playerId -> info */
   disconnectedPlayers: Record<string, { playerName: string; secondsRemaining: number; disconnectedAt: number }>
   readyForNextRound: () => void

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1155,6 +1155,10 @@ export interface LobbySettings {
   readonly gameMode: LobbyGameMode
   /** Free-for-All attack rule (CR 802/803). Only meaningful when gameMode is FREE_FOR_ALL. */
   readonly attackMode: AttackMode
+  /** Two-Headed Giant: true = random teams each game (default); false = host-set teams. */
+  readonly randomTeams: boolean
+  /** Two-Headed Giant manual team assignment: playerId -> team index (0/1). Empty = unset. */
+  readonly teamAssignments: Readonly<Record<string, number>>
 }
 
 export type LobbyGameMode = 'TOURNAMENT' | 'FREE_FOR_ALL' | 'TWO_HEADED_GIANT'
@@ -2092,6 +2096,10 @@ export interface UpdateLobbySettingsMessage {
   readonly gameMode?: LobbyGameMode
   /** Free-for-All attack rule ('MULTIPLE' / 'LEFT' / 'RIGHT'). Omit to leave unchanged. */
   readonly attackMode?: AttackMode
+  /** Two-Headed Giant: true = random teams, false = host-set teams. Omit to leave unchanged. */
+  readonly randomTeams?: boolean
+  /** Two-Headed Giant team assignment: playerId -> team index (0/1). Full map; omit to leave unchanged. */
+  readonly teamAssignments?: Readonly<Record<string, number>>
 }
 
 // Tournament Client Messages
@@ -2321,6 +2329,8 @@ export function createUpdateLobbySettingsMessage(
     aiAssistEnabled?: boolean
     gameMode?: LobbyGameMode
     attackMode?: AttackMode
+    randomTeams?: boolean
+    teamAssignments?: Readonly<Record<string, number>>
   }
 ): UpdateLobbySettingsMessage {
   return { type: 'updateLobbySettings', ...settings }


### PR DESCRIPTION
## What

Two-Headed Giant (CR 810) lobbies used to always pair the four seats by **join order** (seats 0+1 vs 2+3). This makes team formation a host-configurable lobby setting that **defaults to random teams**, with a manual fallback where the host picks the teams.

- **Random (default):** the four seats are shuffled into two teams of two at game start, **re-rolled each game** (so a "play again" pod gets fresh teams).
- **Choose teams:** the host assigns each player to a team by clicking their team chip in the player list.

## How it's wired

- **`TwoHeadedGiantTeams.partition`** (new) — single source of truth for the partition: random shuffle, or the host's `playerId -> team` map. A partial manual assignment is balanced into the open team; an assignment that can't form two pairs of two falls back to deterministic seat-order pairing, so a malformed setup can never wedge game start. Keyed by player id (not seat), so it's correct regardless of how the engine later reorders seats for adjacency (CR 805.1).
- **`TournamentLobby`** gains `randomTeams` (default `true`) and `teamAssignments`. Both flow through `LobbySettings` / `UpdateLobbySettings` DTOs, the `LobbyHandler` update path (host-only, waiting-state-only like the other settings), and Redis persistence (`PersistentLobby` + `LobbyConverter`).
- **`FreeForAllHandler`** builds `GameSession.teams` from the partition (keyed by the seated player ids) instead of the hardcoded `[[0,1],[2,3]]`.
- **Lobby UI (`GameUI.tsx`):** a `Teams` **Random | Choose teams** toggle under the 2HG mode selector; a neutral "Random" chip per player in random mode; host-clickable team chips to reassign players in manual mode, with a caption nudging toward an even 2v2.

## Scope notes

- Only the FFA/tournament lobby exposes 2HG, so the toggle lives there. `QuickGameLobby`'s (UI-less) 2HG path is unchanged.
- New DTO/persistence fields are defaulted, so old clients and previously-persisted lobbies deserialize unchanged.

## Tests

- New `TwoHeadedGiantTeamsTest` covers random coverage, manual assignment, partial-assignment balancing, malformed fallback, and out-of-range indices.
- Existing `TwoHeadedGiant*` lobby/session/scenario tests + `FreeForAllLobbyTest` + `SealedTournamentReconnectionTest` still pass; client `tsc` is clean.
- `docs/data-contracts.md` documents the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)