### PR TITLE
Fix Momir Basic: as-enters effects (enters tapped, choose a color, +1/+1 counters) on minted tokens

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -212,24 +212,28 @@ data class EntersWithChoiceSpellContinuation(
 ) : ContinuationFrame
 
 /**
- * Resume after player makes an "as enters" choice for a land played directly to the battlefield.
+ * Resume after a player makes an "as enters" choice for a permanent put **directly** onto the
+ * battlefield (not cast as a spell) — a land played, or a token minted from a card definition
+ * (e.g. the Momir Basic avatar's random creature). Set up via
+ * [com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements.pauseForEntersWithChoice].
  *
- * Unlike [EntersWithChoiceSpellContinuation] (used for spells), the land is already on
- * the battlefield when this continuation fires — it just needs the chosen value stored.
- * After storing, checks for chained choices (e.g., a land with both color and creature type),
- * and once the final choice resolves, fires triggers from the land entering (e.g. landfall).
+ * Unlike [EntersWithChoiceSpellContinuation] (used for spells), the permanent is already on the
+ * battlefield when this continuation fires — it just needs the chosen value stored. After storing,
+ * checks for chained choices (e.g. both color and creature type), and once the final choice
+ * resolves, fires the entry's ETB triggers off a synthesized [com.wingedsheep.engine.core.ZoneChangeEvent]
+ * (landfall, "when ~ enters", …).
  *
- * @property landId The land entity already on the battlefield
- * @property controllerId The player who played the land
+ * @property entityId The permanent already on the battlefield
+ * @property controllerId The player who controls it
  * @property choiceType What kind of choice was presented
  * @property creatureTypes For CREATURE_TYPE choices, the list of options presented
- * @property fromZone The zone the land was played from (needed to fire entry triggers
- *   after the final choice resolves)
+ * @property fromZone The zone the permanent came from (used to synthesize the entry event after
+ *   the final choice resolves); `null` for a freshly-minted token with no prior zone.
  */
 @Serializable
-data class EntersWithChoiceLandContinuation(
+data class EntersWithChoiceOnBattlefieldContinuation(
     override val decisionId: String,
-    val landId: EntityId,
+    val entityId: EntityId,
     val controllerId: EntityId,
     val choiceType: com.wingedsheep.sdk.scripting.ChoiceType,
     val creatureTypes: List<String> = emptyList(),
@@ -239,7 +243,10 @@ data class EntersWithChoiceLandContinuation(
     /** For [com.wingedsheep.sdk.scripting.ChoiceType.BASIC_LAND_TYPE] choices, see
      *  [EntersWithChoiceSpellContinuation.landTypes]. */
     val landTypes: List<String> = emptyList(),
-    val fromZone: Zone = Zone.HAND
+    /** For [com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT] choices, see
+     *  [EntersWithChoiceSpellContinuation.opponentIds]. */
+    val opponentIds: List<EntityId> = emptyList(),
+    val fromZone: Zone? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -216,7 +216,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ModalPreChosenContinuation::class)
         subclass(CloneEntersContinuation::class)
         subclass(EntersWithChoiceSpellContinuation::class)
-        subclass(EntersWithChoiceLandContinuation::class)
+        subclass(EntersWithChoiceOnBattlefieldContinuation::class)
         subclass(PayLifeOrEnterTappedLandContinuation::class)
         subclass(PayLifeOrEnterTappedSpellContinuation::class)
         subclass(RevealCountersContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -23,7 +23,6 @@ import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.sdk.core.CardType
-import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
 import com.wingedsheep.sdk.scripting.OnEnterRunEffect
@@ -320,148 +319,19 @@ class PlayLandHandler(
                 val events = listOf(zoneChangeEvent)
                 newState = newState.tick()
 
-                val chooserId = when (firstChoice.chooser) {
-                    com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
-                        newState.getOpponents(action.playerId).firstOrNull() ?: action.playerId
-                    else -> action.playerId
-                }
-
-                val result = when (firstChoice.choiceType) {
-                    ChoiceType.COLOR -> {
-                        val decisionId = "choose-color-land-enters-${action.cardId.value}"
-                        val decision = com.wingedsheep.engine.core.ChooseColorDecision(
-                            id = decisionId,
-                            playerId = chooserId,
-                            prompt = "Choose a color",
-                            context = com.wingedsheep.engine.core.DecisionContext(
-                                sourceId = action.cardId,
-                                sourceName = cardComponent.name,
-                                phase = com.wingedsheep.engine.core.DecisionPhase.RESOLUTION
-                            )
-                        )
-                        val continuation = com.wingedsheep.engine.core.EntersWithChoiceLandContinuation(
-                            decisionId = decisionId,
-                            landId = action.cardId,
-                            controllerId = action.playerId,
-                            choiceType = ChoiceType.COLOR,
-                            fromZone = fromZone
-                        )
-                        val pausedState = newState
-                            .pushContinuation(continuation)
-                            .withPendingDecision(decision)
-                        ExecutionResult.paused(pausedState, decision, events)
-                    }
-
-                    ChoiceType.CREATURE_TYPE -> {
-                        val creatureTypeOptions = firstChoice.allowedCreatureTypes
-                            ?: com.wingedsheep.sdk.core.Subtype.ALL_CREATURE_TYPES
-                        val decisionId = "choose-creature-type-land-enters-${action.cardId.value}"
-                        val decision = com.wingedsheep.engine.core.ChooseOptionDecision(
-                            id = decisionId,
-                            playerId = chooserId,
-                            prompt = "Choose a creature type",
-                            context = com.wingedsheep.engine.core.DecisionContext(
-                                sourceId = action.cardId,
-                                sourceName = cardComponent.name,
-                                phase = com.wingedsheep.engine.core.DecisionPhase.RESOLUTION
-                            ),
-                            options = creatureTypeOptions,
-                            defaultSearch = ""
-                        )
-                        val continuation = com.wingedsheep.engine.core.EntersWithChoiceLandContinuation(
-                            decisionId = decisionId,
-                            landId = action.cardId,
-                            controllerId = action.playerId,
-                            choiceType = ChoiceType.CREATURE_TYPE,
-                            creatureTypes = creatureTypeOptions,
-                            fromZone = fromZone
-                        )
-                        val pausedState = newState
-                            .pushContinuation(continuation)
-                            .withPendingDecision(decision)
-                        ExecutionResult.paused(pausedState, decision, events)
-                    }
-
-                    ChoiceType.CREATURE_ON_BATTLEFIELD -> {
-                        // Lands don't use CREATURE_ON_BATTLEFIELD, but handle gracefully
-                        null
-                    }
-
-                    ChoiceType.BASIC_LAND_TYPE -> {
-                        val landTypeOptions = com.wingedsheep.sdk.core.Subtype.ALL_BASIC_LAND_TYPES.toList()
-                        val decisionId = "choose-land-type-land-enters-${action.cardId.value}"
-                        val decision = com.wingedsheep.engine.core.ChooseOptionDecision(
-                            id = decisionId,
-                            playerId = chooserId,
-                            prompt = "Choose a basic land type",
-                            context = com.wingedsheep.engine.core.DecisionContext(
-                                sourceId = action.cardId,
-                                sourceName = cardComponent.name,
-                                phase = com.wingedsheep.engine.core.DecisionPhase.RESOLUTION
-                            ),
-                            options = landTypeOptions,
-                            defaultSearch = ""
-                        )
-                        val continuation = com.wingedsheep.engine.core.EntersWithChoiceLandContinuation(
-                            decisionId = decisionId,
-                            landId = action.cardId,
-                            controllerId = action.playerId,
-                            choiceType = ChoiceType.BASIC_LAND_TYPE,
-                            landTypes = landTypeOptions,
-                            fromZone = fromZone
-                        )
-                        val pausedState = newState
-                            .pushContinuation(continuation)
-                            .withPendingDecision(decision)
-                        ExecutionResult.paused(pausedState, decision, events)
-                    }
-
-                    ChoiceType.MODE -> {
-                        if (firstChoice.modeOptions.isEmpty()) {
-                            null
-                        } else {
-                            val decisionId = "choose-mode-land-enters-${action.cardId.value}"
-                            val decision = com.wingedsheep.engine.core.ChooseOptionDecision(
-                                id = decisionId,
-                                playerId = chooserId,
-                                prompt = "Choose for ${cardComponent.name}",
-                                context = com.wingedsheep.engine.core.DecisionContext(
-                                    sourceId = action.cardId,
-                                    sourceName = cardComponent.name,
-                                    phase = com.wingedsheep.engine.core.DecisionPhase.RESOLUTION
-                                ),
-                                options = firstChoice.modeOptions.map { it.label },
-                                optionMetadata = firstChoice.modeOptions.map {
-                                    com.wingedsheep.engine.core.OptionMetadata(
-                                        id = it.id,
-                                        description = it.description,
-                                        iconKey = it.iconKey
-                                    )
-                                }
-                            )
-                            val continuation = com.wingedsheep.engine.core.EntersWithChoiceLandContinuation(
-                                decisionId = decisionId,
-                                landId = action.cardId,
-                                controllerId = action.playerId,
-                                choiceType = ChoiceType.MODE,
-                                modeOptionIds = firstChoice.modeOptions.map { it.id },
-                                fromZone = fromZone
-                            )
-                            val pausedState = newState
-                                .pushContinuation(continuation)
-                                .withPendingDecision(decision)
-                            ExecutionResult.paused(pausedState, decision, events)
-                        }
-                    }
-
-                    ChoiceType.OPPONENT -> {
-                        // Lands don't currently use the OPPONENT choice type, but the branch is
-                        // present so [ChoiceType]'s exhaustive `when` compiles. If a future
-                        // land needs "choose an opponent" on entry, wire the prompt + opponent-id
-                        // continuation here, matching the spell path in [StackResolver].
-                        null
-                    }
-                }
+                // Build the choice prompt + entity-keyed continuation via the shared on-battlefield
+                // entry helper (also used by Momir token minting). The land is already on the
+                // battlefield; the resumer records the choice and fires entry triggers afterward.
+                val result = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                    .pauseForEntersWithChoice(
+                        state = newState,
+                        entityId = action.cardId,
+                        controllerId = action.playerId,
+                        cardComponent = cardComponent,
+                        choice = firstChoice,
+                        fromZone = fromZone,
+                        carryEvents = events
+                    )
                 if (result != null) return result
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -25,7 +25,7 @@ class ModalAndCloneContinuationResumer(
         resumer(ModalTargetContinuation::class, ::resumeModalTarget),
         resumer(CloneEntersContinuation::class, ::resumeCloneEnters),
         resumer(EntersWithChoiceSpellContinuation::class, ::resumeEntersWithChoiceSpell),
-        resumer(EntersWithChoiceLandContinuation::class, ::resumeEntersWithChoiceLand),
+        resumer(EntersWithChoiceOnBattlefieldContinuation::class, ::resumeEntersWithChoiceOnBattlefield),
         resumer(PayLifeOrEnterTappedLandContinuation::class, ::resumePayLifeOrEnterTappedLand),
         resumer(PayLifeOrEnterTappedSpellContinuation::class, ::resumePayLifeOrEnterTappedSpell),
         resumer(RevealCountersContinuation::class, ::resumeRevealCounters),
@@ -624,19 +624,20 @@ class ModalAndCloneContinuationResumer(
      * Resume after player makes an "as enters" choice for a land played directly to the battlefield.
      * The land is already on the battlefield — just store the chosen value and check for chained choices.
      */
-    fun resumeEntersWithChoiceLand(
+    fun resumeEntersWithChoiceOnBattlefield(
         state: GameState,
-        continuation: EntersWithChoiceLandContinuation,
+        continuation: EntersWithChoiceOnBattlefieldContinuation,
         response: DecisionResponse,
         checkForMore: CheckForMore
     ): ExecutionResult {
+        val entityId = continuation.entityId
         // Store the chosen value based on choice type — into the unified cast-choices bag.
         var newState = when (continuation.choiceType) {
             com.wingedsheep.sdk.scripting.ChoiceType.COLOR -> {
                 if (response !is ColorChosenResponse) {
                     return ExecutionResult.error(state, "Expected color choice response")
                 }
-                state.updateEntity(continuation.landId) { c ->
+                state.updateEntity(entityId) { c ->
                     c.withCastChoice(ChoiceSlot.COLOR, ChoiceValue.ColorChoice(response.color))
                 }
             }
@@ -646,13 +647,19 @@ class ModalAndCloneContinuationResumer(
                 }
                 val chosenType = continuation.creatureTypes.getOrNull(response.optionIndex)
                     ?: return ExecutionResult.error(state, "Invalid creature type index: ${response.optionIndex}")
-                state.updateEntity(continuation.landId) { c ->
+                state.updateEntity(entityId) { c ->
                     c.withCastChoice(ChoiceSlot.CREATURE_TYPE, ChoiceValue.TextChoice(chosenType))
                 }
             }
             com.wingedsheep.sdk.scripting.ChoiceType.CREATURE_ON_BATTLEFIELD -> {
-                // Lands don't use this choice type, but handle gracefully
-                return checkForMore(state, emptyList())
+                if (response !is CardsSelectedResponse) {
+                    return ExecutionResult.error(state, "Expected cards selected response for creature choice")
+                }
+                val chosenCreatureId = response.selectedCards.firstOrNull()
+                    ?: return ExecutionResult.error(state, "No creature selected")
+                state.updateEntity(entityId) { c ->
+                    c.withCastChoice(ChoiceSlot.CREATURE, ChoiceValue.EntityChoice(chosenCreatureId))
+                }
             }
             com.wingedsheep.sdk.scripting.ChoiceType.MODE -> {
                 if (response !is OptionChosenResponse) {
@@ -660,7 +667,7 @@ class ModalAndCloneContinuationResumer(
                 }
                 val modeId = continuation.modeOptionIds.getOrNull(response.optionIndex)
                     ?: return ExecutionResult.error(state, "Invalid mode option index: ${response.optionIndex}")
-                state.updateEntity(continuation.landId) { c ->
+                state.updateEntity(entityId) { c ->
                     c.withCastChoice(ChoiceSlot.MODE, ChoiceValue.TextChoice(modeId))
                 }
             }
@@ -670,20 +677,25 @@ class ModalAndCloneContinuationResumer(
                 }
                 val chosenType = continuation.landTypes.getOrNull(response.optionIndex)
                     ?: return ExecutionResult.error(state, "Invalid land type index: ${response.optionIndex}")
-                state.updateEntity(continuation.landId) { c ->
+                state.updateEntity(entityId) { c ->
                     c.withCastChoice(ChoiceSlot.LAND_TYPE, ChoiceValue.TextChoice(chosenType))
                 }
             }
             com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT -> {
-                // Lands don't currently surface an opponent choice (no land card uses it),
-                // but the branch is here for exhaustiveness over [ChoiceType].
-                return checkForMore(state, emptyList())
+                if (response !is OptionChosenResponse) {
+                    return ExecutionResult.error(state, "Expected option chosen response for opponent choice")
+                }
+                val chosenOpponent = continuation.opponentIds.getOrNull(response.optionIndex)
+                    ?: return ExecutionResult.error(state, "Invalid opponent index: ${response.optionIndex}")
+                state.updateEntity(entityId) { c ->
+                    c.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosenOpponent))
+                }
             }
         }
 
-        // Check if the land has remaining choices to chain to
-        val landContainer = newState.getEntity(continuation.landId)
-        val cardComponent = landContainer?.get<CardComponent>()
+        // Check if the permanent has remaining choices to chain to (e.g. color + creature type).
+        val entityContainer = newState.getEntity(entityId)
+        val cardComponent = entityContainer?.get<CardComponent>()
         val cardDef = cardComponent?.let { services.cardRegistry.getCard(it.cardDefinitionId) }
 
         val nextChoice = cardDef?.script?.replacementEffects
@@ -691,52 +703,20 @@ class ModalAndCloneContinuationResumer(
             ?.sortedBy { it.choiceType.ordinal }
             ?.firstOrNull { it.choiceType.ordinal > continuation.choiceType.ordinal }
 
-        if (nextChoice != null) {
-            val chooserId = when (nextChoice.chooser) {
-                com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
-                    newState.getOpponents(continuation.controllerId).firstOrNull() ?: continuation.controllerId
-                else -> continuation.controllerId
-            }
-
-            when (nextChoice.choiceType) {
-                com.wingedsheep.sdk.scripting.ChoiceType.CREATURE_TYPE -> {
-                    val allCreatureTypes = com.wingedsheep.sdk.core.Subtype.ALL_CREATURE_TYPES
-                    val decisionId = "choose-creature-type-land-enters-${continuation.landId.value}"
-                    val decision = ChooseOptionDecision(
-                        id = decisionId,
-                        playerId = chooserId,
-                        prompt = "Choose a creature type",
-                        context = DecisionContext(
-                            sourceId = continuation.landId,
-                            sourceName = cardComponent.name,
-                            phase = DecisionPhase.RESOLUTION
-                        ),
-                        options = allCreatureTypes,
-                        defaultSearch = ""
-                    )
-                    val nextContinuation = EntersWithChoiceLandContinuation(
-                        decisionId = decisionId,
-                        landId = continuation.landId,
-                        controllerId = continuation.controllerId,
-                        choiceType = com.wingedsheep.sdk.scripting.ChoiceType.CREATURE_TYPE,
-                        creatureTypes = allCreatureTypes,
-                        fromZone = continuation.fromZone
-                    )
-                    val pausedState = newState
-                        .pushContinuation(nextContinuation)
-                        .withPendingDecision(decision)
-                    return ExecutionResult.paused(pausedState, decision)
-                }
-                else -> { /* No other chaining needed for lands */ }
-            }
+        if (nextChoice != null && cardComponent != null) {
+            val result = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements.pauseForEntersWithChoice(
+                newState, entityId, continuation.controllerId, cardComponent, nextChoice, continuation.fromZone
+            )
+            if (result != null) return result
+            // null means the chained choice couldn't be presented — fall through to fire triggers.
         }
 
-        // Final choice resolved — fire any triggers from the land entering
-        // (e.g., landfall). The land already moved to the battlefield when it was
-        // played; we synthesize the matching ZoneChangeEvent here so triggers
-        // can react now that the chosen value is recorded.
+        // Final choice resolved — fire any triggers from the permanent entering (e.g. landfall,
+        // "when ~ enters"). The permanent already moved to the battlefield when it was placed; we
+        // synthesize the matching ZoneChangeEvent here so triggers can react now that the chosen
+        // value is recorded.
         val zoneChangeEvent = ZoneChangeEvent(
-            continuation.landId,
+            entityId,
             cardComponent?.name ?: "Unknown",
             continuation.fromZone,
             Zone.BATTLEFIELD,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -1,0 +1,233 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ContinuationFrame
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EntersWithChoiceOnBattlefieldContinuation
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.OptionMetadata
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Applies a permanent's own "as-enters" [EntersWithChoice] replacement (CR 614.12 — choose a
+ * color / creature type / mode / … as the permanent enters) to an entity that has *already* been
+ * placed on the battlefield **directly** — i.e. not cast as a spell that resolves off the stack.
+ *
+ * Two callers share this seam:
+ *  - [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] — a land played directly, and
+ *  - [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition] — a token minted from a
+ *    card definition (e.g. the Momir Basic avatar's random-creature token).
+ *
+ * The spell-resolution path keeps its own pre-battlefield variant
+ * ([com.wingedsheep.engine.mechanics.stack.StackResolver.pauseForEntersWithChoice]) because there
+ * the entity is still a `SpellOnStackComponent` on the stack, not yet a permanent.
+ *
+ * The choice pauses for a player decision. [EntersWithChoiceOnBattlefieldContinuation]'s resumer
+ * records the chosen value into the entity's `CastChoicesComponent`, chains to any remaining
+ * choice, and then fires the entry's ETB triggers off a synthesized [ZoneChangeEvent] (using the
+ * continuation's `fromZone`). **ETB triggers are therefore fired by the resumer, never by the
+ * caller** — a caller whose paused result is run through trigger detection (e.g. an effect
+ * resolving via `StackResolver`) must NOT also include the entry battlefield [ZoneChangeEvent] in
+ * [carryEvents], or the triggers fire twice.
+ */
+object PermanentEntryReplacements {
+
+    /**
+     * Build the paused [ExecutionResult] for a permanent's first/next [EntersWithChoice].
+     *
+     * @param entityId the permanent already on the battlefield.
+     * @param controllerId its controller.
+     * @param cardComponent its card component (for the prompt name).
+     * @param choice the choice to present.
+     * @param fromZone the zone the permanent came from, used to synthesize the entry
+     *   [ZoneChangeEvent] in the resumer; `null` for a freshly-minted token (no prior zone).
+     * @param carryEvents events already produced by the caller to forward with the pause (e.g.
+     *   counters added). Must NOT include the entry battlefield [ZoneChangeEvent] when the caller's
+     *   result is trigger-detected (see class docs).
+     * @return a paused [ExecutionResult], or `null` if the choice cannot be presented (e.g.
+     *   `CREATURE_ON_BATTLEFIELD` with no other creatures, an empty `MODE`/`OPPONENT` set) — the
+     *   caller then completes entry normally.
+     */
+    fun pauseForEntersWithChoice(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        cardComponent: CardComponent,
+        choice: EntersWithChoice,
+        fromZone: Zone?,
+        carryEvents: List<GameEvent> = emptyList(),
+    ): ExecutionResult? {
+        val chooserId = when (choice.chooser) {
+            Player.AnOpponent -> state.getOpponents(controllerId).firstOrNull() ?: controllerId
+            else -> controllerId
+        }
+        val name = cardComponent.name
+
+        fun context(decisionId: String) = DecisionContext(
+            sourceId = entityId,
+            sourceName = name,
+            phase = DecisionPhase.RESOLUTION
+        )
+
+        fun pause(decision: PendingDecision, continuation: ContinuationFrame): ExecutionResult {
+            val paused = state.pushContinuation(continuation).withPendingDecision(decision)
+            return ExecutionResult.paused(paused, decision, carryEvents)
+        }
+
+        return when (choice.choiceType) {
+            ChoiceType.COLOR -> {
+                val id = "choose-color-enters-${entityId.value}"
+                pause(
+                    ChooseColorDecision(id, chooserId, "Choose a color", context(id)),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.COLOR,
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.CREATURE_TYPE -> {
+                val options = choice.allowedCreatureTypes ?: Subtype.ALL_CREATURE_TYPES
+                val id = "choose-creature-type-enters-${entityId.value}"
+                pause(
+                    ChooseOptionDecision(
+                        id = id,
+                        playerId = chooserId,
+                        prompt = "Choose a creature type",
+                        context = context(id),
+                        options = options,
+                        defaultSearch = ""
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.CREATURE_TYPE,
+                        creatureTypes = options,
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.CREATURE_ON_BATTLEFIELD -> {
+                val creatures = state.getBattlefield().filter { eid ->
+                    if (eid == entityId) return@filter false
+                    val container = state.getEntity(eid) ?: return@filter false
+                    val card = container.get<CardComponent>() ?: return@filter false
+                    state.projectedState.getController(eid) == controllerId && card.typeLine.isCreature
+                }
+                if (creatures.isEmpty()) return null
+                val id = "choose-creature-enters-${entityId.value}"
+                pause(
+                    SelectCardsDecision(
+                        id = id,
+                        playerId = controllerId,
+                        prompt = "Choose another creature you control",
+                        context = context(id),
+                        options = creatures,
+                        minSelections = 1,
+                        maxSelections = 1,
+                        useTargetingUI = true
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.CREATURE_ON_BATTLEFIELD,
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.MODE -> {
+                if (choice.modeOptions.isEmpty()) return null
+                val id = "choose-mode-enters-${entityId.value}"
+                pause(
+                    ChooseOptionDecision(
+                        id = id,
+                        playerId = chooserId,
+                        prompt = "Choose for $name",
+                        context = context(id),
+                        options = choice.modeOptions.map { it.label },
+                        optionMetadata = choice.modeOptions.map {
+                            OptionMetadata(id = it.id, description = it.description, iconKey = it.iconKey)
+                        }
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.MODE,
+                        modeOptionIds = choice.modeOptions.map { it.id },
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.BASIC_LAND_TYPE -> {
+                val options = Subtype.ALL_BASIC_LAND_TYPES.toList()
+                val id = "choose-land-type-enters-${entityId.value}"
+                pause(
+                    ChooseOptionDecision(
+                        id = id,
+                        playerId = chooserId,
+                        prompt = "Choose a basic land type",
+                        context = context(id),
+                        options = options,
+                        defaultSearch = ""
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.BASIC_LAND_TYPE,
+                        landTypes = options,
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.OPPONENT -> {
+                val opponentIds = state.turnOrder.filter { it != chooserId }
+                if (opponentIds.isEmpty()) return null
+                val opponentNames = opponentIds.map { pid ->
+                    state.getEntity(pid)?.get<PlayerComponent>()?.name ?: "Player ${pid.value}"
+                }
+                val id = "choose-opponent-enters-${entityId.value}"
+                pause(
+                    ChooseOptionDecision(
+                        id = id,
+                        playerId = chooserId,
+                        prompt = "Choose an opponent",
+                        context = context(id),
+                        options = opponentNames
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.OPPONENT,
+                        opponentIds = opponentIds,
+                        fromZone = fromZone
+                    )
+                )
+            }
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateRandomCreatureTokenWithManaValueExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateRandomCreatureTokenWithManaValueExecutor.kt
@@ -65,6 +65,7 @@ class CreateRandomCreatureTokenWithManaValueExecutor(
             state = stateAfterPick,
             cardDef = chosen,
             controllerId = context.controllerId,
+            cardRegistry = cardRegistry,
             staticAbilityHandler = staticAbilityHandler,
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -3,15 +3,23 @@ package com.wingedsheep.engine.handlers.effects.token
 import com.wingedsheep.engine.core.CardEntityFactory
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 /**
  * Mints a token that is a copy of a bare [CardDefinition] — one not instantiated in any zone —
@@ -27,15 +35,38 @@ import com.wingedsheep.sdk.model.EntityId
  * The token enters as a token copy with the definition's full abilities (resolved by name through
  * the registry, like any token). It carries no cast-time `{X}` — it never went on the stack — so a
  * copied creature's own `{X}` reads 0, matching CR for cards put onto the battlefield without being
- * cast. ETB triggers fire off the emitted [ZoneChangeEvent]; global "enters with counters" grants
- * are applied via [EntersWithCountersHelper], identical to the in-zone token-copy tail.
+ * cast.
+ *
+ * Because the token is put onto the battlefield directly (not cast), it runs the same "as-enters"
+ * replacement effects (CR 614) a directly-entering permanent would — mirroring
+ * [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler]:
+ *  - **[EntersTapped]** (Diregraf Ghoul, "enters tapped") taps the token. The shock-land
+ *    `payLifeCost` form is land-only, so a minted creature only ever has the simple form.
+ *  - **self + global [EntersWithCounters]/[EntersWithDynamicCounters]** add counters (a creature
+ *    that "enters with N +1/+1 counters", plus grants from other permanents) via
+ *    [EntersWithCountersHelper].
+ *  - **[EntersWithChoice]** (Alloy Golem, "as this enters, choose a color") pauses for a player
+ *    decision via [PermanentEntryReplacements]; the chosen value is recorded in
+ *    `CastChoicesComponent` and the token's ETB triggers fire from the resumer afterward.
+ *
+ * "When ~ enters" *triggered* abilities fire off the emitted [ZoneChangeEvent] (when there is no
+ * choice) or from the [EntersWithChoiceOnBattlefieldContinuation] resumer (when a choice paused —
+ * we deliberately omit the [ZoneChangeEvent] in that case so the triggers aren't detected twice).
+ *
+ * (Rarer as-enters replacements that pause for their own decision — Amplify reveal, Devour
+ * sacrifice, EntersAsCopy — are not applied to minted tokens; a minted copy of such a creature
+ * simply enters with zero amplify/devour counters. They are vanishingly rare in a random-creature
+ * pool and would require generalizing their spell-keyed continuations.)
  */
 object TokenFromDefinition {
+
+    private val conditionEvaluator = ConditionEvaluator()
 
     fun mint(
         state: GameState,
         cardDef: CardDefinition,
         controllerId: EntityId,
+        cardRegistry: CardRegistry,
         staticAbilityHandler: StaticAbilityHandler? = null,
     ): EffectResult {
         val (tokenId, stateWithId) = state.newEntity()
@@ -53,6 +84,50 @@ object TokenFromDefinition {
         var newState = stateWithId.withEntity(tokenId, container)
         newState = BattlefieldEntry.place(newState, controllerId, tokenId)
 
+        // As-enters: enters tapped (CR 614). The payLifeCost (shock-land) form is land-only.
+        val entersTapped = cardDef.script.replacementEffects.filterIsInstance<EntersTapped>().firstOrNull()
+        if (entersTapped != null && entersTapped.payLifeCost == null) {
+            val shouldEnterTapped = entersTapped.unlessCondition?.let { condition ->
+                !conditionEvaluator.evaluate(
+                    newState, condition, EffectContext(sourceId = tokenId, controllerId = controllerId)
+                )
+            } ?: true
+            if (shouldEnterTapped) {
+                newState = newState.updateEntity(tokenId) { c -> c.with(TappedComponent) }
+            }
+        }
+
+        // As-enters: the token's own + global "enters with counters" (CR 614).
+        val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
+            newState, tokenId, controllerId, cardRegistry
+        )
+        newState = stateWithCounters
+
+        // As-enters: "choose X as this enters" (CR 614.12). Pauses for a player decision; the
+        // resumer records the choice and fires the token's ETB triggers off a synthesized
+        // ZoneChangeEvent — so we deliberately do NOT emit the entry ZoneChangeEvent here when we
+        // pause (the resolution path would otherwise detect those triggers now AND again in the
+        // resumer, firing them twice). Counters already added ride along as carryEvents.
+        val firstChoice = cardDef.script.replacementEffects
+            .filterIsInstance<EntersWithChoice>()
+            .sortedBy { it.choiceType.ordinal }
+            .firstOrNull()
+        if (firstChoice != null) {
+            val cardComponent = newState.getEntity(tokenId)?.get<CardComponent>()
+            if (cardComponent != null) {
+                val paused = PermanentEntryReplacements.pauseForEntersWithChoice(
+                    state = newState,
+                    entityId = tokenId,
+                    controllerId = controllerId,
+                    cardComponent = cardComponent,
+                    choice = firstChoice,
+                    fromZone = null,
+                    carryEvents = counterEvents
+                )
+                if (paused != null) return EffectResult.from(paused)
+            }
+        }
+
         val event = ZoneChangeEvent(
             entityId = tokenId,
             entityName = cardDef.name,
@@ -61,10 +136,6 @@ object TokenFromDefinition {
             ownerId = controllerId
         )
 
-        val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyGlobalEntersWithCounters(
-            newState, tokenId, controllerId
-        )
-
-        return EffectResult.success(stateWithCounters, listOf(event) + counterEvents)
+        return EffectResult.success(newState, listOf(event) + counterEvents)
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
@@ -1,10 +1,14 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Format
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -85,6 +89,136 @@ class MomirBasicScenarioTest : ScenarioTestBase() {
             val token = game.state.getEntity(tokens.first())!!
             token.has<TokenComponent>().shouldBeTrue()
             token.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+        }
+
+        test("ETB draw trigger fires for the minted token") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Elvish Visionary")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withCardsInHand(1, "Mountain", 2)
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            val handBefore = game.state.getZone(game.player1Id, Zone.HAND).size
+            // Elvish Visionary is mana value 2; X=2 picks it.
+            game.execute(game.momirAction(xValue = 2)).error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Elvish Visionary") shouldHaveSize 1
+            // ETB: "When Elvish Visionary enters the battlefield, draw a card."
+            // Hand: started at 2, discarded 1 for the cost, +1 from the ETB draw = 2.
+            game.state.getZone(game.player1Id, Zone.HAND).size shouldBe handBefore
+        }
+
+        test("search-library ETB (Wood Elves) fires for the minted token") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Wood Elves")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Plains", 6)
+                .withCardsInHand(1, "Mountain", 2)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            // Wood Elves is mana value 3.
+            game.execute(game.momirAction(xValue = 3)).error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Wood Elves") shouldHaveSize 1
+            // The ETB trigger fired and is asking which card to search for.
+            val forestId = game.findCardsInLibrary(1, "Forest").single()
+            game.selectCards(listOf(forestId))
+            game.resolveStack()
+            game.isOnBattlefield("Forest").shouldBeTrue()
+        }
+
+        test("targeting ETB (Flametongue Kavu) fires for the minted token") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Flametongue Kavu")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardsInHand(1, "Plains", 2)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+
+            // Flametongue Kavu is mana value 4.
+            game.execute(game.momirAction(xValue = 4)).error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Flametongue Kavu") shouldHaveSize 1
+            // The ETB trigger fired and is asking for a target creature.
+            val bearsId = game.findPermanent("Grizzly Bears")!!
+            game.selectTargets(listOf(bearsId))
+            game.resolveStack()
+            // ETB: deals 4 damage to the only creature -> Grizzly Bears (2/2) dies.
+            game.isInGraveyard(2, "Grizzly Bears").shouldBeTrue()
+        }
+
+        test("an 'enters tapped' minted token enters tapped (Diregraf Ghoul)") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Diregraf Ghoul")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withCardsInHand(1, "Mountain", 2)
+                .build()
+
+            // Diregraf Ghoul is mana value 1.
+            game.execute(game.momirAction(xValue = 1)).error shouldBe null
+            game.resolveStack()
+
+            val token = game.findPermanents("Diregraf Ghoul").single()
+            // As-enters replacement (CR 614): "This creature enters tapped."
+            game.state.getEntity(token)!!.has<TappedComponent>().shouldBeTrue()
+        }
+
+        test("a minted token applies its own enters-with-counters (Servant of the Scale)") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Servant of the Scale")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withCardsInHand(1, "Mountain", 2)
+                .build()
+
+            // Servant of the Scale is mana value 1; a 0/0 that enters with a +1/+1 counter.
+            game.execute(game.momirAction(xValue = 1)).error shouldBe null
+            game.resolveStack()
+
+            val token = game.findPermanents("Servant of the Scale").single()
+            // The +1/+1 counter made it a 1/1 in the projected state.
+            game.state.projectedState.getPower(token) shouldBe 1
+            game.state.projectedState.getToughness(token) shouldBe 1
+        }
+
+        test("a minted token prompts its as-enters choice and becomes the chosen color (Alloy Golem)") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Alloy Golem")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Mountain", 8)
+                .withCardsInHand(1, "Forest", 2)
+                .build()
+
+            // Alloy Golem is mana value 6.
+            game.execute(game.momirAction(xValue = 6)).error shouldBe null
+            game.resolveStack()
+
+            // As-enters replacement (CR 614.12): "As this creature enters, choose a color."
+            // The minted token must surface the color prompt — the bug was that it never did.
+            val decision = game.getPendingDecision()
+            decision.shouldNotBeNull()
+            (decision is ChooseColorDecision).shouldBeTrue()
+
+            game.submitDecision(ColorChosenResponse(decision!!.id, Color.RED))
+            game.resolveStack()
+
+            val token = game.findPermanents("Alloy Golem").single()
+            // "This creature is the chosen color." (still an artifact, which is colorless by default).
+            game.state.projectedState.getColors(token) shouldContain "RED"
         }
 
         test("the random copy is filtered to the chosen mana value") {


### PR DESCRIPTION
## Problem

In Momir Basic, ETB effects appeared not to trigger for creatures the avatar minted. The reported examples were:

- **Alloy Golem** — never prompted "as this creature enters, choose a color"
- **Diregraf Ghoul** — didn't enter the battlefield tapped

The common thread is that **both are as-enters _replacement_ effects** (`EntersWithChoice`, `EntersTapped`), not "When ~ enters" _triggered_ abilities. A normally cast/played permanent runs these through `StackResolver.enterPermanentOnBattlefield` / `PlayLandHandler`, but `TokenFromDefinition.mint` (the Momir random-creature minter) put the token directly on the battlefield via `BattlefieldEntry.place` and only applied **global** enters-with-counters — skipping the permanent's own as-enters replacements.

Triggered "When ~ enters" abilities (draw, search, targeted damage) already worked, because they fire off the emitted `ZoneChangeEvent` — a separate mechanism. That's why it looked like ETBs failed only for *some* creatures.

## Fix

Route token minting through the same as-enters handling a directly-entering permanent runs:

- `EntersTapped` (simple form) taps the token. (The shock-land `payLifeCost` form is land-only, so a minted creature only ever has the simple form.)
- self + global `EntersWithCounters` / `EntersWithDynamicCounters` add counters.
- `EntersWithChoice` pauses for the player's choice; the chosen value is recorded in `CastChoicesComponent` and read back by static abilities (e.g. Alloy Golem's `GrantChosenColor`).

Rather than add a third copy of this logic, the on-battlefield "choose as it enters" boilerplate that `PlayLandHandler` already had was extracted into a shared `PermanentEntryReplacements.pauseForEntersWithChoice`, and the land-only `EntersWithChoiceLandContinuation` was generalized into the entity-keyed `EntersWithChoiceOnBattlefieldContinuation` (now covering every `ChoiceType` and chaining via the shared helper). Both the land-play and token-minting paths use it. Net result: `PlayLandHandler` shrank ~150 lines.

The continuation's resumer fires the entry's ETB triggers after the choice resolves, so when minting pauses for a choice it deliberately omits the entry `ZoneChangeEvent` to avoid detecting those triggers twice.

### Known limitation

Rarer as-enters replacements that pause for their *own* decision (Amplify reveal, Devour, `EntersAsCopy`) are still not applied to minted tokens; such a creature simply enters with zero amplify/devour counters. They're vanishingly rare in a random-creature pool and would require generalizing their spell-keyed continuations.

## Tests (`MomirBasicScenarioTest`, rules-engine)

New, through the real `ActionProcessor`:
- Diregraf Ghoul minted by Momir enters tapped
- Servant of the Scale enters with its +1/+1 counter (projected 1/1)
- Alloy Golem surfaces the `ChooseColorDecision` and becomes the chosen color
- ETB *trigger* coverage that was previously missing: draw (Elvish Visionary), library search (Wood Elves), targeted damage (Flametongue Kavu)

Full `:rules-engine` suite green; `RiptideReplicator` (chained `EntersWithChoice`) and the `EntersTapped` land tests confirm the `PlayLandHandler` refactor is regression-free; `game-server` / `ai` / `engine-gym` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)