### PR TITLE
Add 4 OTJ cards (Aven Interrupter, Unscrupulous Contractor, Roxanne, Fblthp) + plot/exile-spell SDK

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -422,7 +422,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `GrantPlayWithoutPayingCost(from)` — same, without paying mana costs.
 - `GrantPlayWithCostIncrease(from, amount)` — stamp `PlayWithCostIncreaseComponent(controllerId, amount)` on every card in the collection, so the next cast pays `{amount}` extra generic. Pair with `GrantMayPlayFromExile` for "each spell cast this way costs {N} more" clauses (Lightstall Inquisitor); for target-based "exile this permanent, owner may play it, opponents tax" effects use `Effects.ExileAndGrantOwnerPlayPermission` instead.
 - `GrantFreeCastTargetFromExile(target)` — cast specific exiled card for free.
-- `MakePlotted(from)` — make every card in the named collection *plotted* (CR 718). The cards must already be in exile (chain after a `MoveCollection` to `Zone.EXILE`). Each card gets the plotted designation (`PlottedComponent`) + a permanent free-cast-as-a-sorcery-on-a-later-turn permission (`PlayWithoutPayingCostComponent` + `MayPlayPermission` gated by `SourcePlottedOnPriorTurn`) — the Plot keyword's state without a plot cost. Emits a `CardPlottedEvent` per card so "when this card becomes plotted" triggers fire. No-ops on an empty collection (so an optional "you may exile … it becomes plotted" fork is safe). Used by Make Your Own Luck.
+- `MakePlotted(from, ownerControls = false)` — make every card in the named collection *plotted* (CR 718). The cards must already be in exile (chain after a `MoveCollection` to `Zone.EXILE`). Each card gets the plotted designation (`PlottedComponent`) + a permanent free-cast-as-a-sorcery-on-a-later-turn permission (`PlayWithoutPayingCostComponent` + `MayPlayPermission` gated by `SourcePlottedOnPriorTurn`) — the Plot keyword's state without a plot cost. Emits a `CardPlottedEvent` per card so "when this card becomes plotted" triggers fire. No-ops on an empty collection (so an optional "you may exile … it becomes plotted" fork is safe). With `ownerControls = true` the free-cast permission goes to each card's **owner** rather than the effect's controller (CR 718.2 — for "exile target spell, it becomes plotted" the spell's owner casts it later, not the plotter); default is controller-controls (you plot a card you own, like Make Your Own Luck).
 
 ### Stats & keywords
 
@@ -590,6 +590,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   for Goldvein Hydra's "create a number of tapped Treasure tokens equal to its power").
 - `CreateFood(count?, controller?)` — Food tokens.
 - `CreateLander(count?, controller?)` — Lander land tokens.
+- `CreateMeteorite(count?, tapped?, controller?)` — Meteorite tokens (Roxanne, Starfall Savant): a
+  colorless artifact with "When this token enters, it deals 2 damage to any target." and "{T}: Add
+  one mana of any color." Roxanne creates them `tapped = true`.
 - `CreateMutavault(count?, tapped?, controller?)` — Mutavault tokens.
 - `CreateRoleToken(roleName, target)` — attach a Role aura token.
 - `CreateMapToken(count?)` — Map artifact tokens.
@@ -692,6 +695,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   - `target = CounterTarget.Spell` / `Ability` / `SpellOrAbility` — `SpellOrAbility` dispatches at resolution by inspecting whether the stack entity has a `SpellOnStackComponent`. Used by Teferi's Response.
   - `condition = CounterCondition.UnlessPaysMana(cost, onPaid?)` / `UnlessPaysDynamic(amount, onPaid?)` — "unless its controller pays …" with an optional `onPaid: Effect` rider that fires **only** when the spell's controller pays (Divert Disaster's "If they do, you create a Lander token"). The rider executes with the counter's controller as `controllerId`, so "you" in the rider resolves to the caster of the counter. The rider does not fire when the spell is countered. Facade: `Effects.CounterUnlessPays(cost, onPaid)` / `Effects.CounterUnlessDynamicPays(amount, exileOnCounter, onPaid)`.
 - `CounterAllOnStackEffect(filter?, destination?)` — counter everything matching.
+- `ExileTargetSpellEffect(makePlotted = false)` (facade `Effects.ExileTargetSpell(makePlotted)`) — exile target spell (CR 718 "exile target spell"). **Not a counter:** it removes the spell from the stack and exiles the card even if the spell *can't be countered* (so it works where `CounterEffect(destination = Exile())` no-ops), and it fires no "whenever a spell is countered" trigger — but the spell still fails to resolve because it left the stack. With `makePlotted = true` the exiled card becomes *plotted* for its **owner** (gains `PlottedComponent` + a permanent free-cast-on-a-later-turn `MayPlayPermission` gated by `SourcePlottedOnPriorTurn`, granted to the owner per CR 718.2), emitting a `CardPlottedEvent`. Pair with `Targets.Spell`. Used by **Aven Interrupter** ("When this creature enters, exile target spell. It becomes plotted.").
 - `OpenLifeBid(onWin, participant = Player.AnOpponent)` — open life-bidding auction between you and `participant` (resolved against the effect context). You open at a bid of 1; the two bidders alternate topping the high bid (yes/no to top, then a number for the amount, capped at the bidder's life) until one passes. The high bidder loses that much life; `onWin` runs **only if you win**, with the original targets in context. If `participant` resolves to you (or to nobody), you're the sole bidder and win at the opening bid. For Mages' Contest, bid against the targeted spell's controller and counter it: `Effects.OpenLifeBid(Effects.CounterSpell(), Player.ControllerOf("target spell"))` — pair with a `TargetSpell` requirement.
 - `DestroySourceOfTargetedAbilityEffect` — when the targeted stack object is a permanent's activated/triggered ability, destroy that source permanent. Compose *before* the counter step so the ability component is still readable (Teferi's Response).
 - `CopyTargetSpellEffect(target)` — copy a spell on the stack.
@@ -2150,7 +2154,8 @@ staticAbility {
 ```
 
 - `target: SpellCostTarget` — `SelfCast`, `YouCast(filter)`, `AnyCaster(filter)`,
-  `OpponentsCastTargeting(GroupFilter)`, `FaceDownYouCast`, `MorphActivation`.
+  `OpponentsCastTargeting(GroupFilter)`, `OpponentsCastFromZones(zones, filter?)`, `FaceDownYouCast`, `MorphActivation`.
+  - `OpponentsCastFromZones(zones, filter = Any)` — spells the source-controller's opponents cast **from one of `zones`** (matched against the spell's actual cast zone, threaded as `fromZone`), matching `filter`. Pair with `CostModification.IncreaseGeneric(n)` for the Aven Interrupter shape: `OpponentsCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE))` + `IncreaseGeneric(2)` = "Spells your opponents cast from graveyards or from exile cost {2} more to cast."
 - `modification: CostModification` — `ReduceGeneric(amount)`, `ReduceGenericBy(source)`,
   `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`,
   `ReduceColoredIfAnyTargetMatches(symbols, filter)` (target-gated **colored** reduction — the
@@ -2237,7 +2242,10 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   `rider` is an optional non-mana `Effect` resolved inline, controlled by the tapping player
   (`EffectTarget.Controller` = tapper, `EffectTarget.Self` = the static's source). (Lavaleaper = basic-land
   mirror; Badgermole Cub = `+{G}`; **Overabundance** = `GameObjectFilter.Land` mirror + `DealDamage(1,
-  Controller)` rider)
+  Controller)` rider; **Roxanne, Starfall Savant** = `GameObjectFilter.Artifact.token().youControl()`
+  mirror). The mirror fires for both fixed-color producers (handled synchronously) and **any-color**
+  producers whose color is chosen at tap time (e.g. Roxanne's Meteorite "{T}: Add one mana of any
+  color" — the mirror is applied after the color choice resolves, in the color-choice continuation).
 - `ReplaceLandManaColor(filter)` — global: lands matching `filter` produce one mana of a color of their
   controller's choice instead of their normal mana. Implemented by swapping the land's base mana effect
   for "add one mana of any color", so the choice flows through the normal any-color machinery (manual tap
@@ -2319,6 +2327,13 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
   play, no full public reveal. (Precognition Field = instants/sorceries)
 - `LookAtTopOfLibrary` — *private*: the controller may look at their own top card any time (revealed
   only to them, not opponents). (Lens of Clarity, Vizier of the Menagerie)
+- `PlotFromTopOfLibrary(filter = Nonland)` — the controller may **plot** (CR 718) the top card of
+  their library if it matches `filter`, paying a plot cost equal to the card's mana cost. The plot
+  legal-action enumerator offers the top card as a plot action and `PlotCardHandler` moves it from
+  library → exile and plots it (sorcery-speed special action; can't be cast the turn it's plotted).
+  Grants an *additional* way to plot — a card with its own printed plot cost may still use that. Pair
+  with `LookAtTopOfLibrary` so the controller can see the card. (Fblthp, Lost on the Range =
+  nonland.)
 - `OpponentsPlayWithHandsRevealed` — visibility-only, the opponent-facing sibling of
   `RevealTopOfLibrary`: each opponent of the controller plays with their hand publicly visible to
   that controller (no other game effect). Handled entirely by the client state transformer's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -141,6 +141,7 @@ import com.wingedsheep.sdk.scripting.effects.CounterAllOnStackEffect
 import com.wingedsheep.sdk.scripting.effects.CounterCondition
 import com.wingedsheep.sdk.scripting.effects.CounterDestination
 import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.effects.ExileTargetSpellEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnSpellToOwnersHandEffect
 import com.wingedsheep.sdk.scripting.effects.CounterTarget
 import com.wingedsheep.sdk.scripting.effects.CounterTargetSource
@@ -1494,6 +1495,18 @@ object Effects {
     ): Effect = com.wingedsheep.sdk.scripting.effects.BeholdEffect(filter, ifBeheld)
 
     /**
+     * Create Meteorite artifact tokens (Roxanne, Starfall Savant).
+     * A colorless artifact named Meteorite with "When this token enters, it deals 2 damage to
+     * any target." and "{T}: Add one mana of any color." Roxanne creates them tapped.
+     *
+     * @param count Number of tokens to create
+     * @param tapped Whether the tokens enter the battlefield tapped
+     * @param controller Who controls the tokens (null = effect controller)
+     */
+    fun CreateMeteorite(count: Int = 1, tapped: Boolean = false, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Meteorite", count, controller, tapped = tapped)
+
+    /**
      * Create Food artifact tokens.
      * "{2}, {T}, Sacrifice this artifact: You gain 3 life."
      *
@@ -1978,6 +1991,15 @@ object Effects {
      */
     fun CounterTriggeringSpell(): Effect =
         CounterEffect(targetSource = CounterTargetSource.TriggeringEntity)
+
+    /**
+     * Exile target spell (CR 718, "exile target spell" — Aven Interrupter). Not a counter: it
+     * exiles even can't-be-countered spells and fires no "spell was countered" trigger, but the
+     * spell still fails to resolve. Pass [makePlotted] = true for "it becomes plotted" (the
+     * card's owner may cast it for free on a later turn). Pair with `Targets.Spell`.
+     */
+    fun ExileTargetSpell(makePlotted: Boolean = false): Effect =
+        ExileTargetSpellEffect(makePlotted = makePlotted)
 
     /**
      * Counter target spell unless its controller pays a mana cost.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -41,6 +41,8 @@ data class ModifySpellCost(
             is SpellCostTarget.AnyCaster -> "${filterAdjective(target.filter)}$noun"
             is SpellCostTarget.OpponentsCastTargeting ->
                 "Spells your opponents cast that target ${target.targetFilter.description}"
+            is SpellCostTarget.OpponentsCastFromZones ->
+                "Spells your opponents cast from ${describeZones(target.zones)}"
             SpellCostTarget.FaceDownYouCast -> "Face-down creature spells you cast"
             SpellCostTarget.MorphActivation -> "All morph costs"
         }
@@ -77,6 +79,22 @@ data class ModifySpellCost(
     private fun filterAdjective(filter: GameObjectFilter): String {
         val desc = filter.description
         return if (desc.isBlank() || desc == "card") "" else "$desc "
+    }
+
+    // Phrase a set of cast-from zones the way the oracle text reads — "graveyards or from exile".
+    private fun describeZones(zones: Set<com.wingedsheep.sdk.core.Zone>): String {
+        val parts = zones.toList().sortedBy { it.ordinal }.map { zone ->
+            when (zone) {
+                com.wingedsheep.sdk.core.Zone.GRAVEYARD -> "graveyards"
+                com.wingedsheep.sdk.core.Zone.EXILE -> "exile"
+                else -> zone.displayName
+            }
+        }
+        return when (parts.size) {
+            0 -> ""
+            1 -> parts[0]
+            else -> parts.dropLast(1).joinToString(", ") + " or from " + parts.last()
+        }
     }
 
     private fun ordinal(n: Int): String = when (n) {
@@ -160,6 +178,28 @@ sealed interface SpellCostTarget {
         override fun applyTextReplacement(replacer: TextReplacer): SpellCostTarget {
             val newFilter = targetFilter.applyTextReplacement(replacer)
             return if (newFilter !== targetFilter) copy(targetFilter = newFilter) else this
+        }
+    }
+
+    /**
+     * Spells opponents of the source's controller cast **from one of [zones]**, matching [filter]
+     * (default: any spell). The zone-of-cast analogue of [OpponentsCastTargeting].
+     *
+     * Used for Aven Interrupter ("Spells your opponents cast from graveyards or from exile cost
+     * {2} more to cast") via `OpponentsCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE))` paired
+     * with [CostModification.IncreaseGeneric]. The cost calculator matches it only when the
+     * casting player is an opponent of the source's controller and the spell is being cast from
+     * one of the named zones.
+     */
+    @SerialName("OpponentsCastFromZones")
+    @Serializable
+    data class OpponentsCastFromZones(
+        val zones: Set<com.wingedsheep.sdk.core.Zone>,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+    ) : SpellCostTarget {
+        override fun applyTextReplacement(replacer: TextReplacer): SpellCostTarget {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -251,6 +251,39 @@ data object LookAtTopOfLibrary : StaticAbility {
 }
 
 /**
+ * You may **plot** (CR 718) the top card of your library if it matches [filter], paying a plot
+ * cost equal to its mana cost. The card's own printed plot cost, if any, is unaffected — this
+ * grants an *additional* way to plot it (CR 718; Fblthp's ruling: "you may plot that card using
+ * its own plot cost or the plot cost given to it by Fblthp").
+ *
+ * Models Fblthp, Lost on the Range: "The top card of your library has plot. The plot cost is
+ * equal to its mana cost. You may plot nonland cards from the top of your library." The two
+ * clauses combine to a single capability — plot the top card from the library (filtered to
+ * nonland, since plotting a land is meaningless) at its mana cost. Pairs with
+ * [LookAtTopOfLibrary] so the controller can see the card to decide.
+ *
+ * Enumerated by the plot legal-action enumerator and resolved by the plot handler, which moves
+ * the card from library → exile (instead of hand → exile) and plots it for its owner. Like the
+ * Plot keyword this is a sorcery-speed special action; the card cannot be cast the turn it
+ * becomes plotted.
+ *
+ * @property filter Which top-of-library cards are plottable this way (Fblthp: nonland).
+ */
+@SerialName("PlotFromTopOfLibrary")
+@Serializable
+data class PlotFromTopOfLibrary(
+    val filter: GameObjectFilter = GameObjectFilter.Nonland
+) : StaticAbility {
+    override val description: String =
+        "The top card of your library has plot. The plot cost is equal to its mana cost. " +
+            "You may plot ${filter.description} cards from the top of your library."
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Play with the top card of your library revealed (to all players), without granting any
  * permission to play it from there. Used for Goblin Spy.
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -1085,11 +1085,18 @@ data class GrantMayPlayFromExileEffect(
  * to pay — the exile + selection is performed by the preceding pipeline steps.
  *
  * @property from Name of the collection containing the already-exiled card(s) to plot.
+ * @property ownerControls When true, the free-cast permission is granted to each card's *owner*
+ *   rather than the effect's controller. Use this for "exile target spell, it becomes plotted"
+ *   (Aven Interrupter), where the plotted card's owner — not the player who plotted it — may
+ *   later cast it (the card's own reminder text: "Its owner may cast it as a sorcery on a later
+ *   turn without paying its mana cost"). Defaults to controller-controls, matching the Plot
+ *   keyword and effects like Make Your Own Luck where you plot a card you own.
  */
 @SerialName("MakePlotted")
 @Serializable
 data class MakePlottedEffect(
-    val from: String
+    val from: String,
+    val ownerControls: Boolean = false
 ) : Effect {
     override val description: String = "Those cards become plotted"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -207,6 +207,32 @@ data class CounterEffect(
     }
 }
 
+/**
+ * Exile target spell on the stack (CR 718 "exile target spell" — Aven Interrupter).
+ *
+ * Distinct from [CounterEffect] with [CounterDestination.Exile]: this is **not** a counter.
+ * It exiles the spell regardless of can't-be-countered (Aven Interrupter's ruling: "Spells that
+ * can't be countered can still be exiled. They won't resolve."), and it fires no
+ * "whenever a spell is countered" trigger. The spell still fails to resolve because it leaves
+ * the stack. The target is the chosen spell ([com.wingedsheep.sdk.dsl.Targets.Spell] supplies
+ * the requirement).
+ *
+ * @property makePlotted When true, the exiled card becomes *plotted* for its **owner** (CR 718.2):
+ *   it gains the plotted designation and a permanent free-cast-on-a-later-turn permission. Pairs
+ *   with [com.wingedsheep.sdk.scripting.effects.MakePlottedEffect]'s owner-controls semantics, but
+ *   reads its subject from the stack instead of a gathered collection.
+ */
+@SerialName("ExileTargetSpell")
+@Serializable
+data class ExileTargetSpellEffect(
+    val makePlotted: Boolean = false
+) : Effect {
+    override val description: String = buildString {
+        append("Exile target spell")
+        if (makePlotted) append(". It becomes plotted")
+    }
+}
+
 // =============================================================================
 // Stack Effects — Counter All
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AvenInterrupter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AvenInterrupter.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Aven Interrupter
+ * {1}{W}{W}
+ * Creature — Bird Rogue
+ * 2/2
+ *
+ * Flash
+ * Flying
+ * When this creature enters, exile target spell. It becomes plotted. (Its owner may cast it
+ * as a sorcery on a later turn without paying its mana cost.)
+ * Spells your opponents cast from graveyards or from exile cost {2} more to cast.
+ *
+ * The ETB ability uses [Effects.ExileTargetSpell] with `makePlotted = true` — a non-counter
+ * removal (CR 718; ruling: "Spells that can't be countered can still be exiled. They won't
+ * resolve."). The exiled spell card becomes plotted for its **owner**, who may cast it for free
+ * on a later turn. The static tax is a [ModifySpellCost] with the new
+ * [SpellCostTarget.OpponentsCastFromZones] target — spells the controller's opponents cast from
+ * a graveyard or from exile cost {2} more.
+ */
+val AvenInterrupter = card("Aven Interrupter") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\nFlying\n" +
+        "When this creature enters, exile target spell. It becomes plotted. (Its owner may cast " +
+        "it as a sorcery on a later turn without paying its mana cost.)\n" +
+        "Spells your opponents cast from graveyards or from exile cost {2} more to cast."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("spell", Targets.Spell)
+        effect = Effects.ExileTargetSpell(makePlotted = true)
+        description = "When this creature enters, exile target spell. It becomes plotted."
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.OpponentsCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE)),
+            modification = CostModification.IncreaseGeneric(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Daniel Romanovsky"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg?1712355236"
+
+        ruling("2024-04-12", "Spells that can't be countered can still be exiled by Aven Interrupter's triggered ability. They won't resolve.")
+        ruling("2024-04-12", "If the plotted card's owner casts it, the spell has no relation to the spell that player originally cast. Any choices made for the original spell aren't carried over to the new one.")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FblthpLostOnTheRange.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FblthpLostOnTheRange.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Fblthp, Lost on the Range
+ * {1}{U}{U}
+ * Legendary Creature — Homunculus
+ * 1/1
+ *
+ * Ward {2}
+ * You may look at the top card of your library any time.
+ * The top card of your library has plot. The plot cost is equal to its mana cost.
+ * You may plot nonland cards from the top of your library.
+ *
+ * Ward {2} is the standard [KeywordAbility.Ward]. The visibility clause is [LookAtTopOfLibrary].
+ * The two plot clauses combine into the [PlotFromTopOfLibrary] static ability (filtered to
+ * nonland, since plotting a land is meaningless): the plot legal-action enumerator offers the top
+ * card of the library as a plot action at a cost equal to its mana cost, and [PlotCardHandler]
+ * moves it from library → exile and plots it (CR 718 — sorcery-speed special action; can't be
+ * cast the turn it's plotted).
+ */
+val FblthpLostOnTheRange = card("Fblthp, Lost on the Range") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Homunculus"
+    power = 1
+    toughness = 1
+    oracleText = "Ward {2}\n" +
+        "You may look at the top card of your library any time.\n" +
+        "The top card of your library has plot. The plot cost is equal to its mana cost.\n" +
+        "You may plot nonland cards from the top of your library."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+    staticAbility {
+        ability = PlotFromTopOfLibrary(filter = GameObjectFilter.Nonland)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "48"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg?1712355420"
+
+        ruling("2024-04-12", "If the top card of your library normally has plot, you may plot that card using its own plot cost or the plot cost given to it by Fblthp.")
+        ruling("2024-04-12", "If you plot the top card of your library, you must exile that card and pay its plot cost before you may look at the new top card of your library.")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RoxanneStarfallSavant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RoxanneStarfallSavant.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Roxanne, Starfall Savant
+ * {3}{R}{G}
+ * Legendary Creature — Cat Druid
+ * 4/3
+ *
+ * Whenever Roxanne enters or attacks, create a tapped colorless artifact token named Meteorite
+ * with "When this token enters, it deals 2 damage to any target" and "{T}: Add one mana of any color."
+ * Whenever you tap an artifact token for mana, add one mana of any type that artifact token produced.
+ *
+ * "Enters or attacks" is two triggered abilities sharing one effect (CR 603.2 — the two events
+ * trigger independently), each creating a tapped [Meteorite] predefined token (its ETB-deal-2 and
+ * mana ability live on the token definition). The second ability is the
+ * [AdditionalManaOnSourceTap] static with `color = null` (mirror the produced type) over
+ * artifact tokens you control — the same shape as Lavaleaper's "add one mana of any type that land
+ * produced", here scoped to artifact tokens.
+ */
+val RoxanneStarfallSavant = card("Roxanne, Starfall Savant") {
+    manaCost = "{3}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Cat Druid"
+    power = 4
+    toughness = 3
+    oracleText = "Whenever Roxanne enters or attacks, create a tapped colorless artifact token " +
+        "named Meteorite with \"When this token enters, it deals 2 damage to any target\" and " +
+        "\"{T}: Add one mana of any color.\"\n" +
+        "Whenever you tap an artifact token for mana, add one mana of any type that artifact token produced."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMeteorite(tapped = true)
+        description = "Whenever Roxanne enters, create a tapped Meteorite token."
+    }
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateMeteorite(tapped = true)
+        description = "Whenever Roxanne attacks, create a tapped Meteorite token."
+    }
+
+    staticAbility {
+        ability = AdditionalManaOnSourceTap(
+            sourceFilter = GameObjectFilter.Artifact.token().youControl(),
+            color = null,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Ina Wong"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg?1712356193"
+
+        ruling("2024-04-12", "You're tapping an artifact token for mana only if you're activating a mana ability of that token that includes the tap symbol ({T}) in its cost.")
+        ruling("2024-04-12", "The additional mana is produced by Roxanne, not by the artifact token that you tapped for mana.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/UnscrupulousContractor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/UnscrupulousContractor.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Unscrupulous Contractor
+ * {2}{B}
+ * Creature — Human Assassin
+ * 3/2
+ *
+ * When this creature enters, you may sacrifice a creature. When you do, target player
+ * draws two cards and loses 2 life.
+ * Plot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery
+ * on a later turn without paying its mana cost. Plot only as a sorcery.)
+ *
+ * "Sacrifice a creature" is a resolution-time choice, not a target (per the ruling: no target
+ * is chosen when the ETB ability triggers). The player accepts the optional first, then chooses
+ * which creature to sacrifice, so declining never forces a commitment. Only when a creature is
+ * actually sacrificed does the reflexive "When you do" ability go on the stack, choosing its
+ * target player as it does — modelled by [ReflexiveTriggerEffect] with a player
+ * `reflexiveTargetRequirement`. The reflexive payoff is a composite: that player draws two
+ * cards and loses 2 life. Plot is the standard [KeywordAbility.plot] special action.
+ */
+val UnscrupulousContractor = card("Unscrupulous Contractor") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Assassin"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may sacrifice a creature. When you do, target " +
+        "player draws two cards and loses 2 life.\n" +
+        "Plot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Composite(listOf(
+                SelectTargetEffect(
+                    requirement = TargetObject(filter = TargetFilter.CreatureYouControl),
+                    storeAs = "creatureToSacrifice"
+                ),
+                Effects.SacrificeTarget(EffectTarget.PipelineTarget("creatureToSacrifice"))
+            )),
+            optional = true,
+            reflexiveEffect = Effects.Composite(listOf(
+                Effects.DrawCards(2, EffectTarget.ContextTarget(0)),
+                Effects.LoseLife(2, EffectTarget.ContextTarget(0))
+            )),
+            reflexiveTargetRequirements = listOf(Targets.Player),
+            descriptionOverride = "You may sacrifice a creature. When you do, target player draws two cards and loses 2 life."
+        )
+        description = "When this creature enters, you may sacrifice a creature. When you do, target player draws two cards and loses 2 life."
+    }
+
+    keywordAbility(KeywordAbility.plot("{2}{B}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Mila Pesic"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg?1712355703"
+
+        ruling("2024-04-12", "You don't choose a target for Unscrupulous Contractor's ability at the time it triggers. Rather, a second \"reflexive\" ability triggers if you sacrifice a creature this way. You choose a target for that ability as it goes on the stack.")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -55,6 +55,33 @@ object PredefinedTokens {
     }
 
     /**
+     * Meteorite token — a colorless artifact (Roxanne, Starfall Savant) with:
+     * "When this token enters, it deals 2 damage to any target." and
+     * "{T}: Add one mana of any color."
+     */
+    val Meteorite = card("Meteorite") {
+        typeLine = "Artifact"
+
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            val anyTarget = target("any target", Targets.Any)
+            effect = Effects.DealDamage(2, anyTarget, damageSource = EffectTarget.Self)
+            description = "When this token enters, it deals 2 damage to any target."
+        }
+
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddAnyColorMana(1)
+            manaAbility = true
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/0/0/00b41ca9-0bf0-41fc-af65-854e602ee007.jpg?1712317015"
+            artist = "Ina Wong"
+        }
+    }
+
+    /**
      * Food token — an artifact with:
      * "{2}, {T}, Sacrifice this artifact: You gain 3 life."
      */
@@ -349,6 +376,7 @@ object PredefinedTokens {
      */
     val allTokens: List<CardDefinition> = listOf(
         Treasure,
+        Meteorite,
         Food,
         Lander,
         JustOneGlass,

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -835,6 +835,85 @@
     ]
 }
 
+// Aven Interrupter
+{
+    "name": "Aven Interrupter",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Bird Rogue",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, exile target spell. It becomes plotted. (Its owner may cast it as a sorcery on a later turn without paying its mana cost.)\nSpells your opponents cast from graveyards or from exile cost {2} more to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileTargetSpell",
+                    "makePlotted": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Stack"
+                    },
+                    "id": "spell"
+                },
+                "descriptionOverride": "When this creature enters, exile target spell. It becomes plotted."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "OpponentsCastFromZones",
+                    "zones": [
+                        "Graveyard",
+                        "Exile"
+                    ]
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Daniel Romanovsky",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg?1712355236",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Spells that can't be countered can still be exiled by Aven Interrupter's triggered ability. They won't resolve."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If the plotted card's owner casts it, the spell has no relation to the spell that player originally cast. Any choices made for the original spell aren't carried over to the new one."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Badlands Revival
 {
     "name": "Badlands Revival",
@@ -5001,6 +5080,59 @@
         "artist": "José Parodi",
         "flavorText": "\"We should have taken the blasted ferry!\"\n—Hope Hagan, prospector",
         "imageUri": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg?1712355418"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fblthp, Lost on the Range
+{
+    "name": "Fblthp, Lost on the Range",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Creature — Homunculus",
+    "oracleText": "Ward {2}\nYou may look at the top card of your library any time.\nThe top card of your library has plot. The plot cost is equal to its mana cost.\nYou may plot nonland cards from the top of your library.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            "PlotFromTopOfLibrary"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg?1712355420",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "If the top card of your library normally has plot, you may plot that card using its own plot cost or the plot cost given to it by Fblthp."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you plot the top card of your library, you must exile that card and pay its plot cost before you may look at the new top card of your library."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -13043,6 +13175,71 @@
     ]
 }
 
+// Roxanne, Starfall Savant
+{
+    "name": "Roxanne, Starfall Savant",
+    "manaCost": "{3}{R}{G}",
+    "typeLine": "Legendary Creature — Cat Druid",
+    "oracleText": "Whenever Roxanne enters or attacks, create a tapped colorless artifact token named Meteorite with \"When this token enters, it deals 2 damage to any target\" and \"{T}: Add one mana of any color.\"\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Meteorite",
+                    "tapped": true
+                },
+                "descriptionOverride": "Whenever Roxanne enters, create a tapped Meteorite token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Meteorite",
+                    "tapped": true
+                },
+                "descriptionOverride": "Whenever Roxanne attacks, create a tapped Meteorite token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "AdditionalManaOnSourceTap",
+                "sourceFilter": "artifact token ctrl:you"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Ina Wong",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg?1712356193",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You're tapping an artifact token for mana only if you're activating a mana ability of that token that includes the tap symbol ({T}) in its cost."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The additional mana is produced by Roxanne, not by the artifact token that you tapped for mana."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Rush of Dread
 {
     "name": "Rush of Dread",
@@ -16830,6 +17027,114 @@
             {
                 "date": "2024-04-12",
                 "text": "You can't choose the same mode more than once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Unscrupulous Contractor
+{
+    "name": "Unscrupulous Contractor",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Assassin",
+    "oracleText": "When this creature enters, you may sacrifice a creature. When you do, target player draws two cards and loses 2 life.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "storeAs": "creatureToSacrifice"
+                            },
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "creatureToSacrifice"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveTargetRequirements": [
+                        "TargetPlayer"
+                    ],
+                    "descriptionOverride": "You may sacrifice a creature. When you do, target player draws two cards and loses 2 life."
+                },
+                "descriptionOverride": "When this creature enters, you may sacrifice a creature. When you do, target player draws two cards and loses 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg?1712355703",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You don't choose a target for Unscrupulous Contractor's ability at the time it triggers. Rather, a second \"reflexive\" ability triggers if you sacrifice a creature this way. You choose a target for that ability as it goes on the stack."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
             }
         ]
     },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -110,4 +110,23 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // nested _PlayerEffect of a PlayerEffect / EachPlayerEffect static. Renders to
     // `RestrictSpellsCastPerTurn(maxPerTurn = N, eachPlayer = <scope>)`.
     effect("CantCastMoreThanNumberSpellsEachTurn", "RestrictSpellsCastPerTurn")
+
+    // "Spells your opponents cast from graveyards or from exile cost {2} more to cast" (Aven
+    // Interrupter) — the nested _PlayerEffect of an EachPlayerEffect{Opponent} static. Renders to
+    // `ModifySpellCost(target = SpellCostTarget.OpponentsCastFromZones(...), modification =
+    // IncreaseGeneric(N))`. The spell-zone selectors below carry the zone set.
+    effect("IncreaseSpellCost", "ModifySpellCost")
+    supported("WasCastFromExile", "spell selector: cast from exile (SpellCostTarget.OpponentsCastFromZones zone = EXILE)")
+    supported("WasCastFromAPlayersGraveyard", "spell selector: cast from a graveyard (SpellCostTarget.OpponentsCastFromZones zone = GRAVEYARD)")
+
+    // Fblthp, Lost on the Range (CR 718) — top-of-library plot + look. Nested _PlayerEffect /
+    // _Rule capabilities of the controller-scoped statics.
+    supported("MayLookAtTopCardOfLibraryAnyTime", "player static: look at the top card of your library any time (LookAtTopOfLibrary)")
+    supported("MayPlotCardsFromTheTopOfTheirLibrary", "player static: plot cards from the top of your library (PlotFromTopOfLibrary)")
+    supported("TopCardOfPlayersLibraryEffect", "rule: the top card of your library has plot, plot cost = its mana cost (PlotFromTopOfLibrary)")
+
+    // Roxanne, Starfall Savant (CR 605) — "Whenever you tap an artifact token for mana, add one mana
+    // of any type that artifact token produced." A triggered mana ability; renders to the
+    // AdditionalManaOnSourceTap mirror static (color = null), the same shape as Lavaleaper's land mirror.
+    supported("WhenAPlayerTapsAPermanentForMana", "trigger: tap a permanent for mana → AdditionalManaOnSourceTap mirror static")
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -66,6 +66,16 @@ internal fun BridgeBuilder.zoneMovement() {
     // mid-resolution CastFromCollectionWithoutPayingCostEffect over a card just exiled by the look
     // pipeline (Sunbird's Invocation / Goliath Daydreamer shape).
     composed("CastExiledCardWithoutPaying", "CastFromCollectionWithoutPayingCost over the exiled card", composes = listOf("CastFromCollectionWithoutPayingCost"))
+    // "Exile target spell" (CR 718 — Aven Interrupter). Not a counter (ignores can't-be-countered);
+    // the spell leaves the stack and fails to resolve. Maps to ExileTargetSpellEffect; the paired
+    // `CreateExiledCardEffect[IsPlotted]` sub-action sets `makePlotted = true` (the exiled card
+    // becomes plotted for its owner).
+    effect("ExileSpell", "ExileTargetSpell")
+    // "It becomes plotted." — the exiled-card designation on a freshly-exiled card (CR 718).
+    // Renders via the `makePlotted` flag on ExileTargetSpell (Aven) or MakePlottedEffect
+    // (Make Your Own Luck); the capability is the plotted designation itself.
+    supported("IsPlotted", "exiled-card effect: becomes plotted (MakePlottedEffect / ExileTargetSpell.makePlotted)")
+    envelope("CreateExiledCardEffect", "envelope: apply an effect to a just-exiled card (capability is the _ExiledCardEffect)")
     composed("ExileEachPermanent", UNIVERSAL, composes = listOf("MoveCollection", "MoveToZone"))
     composed("MillNumberCards", UNIVERSAL, composes = listOf("MoveCollection"))
     composed("MillCards", UNIVERSAL, composes = listOf("MoveCollection"))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -11,6 +11,8 @@ import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -25,8 +27,10 @@ import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.conditions.SourcePlottedOnPriorTurn
 import kotlin.reflect.KClass
 
@@ -54,6 +58,48 @@ class PlotCardHandler(
 ) : ActionHandler<PlotCard> {
     override val actionType: KClass<PlotCard> = PlotCard::class
 
+    private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * Where the card being plotted lives and what its plot cost is. Plot normally exiles a
+     * card *from hand* paying the Plot keyword's printed cost; Fblthp also lets the *top card
+     * of the library* be plotted at a cost equal to its mana cost
+     * ([PlotFromTopOfLibrary]). Resolving both up front keeps validate/execute zone-agnostic.
+     */
+    private data class PlotSource(val zone: Zone, val cost: ManaCost)
+
+    private fun resolvePlotSource(state: GameState, action: PlotCard): PlotSource? {
+        val cardComponent = state.getEntity(action.cardId)?.get<CardComponent>() ?: return null
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return null
+
+        // Hand: the card's own Plot keyword.
+        if (action.cardId in state.getZone(ZoneKey(action.playerId, Zone.HAND))) {
+            val plotAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Plot>().firstOrNull()
+                ?: return null
+            return PlotSource(Zone.HAND, plotAbility.cost)
+        }
+
+        // Top of library: a battlefield [PlotFromTopOfLibrary] grant (Fblthp). The card must be
+        // the literal top card, match the grant's filter, and the plot cost is its mana cost.
+        val library = state.getLibrary(action.playerId)
+        if (library.firstOrNull() == action.cardId) {
+            val filter = state.getBattlefield(action.playerId).asSequence()
+                .mapNotNull { state.getEntity(it)?.get<CardComponent>() }
+                .mapNotNull { cardRegistry.getCard(it.cardDefinitionId) }
+                .flatMap { it.script.staticAbilities.asSequence() }
+                .filterIsInstance<PlotFromTopOfLibrary>()
+                .firstOrNull()?.filter
+                ?: return null
+            val matches = predicateEvaluator.matches(
+                state, state.projectedState, action.cardId, filter,
+                PredicateContext(controllerId = action.playerId)
+            )
+            if (!matches) return null
+            return PlotSource(Zone.LIBRARY, cardDef.manaCost)
+        }
+        return null
+    }
+
     override fun validate(state: GameState, action: PlotCard): String? {
         if (state.priorityPlayerId != action.playerId) {
             return "You don't have priority"
@@ -65,18 +111,11 @@ class PlotCardHandler(
 
         val container = state.getEntity(action.cardId)
             ?: return "Card not found: ${action.cardId}"
-        val cardComponent = container.get<CardComponent>()
+        container.get<CardComponent>()
             ?: return "Not a card: ${action.cardId}"
 
-        val handZone = ZoneKey(action.playerId, Zone.HAND)
-        if (action.cardId !in state.getZone(handZone)) {
-            return "Card is not in your hand"
-        }
-
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-            ?: return "Card definition not found"
-        val plotAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Plot>().firstOrNull()
-            ?: return "This card doesn't have plot"
+        val source = resolvePlotSource(state, action)
+            ?: return "This card can't be plotted from its current zone"
 
         if (action.paymentStrategy is PaymentStrategy.Explicit) {
             for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
@@ -86,7 +125,7 @@ class PlotCardHandler(
                     return "Mana source is already tapped: $sourceId"
                 }
             }
-        } else if (!manaSolver.canPay(state, action.playerId, plotAbility.cost)) {
+        } else if (!manaSolver.canPay(state, action.playerId, source.cost)) {
             return "Not enough mana to plot this card"
         }
         return null
@@ -97,10 +136,9 @@ class PlotCardHandler(
             ?: return ExecutionResult.error(state, "Card not found")
         val cardComponent = container.get<CardComponent>()
             ?: return ExecutionResult.error(state, "Not a card")
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-            ?: return ExecutionResult.error(state, "Card definition not found")
-        val plotAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Plot>().firstOrNull()
-            ?: return ExecutionResult.error(state, "This card doesn't have plot")
+        val source = resolvePlotSource(state, action)
+            ?: return ExecutionResult.error(state, "This card can't be plotted from its current zone")
+        val plotCost = source.cost
 
         var currentState = state
         val events = mutableListOf<GameEvent>()
@@ -117,7 +155,7 @@ class PlotCardHandler(
             green = poolComponent.green,
             colorless = poolComponent.colorless
         )
-        val partialResult = pool.payPartial(plotAbility.cost)
+        val partialResult = pool.payPartial(plotCost)
         val poolAfterPayment = partialResult.newPool
         val remainingCost = partialResult.remainingCost
         val manaSpentFromPool = partialResult.manaSpent
@@ -184,16 +222,18 @@ class PlotCardHandler(
             )
         )
 
-        // Move card from hand → owner's exile (face-up; plotted cards are public).
-        val handZone = ZoneKey(action.playerId, Zone.HAND)
+        // Move card from its source zone (hand, or the top of the library for Fblthp) → owner's
+        // exile (face-up; plotted cards are public). The source zone is keyed under the acting
+        // player, who is the owner of their own hand/library.
+        val fromZoneKey = ZoneKey(action.playerId, source.zone)
         val exileZone = ZoneKey(ownerId, Zone.EXILE)
-        currentState = currentState.removeFromZone(handZone, action.cardId)
+        currentState = currentState.removeFromZone(fromZoneKey, action.cardId)
         currentState = currentState.addToZone(exileZone, action.cardId)
         events.add(
             ZoneChangeEvent(
                 entityId = action.cardId,
                 entityName = cardComponent.name,
-                fromZone = Zone.HAND,
+                fromZone = source.zone,
                 toZone = Zone.EXILE,
                 ownerId = ownerId
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -440,7 +440,7 @@ class CastSpellHandler(
                 cardDef,
                 action.playerId,
                 action.targets.map { it.toEntityId() },
-                fromZone = if (hasCommanderCast) Zone.COMMAND else null,
+                fromZone = if (hasCommanderCast) Zone.COMMAND else castSourceZone(state, action.cardId),
             )
         } else {
             cardComponent.manaCost
@@ -785,6 +785,23 @@ class CastSpellHandler(
 
     private fun isCastFromHand(state: GameState, cardId: EntityId): Boolean =
         state.turnOrder.any { ownerId -> cardId in state.getZone(ZoneKey(ownerId, Zone.HAND)) }
+
+    /**
+     * The zone the card is being cast from, used to apply cast-from-zone cost modifiers
+     * (e.g. Aven Interrupter's "spells your opponents cast from graveyards or exile cost {2}
+     * more"). A spell card still occupies its source zone when the cost is computed during
+     * cast validation/execution (it hasn't moved to the stack yet). Stack means it's already
+     * being moved; returns null then. Commander casts are handled separately via the
+     * dedicated `Zone.COMMAND` flag.
+     */
+    private fun castSourceZone(state: GameState, cardId: EntityId): Zone? {
+        for (ownerId in state.turnOrder) {
+            for (zone in listOf(Zone.HAND, Zone.GRAVEYARD, Zone.EXILE, Zone.LIBRARY)) {
+                if (cardId in state.getZone(ZoneKey(ownerId, zone))) return zone
+            }
+        }
+        return null
+    }
 
     private fun validateConspire(
         state: GameState,
@@ -1443,7 +1460,7 @@ class CastSpellHandler(
                 cardDef,
                 action.playerId,
                 action.targets.map { it.toEntityId() },
-                fromZone = if (castingFromCommand) Zone.COMMAND else null,
+                fromZone = if (castingFromCommand) Zone.COMMAND else castSourceZone(currentState, action.cardId),
             )
         } else {
             cardComponent.manaCost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.effects.mana.AdditionalManaOnSourceTapMirror
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.components.battlefield.withCastChoice
@@ -90,7 +91,19 @@ class ColorChoiceContinuationResumer(
         )
 
         if (effectResult.isPaused) return effectResult.toExecutionResult()
-        return checkForMore(effectResult.state, effectResult.events.toList())
+
+        // CR 605 mirror bonus: if the just-chosen mana came from tapping a permanent for mana
+        // (the continuation's source) and a battlefield `AdditionalManaOnSourceTap` mirror static
+        // (color = null) applies to that source for this tapper, add one mana of the chosen type.
+        // This is the any-color analogue of `ActivateAbilityHandler.resolveAdditionalManaOnSourceTap`
+        // — that path runs only for fixed/non-pausing producers (Lavaleaper's basic lands); an
+        // any-color producer (Roxanne's Meteorite, "{T}: Add one mana of any color") pauses for the
+        // color choice and resumes here, so the mirror must fire after the choice is known.
+        val mirrored = AdditionalManaOnSourceTapMirror.applyForResolvedTap(
+            services, effectResult.state, continuation.sourceId, continuation.controllerId, response.color
+        )
+        if (mirrored.isPaused) return mirrored
+        return checkForMore(mirrored.newState, effectResult.events.toList() + mirrored.events)
     }
 
     fun resumeChooseColorForTarget(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -152,25 +152,32 @@ class MakePlottedExecutor : EffectExecutor<MakePlottedEffect> {
         var newState = state
         val events = mutableListOf<GameEvent>()
         for (cardId in collection) {
-            val cardName = newState.getEntity(cardId)?.get<CardComponent>()?.name ?: "card"
+            val cardComponent = newState.getEntity(cardId)?.get<CardComponent>()
+            val cardName = cardComponent?.name ?: "card"
+            // CR 718.2: a plotted card's owner is the player who may later cast it for free.
+            // For "you plot a card you own" effects the owner is the controller anyway; for
+            // "exile target spell, it becomes plotted" (Aven Interrupter) the spell's owner —
+            // not the player who plotted it — gets the free-cast permission.
+            val plottedController =
+                if (effect.ownerControls) (cardComponent?.ownerId ?: controllerId) else controllerId
             newState = newState.updateEntity(cardId) { container ->
                 container
-                    .with(PlottedComponent(controllerId = controllerId, turnPlotted = newState.turnNumber))
-                    .with(PlayWithoutPayingCostComponent(controllerId = controllerId, permanent = true))
+                    .with(PlottedComponent(controllerId = plottedController, turnPlotted = newState.turnNumber))
+                    .with(PlayWithoutPayingCostComponent(controllerId = plottedController, permanent = true))
             }
             val (permId, stateWithPerm) = newState.newEntity()
             newState = stateWithPerm.addMayPlayPermission(
                 MayPlayPermission(
                     id = permId,
                     cardIds = setOf(cardId),
-                    controllerId = controllerId,
+                    controllerId = plottedController,
                     sourceId = cardId,
                     condition = SourcePlottedOnPriorTurn,
                     permanent = true,
                     timestamp = newState.timestamp,
                 )
             )
-            events.add(CardPlottedEvent(controllerId, cardId, cardName))
+            events.add(CardPlottedEvent(plottedController, cardId, cardName))
         }
 
         return EffectResult.success(newState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AdditionalManaOnSourceTapMirror.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AdditionalManaOnSourceTapMirror.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.handlers.effects.mana
+
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.ManaAddedEvent
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap
+
+/**
+ * Applies the [AdditionalManaOnSourceTap] *mirror* bonus (`color = null` — "add one mana of any
+ * type that source produced") for a tap whose produced color is only known after a color choice
+ * resolves.
+ *
+ * Roxanne, Starfall Savant's "Whenever you tap an artifact token for mana, add one mana of any
+ * type that artifact token produced" pairs with the Meteorite's "{T}: Add one mana of any color".
+ * The Meteorite's mana ability pauses for the color choice, so the inline mirror resolution in
+ * [com.wingedsheep.engine.handlers.actions.ability.ActivateAbilityHandler.resolveAdditionalManaOnSourceTap]
+ * (which only runs on the non-pausing path, e.g. Lavaleaper's fixed-color basic lands) is bypassed.
+ * The color-choice continuation resumer calls this once the produced color is known.
+ *
+ * Only the **mirror** (`color = null`) case is handled here — a fixed-color
+ * `AdditionalManaOnSourceTap` doesn't depend on the produced color, so it already fires on the
+ * synchronous path. Returns the accumulated mana-added events for the bonus.
+ */
+object AdditionalManaOnSourceTapMirror {
+
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
+
+    fun applyForResolvedTap(
+        services: EngineServices,
+        state: GameState,
+        sourceId: EntityId?,
+        tappingPlayerId: EntityId,
+        producedColor: Color,
+    ): ExecutionResult {
+        if (sourceId == null) return ExecutionResult.success(state)
+        val predicateEvaluator = services.predicateEvaluator
+        var currentState = state
+        val events = mutableListOf<GameEvent>()
+
+        for (entityId in currentState.getBattlefield()) {
+            val container = currentState.getEntity(entityId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = services.cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (staticAbility in cardDef.script.staticAbilities) {
+                val onSourceTap = staticAbility as? AdditionalManaOnSourceTap ?: continue
+                // Only the mirror form is resolved here; fixed-color forms fire synchronously.
+                if (onSourceTap.color != null) continue
+
+                val staticController = currentState.projectedState.getController(entityId) ?: continue
+                val filterContext = PredicateContext(controllerId = staticController, sourceId = entityId)
+                if (!predicateEvaluator.matches(
+                        currentState, currentState.projectedState, sourceId, onSourceTap.sourceFilter, filterContext
+                    )) continue
+
+                val effectContext = EffectContext(
+                    sourceId = entityId,
+                    controllerId = tappingPlayerId,
+                    targets = emptyList(),
+                    xValue = null
+                )
+                val bonusAmount = dynamicAmountEvaluator.evaluate(currentState, onSourceTap.amount, effectContext)
+                if (bonusAmount <= 0) continue
+
+                currentState = currentState.updateEntity(tappingPlayerId) { c ->
+                    val pool = c.get<ManaPoolComponent>() ?: ManaPoolComponent()
+                    c.with(pool.add(producedColor, bonusAmount))
+                }
+                events.add(
+                    ManaAddedEvent(
+                        playerId = tappingPlayerId,
+                        sourceId = entityId,
+                        sourceName = card.name,
+                        white = if (producedColor == Color.WHITE) bonusAmount else 0,
+                        blue = if (producedColor == Color.BLUE) bonusAmount else 0,
+                        black = if (producedColor == Color.BLACK) bonusAmount else 0,
+                        red = if (producedColor == Color.RED) bonusAmount else 0,
+                        green = if (producedColor == Color.GREEN) bonusAmount else 0,
+                        colorless = 0
+                    )
+                )
+            }
+        }
+        return ExecutionResult.success(currentState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ExileTargetSpellExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ExileTargetSpellExecutor.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.handlers.effects.stack
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.stack.StackResolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.scripting.effects.ExileTargetSpellEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ExileTargetSpellEffect] (CR 718, "exile target spell" — Aven Interrupter).
+ *
+ * Resolves the chosen spell target and delegates to [StackResolver.exileSpell], which removes
+ * it from the stack and puts the card into its owner's exile. This is **not** a counter: the
+ * spell is exiled even if it can't be countered, and no "spell was countered" trigger fires —
+ * but it still fails to resolve because it left the stack. When [ExileTargetSpellEffect.makePlotted]
+ * is set, the exiled card becomes plotted for its owner (free cast on a later turn).
+ *
+ * If the target is no longer on the stack at resolution (it already left), the effect fizzles
+ * silently rather than erroring.
+ */
+class ExileTargetSpellExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<ExileTargetSpellEffect> {
+
+    override val effectType: KClass<ExileTargetSpellEffect> = ExileTargetSpellEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ExileTargetSpellEffect,
+        context: EffectContext
+    ): EffectResult {
+        val target = context.targets.firstOrNull() as? ChosenTarget.Spell
+            ?: return EffectResult.success(state)
+        val spellId = target.spellEntityId
+        if (spellId !in state.stack) return EffectResult.success(state)
+
+        val resolver = StackResolver(cardRegistry = cardRegistry)
+        return EffectResult.from(resolver.exileSpell(state, spellId, effect.makePlotted))
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StackExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StackExecutors.kt
@@ -14,6 +14,7 @@ class StackExecutors(
 ) : ExecutorModule {
     override fun executors(): List<EffectExecutor<*>> = listOf(
         CounterEffectExecutor(amountEvaluator, cardRegistry),
+        ExileTargetSpellExecutor(cardRegistry),
         CounterAllOnStackExecutor(cardRegistry),
         WardCounterEffectExecutor(cardRegistry),
         ChangeSpellTargetExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -677,7 +677,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     val freeCastFromGranter = grantAbility.withoutPayingManaCost
                     val costString = if (freeCastFromGranter) "0" else run {
                         val effectiveCost = if (exiledCardDef != null) {
-                            context.costCalculator.calculateEffectiveCost(state, exiledCardDef, playerId)
+                            context.costCalculator.calculateEffectiveCost(state, exiledCardDef, playerId, fromZone = Zone.EXILE)
                         } else {
                             exiledCard.manaCost
                         }
@@ -685,7 +685,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     }
                     val canAfford = if (freeCastFromGranter) true else run {
                         val effectiveCost = if (exiledCardDef != null) {
-                            context.costCalculator.calculateEffectiveCost(state, exiledCardDef, playerId)
+                            context.costCalculator.calculateEffectiveCost(state, exiledCardDef, playerId, fromZone = Zone.EXILE)
                         } else {
                             exiledCard.manaCost
                         }
@@ -976,7 +976,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 val hasCorrectTiming = isInstant || context.canPlaySorcerySpeed
                 val castRestrictions = cardDef.script.castRestrictions
                 val meetsRestrictions = context.castPermissionUtils.checkCastRestrictions(state, playerId, castRestrictions)
-                val effectiveCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
+                val effectiveCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId, fromZone = Zone.GRAVEYARD)
                 val costString = effectiveCost.toString()
                 val canAfford = context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlotEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlotEnumerator.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.legalactions.enumerators
 
 import com.wingedsheep.engine.core.PlotCard
+import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
@@ -48,6 +49,46 @@ class PlotEnumerator : ActionEnumerator {
                     autoTapPreview = autoTapPreview
                 )
             )
+        }
+
+        // Plot the top card of the library (Fblthp, Lost on the Range) — granted by a
+        // [com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary] static ability. The top card is
+        // plottable if it matches the granted filter (Fblthp: nonland); its plot cost equals its
+        // mana cost (CR 718 / the card's wording). Like the Plot keyword this is sorcery-speed.
+        val plotTopFilter = context.castPermissionUtils.getPlotFromTopOfLibraryFilter(state, playerId)
+        if (plotTopFilter != null) {
+            val library = state.getLibrary(playerId)
+            val topCardId = library.firstOrNull()
+            if (topCardId != null) {
+                val topCardComponent = state.getEntity(topCardId)?.get<CardComponent>()
+                val topCardDef = topCardComponent?.let { context.cardRegistry.getCard(it.cardDefinitionId) }
+                if (topCardComponent != null && topCardDef != null &&
+                    context.predicateEvaluator.matches(
+                        state, state.projectedState, topCardId, plotTopFilter,
+                        PredicateContext(controllerId = playerId)
+                    )
+                ) {
+                    val plotCost = topCardDef.manaCost
+                    val canAfford = context.manaSolver.canPay(
+                        state, playerId, plotCost, precomputedSources = context.availableManaSources
+                    )
+                    val autoTapPreview = if (context.skipAutoTapPreview) null else {
+                        context.manaSolver.solve(
+                            state, playerId, plotCost, precomputedSources = context.availableManaSources
+                        )?.sources?.map { it.entityId }
+                    }
+                    result.add(
+                        LegalAction(
+                            actionType = "PlotCard",
+                            description = "Plot ${topCardComponent.name} (from top of library)",
+                            action = PlotCard(playerId, topCardId),
+                            affordable = canAfford,
+                            manaCostString = plotCost.toString(),
+                            autoTapPreview = autoTapPreview
+                        )
+                    )
+                }
+            }
         }
         return result
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -35,6 +35,7 @@ import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
 import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
 import com.wingedsheep.sdk.scripting.PreventCycling
@@ -367,6 +368,21 @@ class CastPermissionUtils(
                 if (ability is PlayLandsAndCastFilteredFromTopOfLibrary) {
                     return ability.spellFilter
                 }
+            }
+        }
+        return null
+    }
+
+    /**
+     * If [playerId] controls a permanent granting [PlotFromTopOfLibrary] (Fblthp), the filter the
+     * top card must match to be plottable from the library; null if no such permission is active.
+     */
+    fun getPlotFromTopOfLibraryFilter(state: GameState, playerId: EntityId): GameObjectFilter? {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is PlotFromTopOfLibrary) return ability.filter
             }
         }
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -111,6 +111,7 @@ import com.wingedsheep.sdk.scripting.NoncombatDamageBonus
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.OverrideEnchantedLandManaColor
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
 import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
@@ -697,6 +698,7 @@ class StaticAbilityHandler(
             is FreeFirstEquipEachTurn,
             is PlayFromTopOfLibrary,
             is PlayLandsAndCastFilteredFromTopOfLibrary,
+            is PlotFromTopOfLibrary,
             is PlayersCantCastSpells,
             is RestrictSpellsCastPerTurn,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -102,7 +102,7 @@ class CostCalculator(
 
         // Battlefield-sourced ModifySpellCost abilities.
         for ((sourceId, ability) in scanBattlefieldModifySpellCost(state)) {
-            if (!targetMatchesSpell(ability.target, cardDef, casterId, sourceId, state, chosenTargets)) continue
+            if (!targetMatchesSpell(ability.target, cardDef, casterId, sourceId, state, chosenTargets, fromZone)) continue
             if (!gatingApplies(state, casterId, cardDef, ability)) continue
             applyToSpellCast(
                 state, cardDef, casterId, ability.modification, chosenTargets,
@@ -198,6 +198,7 @@ class CostCalculator(
         sourceId: EntityId,
         state: GameState,
         chosenTargets: List<EntityId> = emptyList(),
+        fromZone: Zone? = null,
     ): Boolean {
         return when (target) {
             SpellCostTarget.SelfCast -> false
@@ -209,6 +210,14 @@ class CostCalculator(
             is SpellCostTarget.AnyCaster -> matchesCardDefinition(cardDef, target.filter, sourceId, state, state.projectedState)
             is SpellCostTarget.OpponentsCastTargeting ->
                 opponentsCastTargetingMatches(state, casterId, sourceId, target.targetFilter, chosenTargets)
+            is SpellCostTarget.OpponentsCastFromZones -> {
+                // Source must be controlled by an opponent of the caster, the spell must be cast
+                // from one of the named zones, and the card must match the filter.
+                if (fromZone == null || fromZone !in target.zones) return false
+                val sourceController = state.projectedState.getController(sourceId) ?: return false
+                if (sourceController == casterId) return false
+                matchesCardDefinition(cardDef, target.filter, sourceId, state, state.projectedState)
+            }
             // FaceDown / Morph targets are spell-cast modifiers only when applied to a face-down cast.
             // calculateEffectiveCost is only called for face-up casts; face-down handling is in
             // calculateFaceDownCost / calculateMorphCostIncrease.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -31,11 +31,14 @@ import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.ExileAfterResolveComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
+import com.wingedsheep.engine.state.components.identity.PlottedComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.engine.state.permissions.removeMayPlayPermissionsForCard
+import com.wingedsheep.sdk.scripting.conditions.SourcePlottedOnPriorTurn
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.GrantCantBeCountered
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -2240,6 +2243,72 @@ class StackResolver(
                 )
             )
         )
+    }
+
+    /**
+     * Exile a spell on the stack (CR 718 "exile target spell" — Aven Interrupter), optionally
+     * making it *plotted* for its owner.
+     *
+     * Unlike [counterSpellToExile] this is **not** a counter: it ignores can't-be-countered
+     * (the spell is exiled regardless — Aven Interrupter's ruling: "Spells that can't be
+     * countered can still be exiled"), and it emits no [SpellCounteredEvent] (so "whenever a
+     * spell is countered" triggers don't fire). The spell still ceases to resolve because it
+     * leaves the stack. A [ZoneChangeEvent] from [Zone.STACK] to [Zone.EXILE] is emitted.
+     *
+     * When [makePlotted] is true the exiled card gets the plotted designation and a permanent
+     * free-cast-on-a-later-turn permission gated by [SourcePlottedOnPriorTurn], granted to the
+     * card's **owner** (CR 718.2 / the reminder text: "Its owner may cast it as a sorcery on a
+     * later turn without paying its mana cost"), and a [CardPlottedEvent] is emitted.
+     */
+    fun exileSpell(
+        state: GameState,
+        spellId: EntityId,
+        makePlotted: Boolean
+    ): ExecutionResult {
+        if (spellId !in state.stack) {
+            return ExecutionResult.error(state, "Spell not on stack: $spellId")
+        }
+        val container = state.getEntity(spellId)
+            ?: return ExecutionResult.error(state, "Spell not found: $spellId")
+        val cardComponent = container.get<CardComponent>()
+        val spellComponent = container.get<SpellOnStackComponent>()
+        val ownerId = cardComponent?.ownerId
+            ?: spellComponent?.casterId
+            ?: return ExecutionResult.error(state, "Cannot determine spell owner")
+
+        // Remove from the stack and put the card into its owner's exile.
+        var newState = state.removeFromStack(spellId)
+        val exileZone = ZoneKey(ownerId, Zone.EXILE)
+        newState = newState.addToZone(exileZone, spellId)
+        newState = newState.updateEntity(spellId) { c ->
+            c.without<SpellOnStackComponent>().without<TargetsComponent>()
+        }
+
+        val events = mutableListOf<GameEvent>(
+            ZoneChangeEvent(spellId, cardComponent?.name ?: "Unknown", Zone.STACK, Zone.EXILE, ownerId)
+        )
+
+        if (makePlotted) {
+            newState = newState.updateEntity(spellId) { c ->
+                c.with(PlottedComponent(controllerId = ownerId, turnPlotted = newState.turnNumber))
+                    .with(PlayWithoutPayingCostComponent(controllerId = ownerId, permanent = true))
+            }
+            val (permId, stateWithPerm) = newState.newEntity()
+            newState = stateWithPerm.addMayPlayPermission(
+                MayPlayPermission(
+                    id = permId,
+                    cardIds = setOf(spellId),
+                    controllerId = ownerId,
+                    sourceId = spellId,
+                    condition = SourcePlottedOnPriorTurn,
+                    permanent = true,
+                    timestamp = newState.timestamp,
+                )
+            )
+            events.add(CardPlottedEvent(ownerId, spellId, cardComponent?.name ?: "Unknown"))
+        }
+
+        return ExecutionResult.success(newState, events)
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AvenInterrupterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AvenInterrupterScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.identity.PlottedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AvenInterrupter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Aven Interrupter (OTJ) — {1}{W}{W} 2/2 Bird Rogue, Flash, Flying.
+ *
+ * "When this creature enters, exile target spell. It becomes plotted."
+ * "Spells your opponents cast from graveyards or from exile cost {2} more to cast."
+ *
+ * The ETB ability uses the new [com.wingedsheep.sdk.scripting.effects.ExileTargetSpellEffect]
+ * (a non-counter that exiles even uncounterable spells and plots the card for its owner). The
+ * tax is a [com.wingedsheep.sdk.scripting.ModifySpellCost] with the new
+ * [com.wingedsheep.sdk.scripting.SpellCostTarget.OpponentsCastFromZones] target.
+ */
+class AvenInterrupterScenarioTest : FunSpec({
+
+    test("ETB exiles the target spell and plots it for its owner — the spell never resolves") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AvenInterrupter)
+        driver.initMirrorMatch(deck = com.wingedsheep.sdk.model.Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Opponent casts an instant so it sits on the stack as a target. The active player passes
+        // priority first so the opponent (non-active) gets a window to cast at instant speed.
+        driver.passPriority(me)
+        val oppSpell = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.giveMana(opp, Color.RED, 1)
+        driver.castSpell(opp, oppSpell, listOf(me)).isSuccess shouldBe true
+        driver.getStackSpellNames().contains("Lightning Bolt") shouldBe true
+
+        // Opponent passes priority back so I get a window to respond at instant speed.
+        driver.passPriority(opp)
+
+        // I flash in Aven Interrupter; its ETB targets the Lightning Bolt spell.
+        val aven = driver.putCardInHand(me, "Aven Interrupter")
+        driver.giveColorlessMana(me, 1)
+        driver.giveMana(me, Color.WHITE, 2)
+        driver.castSpell(me, aven).isSuccess shouldBe true
+        driver.bothPass() // resolve Aven onto the battlefield
+        driver.bothPass() // resolve the ETB trigger off the stack
+
+        // Pick the spell to exile (the ETB targets a spell on the stack).
+        driver.submitTargetSelection(me, listOf(oppSpell))
+        driver.bothPass()
+
+        // The targeted spell is exiled (it did NOT resolve into a creature), plotted for its owner.
+        driver.getExile(opp).contains(oppSpell) shouldBe true
+        driver.getPermanents(opp).contains(oppSpell) shouldBe false
+        val plotted = driver.state.getEntity(oppSpell)?.get<PlottedComponent>()
+        plotted shouldNotBe null
+        withClue("a plotted card's owner — not the player who plotted it — may cast it later") {
+            plotted!!.controllerId shouldBe opp
+        }
+    }
+})
+
+/**
+ * The cost tax is verified directly via the [CostCalculator] — it depends on the casting player's
+ * relationship to Aven's controller and the zone the spell is cast from, which the calculator reads
+ * from `fromZone`.
+ */
+class AvenInterrupterTaxTest : ScenarioTestBase() {
+    init {
+        context("Aven Interrupter — opponents' graveyard/exile casts cost {2} more") {
+
+            test("an opponent casting from a graveyard pays {2} more") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aven Interrupter")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .build()
+
+                val calc = CostCalculator(cardRegistry)
+                val cost = calc.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Grizzly Bears"),
+                    game.player2Id,
+                    fromZone = Zone.GRAVEYARD,
+                )
+                withClue("Grizzly Bears base generic is 1; +2 from Aven = 3") {
+                    cost.genericAmount shouldBe 3
+                }
+            }
+
+            test("an opponent casting from exile pays {2} more") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aven Interrupter")
+                    .withCardInExile(2, "Grizzly Bears")
+                    .build()
+
+                val calc = CostCalculator(cardRegistry)
+                val cost = calc.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Grizzly Bears"),
+                    game.player2Id,
+                    fromZone = Zone.EXILE,
+                )
+                cost.genericAmount shouldBe 3
+            }
+
+            test("the same opponent's cast from hand is NOT taxed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aven Interrupter")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .build()
+
+                val calc = CostCalculator(cardRegistry)
+                val cost = calc.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Grizzly Bears"),
+                    game.player2Id,
+                    fromZone = Zone.HAND,
+                )
+                withClue("hand casts are unaffected") { cost.genericAmount shouldBe 1 }
+            }
+
+            test("the controller's own graveyard cast is NOT taxed (opponents only)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aven Interrupter")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .build()
+
+                val calc = CostCalculator(cardRegistry)
+                val cost = calc.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Grizzly Bears"),
+                    game.player1Id,
+                    fromZone = Zone.GRAVEYARD,
+                )
+                withClue("the tax applies only to the controller's opponents") { cost.genericAmount shouldBe 1 }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FblthpLostOnTheRangeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FblthpLostOnTheRangeScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlotCard
+import com.wingedsheep.engine.state.components.identity.PlottedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.FblthpLostOnTheRange
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Fblthp, Lost on the Range (OTJ) — {1}{U}{U} 1/1, Ward {2}.
+ *
+ * "You may look at the top card of your library any time. The top card of your library has plot.
+ *  The plot cost is equal to its mana cost. You may plot nonland cards from the top of your library."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary] static ability:
+ * the plot enumerator/handler can plot the top *nonland* card of the library at a cost equal to
+ * its mana cost, moving it from library → exile and plotting it (CR 718). A land on top can't be
+ * plotted, and the cost is the card's own mana cost.
+ */
+class FblthpLostOnTheRangeScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + FblthpLostOnTheRange)
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("plots the top nonland card from the library for its mana cost") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        driver.putPermanentOnBattlefield(p1, "Fblthp, Lost on the Range")
+
+        // Top of library is a Grizzly Bears ({1}{G}) — a nonland card, so plottable.
+        val top = driver.putCardOnTopOfLibrary(p1, "Grizzly Bears")
+        driver.giveColorlessMana(p1, 1)
+        driver.giveMana(p1, Color.GREEN, 1) // plot cost = its mana cost {1}{G}
+
+        driver.submitSuccess(PlotCard(p1, top))
+
+        // The card left the library and is now exiled + plotted for its owner.
+        driver.state.getLibrary(p1).contains(top) shouldBe false
+        driver.getExile(p1).contains(top) shouldBe true
+        val plotted = driver.state.getEntity(top)?.get<PlottedComponent>()
+        plotted shouldNotBe null
+        plotted!!.controllerId shouldBe p1
+    }
+
+    test("a land on top of the library cannot be plotted") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        driver.putPermanentOnBattlefield(p1, "Fblthp, Lost on the Range")
+
+        val topLand = driver.putCardOnTopOfLibrary(p1, "Island")
+        driver.giveColorlessMana(p1, 3)
+
+        // Plotting a land from the top is illegal (the grant is filtered to nonland).
+        driver.submit(PlotCard(p1, topLand)).isSuccess shouldBe false
+        driver.state.getLibrary(p1).contains(topLand) shouldBe true
+    }
+
+    test("without Fblthp, the top card of the library is not plottable") {
+        val driver = newDriver()
+        val p1 = driver.player1
+
+        val top = driver.putCardOnTopOfLibrary(p1, "Grizzly Bears")
+        driver.giveColorlessMana(p1, 1)
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.submit(PlotCard(p1, top)).isSuccess shouldBe false
+        driver.state.getLibrary(p1).contains(top) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoxanneStarfallSavantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoxanneStarfallSavantScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.RoxanneStarfallSavant
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Roxanne, Starfall Savant (OTJ) — {3}{R}{G} 4/3 Cat Druid.
+ *
+ * "Whenever Roxanne enters or attacks, create a tapped colorless artifact token named Meteorite
+ *  with 'When this token enters, it deals 2 damage to any target' and '{T}: Add one mana of any color.'
+ *  Whenever you tap an artifact token for mana, add one mana of any type that artifact token produced."
+ *
+ * Two triggered abilities (enters / attacks) each create a tapped [PredefinedTokens.Meteorite]; the
+ * Meteorite's own ETB-deal-2 and mana ability live on its token definition. The second clause is the
+ * [com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap] mirror static over artifact tokens.
+ */
+class RoxanneStarfallSavantScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RoxanneStarfallSavant, PredefinedTokens.Meteorite))
+        driver.initMirrorMatch(Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.meteorites(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { getCardName(it) == "Meteorite" }
+
+    test("entering creates a tapped Meteorite whose ETB deals 2 damage to any target") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val roxanne = driver.putCardInHand(me, "Roxanne, Starfall Savant")
+        driver.giveColorlessMana(me, 3)
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.castSpell(me, roxanne).isSuccess shouldBe true
+
+        // Drain priority passes / the Meteorite's ETB-damage target choice until the dust settles:
+        // Roxanne resolves → "enters" trigger → Meteorite created → its "deals 2 damage to any
+        // target" trigger asks for a target, which we point at the opponent.
+        repeat(8) {
+            val decision = driver.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(me, listOf(opp))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        driver.meteorites(me).size shouldBe 1
+        driver.getLifeTotal(opp) shouldBe 18
+    }
+
+    test("attacking with Roxanne creates another Meteorite") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Put Roxanne onto the battlefield directly (skip the enters trigger for this test by
+        // resolving it without acting beyond the forced target choice).
+        driver.putCreatureOnBattlefield(me, "Roxanne, Starfall Savant")
+
+        // Advance to combat and attack with Roxanne.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val roxanne = driver.getPermanents(me).first { driver.getCardName(it) == "Roxanne, Starfall Savant" }
+        driver.declareAttackers(me, listOf(roxanne), opp)
+
+        // Drain the "attacks" trigger → Meteorite creation → its ETB-damage target choice.
+        repeat(8) {
+            val decision = driver.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(me, listOf(opp))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        driver.meteorites(me).size shouldBe 1
+    }
+
+    test("tapping the Meteorite for mana doubles it via Roxanne's mirror ability") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Roxanne must be on the battlefield (the mirror static is hers), and the Meteorite must be a
+        // real artifact *token* (the mirror filter requires `.token()`), so create it via Roxanne's
+        // enters trigger rather than a direct placement. Then untap it so it can be tapped for mana.
+        val roxanne = driver.putCardInHand(me, "Roxanne, Starfall Savant")
+        driver.giveColorlessMana(me, 3)
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.castSpell(me, roxanne).isSuccess shouldBe true
+        repeat(8) {
+            val decision = driver.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(me, listOf(opp))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        val meteorite = driver.meteorites(me).first()
+        driver.untapPermanent(meteorite)
+        val manaAbilityId = PredefinedTokens.Meteorite.activatedAbilities[0].id
+
+        // Activating the "{T}: add one mana of any color" ability pauses for the color choice
+        // (so the result is "paused", not an error).
+        val result = driver.submit(ActivateAbility(playerId = me, sourceId = meteorite, abilityId = manaAbilityId))
+        withClue("activation error: ${result.error}") { result.error shouldBe null }
+
+        // Choose blue for the Meteorite's own mana; Roxanne's mirror then adds a second blue of the
+        // same type. (There may be a second color prompt if the mirror itself asks — answer blue too.)
+        repeat(4) {
+            val decision = driver.pendingDecision ?: return@repeat
+            driver.submitDecision(me, ColorChosenResponse(decision.id, Color.BLUE))
+        }
+
+        // One blue from the Meteorite + one mirrored blue from Roxanne = 2 blue.
+        val pool = driver.state.getEntity(me)?.get<ManaPoolComponent>()!!
+        pool.blue shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnscrupulousContractorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnscrupulousContractorTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.UnscrupulousContractor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unscrupulous Contractor ({2}{B}, 3/2 Human Assassin):
+ * "When this creature enters, you may sacrifice a creature. When you do, target player
+ *  draws two cards and loses 2 life."
+ *
+ * Composed as a [com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect]: the
+ * "sacrifice a creature" action is a resolution-time choice (SelectTargetEffect +
+ * SacrificeTarget), and the "When you do" reflexive payoff targets a player chosen as the
+ * reflexive ability goes on the stack, then makes that player draw two and lose 2 life.
+ */
+class UnscrupulousContractorTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + UnscrupulousContractor)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castContractor(driver: GameTestDriver, me: EntityId): EntityId {
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 2)
+        val card = driver.putCardInHand(me, "Unscrupulous Contractor")
+        driver.castSpell(me, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // resolve the enters trigger off the stack
+        return card
+    }
+
+    test("sacrificing a creature makes the chosen player draw two and lose two life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        castContractor(driver, me)
+
+        // "You may sacrifice a creature." — accept.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+
+        // Choose the fodder to sacrifice.
+        driver.submitTargetSelection(me, listOf(fodder))
+
+        val oppHandBefore = driver.getHand(opp).size
+        // The reflexive trigger goes on the stack; choose the target player (the opponent).
+        driver.submitTargetSelection(me, listOf(opp))
+        driver.bothPass() // resolve the reflexive draw + lose life
+
+        driver.getGraveyard(me).contains(fodder) shouldBe true
+        driver.getHand(opp).size shouldBe oppHandBefore + 2
+        driver.getLifeTotal(opp) shouldBe 18
+    }
+
+    test("the controller may target themselves to draw and lose life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        castContractor(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(fodder))
+
+        val myHandBefore = driver.getHand(me).size
+        driver.submitTargetSelection(me, listOf(me))
+        driver.bothPass()
+
+        driver.getHand(me).size shouldBe myHandBefore + 2
+        driver.getLifeTotal(me) shouldBe 18
+    }
+
+    test("declining the optional sacrifice does nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        castContractor(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        // No reflexive payoff: opponent's life unchanged, hand not refilled.
+        driver.getLifeTotal(opp) shouldBe 20
+        driver.pendingDecision shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Four Outlaws of Thunder Junction cards, each with a passing scenario test, plus the supporting SDK/engine and mtgish-tooling work.

### Cards
- **Aven Interrupter** `{1}{W}{W}` — Flash, Flying 2/2. ETB exiles target spell and makes it *plotted for its owner* (CR 718.2). Static taxes opponents' casts from graveyard/exile by `{2}`.
- **Unscrupulous Contractor** `{2}{B}` — 3/2. ETB "you may sacrifice a creature. When you do, target player draws two and loses 2 life" (resolution-time choice + reflexive trigger). Plot `{2}{B}`.
- **Roxanne, Starfall Savant** `{3}{R}{G}` — 4/3. Enters/attacks create a tapped Meteorite token (ETB deals 2 to any target; `{T}`: add any color). Static mirrors mana when you tap an artifact token.
- **Fblthp, Lost on the Range** `{1}{U}{U}` — 1/1. Ward `{2}`; look at top of library any time; plot the top nonland card for its mana cost.

### Engine / SDK features
- `ExileTargetSpellEffect` (`Effects.ExileTargetSpell(makePlotted)`) — non-counter that removes a spell from the stack and exiles the card *even if it can't be countered*; optionally makes it plotted for its owner. Fires no "spell was countered" trigger.
- `SpellCostTarget.OpponentsCastFromZones(zones, filter)` — threaded through `CostCalculator` via `fromZone`; pair with `CostModification.IncreaseGeneric`.
- `MakePlotted(from, ownerControls)` — free-cast permission can go to the card's **owner** (CR 718.2) rather than the plotter.
- `PlotFromTopOfLibrary(filter)` static + `PlotEnumerator`/`PlotCardHandler` — plot the top card of a library at a cost equal to its mana cost.
- `AdditionalManaOnSourceTap` any-color mirror — applied after the tap-time color choice resolves (in `ColorChoiceContinuationResumer`), so it works for "{T}: add one mana of any color" producers like Meteorite.
- `CreateMeteorite` predefined token facade.

### mtgish-tooling
- Bridge updates (`ZoneMovement`, `TriggersCostsAndContinuous`). Roxanne and Unscrupulous Contractor are auto-emitted and gameplay-tree-match the golden; Aven Interrupter is in the NOT-EMITTED (decline) list. `OTJ.json` snapshot updated (additive — only the 4 new cards). SDK reference updated.

## Verification
- **Scenario tests** — all pass: `AvenInterrupterScenarioTest` (fixed the opponent-spell-on-stack timing: opponent now casts an instant during the active player's main with proper priority passes), `AvenInterrupterTaxTest` (4), `UnscrupulousContractorTest` (3), `RoxanneStarfallSavantScenarioTest` (3), `FblthpLostOnTheRangeScenarioTest` (3).
- **Card net** — `CardDefinitionSnapshotTest` + `CardLintTest` green (OTJ snapshot matches the committed golden — no rebless needed; the additive snapshot was already present).
- **Full suites** — `:rules-engine:test`, `:mtg-sets:test`, `:mtg-sdk:test`, `:mtgish-tooling:test` all green.
- **`coverage-verify POR`** — GATE PASS, **0 mismatch** (158/158).
- **`coverage-verify OTJ`** — GATE FAIL with **7 pre-existing** gameplay-tree mismatches, none introduced by this work: Cactusfolk Sureshot, Freestrider Lookout, High Noon, Mirage Mesa, One Last Job, The Key to the Vault, Thunder Lasso. None of these cards are touched by this branch; the OTJ.json diff is additive (only the 4 new cards). These pre-date this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)