### PR TITLE
OTJ cards batch A: Assimilation Aegis, Fortune, Trash the Town

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1090,6 +1090,21 @@ effect = Effects.Pipeline {
 }
 ```
 
+**Special `gather` sources** (component-backed, no zone scan):
+
+- `CardSource.Self` — the ability's own source card, in whatever zone it currently sits.
+- `CardSource.TappedAsCost` — the permanents tapped to pay the activation cost.
+- `CardSource.ChosenTargets` — the spell/ability's already-resolved targets.
+- `CardSource.FromLinkedExile(count?)` — the cards in the source's linked-exile pile.
+- `CardSource.LastKnownCombatPairedWithSource` — creatures blocking/blocked by the source at the
+  moment it last left the battlefield (Abu Ja'far).
+- `CardSource.CreaturesThatSaddledSource` — the creatures that saddled the source Mount this turn
+  (CR 702.171c), read off its crew/saddle-contributors record and restricted to creatures still on
+  the battlefield. Backs "exile it and up to one creature that saddled it this turn, then return
+  those cards" (Fortune, Loyal Steed): `gather(CreaturesThatSaddledSource)` → `chooseUpTo(1)` →
+  exile linked to the Mount alongside `CardSource.Self` → `gather(FromLinkedExile())` → return
+  under owners' control.
+
 A card needing a genuinely **new step semantic** (a new capture kind, a new decision shape) still
 adds the `Effect` + executor first (`add-feature`); the builder only composes the existing
 vocabulary. The JSON/custom-card authoring path is unchanged — raw step types stay `@Serializable`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -215,6 +215,22 @@ sealed interface CardSource {
     data object LastKnownCombatPairedWithSource : CardSource {
         override val description: String = "creatures blocking or blocked by it"
     }
+
+    /**
+     * The creatures that saddled the effect's source this turn (CR 702.171c) — the union of every
+     * creature tapped to pay a Saddle ability's cost on this Mount, read off the source's
+     * `CrewSaddleContributorsComponent`. Restricted to creatures still on the battlefield, since a
+     * saddler that has since left can't be affected (the component records last-known crew/saddle
+     * contributors and is cleared at cleanup).
+     *
+     * Backs "exile … up to one creature that saddled it this turn" (Fortune, Loyal Steed): gather
+     * the saddlers, then [SelectFromCollectionEffect] picks up to one of them.
+     */
+    @SerialName("CreaturesThatSaddledSource")
+    @Serializable
+    data object CreaturesThatSaddledSource : CardSource {
+        override val description: String = "creatures that saddled it this turn"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FortuneLoyalSteed.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FortuneLoyalSteed.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+
+/**
+ * Fortune, Loyal Steed
+ * {2}{W}
+ * Legendary Creature — Beast Mount
+ * 2/4
+ *
+ * When Fortune enters, scry 2.
+ * Whenever Fortune attacks while saddled, at end of combat, exile it and up to one creature
+ * that saddled it this turn, then return those cards to the battlefield under their owner's
+ * control.
+ * Saddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount
+ * becomes saddled until end of turn. Saddle only as a sorcery.)
+ *
+ * "While saddled" is the intervening-if [Conditions.SourceIsSaddled] (CR 603.4) on the attack
+ * trigger. The attack trigger doesn't blink immediately — it schedules a delayed
+ * [Step.END_COMBAT] trigger ([CreateDelayedTriggerEffect]) that does the exile/return, so the
+ * creatures stay in combat and the blink happens after damage.
+ *
+ * The delayed trigger is a linked-exile flicker (CR 603.6e / 707-style blink): it gathers the
+ * creatures that saddled Fortune this turn ([CardSource.CreaturesThatSaddledSource], read off
+ * Fortune's crew/saddle-contributors record) and lets the controller pick **up to one**; it then
+ * exiles that chosen saddler and Fortune itself ([CardSource.Self]) linked to Fortune, and finally
+ * returns everything from the linked exile to the battlefield under each card's owner's control
+ * ([Patterns.Exile.returnLinkedExile] with `underOwnersControl = true`). A creature that already
+ * left play is dropped by the saddler gather, and if Fortune itself has left, its linked exile is
+ * empty and the return is a harmless no-op.
+ */
+val FortuneLoyalSteed = card("Fortune, Loyal Steed") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Beast Mount"
+    power = 2
+    toughness = 4
+    oracleText = "When Fortune enters, scry 2.\n" +
+        "Whenever Fortune attacks while saddled, at end of combat, exile it and up to one " +
+        "creature that saddled it this turn, then return those cards to the battlefield under " +
+        "their owner's control.\n" +
+        "Saddle 1 (Tap any number of other creatures you control with total power 1 or more: " +
+        "This Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.saddle(1))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END_COMBAT,
+            effect = Effects.Pipeline {
+                // Up to one of the creatures that saddled Fortune this turn.
+                val saddlers = gather(CardSource.CreaturesThatSaddledSource)
+                val chosenSaddler = chooseUpTo(
+                    1,
+                    from = saddlers,
+                    useTargetingUI = true,
+                    prompt = "Choose up to one creature that saddled Fortune this turn to exile with it"
+                )
+                // Exile Fortune itself and the chosen saddler, linked to Fortune.
+                val self = gather(CardSource.Self)
+                exile(self, linkToSource = true)
+                exile(chosenSaddler, linkToSource = true)
+                // Return everything Fortune exiled, under each card's owner's control.
+                val returning = gather(CardSource.FromLinkedExile())
+                move(
+                    returning,
+                    CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true
+                )
+            }
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg?1712355270"
+
+        ruling("2024-04-12", "If Fortune leaves the battlefield before its triggered ability resolves at end of combat, the creature that saddled it (if any) is still exiled and returned.")
+        ruling("2024-04-12", "The exiled cards return to the battlefield as new objects with no relation to their previous existence. Any Auras or Equipment that were attached to them are put into their owners' graveyards.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TrashTheTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TrashTheTown.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trash the Town {G}
+ * Instant
+ *
+ * Spree (Choose one or more additional costs.)
+ * + {2} — Put two +1/+1 counters on target creature.
+ * + {1} — Target creature gains trample until end of turn.
+ * + {1} — Until end of turn, target creature gains "Whenever this creature deals combat
+ *   damage to a player, draw two cards."
+ *
+ * Spree is modeled as a [ModalEffect] with `minChooseCount = 1`, `chooseCount = modes.size`
+ * and per-mode `additionalManaCost` (CR 702.166): at least one mode must be chosen, no mode
+ * twice, each with its own additional cost. Every mode targets a creature independently
+ * (its own `ContextTarget(0)`).
+ *
+ * The third mode grants a triggered ability until end of turn ([GrantTriggeredAbilityEffect]
+ * defaults to [com.wingedsheep.sdk.scripting.Duration.EndOfTurn]); the granted
+ * "deals combat damage to a player → draw two cards" ability draws for the creature's
+ * controller ([EffectTarget.Controller]).
+ */
+val TrashTheTown = card("Trash the Town") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Spree (Choose one or more additional costs.)\n" +
+        "+ {2} — Put two +1/+1 counters on target creature.\n" +
+        "+ {1} — Target creature gains trample until end of turn.\n" +
+        "+ {1} — Until end of turn, target creature gains \"Whenever this creature deals " +
+        "combat damage to a player, draw two cards.\""
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode(
+                    effect = Effects.AddCounters("+1/+1", 2, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {2} — Put two +1/+1 counters on target creature.",
+                    additionalManaCost = "{2}"
+                ),
+                Mode(
+                    effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {1} — Target creature gains trample until end of turn.",
+                    additionalManaCost = "{1}"
+                ),
+                Mode(
+                    effect = GrantTriggeredAbilityEffect(
+                        ability = TriggeredAbility.create(
+                            trigger = Triggers.DealsCombatDamageToPlayer.event,
+                            binding = Triggers.DealsCombatDamageToPlayer.binding,
+                            effect = Effects.DrawCards(2)
+                        ),
+                        target = EffectTarget.ContextTarget(0)
+                    ),
+                    targetRequirements = listOf(Targets.Creature),
+                    description = "+ {1} — Until end of turn, target creature gains \"Whenever " +
+                        "this creature deals combat damage to a player, draw two cards.\"",
+                    additionalManaCost = "{1}"
+                )
+            ),
+            chooseCount = 3,
+            minChooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "186"
+        artist = "David Auden Nash"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg?1712860614"
+
+        ruling("2024-04-12", "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree.")
+        ruling("2024-04-12", "You can't choose the same mode more than once.")
+        ruling("2024-04-12", "Each chosen mode requires a target. You may choose the same creature as the target for multiple modes.")
+        ruling("2024-04-12", "The mana value of a spell with spree is determined only by its mana cost. It doesn't matter which modes you choose or which additional costs you pay.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5718,6 +5718,187 @@
     ]
 }
 
+// Fortune, Loyal Steed
+{
+    "name": "Fortune, Loyal Steed",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Beast Mount",
+    "oracleText": "When Fortune enters, scry 2.\nWhenever Fortune attacks while saddled, at end of combat, exile it and up to one creature that saddled it this turn, then return those cards to the battlefield under their owner's control.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END_COMBAT",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "CreaturesThatSaddledSource",
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected1",
+                                "prompt": "Choose up to one creature that saddled Fortune this turn to exile with it",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": "Self",
+                                "storeAs": "gathered2"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "gathered2",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected1",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "gathered5"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "gathered5",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "underOwnersControl": true
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "RARE",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg?1712355270",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "If Fortune leaves the battlefield before its triggered ability resolves at end of combat, the creature that saddled it (if any) is still exiled and returned."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The exiled cards return to the battlefield as new objects with no relation to their previous existence. Any Auras or Equipment that were attached to them are put into their owners' graveyards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Freestrider Commando
 {
     "name": "Freestrider Commando",
@@ -17384,6 +17565,125 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Trash the Town
+{
+    "name": "Trash the Town",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Spree (Choose one or more additional costs.)\n+ {2} — Put two +1/+1 counters on target creature.\n+ {1} — Target creature gains trample until end of turn.\n+ {1} — Until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, draw two cards.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 2,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {2} — Put two +1/+1 counters on target creature.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Target creature gains trample until end of turn.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "GrantTriggeredAbility",
+                        "ability": {
+                            "id": "ability_1",
+                            "trigger": {
+                                "type": "DealsDamageEvent",
+                                "damageType": "DamageCombat",
+                                "recipient": "AnyPlayer"
+                            },
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "+ {1} — Until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, draw two cards.\"",
+                    "additionalManaCost": "{1}"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "UNCOMMON",
+        "artist": "David Auden Nash",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg?1712860614",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You must choose at least one of the listed modes and pay its associated additional cost in order to cast a spell with spree."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't choose the same mode more than once."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Each chosen mode requires a target. You may choose the same creature as the target for multiple modes."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The mana value of a spell with spree is determined only by its mana cost. It doesn't matter which modes you choose or which additional costs you pay."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
 import com.wingedsheep.engine.state.components.stack.entityIds
 import kotlin.reflect.KClass
@@ -200,6 +201,20 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 val battlefield = state.getBattlefield().toSet()
                 (context.triggerLastKnownBlockingOrBlockedByIds ?: emptyList())
                     .filter { it in battlefield }
+            }
+
+            is CardSource.CreaturesThatSaddledSource -> {
+                // CR 702.171c — the creatures tapped to saddle this Mount this turn, recorded on
+                // the source's CrewSaddleContributorsComponent. Restrict to creatures still on the
+                // battlefield; one that already left can't be exiled/returned.
+                val sourceId = context.sourceId
+                    ?: return EffectResult.error(state, "No source entity for CreaturesThatSaddledSource")
+                val battlefield = state.getBattlefield().toSet()
+                state.getEntity(sourceId)
+                    ?.get<CrewSaddleContributorsComponent>()
+                    ?.creatureIds
+                    ?.filter { it in battlefield }
+                    ?: emptyList()
             }
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FortuneLoyalSteedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FortuneLoyalSteedScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.FortuneLoyalSteed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.core.SelectCardsDecision
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Fortune, Loyal Steed (OTJ rare Beast Mount), {2}{W}.
+ *
+ * - When Fortune enters, scry 2.
+ * - Whenever Fortune attacks while saddled, at end of combat, exile it and up to one creature
+ *   that saddled it this turn, then return those cards to the battlefield under their owner's
+ *   control.
+ * - Saddle 1.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.CardSource.CreaturesThatSaddledSource]
+ * gather (the creatures that saddled the Mount) feeding the end-of-combat linked-exile blink.
+ */
+class FortuneLoyalSteedScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + FortuneLoyalSteed)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.isSaddled(id: EntityId): Boolean =
+        state.getEntity(id)?.has<SaddledComponent>() == true
+
+    test("ETB scry 2 resolves without error when Fortune is cast") {
+        val driver = createDriver()
+        val player = driver.player1
+        val spell = driver.putCardInHand(player, "Fortune, Loyal Steed")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.WHITE, 1) // {W}
+        driver.giveColorlessMana(player, 2)                              // {2}
+        driver.submitSuccess(com.wingedsheep.engine.core.CastSpell(player, spell))
+        // Resolving Fortune fires its enter trigger (scry 2); pass to the next main phase, letting
+        // the auto-resolver answer the resulting library-reorder decision.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.findPermanent(player, "Fortune, Loyal Steed") shouldNotBe null
+    }
+
+    test("attacks while saddled: at end of combat, Fortune and its saddler are blinked") {
+        val driver = createDriver()
+        val fortune = driver.putCreatureOnBattlefield(driver.player1, "Fortune, Loyal Steed")
+        val saddler = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // power 2 >= saddle 1
+        driver.removeSummoningSickness(fortune)
+
+        // Saddle Fortune with the bear (taps the bear, marks Fortune saddled).
+        driver.submitSuccess(SaddleMount(driver.player1, fortune, listOf(saddler)))
+        driver.bothPass()
+        driver.isSaddled(fortune) shouldBe true
+        driver.isTapped(saddler) shouldBe true
+
+        // Attack with Fortune.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(fortune), driver.player2)
+        driver.bothPass() // resolve the attacks-while-saddled trigger (schedules the delayed blink)
+        driver.isTapped(fortune) shouldBe true // attacking tapped Fortune
+
+        // Advance toward end of combat. The delayed trigger fires and asks the controller to pick
+        // up to one creature that saddled Fortune; choose the bear.
+        var guard = 0
+        while (driver.pendingDecision !is SelectCardsDecision && driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+            if (driver.pendingDecision != null) {
+                driver.autoResolveDecision()
+            } else if (driver.state.priorityPlayerId != null) {
+                driver.bothPass()
+            }
+        }
+        val decision = driver.pendingDecision as? SelectCardsDecision
+            ?: error("Expected a SelectCardsDecision for the saddler choice (have ${driver.pendingDecision}, step ${driver.state.step})")
+        // The bear that saddled Fortune is among the options.
+        decision.options.contains(saddler) shouldBe true
+        driver.submitCardSelection(decision.playerId, listOf(saddler))
+
+        // Finish out combat so the linked-exile return resolves.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Exactly one Fortune is on the battlefield (it was exiled and returned, not duplicated),
+        // and it re-entered untapped (it had been tapped attacking).
+        val fortunesAfter = driver.getCreatures(driver.player1).filter {
+            driver.state.getEntity(it)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ==
+                "Fortune, Loyal Steed"
+        }
+        fortunesAfter.size shouldBe 1
+        driver.isTapped(fortunesAfter.single()) shouldBe false
+
+        // The saddler was exiled and returned too — untapped (it had been tapped to saddle).
+        val saddlerAfter = driver.findPermanent(driver.player1, "Grizzly Bears")
+        saddlerAfter shouldNotBe null
+        driver.isTapped(saddlerAfter!!) shouldBe false
+    }
+
+    test("attacks while NOT saddled: no end-of-combat blink") {
+        val driver = createDriver()
+        val fortune = driver.putCreatureOnBattlefield(driver.player1, "Fortune, Loyal Steed")
+        driver.removeSummoningSickness(fortune)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(fortune), driver.player2)
+
+        // Run through combat: no saddle means no trigger, no blink — Fortune stays the same object.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.findPermanent(driver.player1, "Fortune, Loyal Steed") shouldBe fortune
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrashTheTownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrashTheTownScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TrashTheTown
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Trash the Town (OTJ Spree instant), {G}.
+ *
+ * + {2} — Put two +1/+1 counters on target creature.
+ * + {1} — Target creature gains trample until end of turn.
+ * + {1} — Until end of turn, target creature gains "Whenever this creature deals combat
+ *   damage to a player, draw two cards."
+ */
+class TrashTheTownScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + TrashTheTown)
+        return driver
+    }
+
+    fun GameTestDriver.plusCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("Mode 1 ({2}) puts two +1/+1 counters on target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2
+        driver.plusCounters(bear) shouldBe 0
+
+        val spell = driver.putCardInHand(player, "Trash the Town")
+        driver.giveMana(player, Color.GREEN, 1) // {G}
+        driver.giveColorlessMana(player, 2)      // {2} for mode 0
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear)))
+            )
+        )
+        driver.bothPass()
+
+        driver.plusCounters(bear) shouldBe 2
+    }
+
+    test("Mode 2 ({1}) grants trample until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.state.projectedState.hasKeyword(bear, Keyword.TRAMPLE) shouldBe false
+
+        val spell = driver.putCardInHand(player, "Trash the Town")
+        driver.giveMana(player, Color.GREEN, 1) // {G}
+        driver.giveColorlessMana(player, 1)      // {1} for mode 1
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear)))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.projectedState.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("Mode 3 ({1}) grants 'deals combat damage to a player → draw two' for the turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.removeSummoningSickness(bear)
+
+        val spell = driver.putCardInHand(player, "Trash the Town")
+        driver.giveMana(player, Color.GREEN, 1) // {G}
+        driver.giveColorlessMana(player, 1)      // {1} for mode 2
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear)))
+            )
+        )
+        driver.bothPass()
+
+        val handBefore = driver.getHandSize(player)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(bear), opponent)
+        // Resolve combat damage; the granted trigger fires on combat damage to the opponent.
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        // Drew two cards from the granted ability.
+        driver.getHandSize(player) shouldBe handBefore + 2
+    }
+
+    test("Multiple modes ({2}+{1}) apply both counters and trample to the same creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(player, "Trash the Town")
+        driver.giveMana(player, Color.GREEN, 1) // {G}
+        driver.giveColorlessMana(player, 3)      // {2} + {1}
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear), ChosenTarget.Permanent(bear)),
+                chosenModes = listOf(0, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(bear)),
+                    listOf(ChosenTarget.Permanent(bear))
+                )
+            )
+        )
+        driver.bothPass()
+
+        driver.plusCounters(bear) shouldBe 2
+        driver.state.projectedState.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements two of the three requested Outlaws of Thunder Junction cards and defers the third (Assimilation Aegis) as documented engine-gap work.

## Cards added

### Trash the Town — `{G}` Instant (Spree)
Modeled as a `ModalEffect` with per-mode `additionalManaCost` (`minChooseCount=1`):
- `+ {2}` — two +1/+1 counters on target creature
- `+ {1}` — target creature gains trample until end of turn
- `+ {1}` — until end of turn, target creature gains "Whenever this creature deals combat damage to a player, draw two cards" (`GrantTriggeredAbilityEffect`, default `Duration.EndOfTurn`)

No new SDK surface — composed entirely from existing facades.

### Fortune, Loyal Steed — `{2}{W}` Legendary Beast Mount 2/4
- ETB scry 2
- Saddle 1
- Attacks-while-saddled (`Conditions.SourceIsSaddled` intervening-if) schedules a delayed `Step.END_COMBAT` trigger that blinks Fortune **and up to one creature that saddled it this turn**, returning both under their owners' control.

The blink is an inline `Effects.Pipeline`: gather saddlers → `chooseUpTo(1)` → exile `Self` + the chosen saddler linked to Fortune → `gather(FromLinkedExile())` → return to battlefield under owners' control (same proven shape as Another Round, adapted to a self-blinking permanent).

## New SDK building block
`CardSource.CreaturesThatSaddledSource` — gathers the creatures that saddled the source Mount this turn (CR 702.171c) from its `CrewSaddleContributorsComponent`, restricted to creatures still on the battlefield. Added following the `TappedAsCost` / `LastKnownCombatPairedWithSource` precedent (one `when` branch in `GatherCardsExecutor`), and documented in `docs/card-sdk-language-reference.md` §5.5.

## Deferred: Assimilation Aegis
Requires a **new becomes-attached trigger/event** + a **copy-of-card-in-linked-exile** effect + a **for-as-long-as-attached** continuous-effect duration — none of which exist yet. This is the documented engine gap in `backlog/otj-engine-gaps.md` item 12 (add-feature scope). Left out to keep the build green rather than ship a lossy approximation; the ETB exile-until-leaves half is already supported.

## mtgish-tooling
All three batch cards correctly tier **SCAFFOLD** (granted-ability-with-duration, delayed end-of-combat blink, and becomes-attached copy are shapes the emitter must decline per the fidelity policy). No emitter change is warranted.
- `just coverage-verify POR` → **GATE PASS, 158/158** (0-mismatch held)
- `EmitterGoldenTest` → all vendored sets pass, unchanged
- The OTJ gate's 7 mismatches are all pre-existing, unrelated cards (OTJ is not a 0-mismatch verified set); none are the cards in this PR.

## Tests
- `FortuneLoyalSteedScenarioTest` (3) + `TrashTheTownScenarioTest` (5) — all pass
- `CardDefinitionSnapshotTest` re-blessed (OTJ.json: only the two new cards added)
- `CardLintTest`, `:mtg-sdk:test`, `:mtg-sets:test`, serialization & saddle/linked-exile engine tests — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)