### PR TITLE
OTJ cards batch C: Doc Aurlock, Selvala, Laughing Jasper Flint

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2173,8 +2173,9 @@ staticAbility {
 ```
 
 - `target: SpellCostTarget` — `SelfCast`, `YouCast(filter)`, `AnyCaster(filter)`,
-  `OpponentsCastTargeting(GroupFilter)`, `OpponentsCastFromZones(zones, filter?)`, `FaceDownYouCast`, `MorphActivation`.
+  `OpponentsCastTargeting(GroupFilter)`, `OpponentsCastFromZones(zones, filter?)`, `YouCastFromZones(zones, filter?)`, `FaceDownYouCast`, `MorphActivation`.
   - `OpponentsCastFromZones(zones, filter = Any)` — spells the source-controller's opponents cast **from one of `zones`** (matched against the spell's actual cast zone, threaded as `fromZone`), matching `filter`. Pair with `CostModification.IncreaseGeneric(n)` for the Aven Interrupter shape: `OpponentsCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE))` + `IncreaseGeneric(2)` = "Spells your opponents cast from graveyards or from exile cost {2} more to cast."
+  - `YouCastFromZones(zones, filter = Any)` — the you-cast analogue: spells the **source's controller** casts **from one of `zones`**, matching `filter`. Pair with `CostModification.ReduceGeneric(n)` for Doc Aurlock, Grizzled Genius: `YouCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE))` + `ReduceGeneric(2)` = "Spells you cast from your graveyard or from exile cost {2} less to cast." (Only the normal-cast path threads `fromZone`; alternative-cost casts such as flashback compute their own base cost and are unaffected.)
 - `modification: CostModification` — `ReduceGeneric(amount)`, `ReduceGenericBy(source)`,
   `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`,
   `ReduceColoredIfAnyTargetMatches(symbols, filter)` (target-gated **colored** reduction — the
@@ -2213,6 +2214,30 @@ staticAbility {
     fixed conditional reduction pair it with `ReduceGeneric` (Mental Modulation:
     `ReduceGeneric(1)` gated by `OnlyIf(IsYourTurn)`; Lashwhip Predator / Arwen's Gift gate on a
     `Compare(...)`).
+
+**Plot cost statics — `ModifyPlotCost`**
+
+Plot (CR 718) is a *special action*, not a spell, so `ModifySpellCost` never touches it.
+`ModifyPlotCost(target, modification)` is its dedicated cost modifier, evaluated by the engine's
+`PlotCostReducer` (consulted by both the plot legal-action enumerator and the plot handler so
+affordability and payment stay in lockstep).
+
+```kotlin
+staticAbility {
+    ability = ModifyPlotCost(
+        target = PlotCostTarget.YouPlotFromHand,
+        modification = CostModification.ReduceGeneric(2),
+    )
+}
+```
+
+- `target: PlotCostTarget` — currently `YouPlotFromHand` (cards the source's controller plots from
+  hand; a future "plot from top of library" / Fblthp variant slots in as a new `PlotCostTarget`
+  without changing call sites).
+- `modification: CostModification` — reuses the spell-cost vocabulary, but only the flat generic
+  shapes (`ReduceGeneric` / `IncreaseGeneric`) are meaningful since a printed plot cost is a flat
+  mana cost; generic is floored at {0} and colored pips are never reduced. Doc Aurlock, Grizzled
+  Genius: "Plotting cards from your hand costs {2} less" = `ReduceGeneric(2)`.
 
 **Global denial statics** (no `filter`/`duration` block — they're singleton-style)
 
@@ -3081,8 +3106,12 @@ Numbers computed at resolution time.
   permanents. `aggregation` defaults to `COUNT`; other modes: `MAX`/`MIN`/`SUM` over a
   `property` (`POWER`/`TOUGHNESS`/`MANA_VALUE`), and the distinct-set counters
   `DISTINCT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_NAMES`, `DISTINCT_BASIC_LAND_SUBTYPES`
-  (Domain), and `DISTINCT_COUNTER_TYPES` (the number of different kinds of counters present
-  across the group — same kind on several permanents counts once).
+  (Domain), `DISTINCT_COUNTER_TYPES` (the number of different kinds of counters present
+  across the group — same kind on several permanents counts once), and `DISTINCT_VALUES`
+  (the number of *distinct values* of the configured `property` — Selvala, Eager Trailblazer's
+  "the number of different powers among creatures you control" via
+  `aggregation = DISTINCT_VALUES, property = POWER`; two permanents sharing a value count once).
+  Builder shortcut: `DynamicAmounts.battlefield(player, filter).distinctValues(CardNumericProperty.POWER)`.
 - `AggregateZone(player, zone, filter?, aggregation?)` — count cards in a zone.
 - `CountPermanentsOfType(player, subtype)` — count by creature type.
 - `CountCreaturesYouControl` — shorthand for "your creatures".

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -67,6 +67,15 @@ object DynamicAmounts {
 
         fun sumPower(): DynamicAmount =
             DynamicAmount.AggregateBattlefield(player, filter, Aggregation.SUM, CardNumericProperty.POWER)
+
+        /**
+         * The number of distinct values of [property] (power / toughness / mana value) among the
+         * matched permanents — e.g. `distinctValues(POWER)` for "the number of different powers
+         * among creatures you control" (Selvala, Eager Trailblazer). Two permanents sharing a
+         * value count once.
+         */
+        fun distinctValues(property: CardNumericProperty): DynamicAmount =
+            DynamicAmount.AggregateBattlefield(player, filter, Aggregation.DISTINCT_VALUES, property)
     }
 
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -43,6 +43,8 @@ data class ModifySpellCost(
                 "Spells your opponents cast that target ${target.targetFilter.description}"
             is SpellCostTarget.OpponentsCastFromZones ->
                 "Spells your opponents cast from ${describeZones(target.zones)}"
+            is SpellCostTarget.YouCastFromZones ->
+                "Spells you cast from ${describeZones(target.zones)}"
             SpellCostTarget.FaceDownYouCast -> "Face-down creature spells you cast"
             SpellCostTarget.MorphActivation -> "All morph costs"
         }
@@ -152,6 +154,28 @@ sealed interface SpellCostTarget {
     @SerialName("AnyCaster")
     @Serializable
     data class AnyCaster(val filter: GameObjectFilter) : SpellCostTarget {
+        override fun applyTextReplacement(replacer: TextReplacer): SpellCostTarget {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
+     * Spells the source's controller casts **from one of [zones]**, matching [filter]
+     * (default: any spell). The you-cast analogue of [OpponentsCastFromZones].
+     *
+     * Used for Doc Aurlock, Grizzled Genius ("Spells you cast from your graveyard or from
+     * exile cost {2} less to cast") via
+     * `YouCastFromZones(setOf(Zone.GRAVEYARD, Zone.EXILE))` paired with
+     * [CostModification.ReduceGeneric]. The cost calculator matches it only when the casting
+     * player controls the source and the spell is being cast from one of the named zones.
+     */
+    @SerialName("YouCastFromZones")
+    @Serializable
+    data class YouCastFromZones(
+        val zones: Set<com.wingedsheep.sdk.core.Zone>,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+    ) : SpellCostTarget {
         override fun applyTextReplacement(replacer: TextReplacer): SpellCostTarget {
             val newFilter = filter.applyTextReplacement(replacer)
             return if (newFilter !== filter) copy(filter = newFilter) else this
@@ -601,4 +625,58 @@ sealed interface CostReductionSource {
         override val description: String =
             "the number of ${filter.description} on the battlefield"
     }
+}
+
+/**
+ * Static ability that modifies the cost of the **Plot** special action (CR 718).
+ *
+ * Plot is not a spell, so [ModifySpellCost] does not touch it; this is its dedicated cost
+ * modifier. The engine's `PlotCostReducer` scans the battlefield for these and reduces the
+ * plot cost paid by [PlotEnumerator]/`PlotCardHandler`.
+ *
+ * Used for Doc Aurlock, Grizzled Genius ("Plotting cards from your hand costs {2} less") via
+ * `ModifyPlotCost(PlotCostTarget.YouPlotFromHand, CostModification.ReduceGeneric(2))`.
+ *
+ * @property target Which plots the modifier applies to.
+ * @property modification How the cost is changed (reuses the spell-cost [CostModification]
+ *           vocabulary; only generic reductions are currently meaningful for plot).
+ */
+@SerialName("ModifyPlotCost")
+@Serializable
+data class ModifyPlotCost(
+    val target: PlotCostTarget,
+    val modification: CostModification,
+) : StaticAbility {
+    override val description: String = buildString {
+        append(
+            when (target) {
+                PlotCostTarget.YouPlotFromHand -> "Plotting cards from your hand"
+            }
+        )
+        append(
+            when (val m = modification) {
+                is CostModification.ReduceGeneric -> " costs {${m.amount}} less"
+                is CostModification.IncreaseGeneric -> " costs {${m.amount}} more"
+                else -> " has a modified cost"
+            }
+        )
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newModification = modification.applyTextReplacement(replacer)
+        return if (newModification !== modification) copy(modification = newModification) else this
+    }
+}
+
+/**
+ * What a [ModifyPlotCost] applies to. Modeled as a sealed interface so future "plot from the top
+ * of your library" reductions (Fblthp-shaped) slot in as a new variant without changing the
+ * static-ability shape.
+ */
+@Serializable
+sealed interface PlotCostTarget {
+    /** Cards the source's controller plots from their hand (the printed Plot keyword cost). */
+    @SerialName("YouPlotFromHand")
+    @Serializable
+    data object YouPlotFromHand : PlotCostTarget
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
@@ -40,5 +40,12 @@ enum class Aggregation {
      * the same kind on several permanents still counts once. Used for "different kinds of
      * counters among <group>" (e.g. Hundred-Battle Veteran).
      */
-    DISTINCT_COUNTER_TYPES
+    DISTINCT_COUNTER_TYPES,
+    /**
+     * Count distinct values of the configured [CardNumericProperty] (power, toughness, or mana
+     * value) across all matched entities — e.g. "the number of different powers among creatures
+     * you control" (Selvala, Eager Trailblazer). Requires `property` to be set; two creatures with
+     * the same power count once.
+     */
+    DISTINCT_VALUES
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -697,6 +697,11 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                     if (excludeSelf) append("other ")
                     append(pluralize(filter.description))
                 }
+                Aggregation.DISTINCT_VALUES -> {
+                    append("the number of different ${property?.description ?: "value"} among ")
+                    if (excludeSelf) append("other ")
+                    append(pluralize(filter.description))
+                }
             }
             append(" ")
             when (player) {
@@ -781,6 +786,10 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 }
                 Aggregation.DISTINCT_COUNTER_TYPES -> {
                     append("the number of different kinds of counters among ")
+                    append(pluralize(filter.description))
+                }
+                Aggregation.DISTINCT_VALUES -> {
+                    append("the number of different ${property?.description ?: "value"} among ")
                     append(pluralize(filter.description))
                 }
             }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DocAurlockGrizzledGenius.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DocAurlockGrizzledGenius.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyPlotCost
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.PlotCostTarget
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Doc Aurlock, Grizzled Genius
+ * {G}{U}
+ * Legendary Creature — Bear Druid
+ * 2/3
+ *
+ * Spells you cast from your graveyard or from exile cost {2} less to cast.
+ * Plotting cards from your hand costs {2} less.
+ *
+ * The first half is a [ModifySpellCost] with the new [SpellCostTarget.YouCastFromZones]
+ * (graveyard + exile), matched by the cost calculator only when the casting player controls Doc
+ * Aurlock and the spell is being cast from one of those zones. The second half is a
+ * [ModifyPlotCost] — Plot (CR 718) is a special action, not a spell, so it has its own dedicated
+ * cost-reduction path (`PlotCostReducer`). Both reductions only touch generic mana and floor at
+ * {0}.
+ */
+val DocAurlockGrizzledGenius = card("Doc Aurlock, Grizzled Genius") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Bear Druid"
+    power = 2
+    toughness = 3
+    oracleText = "Spells you cast from your graveyard or from exile cost {2} less to cast.\n" +
+        "Plotting cards from your hand costs {2} less."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCastFromZones(
+                zones = setOf(Zone.GRAVEYARD, Zone.EXILE),
+                filter = GameObjectFilter.Any,
+            ),
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    staticAbility {
+        ability = ModifyPlotCost(
+            target = PlotCostTarget.YouPlotFromHand,
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Learning stops only when you close your mind off to wonder.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg?1712356080"
+
+        ruling("2024-04-12", "The cost reduction applies to the total cost of the spell, including " +
+            "additional costs such as kicker. It can't reduce a spell's cost below the colored mana " +
+            "in its cost.")
+        ruling("2024-04-12", "Plotting a card is a special action, not casting a spell. The plot " +
+            "cost reduction applies only to the cost to plot, and the spell-cast reduction applies " +
+            "only when you actually cast a spell.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LaughingJasperFlint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/LaughingJasperFlint.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantAdditionalTypesToGroup
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Laughing Jasper Flint
+ * {1}{B}{R}
+ * Legendary Creature — Lizard Rogue
+ * 4/3
+ *
+ * Creatures you control but don't own are Mercenaries in addition to their other types.
+ * At the beginning of your upkeep, exile the top X cards of target opponent's library, where X is
+ * the number of outlaws you control. Until end of turn, you may cast spells from among those cards,
+ * and mana of any type can be spent to cast those spells.
+ *
+ * The type-grant uses [GrantAdditionalTypesToGroup] over a "you control but an opponent owns"
+ * filter (`ControlledByYou` AND `OwnedByOpponent`). The upkeep theft gathers the top X (X =
+ * outlaws you control, [Filters.OutlawCreature]) from the targeted opponent's library, moves them
+ * to exile, and grants a may-play-from-exile permission with `withAnyManaType = true` expiring at
+ * end of turn — the same primitive Cruelclaw's Heist uses for "mana of any type can be spent".
+ */
+val LaughingJasperFlint = card("Laughing Jasper Flint") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Lizard Rogue"
+    power = 4
+    toughness = 3
+    oracleText = "Creatures you control but don't own are Mercenaries in addition to their other " +
+        "types.\n" +
+        "At the beginning of your upkeep, exile the top X cards of target opponent's library, " +
+        "where X is the number of outlaws you control. Until end of turn, you may cast spells from " +
+        "among those cards, and mana of any type can be spent to cast those spells."
+
+    staticAbility {
+        ability = GrantAdditionalTypesToGroup(
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withControllerPredicate(
+                    ControllerPredicate.And(
+                        listOf(
+                            ControllerPredicate.ControlledByYou,
+                            ControllerPredicate.OwnedByOpponent,
+                        )
+                    )
+                )
+            ),
+            addSubtypes = listOf("Mercenary"),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.AggregateBattlefield(
+                            player = Player.You,
+                            filter = Filters.OutlawCreature,
+                        ),
+                        player = Player.ContextPlayer(0),
+                    ),
+                    storeAs = "stolenCards",
+                ),
+                MoveCollectionEffect(
+                    from = "stolenCards",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                ),
+                GrantMayPlayFromExileEffect(
+                    from = "stolenCards",
+                    expiry = MayPlayExpiry.EndOfTurn,
+                    withAnyManaType = true,
+                ),
+            )
+        )
+        description = "At the beginning of your upkeep, exile the top X cards of target opponent's " +
+            "library, where X is the number of outlaws you control. Until end of turn, you may cast " +
+            "spells from among those cards, and mana of any type can be spent to cast those spells."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Francis Tneh"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg?1712356142"
+
+        ruling("2024-04-12", "X is determined as the ability resolves, counting the outlaws you " +
+            "control at that time. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)")
+        ruling("2024-04-12", "You must still follow the normal timing permissions and restrictions " +
+            "of the cards you cast this way. Casting a sorcery, for example, is only possible during " +
+            "your main phase while the stack is empty.")
+        ruling("2024-04-12", "Mana of any type can be spent to cast the exiled cards, but you still " +
+            "must pay those costs. A card with {X} in its cost can have X paid with mana of any type.")
+        ruling("2024-04-12", "Any cards you don't cast remain in exile.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SelvalaEagerTrailblazer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SelvalaEagerTrailblazer.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Selvala, Eager Trailblazer
+ * {2}{G}{W}
+ * Legendary Creature — Elf Scout
+ * 4/5
+ *
+ * Vigilance
+ * Whenever you cast a creature spell, create a 1/1 red Mercenary creature token with "{T}: Target
+ * creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+ * {T}: Choose a color. Add one mana of that color for each different power among creatures you
+ * control.
+ *
+ * The mana ability uses the new [Aggregation.DISTINCT_VALUES] over [CardNumericProperty.POWER]
+ * ("number of different powers among creatures you control") feeding [Effects.AddManaOfChoice].
+ * The Mercenary token mirrors Hellspur Posse Boss's token (same OTJ Mercenary print).
+ */
+val SelvalaEagerTrailblazer = card("Selvala, Eager Trailblazer") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Elf Scout"
+    power = 4
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Whenever you cast a creature spell, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a " +
+        "sorcery.\"\n" +
+        "{T}: Choose a color. Add one mana of that color for each different power among creatures " +
+        "you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed,
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+        )
+        description = "Whenever you cast a creature spell, create a 1/1 red Mercenary creature " +
+            "token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate " +
+            "only as a sorcery.\""
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(
+            colorSet = ManaColorSet.AnyColor,
+            amount = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature,
+                aggregation = Aggregation.DISTINCT_VALUES,
+                property = CardNumericProperty.POWER,
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "Choose a color. Add one mana of that color for each different power among " +
+            "creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "231"
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg?1712356210"
+
+        ruling("2024-04-12", "The number of different powers is calculated as the ability resolves. " +
+            "For example, if you control three creatures with powers 1, 1, and 3, there are two " +
+            "different powers, so you add two mana.")
+        ruling("2024-04-12", "If you control no creatures (which can't normally happen, as Selvala " +
+            "is a creature), or if all your creatures have the same power, you still choose a color.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4355,6 +4355,65 @@
     ]
 }
 
+// Doc Aurlock, Grizzled Genius
+{
+    "name": "Doc Aurlock, Grizzled Genius",
+    "manaCost": "{G}{U}",
+    "typeLine": "Legendary Creature — Bear Druid",
+    "oracleText": "Spells you cast from your graveyard or from exile cost {2} less to cast.\nPlotting cards from your hand costs {2} less.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCastFromZones",
+                    "zones": [
+                        "Graveyard",
+                        "Exile"
+                    ]
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                }
+            },
+            {
+                "type": "ModifyPlotCost",
+                "target": "YouPlotFromHand",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Learning stops only when you close your mind off to wonder.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg?1712356080",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The cost reduction applies to the total cost of the spell, including additional costs such as kicker. It can't reduce a spell's cost below the colored mana in its cost."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Plotting a card is a special action, not casting a spell. The plot cost reduction applies only to the cost to plot, and the spell-cast reduction applies only when you actually cast a spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Double Down
 {
     "name": "Double Down",
@@ -8808,6 +8867,137 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Laughing Jasper Flint
+{
+    "name": "Laughing Jasper Flint",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Legendary Creature — Lizard Rogue",
+    "oracleText": "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasAnyOfSubtypes",
+                                                "subtypes": [
+                                                    "Assassin",
+                                                    "Mercenary",
+                                                    "Pirate",
+                                                    "Rogue",
+                                                    "Warlock"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "stolenCards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "stolenCards",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "stolenCards",
+                            "withAnyManaType": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantAdditionalTypesToGroup",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "controllerPredicate": {
+                            "type": "ControllerAnd",
+                            "predicates": [
+                                "ControlledByYou",
+                                "OwnedByOpponent"
+                            ]
+                        }
+                    }
+                },
+                "addSubtypes": [
+                    "Mercenary"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "RARE",
+        "artist": "Francis Tneh",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg?1712356142",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "X is determined as the ability resolves, counting the outlaws you control at that time. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)"
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You must still follow the normal timing permissions and restrictions of the cards you cast this way. Casting a sorcery, for example, is only possible during your main phase while the stack is empty."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Mana of any type can be spent to cast the exiled cards, but you still must pay those costs. A card with {X} in its cost can have X paid with mana of any type."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Any cards you don't cast remain in exile."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -14184,6 +14374,119 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Selvala, Eager Trailblazer
+{
+    "name": "Selvala, Eager Trailblazer",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Legendary Creature — Elf Scout",
+    "oracleText": "Vigilance\nWhenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\""
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "aggregation": "DISTINCT_VALUES",
+                        "property": "POWER"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "Choose a color. Add one mana of that color for each different power among creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "MYTHIC",
+        "artist": "Viko Menezes",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg?1712356210",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The number of different powers is calculated as the ability resolves. For example, if you control three creatures with powers 1, 1, and 3, there are two different powers, so you add two mana."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you control no creatures (which can't normally happen, as Selvala is a creature), or if all your creatures have the same power, you still choose a color."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -121,8 +121,19 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // `ModifySpellCost(target = SpellCostTarget.OpponentsCastFromZones(...), modification =
     // IncreaseGeneric(N))`. The spell-zone selectors below carry the zone set.
     effect("IncreaseSpellCost", "ModifySpellCost")
-    supported("WasCastFromExile", "spell selector: cast from exile (SpellCostTarget.OpponentsCastFromZones zone = EXILE)")
-    supported("WasCastFromAPlayersGraveyard", "spell selector: cast from a graveyard (SpellCostTarget.OpponentsCastFromZones zone = GRAVEYARD)")
+    supported("WasCastFromExile", "spell selector: cast from exile (SpellCostTarget.*CastFromZones zone = EXILE)")
+    supported("WasCastFromAPlayersGraveyard", "spell selector: cast from a graveyard (SpellCostTarget.*CastFromZones zone = GRAVEYARD)")
+
+    // "Spells you cast from your graveyard or from exile cost {N} less" (Doc Aurlock, Grizzled
+    // Genius) — the nested _PlayerEffect of a controller-scoped PlayerEffect{You} static. Renders to
+    // `ModifySpellCost(target = SpellCostTarget.YouCastFromZones(GRAVEYARD, EXILE), modification =
+    // ReduceGeneric(N))`. The you-cast analogue of the IncreaseSpellCost/OpponentsCastFromZones
+    // shape above; the spell-zone selectors are shared.
+    effect("DecreaseSpellCost", "ModifySpellCost")
+    // "Plotting cards from your hand costs {N} less" (Doc Aurlock) — a controller-scoped player
+    // static over the Plot special action (CR 718). Renders to `ModifyPlotCost(target =
+    // PlotCostTarget.YouPlotFromHand, modification = ReduceGeneric(N))`.
+    effect("DecreasePlotFromHandCost", "ModifyPlotCost")
 
     // Fblthp, Lost on the Range (CR 718) — top-of-library plot + look. Nested _PlayerEffect /
     // _Rule capabilities of the controller-scoped statics.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -559,10 +559,14 @@ internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<Stmt>? {
     for (e in effects) {
         val ability = when (e.strField("_PlayerEffect")) {
             "Shroud" -> Lit("GrantShroudToController")
-            // "[Filtered] spells you cast cost {N} less to cast" (Honest Rutstein: creature spells).
-            // Renders only a single bare generic reduction over a spell filter we can name exactly;
-            // a colored/dynamic reduction or a filter we can't express declines -> SCAFFOLD.
+            // "[Filtered] spells you cast cost {N} less to cast" (Honest Rutstein: creature spells;
+            // Doc Aurlock: cast from your graveyard or from exile). Renders only a single bare generic
+            // reduction over a spell filter / zone set we can name exactly; a colored/dynamic
+            // reduction or a filter we can't express declines -> SCAFFOLD.
             "DecreaseSpellCost" -> decreaseSpellCostAbility(e) ?: run { reasons.add("PlayerEffect"); return null }
+            // "Plotting cards from your hand costs {N} less" (Doc Aurlock) -> ModifyPlotCost.
+            "DecreasePlotFromHandCost" ->
+                decreasePlotFromHandCostAbility(e) ?: run { reasons.add("PlayerEffect"); return null }
             // "You can't cast more than N spell(s) each turn" (Yawgmoth's Agenda) — controller-scoped.
             "CantCastMoreThanNumberSpellsEachTurn" ->
                 spellCountRestrictionAbility(e, eachPlayer = false) ?: run { reasons.add("PlayerEffect"); return null }
@@ -624,7 +628,23 @@ private fun EmitCtx.spellCountRestrictionAbility(effect: JsonObject, eachPlayer:
  * renders; any colored symbol, a multi-symbol reduction, or an unrenderable filter returns null. */
 private fun EmitCtx.decreaseSpellCostAbility(effect: JsonObject): Dsl? {
     val a = effect["args"].asArr ?: return null
-    val spellFilter = when (val spells = a.getOrNull(0) as? JsonObject) {
+    val spells = a.getOrNull(0) as? JsonObject
+
+    val symbols = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
+    val amount = symbols[0]["args"].asInt() ?: return null
+
+    // A "cast from your graveyard or from exile" spell filter maps to the zone-scoped
+    // SpellCostTarget.YouCastFromZones (Doc Aurlock). Recognised exactly; anything else declines.
+    castFromZonesSet(spells)?.let { zonesExpr ->
+        return call(
+            "ModifySpellCost",
+            arg("target", call("SpellCostTarget.YouCastFromZones", arg(zonesExpr))),
+            arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+        )
+    }
+
+    val spellFilter = when (spells) {
         null -> "GameObjectFilter.Any"
         else -> when {
             jsonContains(spells, "_Spells", "AnySpell") -> "GameObjectFilter.Any"
@@ -632,12 +652,52 @@ private fun EmitCtx.decreaseSpellCostAbility(effect: JsonObject): Dsl? {
             else -> return null
         }
     }
-    val symbols = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
-    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
-    val amount = symbols[0]["args"].asInt() ?: return null
     return call(
         "ModifySpellCost",
         arg("target", call("SpellCostTarget.YouCast", arg(spellFilter))),
+        arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+    )
+}
+
+/**
+ * Recognise the spell-zone filter `Or[WasCastFromAPlayersGraveyard(You), WasCastFromExile]`
+ * (in either order) and render it as a `setOf(Zone.GRAVEYARD, Zone.EXILE)` expression for
+ * [SpellCostTarget.YouCastFromZones]. Returns null for any other spell filter so the caller falls
+ * back to the plain `YouCast` shape or declines. Only the exact graveyard+exile pair is handled —
+ * the single shape that appears today (Doc Aurlock); a partial/other zone set declines rather than
+ * guess.
+ */
+private fun castFromZonesSet(spells: JsonObject?): String? {
+    if (spells == null) return null
+    val branches = when {
+        spells.strField("_Spells") == "Or" -> (spells["args"] as? JsonArray)?.filterIsInstance<JsonObject>()
+        else -> listOf(spells)
+    } ?: return null
+    val zones = mutableSetOf<String>()
+    for (b in branches) {
+        when (b.strField("_Spells")) {
+            "WasCastFromAPlayersGraveyard" -> zones.add("Zone.GRAVEYARD")
+            "WasCastFromExile" -> zones.add("Zone.EXILE")
+            else -> return null
+        }
+    }
+    if (zones != setOf("Zone.GRAVEYARD", "Zone.EXILE")) return null
+    return "setOf(Zone.GRAVEYARD, Zone.EXILE)"
+}
+
+/**
+ * A `DecreasePlotFromHandCost([<reduction symbols>])` player-static ->
+ * `ModifyPlotCost(target = PlotCostTarget.YouPlotFromHand, modification = CostModification.ReduceGeneric(N))`.
+ * Only a single bare generic reduction renders (Doc Aurlock: "Plotting cards from your hand costs
+ * {2} less"); a colored/multi-symbol reduction declines -> SCAFFOLD.
+ */
+private fun EmitCtx.decreasePlotFromHandCostAbility(effect: JsonObject): Dsl? {
+    val symbols = (effect["args"] as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
+    val amount = symbols[0]["args"].asInt() ?: return null
+    return call(
+        "ModifyPlotCost",
+        arg("target", "PlotCostTarget.YouPlotFromHand"),
         arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -634,6 +634,12 @@ class DynamicAmountEvaluator(
             Aggregation.DISTINCT_COUNTER_TYPES -> matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
                 state.getEntity(entityId)?.get<CountersComponent>()?.counters?.keys ?: emptySet()
             }.size
+            Aggregation.DISTINCT_VALUES -> {
+                val prop = amount.property ?: return 0
+                matchingEntities.mapTo(mutableSetOf()) {
+                    resolveCardNumericProperty(state, projection, it, prop)
+                }.size
+            }
         }
     }
 
@@ -701,6 +707,12 @@ class DynamicAmountEvaluator(
             Aggregation.DISTINCT_COUNTER_TYPES -> {
                 matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
                     state.getEntity(entityId)?.get<CountersComponent>()?.counters?.keys ?: emptySet()
+                }.size
+            }
+            Aggregation.DISTINCT_VALUES -> {
+                val prop = amount.property ?: return 0
+                matchingEntities.mapTo(mutableSetOf()) {
+                    resolveCardNumericProperty(state, null, it, prop)
                 }.size
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -59,6 +59,8 @@ class PlotCardHandler(
     override val actionType: KClass<PlotCard> = PlotCard::class
 
     private val predicateEvaluator = PredicateEvaluator()
+    private val plotCostReducer =
+        com.wingedsheep.engine.mechanics.mana.PlotCostReducer(cardRegistry)
 
     /**
      * Where the card being plotted lives and what its plot cost is. Plot normally exiles a
@@ -72,11 +74,13 @@ class PlotCardHandler(
         val cardComponent = state.getEntity(action.cardId)?.get<CardComponent>() ?: return null
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return null
 
-        // Hand: the card's own Plot keyword.
+        // Hand: the card's own Plot keyword, after any "plotting cards from your hand costs {N}
+        // less" reductions (Doc Aurlock, Grizzled Genius).
         if (action.cardId in state.getZone(ZoneKey(action.playerId, Zone.HAND))) {
             val plotAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Plot>().firstOrNull()
                 ?: return null
-            return PlotSource(Zone.HAND, plotAbility.cost)
+            val reduced = plotCostReducer.effectivePlotCostFromHand(state, action.playerId, plotAbility.cost)
+            return PlotSource(Zone.HAND, reduced)
         }
 
         // Top of library: a battlefield [PlotFromTopOfLibrary] grant (Fblthp). The card must be

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -55,6 +55,8 @@ class EnumerationContext(
     val targetUtils by lazy { TargetEnumerationUtils(predicateEvaluator) }
     val costUtils by lazy { CostEnumerationUtils(manaSolver, costCalculator, predicateEvaluator, cardRegistry) }
     val castPermissionUtils by lazy { CastPermissionUtils(cardRegistry, predicateEvaluator, conditionEvaluator) }
+    // Plot (CR 718) cost reduction — Doc Aurlock-style "plotting cards costs {N} less".
+    val plotCostReducer by lazy { com.wingedsheep.engine.mechanics.mana.PlotCostReducer(cardRegistry) }
 
     // Projected state
     val projected: ProjectedState by lazy { state.projectedState }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -866,7 +866,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     val hasCorrectTiming = isInstant || context.canPlaySorcerySpeed
                     val castRestrictions = cardDef.script.castRestrictions
                     val meetsRestrictions = context.castPermissionUtils.checkCastRestrictions(state, playerId, castRestrictions)
-                    val effectiveCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
+                    val effectiveCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId, fromZone = zone)
                     val costString = effectiveCost.toString()
                     val canAfford = context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlotEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlotEnumerator.kt
@@ -31,12 +31,15 @@ class PlotEnumerator : ActionEnumerator {
             val plotAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Plot>().firstOrNull()
                 ?: continue
 
+            // Apply Doc Aurlock-style "plotting cards from your hand costs {N} less" reductions.
+            val plotCost = context.plotCostReducer.effectivePlotCostFromHand(state, playerId, plotAbility.cost)
+
             val canAfford = context.manaSolver.canPay(
-                state, playerId, plotAbility.cost, precomputedSources = context.availableManaSources
+                state, playerId, plotCost, precomputedSources = context.availableManaSources
             )
             val autoTapPreview = if (context.skipAutoTapPreview) null else {
                 context.manaSolver.solve(
-                    state, playerId, plotAbility.cost, precomputedSources = context.availableManaSources
+                    state, playerId, plotCost, precomputedSources = context.availableManaSources
                 )?.sources?.map { it.entityId }
             }
             result.add(
@@ -45,7 +48,7 @@ class PlotEnumerator : ActionEnumerator {
                     description = "Plot ${cardComponent.name}",
                     action = PlotCard(playerId, cardId),
                     affordable = canAfford,
-                    manaCostString = plotAbility.cost.toString(),
+                    manaCostString = plotCost.toString(),
                     autoTapPreview = autoTapPreview
                 )
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -280,6 +280,10 @@ internal class AffectsFilterResolver {
                         ControllerPredicate.ControlledByYou -> entityController == controller
                         ControllerPredicate.ControlledByOpponent -> entityController != controller
                         ControllerPredicate.ControlledByAny -> true
+                        // Owner-axis leaves read the card's owner relative to the source's
+                        // controller (Laughing Jasper Flint: "creatures you control but don't own").
+                        ControllerPredicate.OwnedByYou -> card.ownerId != null && card.ownerId == controller
+                        ControllerPredicate.OwnedByOpponent -> card.ownerId != null && card.ownerId != controller
                         else -> null // other predicates not applicable in static ability context
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -105,6 +105,7 @@ import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
 import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
 import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
+import com.wingedsheep.sdk.scripting.ModifyPlotCost
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.NoMaximumHandSize
 import com.wingedsheep.sdk.scripting.NoncombatDamageBonus
@@ -705,6 +706,9 @@ class StaticAbilityHandler(
             // Spell costs (CostCalculator):
             is GrantAlternativeCastingCost,
             is ModifySpellCost,
+
+            // Plot special-action cost (PlotCostReducer / PlotEnumerator / PlotCardHandler):
+            is ModifyPlotCost,
 
             // Spells on the stack (StackResolver / GrantedKeywordResolver):
             is GrantCantBeCountered,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -218,6 +218,14 @@ class CostCalculator(
                 if (sourceController == casterId) return false
                 matchesCardDefinition(cardDef, target.filter, sourceId, state, state.projectedState)
             }
+            is SpellCostTarget.YouCastFromZones -> {
+                // Source must be controlled by the caster, the spell must be cast from one of the
+                // named zones, and the card must match the filter (Doc Aurlock).
+                if (fromZone == null || fromZone !in target.zones) return false
+                val sourceController = state.projectedState.getController(sourceId) ?: return false
+                if (sourceController != casterId) return false
+                matchesCardDefinition(cardDef, target.filter, sourceId, state, state.projectedState)
+            }
             // FaceDown / Morph targets are spell-cast modifiers only when applied to a face-down cast.
             // calculateEffectiveCost is only called for face-up casts; face-down handling is in
             // calculateFaceDownCost / calculateMorphCostIncrease.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/PlotCostReducer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/PlotCostReducer.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.mechanics.mana
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifyPlotCost
+import com.wingedsheep.sdk.scripting.PlotCostTarget
+
+/**
+ * Computes the effective cost of the **Plot** special action (CR 718) after applying battlefield
+ * [ModifyPlotCost] static abilities.
+ *
+ * Plot is not a spell, so [CostCalculator] (which works on `ModifySpellCost`) does not touch it;
+ * this is plot's dedicated, parallel cost-reduction path. Both [com.wingedsheep.engine.legalactions.enumerators.PlotEnumerator]
+ * (affordability) and [com.wingedsheep.engine.handlers.actions.ability.PlotCardHandler] (validate +
+ * pay) route their plot cost through here so the two stay in lockstep.
+ *
+ * Only [PlotCostTarget.YouPlotFromHand] is matched today (Doc Aurlock, Grizzled Genius:
+ * "Plotting cards from your hand costs {2} less"); a future "plot from top of library" reduction
+ * adds a [PlotCostTarget] variant without changing call sites. Only generic [CostModification]
+ * reductions/increases are meaningful for plot — the printed plot cost is a flat mana cost.
+ */
+class PlotCostReducer(
+    private val cardRegistry: CardRegistry,
+) {
+    /**
+     * The plot cost [plotterId] actually pays for a card plotted **from hand**, after reductions.
+     * Floored at {0} generic; colored pips are never reduced below the printed requirement.
+     */
+    fun effectivePlotCostFromHand(state: GameState, plotterId: EntityId, baseCost: ManaCost): ManaCost {
+        var totalReduction = 0
+        var totalIncrease = 0
+        for ((sourceId, ability) in scanBattlefield(state)) {
+            if (ability.target != PlotCostTarget.YouPlotFromHand) continue
+            if (state.projectedState.getController(sourceId) != plotterId) continue
+            when (val mod = ability.modification) {
+                is CostModification.ReduceGeneric -> totalReduction += mod.amount
+                is CostModification.IncreaseGeneric -> totalIncrease += mod.amount
+                else -> { /* plot only supports flat generic adjustments */ }
+            }
+        }
+        var cost = baseCost
+        if (totalIncrease > 0) cost = increaseGeneric(cost, totalIncrease)
+        if (totalReduction > 0) cost = cost.reduceGeneric(totalReduction)
+        return cost
+    }
+
+    private fun increaseGeneric(cost: ManaCost, increase: Int): ManaCost {
+        if (increase <= 0) return cost
+        val colored = cost.symbols.filter { it !is com.wingedsheep.sdk.core.ManaSymbol.Generic }
+        val newGeneric = cost.genericAmount + increase
+        val symbols = if (newGeneric > 0) {
+            listOf(com.wingedsheep.sdk.core.ManaSymbol.Generic(newGeneric)) + colored
+        } else colored
+        return ManaCost(symbols)
+    }
+
+    private fun scanBattlefield(state: GameState): List<Pair<EntityId, ModifyPlotCost>> {
+        val results = mutableListOf<Pair<EntityId, ModifyPlotCost>>()
+        for (playerId in state.turnOrder) {
+            for (entityId in state.getBattlefield(playerId)) {
+                val container = state.getEntity(entityId) ?: continue
+                val card = container.get<CardComponent>() ?: continue
+                val def = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+                val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+                for (ability in def.script.effectiveStaticAbilities(classLevel)) {
+                    if (ability is ModifyPlotCost) results += entityId to ability
+                }
+            }
+        }
+        return results
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DocAurlockGrizzledGeniusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DocAurlockGrizzledGeniusScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.mechanics.mana.PlotCostReducer
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DocAurlockGrizzledGenius
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Doc Aurlock, Grizzled Genius — {G}{U} Legendary Creature — Bear Druid 2/3.
+ *
+ * - "Spells you cast from your graveyard or from exile cost {2} less to cast." →
+ *   [com.wingedsheep.sdk.scripting.SpellCostTarget.YouCastFromZones] checked by [CostCalculator].
+ * - "Plotting cards from your hand costs {2} less." → [com.wingedsheep.sdk.scripting.ModifyPlotCost]
+ *   checked by [PlotCostReducer].
+ */
+class DocAurlockGrizzledGeniusScenarioTest : FunSpec({
+
+    // A {4}{R}{R} sorcery used to probe the spell-cast half.
+    val BigSpell = card("Doc Aurlock Test Spell") {
+        manaCost = "{4}{R}{R}"
+        typeLine = "Sorcery"
+    }
+
+    // A {3}{G} creature with plot {5}{G} used to probe the plot half.
+    val PlottableCreature = card("Doc Aurlock Plot Creature") {
+        manaCost = "{3}{G}"
+        typeLine = "Creature — Bear"
+        power = 3
+        toughness = 3
+        keywordAbility(com.wingedsheep.sdk.scripting.KeywordAbility.plot("{5}{G}"))
+    }
+
+    fun registry(): CardRegistry {
+        val r = CardRegistry()
+        r.register(TestCards.all)
+        r.register(DocAurlockGrizzledGenius)
+        r.register(BigSpell)
+        r.register(PlottableCreature)
+        return r
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(DocAurlockGrizzledGenius)
+        d.registerCard(BigSpell)
+        d.registerCard(PlottableCreature)
+        return d
+    }
+
+    fun setup(): Pair<GameTestDriver, com.wingedsheep.sdk.model.EntityId> {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(active, "Doc Aurlock, Grizzled Genius")
+        return d to active
+    }
+
+    test("spell cast from graveyard costs {2} less") {
+        val reg = registry()
+        val calc = CostCalculator(reg)
+        val (d, active) = setup()
+        val spell = reg.requireCard("Doc Aurlock Test Spell")
+        // {4}{R}{R} → −{2} generic → {2}{R}{R}
+        val cost = calc.calculateEffectiveCost(d.state, spell, active, fromZone = Zone.GRAVEYARD)
+        cost.genericAmount shouldBe 2
+        cost.cmc shouldBe 4
+    }
+
+    test("spell cast from exile costs {2} less") {
+        val reg = registry()
+        val calc = CostCalculator(reg)
+        val (d, active) = setup()
+        val spell = reg.requireCard("Doc Aurlock Test Spell")
+        val cost = calc.calculateEffectiveCost(d.state, spell, active, fromZone = Zone.EXILE)
+        cost.genericAmount shouldBe 2
+    }
+
+    test("spell cast from hand is NOT reduced") {
+        val reg = registry()
+        val calc = CostCalculator(reg)
+        val (d, active) = setup()
+        val spell = reg.requireCard("Doc Aurlock Test Spell")
+        val cost = calc.calculateEffectiveCost(d.state, spell, active, fromZone = Zone.HAND)
+        cost.genericAmount shouldBe 4
+    }
+
+    test("spell cast with no fromZone is NOT reduced") {
+        val reg = registry()
+        val calc = CostCalculator(reg)
+        val (d, active) = setup()
+        val spell = reg.requireCard("Doc Aurlock Test Spell")
+        val cost = calc.calculateEffectiveCost(d.state, spell, active)
+        cost.genericAmount shouldBe 4
+    }
+
+    test("opponent's graveyard cast is NOT reduced by my Doc Aurlock") {
+        val reg = registry()
+        val calc = CostCalculator(reg)
+        val (d, active) = setup()
+        val opponent = d.state.turnOrder.first { it != active }
+        val spell = reg.requireCard("Doc Aurlock Test Spell")
+        val cost = calc.calculateEffectiveCost(d.state, spell, opponent, fromZone = Zone.GRAVEYARD)
+        cost.genericAmount shouldBe 4
+    }
+
+    test("plotting a card from hand costs {2} less") {
+        val reg = registry()
+        val reducer = PlotCostReducer(reg)
+        val (d, active) = setup()
+        // base plot cost {5}{G} → −{2} generic → {3}{G}
+        val effective = reducer.effectivePlotCostFromHand(d.state, active, ManaCost.parse("{5}{G}"))
+        effective.genericAmount shouldBe 3
+        effective.cmc shouldBe 4
+    }
+
+    test("plot reduction floors generic at 0 and never reduces colored pips") {
+        val reg = registry()
+        val reducer = PlotCostReducer(reg)
+        val (d, active) = setup()
+        // {1}{G} → −{2} generic → {G} (generic floored at 0, colored kept)
+        val effective = reducer.effectivePlotCostFromHand(d.state, active, ManaCost.parse("{1}{G}"))
+        effective.genericAmount shouldBe 0
+        effective.cmc shouldBe 1
+    }
+
+    test("plot reduction does not apply to an opponent without Doc Aurlock") {
+        val reg = registry()
+        val reducer = PlotCostReducer(reg)
+        val (d, active) = setup()
+        val opponent = d.state.turnOrder.first { it != active }
+        val effective = reducer.effectivePlotCostFromHand(d.state, opponent, ManaCost.parse("{5}{G}"))
+        effective.genericAmount shouldBe 5
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaughingJasperFlintScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaughingJasperFlintScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.LaughingJasperFlint
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Laughing Jasper Flint — {1}{B}{R} Legendary Creature — Lizard Rogue 4/3.
+ *
+ * - "Creatures you control but don't own are Mercenaries in addition to their other types."
+ * - "At the beginning of your upkeep, exile the top X cards of target opponent's library, where X
+ *   is the number of outlaws you control. Until end of turn, you may cast spells from among those
+ *   cards, and mana of any type can be spent to cast those spells."
+ */
+class LaughingJasperFlintScenarioTest : FunSpec({
+
+    // A plain non-outlaw creature to be stolen / re-typed.
+    val PlainBear = card("Jasper Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    // A Pirate (outlaw) to bump the outlaw count.
+    val PirateGoon = card("Jasper Test Pirate") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Human Pirate"
+        power = 2
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(LaughingJasperFlint)
+        d.registerCard(PlainBear)
+        d.registerCard(PirateGoon)
+        return d
+    }
+
+    test("a creature you control but an opponent owns becomes a Mercenary") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = d.activePlayer!!
+        val opponent = d.state.turnOrder.first { it != me }
+
+        d.putCreatureOnBattlefield(me, "Laughing Jasper Flint")
+        // A Bear I control but opponent owns (control-changed): controller = me, owner = opponent.
+        // Owner is read from CardComponent.ownerId, so update that alongside OwnerComponent.
+        val stolenBear = d.putCreatureOnBattlefield(me, "Jasper Test Bear")
+        d.replaceState(d.state.updateEntity(stolenBear) { c ->
+            val card = c.get<CardComponent>()!!
+            c.with(card.copy(ownerId = opponent)).with(OwnerComponent(opponent))
+        })
+
+        val projected = StateProjector().project(d.state)
+        projected.hasSubtype(stolenBear, "Mercenary") shouldBe true
+        // It keeps its original subtype too ("in addition to").
+        projected.hasSubtype(stolenBear, "Bear") shouldBe true
+    }
+
+    test("a creature you control AND own does not gain Mercenary") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = d.activePlayer!!
+
+        d.putCreatureOnBattlefield(me, "Laughing Jasper Flint")
+        val ownBear = d.putCreatureOnBattlefield(me, "Jasper Test Bear")
+
+        StateProjector().project(d.state).hasSubtype(ownBear, "Mercenary") shouldBe false
+    }
+
+    test("upkeep ability exiles top X of target opponent's library where X = outlaws you control") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = d.activePlayer!!
+        val opponent = d.state.turnOrder.first { it != me }
+
+        // Jasper (Rogue) + a Pirate = 2 outlaws I control.
+        d.putCreatureOnBattlefield(me, "Laughing Jasper Flint")
+        d.putCreatureOnBattlefield(me, "Jasper Test Pirate")
+
+        // Seed the opponent's library top with identifiable cards.
+        d.putCardOnTopOfLibrary(opponent, "Jasper Test Bear")
+        d.putCardOnTopOfLibrary(opponent, "Jasper Test Pirate")
+        d.putCardOnTopOfLibrary(opponent, "Jasper Test Bear")
+
+        val opponentExileBefore = d.getExile(opponent).size
+
+        // Advance to my next upkeep (turn 3) so the trigger fires on my beginning-of-upkeep.
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP, maxPasses = 300)   // opponent's upkeep
+        d.passPriorityUntil(Step.UPKEEP, maxPasses = 300)   // back to my upkeep — trigger fires
+
+        // Resolve the upkeep trigger. Single opponent → "target opponent" auto-targets; pass
+        // priority to let the triggered ability resolve. If any decision surfaces, auto-resolve it.
+        repeat(6) {
+            if (d.state.pendingDecision != null) d.autoResolveDecision() else d.bothPass()
+            if (d.getExile(opponent).size > opponentExileBefore) return@repeat
+        }
+
+        // X = 2 outlaws → 2 cards exiled from the opponent's library.
+        d.getExile(opponent).size shouldBe (opponentExileBefore + 2)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelvalaEagerTrailblazerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelvalaEagerTrailblazerScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SelvalaEagerTrailblazer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Selvala, Eager Trailblazer — {2}{G}{W} Legendary Creature — Elf Scout 4/5, vigilance.
+ *
+ * - "{T}: Choose a color. Add one mana of that color for each different power among creatures you
+ *   control." → exercises [com.wingedsheep.sdk.scripting.values.Aggregation.DISTINCT_VALUES] over
+ *   power, feeding [com.wingedsheep.sdk.dsl.Effects.AddManaOfChoice].
+ * - "Whenever you cast a creature spell, create a 1/1 red Mercenary creature token …"
+ */
+class SelvalaEagerTrailblazerScenarioTest : FunSpec({
+
+    val manaAbilityId = SelvalaEagerTrailblazer.activatedAbilities[0].id
+
+    // Power-2 and power-3 vanilla creatures to vary the distinct-power count.
+    val Bear2 = card("Selvala Test Bear 2") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    val Ogre3 = card("Selvala Test Ogre 3") {
+        manaCost = "{2}{R}"
+        typeLine = "Creature — Ogre"
+        power = 3
+        toughness = 3
+    }
+
+    fun createDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(SelvalaEagerTrailblazer)
+        d.registerCard(Bear2)
+        d.registerCard(Ogre3)
+        return d
+    }
+
+    test("mana ability adds one chosen-color mana per different power among creatures you control") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val p = d.activePlayer!!
+
+        // Selvala (power 4) + Bear (2) + Ogre (3) → distinct powers {4,2,3} = 3.
+        val selvala = d.putCreatureOnBattlefield(p, "Selvala, Eager Trailblazer")
+        d.removeSummoningSickness(selvala)
+        d.putCreatureOnBattlefield(p, "Selvala Test Bear 2")
+        d.putCreatureOnBattlefield(p, "Selvala Test Ogre 3")
+
+        val result = d.submit(ActivateAbility(playerId = p, sourceId = selvala, abilityId = manaAbilityId))
+        withClue("error=${result.error} isPaused=${d.isPaused}") {
+            result.isPaused shouldBe true
+        }
+        // Pauses to choose a color.
+        d.pendingDecision.shouldBeInstanceOf<ChooseColorDecision>()
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(p, ColorChosenResponse(decision.id, Color.GREEN))
+
+        val pool = d.state.getEntity(p)?.get<ManaPoolComponent>()
+        pool?.green shouldBe 3
+    }
+
+    test("two creatures sharing a power count once") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val p = d.activePlayer!!
+
+        // Selvala (4) + Bear (2) + Bear (2) → distinct powers {4,2} = 2.
+        val selvala = d.putCreatureOnBattlefield(p, "Selvala, Eager Trailblazer")
+        d.removeSummoningSickness(selvala)
+        d.putCreatureOnBattlefield(p, "Selvala Test Bear 2")
+        d.putCreatureOnBattlefield(p, "Selvala Test Bear 2")
+
+        d.submit(ActivateAbility(playerId = p, sourceId = selvala, abilityId = manaAbilityId))
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(p, ColorChosenResponse(decision.id, Color.WHITE))
+
+        d.state.getEntity(p)?.get<ManaPoolComponent>()?.white shouldBe 2
+    }
+
+    test("casting a creature spell creates a 1/1 red Mercenary token") {
+        val d = createDriver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val p = d.activePlayer!!
+
+        d.putCreatureOnBattlefield(p, "Selvala, Eager Trailblazer")
+
+        val mercenariesBefore = countMercenaries(d, p)
+
+        val bear = d.putCardInHand(p, "Selvala Test Bear 2")
+        d.giveMana(p, Color.GREEN, 2)
+        val result = d.castSpell(p, bear)
+        result.isSuccess shouldBe true
+        // Resolve the cast trigger (token creation) and the spell.
+        d.bothPass()
+
+        countMercenaries(d, p) shouldBe (mercenariesBefore + 1)
+    }
+})
+
+private fun countMercenaries(d: GameTestDriver, playerId: com.wingedsheep.sdk.model.EntityId): Int =
+    d.state.getBattlefield(playerId).count { id ->
+        val card = d.state.getEntity(id)?.get<CardComponent>() ?: return@count false
+        card.typeLine.subtypes.any { it.value == "Mercenary" }
+    }


### PR DESCRIPTION
Implements three Outlaws of Thunder Junction cards via the add-card flow, plus the SDK/engine building blocks they need, and teaches the mtgish emitter the new shapes.

## Cards

### Doc Aurlock, Grizzled Genius — {G}{U} Legendary Creature — Bear Druid 2/3
- **"Spells you cast from your graveyard or from exile cost {2} less to cast."** New `SpellCostTarget.YouCastFromZones` (the you-cast analogue of the existing `OpponentsCastFromZones`), matched in `CostCalculator`. `CastFromZoneEnumerator` now threads `fromZone` on the `MayCastSelfFromZones` path so affordability reflects the discount.
- **"Plotting cards from your hand costs {2} less."** Plot (CR 718) is a *special action*, not a spell, so `ModifySpellCost` can't touch it — added a dedicated `ModifyPlotCost` static + `PlotCostReducer`, consulted by both `PlotEnumerator` (affordability) and `PlotCardHandler` (payment) so the two stay in lockstep.

### Selvala, Eager Trailblazer — {2}{G}{W} Legendary Creature — Elf Scout 4/5, vigilance
- **"{T}: Choose a color. Add one mana of that color for each different power among creatures you control."** New `Aggregation.DISTINCT_VALUES` over a `CardNumericProperty` (POWER), feeding `Effects.AddManaOfChoice`. `DynamicAmounts` builder gains `distinctValues(property)`.
- **"Whenever you cast a creature spell, create a 1/1 red Mercenary token …"** Composes the existing `CreateTokenEffect` + granted sorcery-speed tap-pump activated ability (same Mercenary print as Hellspur Posse Boss).

### Laughing Jasper Flint — {1}{B}{R} Legendary Creature — Lizard Rogue 4/3
- **"Creatures you control but don't own are Mercenaries …"** `GrantAdditionalTypesToGroup` over a `ControlledByYou AND OwnedByOpponent` filter. **Bug fix:** `AffectsFilterResolver` didn't evaluate the `OwnedByYou`/`OwnedByOpponent` leaves, so the composed predicate fell through to Kleene "unknown" and fail-opened to match *every* controlled creature; now those leaves read the card owner vs the source controller.
- **"At the beginning of your upkeep, exile the top X cards of target opponent's library (X = outlaws you control); until end of turn you may cast them, any mana type."** Composes `GatherCards(TopOfLibrary)` + `MoveCollection(EXILE)` + `GrantMayPlayFromExile(withAnyManaType)` with X = `AggregateBattlefield` over `Filters.OutlawCreature`.

## mtgish-tooling
- Emitter now renders **Doc Aurlock whole (AUTO)**: `DecreaseSpellCost` over the graveyard/exile zone filter → `YouCastFromZones`, and `DecreasePlotFromHandCost` → `ModifyPlotCost`. Bridge gains the two capability entries.
- **Selvala** (`ChooseAColor` value selection — the README's known-sloppy area) and **Laughing Jasper Flint** (`EachPermanentLayerEffect` + multi-step theft) correctly remain **SCAFFOLD** rather than emit a lossy approximation.
- `just coverage-verify POR` still **GATE PASS (158/158)**; `EmitterGoldenTest` unchanged across all vendored sets.

## Tests
- Scenario tests for all three cards pass (14 cases: zone/plot cost reductions, distinct-power mana, Mercenary token, control-vs-own type grant, outlaw-counted upkeep theft).
- `CardDefinitionSnapshotTest` reblessed (OTJ.json — additive only, no other card moved); `CardLintTest`, `mtg-sdk`, full `rules-engine`, and `mtgish-tooling` suites green.
- SDK reference doc (`docs/card-sdk-language-reference.md`) updated for `YouCastFromZones`, `ModifyPlotCost`, and `DISTINCT_VALUES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)