### PR TITLE
Fix Furious Forebear self-trigger

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FuriousForebear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FuriousForebear.kt
@@ -6,6 +6,8 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
@@ -22,9 +24,8 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * while Furious Forebear sits in its owner's graveyard. The "you may pay {1}{W}" clause uses
  * [MayPayManaEffect]; on payment the card returns itself from the graveyard to hand.
  *
- * Furious Forebear's own death cannot trigger this: at the moment a creature dies the trigger
- * checks the graveyard zone, where Forebear must already reside, so the dying creature is always
- * a different one.
+ * The engine evaluates graveyard triggers after the death move, so this uses OTHER binding to
+ * preserve the printed timing: Forebear must already be in the graveyard before the creature dies.
  */
 val FuriousForebear = card("Furious Forebear") {
     manaCost = "{1}{W}"
@@ -36,7 +37,11 @@ val FuriousForebear = card("Furious Forebear") {
         "you may pay {1}{W}. If you do, return this card from your graveyard to your hand."
 
     triggeredAbility {
-        trigger = Triggers.YourCreatureDies
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
         triggerZone = Zone.GRAVEYARD
         effect = MayPayManaEffect(
             cost = ManaCost.parse("{1}{W}"),

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -6386,7 +6386,7 @@
                     "from": "Battlefield",
                     "to": "Graveyard"
                 },
-                "binding": "ANY",
+                "binding": "OTHER",
                 "effect": {
                     "type": "Gated",
                     "gate": {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FuriousForebearScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FuriousForebearScenarioTest.kt
@@ -1,93 +1,117 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 
-/**
- * Scenario test for Furious Forebear (TDM #13) — {1}{W} Spirit Warrior, 3/1.
- *
- * "Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}.
- *  If you do, return this card from your graveyard to your hand."
- *
- * A graveyard-zone triggered ability gated to fire only while Furious Forebear sits in its owner's
- * graveyard. We kill another creature the controller owns (Caustic Exhale, -3/-3), then the
- * "you may pay {1}{W}" YesNoDecision surfaces; paying returns Forebear from graveyard to hand.
- * Declining leaves it in the graveyard.
- */
 class FuriousForebearScenarioTest : ScenarioTestBase() {
-
     init {
-        context("Furious Forebear's graveyard death trigger") {
-
-            test("paying {1}{W} when a creature you control dies returns it from graveyard to hand") {
+        context("Furious Forebear") {
+            test("does not trigger from its own death") {
                 val game = scenario()
-                    .withPlayers("Player1", "Player2")
-                    .withCardInGraveyard(1, "Furious Forebear")
-                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 victim
-                    .withCardInHand(1, "Caustic Exhale")
-                    .withLandsOnBattlefield(1, "Swamp", 2) // Caustic Exhale: {B} + {1}
-                    .withLandsOnBattlefield(1, "Plains", 2) // pay {1}{W} for the trigger
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Furious Forebear")
                     .withActivePlayer(1)
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
-                val bears = game.findPermanent("Grizzly Bears")!!
-                val cast = game.castSpell(1, "Caustic Exhale", bears)
-                withClue("Casting Caustic Exhale on Grizzly Bears should succeed: ${cast.error}") {
+                val forebear = game.findPermanent("Furious Forebear")!!
+                val cast = game.castSpell(1, "Shock", forebear)
+                withClue("Shock should cast successfully: ${cast.error}") {
                     cast.error shouldBe null
                 }
+
                 game.resolveStack()
 
-                withClue("Grizzly Bears dies to -3/-3") {
-                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                withClue("Forebear's own death must not create its graveyard trigger") {
+                    game.hasPendingDecision() shouldBe false
+                    game.state.stack.size shouldBe 0
                 }
-
-                // The death triggers Furious Forebear's graveyard ability → "you may pay {1}{W}".
-                val decision = game.getPendingDecision()
-                withClue("A pay-{1}{W} YesNo decision should be pending; got $decision") {
-                    decision.shouldBeInstanceOf<YesNoDecision>()
-                }
-                game.answerYesNo(true)
-                // Paying {1}{W} requires selecting mana sources (no floating mana) — auto-tap.
-                game.submitManaSourcesAutoPay()
-                game.resolveStack()
-
-                withClue("Furious Forebear returns from graveyard to hand") {
-                    game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 0
-                    game.findCardsInHand(1, "Furious Forebear").size shouldBe 1
+                withClue("Forebear should remain in its owner's graveyard") {
+                    game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 1
+                    game.findCardsInHand(1, "Furious Forebear").size shouldBe 0
                 }
             }
 
-            test("declining the payment leaves Furious Forebear in the graveyard") {
+            test("returns from graveyard when another creature you control dies and you pay") {
                 val game = scenario()
-                    .withPlayers("Player1", "Player2")
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
                     .withCardInGraveyard(1, "Furious Forebear")
                     .withCardOnBattlefield(1, "Grizzly Bears")
-                    .withCardInHand(1, "Caustic Exhale")
-                    .withLandsOnBattlefield(1, "Swamp", 2)
-                    .withLandsOnBattlefield(1, "Plains", 2)
                     .withActivePlayer(1)
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
                 val bears = game.findPermanent("Grizzly Bears")!!
-                val cast = game.castSpell(1, "Caustic Exhale", bears)
-                withClue("Casting Caustic Exhale should succeed: ${cast.error}") { cast.error shouldBe null }
-                game.resolveStack()
-
-                val decision = game.getPendingDecision()
-                withClue("A pay-{1}{W} YesNo decision should be pending; got $decision") {
-                    decision.shouldBeInstanceOf<YesNoDecision>()
+                val cast = game.castSpell(1, "Shock", bears)
+                withClue("Shock should cast successfully: ${cast.error}") {
+                    cast.error shouldBe null
                 }
-                game.answerYesNo(false)
+
                 game.resolveStack()
 
-                withClue("Declining leaves Furious Forebear in the graveyard") {
+                withClue("Forebear should ask whether to pay {1}{W}") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                val chooseToPay = game.answerYesNo(true)
+                withClue("Choosing to pay Forebear's trigger should succeed: ${chooseToPay.error}") {
+                    chooseToPay.error shouldBe null
+                }
+                withClue("Forebear should ask which mana sources to use") {
+                    (game.getPendingDecision() is SelectManaSourcesDecision) shouldBe true
+                }
+                val pay = game.submitManaSourcesAutoPay()
+                withClue("Autopaying Forebear's trigger should succeed: ${pay.error}") {
+                    pay.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Forebear should return from graveyard to hand after payment") {
+                    game.findCardsInHand(1, "Furious Forebear").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 0
+                }
+            }
+
+            test("stays in graveyard when another creature you control dies and you decline") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInGraveyard(1, "Furious Forebear")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Shock", bears)
+                withClue("Shock should cast successfully: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Forebear should ask whether to pay {1}{W}") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                val decline = game.answerYesNo(false)
+                withClue("Declining Forebear's trigger should succeed: ${decline.error}") {
+                    decline.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Forebear should stay in graveyard after declining") {
                     game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 1
                     game.findCardsInHand(1, "Furious Forebear").size shouldBe 0
                 }


### PR DESCRIPTION
## Summary
- Change Furious Forebear's graveyard death trigger to exclude the source entity so it cannot trigger from its own death after moving to the graveyard.
- Add scenario coverage for self-death, paying the valid trigger, and declining the valid trigger.
- Update the TDM card snapshot for the trigger binding change.

## Tests
- `./gradlew :rules-engine:test --tests "com.wingedsheep.engine.scenarios.FuriousForebearScenarioTest"`
- `./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest"`
- `./gradlew :mtg-sets:test --tests "*CardLintTest"`
- `just check-card-printing "Furious Forebear"`