### PR TITLE
OTJ cards batch B: Annie Flash, Baron Bertram, Geralf, Gisa

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -996,6 +996,7 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `eachOpponentMayPutFromHand(filter?)` — each opponent may dump a matching card.
 - `putFromHand(filter?, count?, entersTapped?)` — you may put N from hand onto battlefield.
 - `incubate(n)` — make an Incubator token with N counters.
+- `impulse(count?, expiry?)` — impulse draw: exile the top N of your library, may play those cards until `expiry` (default end of turn); played cards still pay their mana. For the play-free variant compose with `GrantPlayWithoutPayingCostEffect` (cf. `shuffleAndExileTopPlayFree`). Irascible Wolverine (1), Annie Flash, the Veteran (2).
 - `returnLinkedExile(underOwnersControl?)` — bring back linked exile pile.
 - `takeFromLinkedExile()` — pull one card from linked exile.
 - `shuffleGraveyardIntoLibrary(target?)` — Elixir of Immortality shape.
@@ -2486,6 +2487,12 @@ composite abilities).
   and `WardCost.Sacrifice(filter)` ("Ward—Sacrifice a Food", Ygra). For sacrifice ward, the opponent
   chooses which matching permanent(s) they control to sacrifice (declining counters their spell); valid
   fodder is matched against projected state, so subtypes granted by continuous effects count.
+  Composite costs ("Ward—{2}, Pay 2 life", Gisa, the Hellraiser) use
+  `KeywordAbility.wardComposite(WardCost.Mana("{2}"), WardCost.Life(2))` → `WardCost.Composite(parts)`.
+  The components are charged one at a time in order; the spell/ability resolves only if every
+  component is paid, and declining or being unable to pay any one component counters it (CR 702.21a).
+  Each component reuses the same per-cost decision flow as a standalone ward, so a composite cost
+  shows one prompt per component. `parts` must be flat atomic ward costs (no nested `Composite`).
 - `Protection(color)` — protection from a single color.
 - `ProtectionFrom(set)` — protection from a set of colors/types.
 - `Protection(ProtectionScope.Supertype("Legendary"))` / `KeywordAbility.protectionFromSupertype("Legendary")` — protection from a supertype, e.g. "protection from legendary creatures" (Tsabo Tavoc). Enforced across targeting, blocking, and combat damage via projected `PROTECTION_FROM_SUPERTYPE_<X>` keywords.
@@ -3425,6 +3432,16 @@ of `AddMana`. The engine empties pools at end of turn, so:
   `CardsDrawnThisTurnComponent`, reset to 0 for every player at turn start). Powers
   characteristic-defining stats like Duelist of the Mind's "power is equal to the number of
   cards you've drawn this turn" via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DRAWN))`.
+
+`SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity?)` /
+`DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` —
+"the number of [other] [subtype]s that entered the battlefield under [player]'s control this turn"
+(Geralf, the Fleshwright — "each other Zombie that entered the battlefield under your control this
+turn"). It's a **turn-history** count: backed by `PermanentsEnteredUnderControlThisTurnComponent`,
+which records each entrant's subtypes (from projected state) at entry, so a permanent that has since
+left the battlefield or lost the type still counts. `excludeTriggeringEntity = true` drops the
+permanent whose entry triggered the ability (giving "each *other*"); because every simultaneous
+entrant is recorded before the triggers resolve, each one sees the others (2024-04-12 ruling).
 
 ---
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -298,6 +298,21 @@ object DynamicAmounts {
         DynamicAmount.TurnTracking(player, TurnTracker.LANDS_ENTERED_UNDER_CONTROL)
 
     /**
+     * "The number of [other] [subtype]s that entered the battlefield under [player]'s control
+     * this turn" (Geralf, the Fleshwright — "each other Zombie that entered the battlefield under
+     * your control this turn"). Counts entries even after the permanent has left or changed type.
+     * Set [excludeTriggeringEntity] for "each *other*" — drops the permanent whose entry triggered
+     * the ability (and, for simultaneous entries, lets each entrant see the others per the
+     * 2024-04-12 ruling).
+     */
+    fun subtypeEnteredUnderControlThisTurn(
+        subtype: com.wingedsheep.sdk.core.Subtype,
+        player: Player = Player.You,
+        excludeTriggeringEntity: Boolean = false
+    ): DynamicAmount =
+        DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity)
+
+    /**
      * "The number of times [player] descended this turn" (CR 700.11) — count of
      * nontoken permanent cards put into [player]'s graveyard from any zone this turn.
      * Used by the descend N / fathomless descent ability words.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/ExilePatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/ExilePatterns.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
@@ -90,6 +91,31 @@ object ExilePatterns {
             destination = CardDestination.ToZone(Zone.HAND),
             unlinkFromSource = true
         )
+    ))
+
+    /**
+     * Impulse draw: exile the top [count] cards of your library, then grant permission to play
+     * those cards until [expiry] (default end of turn). The played cards still cost their mana;
+     * for the "play it without paying its mana cost" variant compose with
+     * [GrantPlayWithoutPayingCostEffect] (see [shuffleAndExileTopPlayFree]).
+     *
+     * Named MTG mechanic ("impulse draw") with multiple users — Irascible Wolverine (1),
+     * Annie Flash, the Veteran (2), etc.
+     */
+    fun impulse(
+        count: Int = 1,
+        expiry: MayPlayExpiry = MayPlayExpiry.EndOfTurn,
+        storeAs: String = "impulseExiled"
+    ): Effect = CompositeEffect(listOf(
+        GatherCardsEffect(
+            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(count)),
+            storeAs = storeAs
+        ),
+        MoveCollectionEffect(
+            from = storeAs,
+            destination = CardDestination.ToZone(Zone.EXILE)
+        ),
+        GrantMayPlayFromExileEffect(storeAs, expiry)
     ))
 
     fun shuffleAndExileTopPlayFree(): Effect = CompositeEffect(listOf(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -75,6 +75,7 @@ sealed interface KeywordAbility {
             is WardCost.Life -> "Ward—Pay ${cost.amount} life"
             is WardCost.Discard -> "Ward—Discard ${cost.description}"
             is WardCost.Sacrifice -> "Ward—Sacrifice ${cost.description}"
+            is WardCost.Composite -> "Ward—${cost.description}"
         }
     }
 
@@ -647,6 +648,14 @@ sealed interface KeywordAbility {
          */
         fun wardSacrifice(filter: GameObjectFilter): KeywordAbility =
             Ward(WardCost.Sacrifice(filter))
+
+        /**
+         * Create Ward with a composite cost — all components must be paid. E.g.
+         * `wardComposite(WardCost.Mana("{2}"), WardCost.Life(2))` for "Ward—{2}, Pay 2 life"
+         * (Gisa, the Hellraiser).
+         */
+        fun wardComposite(vararg parts: WardCost): KeywordAbility =
+            Ward(WardCost.Composite(parts.toList()))
 
         /**
          * Create Hexproof from a color.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
@@ -84,6 +84,7 @@ data class GrantWard(
         is WardCost.Life -> "${filter.description} have \"Ward—Pay ${cost.amount} life.\""
         is WardCost.Discard -> "${filter.description} have \"Ward—Discard ${cost.description}.\""
         is WardCost.Sacrifice -> "${filter.description} have \"Ward—Sacrifice ${cost.description}.\""
+        is WardCost.Composite -> "${filter.description} have \"Ward—${cost.description}.\""
     }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -345,6 +345,21 @@ sealed interface WardCost {
     data class Sacrifice(val filter: GameObjectFilter) : WardCost {
         override val description: String = "a ${filter.description}"
     }
+
+    /**
+     * A ward cost made of two or more component costs that must *all* be paid — e.g.
+     * "Ward—{2}, Pay 2 life." (Gisa, the Hellraiser). The components are paid one at a time
+     * in order; declining or being unable to pay any one component counters the spell or
+     * ability (CR 702.21a — a single ward cost whose payment is composed of multiple parts).
+     *
+     * Nesting another [Composite] inside [parts] is not supported (and not needed by any
+     * printed card); keep [parts] a flat list of atomic ward costs.
+     */
+    @SerialName("WardCost.Composite")
+    @Serializable
+    data class Composite(val parts: List<WardCost>) : WardCost {
+        override val description: String = parts.joinToString(", ") { it.description }
+    }
 }
 
 /**
@@ -365,6 +380,7 @@ data class WardCounterEffect(
         is WardCost.Life -> "Counter it unless its controller pays ${cost.amount} life"
         is WardCost.Discard -> "Counter it unless its controller discards ${cost.description}"
         is WardCost.Sacrifice -> "Counter it unless its controller sacrifices ${cost.description}"
+        is WardCost.Composite -> "Counter it unless its controller pays ${cost.description}"
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -990,4 +990,35 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override val description: String = "the number of creatures that crewed or saddled it this turn"
     }
 
+    /**
+     * The number of permanents of creature [subtype] that entered the battlefield under
+     * [player]'s control this turn (counting even those that have since left or changed type —
+     * the entry event is what's tracked). When [excludeTriggeringEntity] is true, the permanent
+     * whose entry triggered the ability is not counted, giving "each *other* [subtype]" wording
+     * (Geralf, the Fleshwright). Simultaneous entries each see the others (2024-04-12 ruling).
+     *
+     * Backed by `PermanentsEnteredUnderControlThisTurnComponent`; the triggering entity is read
+     * from the resolution context's triggering-entity id.
+     */
+    @SerialName("SubtypeEnteredUnderControlThisTurn")
+    @Serializable
+    data class SubtypeEnteredUnderControlThisTurn(
+        val player: Player,
+        val subtype: com.wingedsheep.sdk.core.Subtype,
+        val excludeTriggeringEntity: Boolean = false
+    ) : DynamicAmount {
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount {
+            val new = replacer.replaceSubtype(subtype)
+            return if (new == subtype) this else copy(subtype = new)
+        }
+        override val description: String = buildString {
+            append("the number of ")
+            if (excludeTriggeringEntity) append("other ")
+            append(subtype.value)
+            append("s that entered the battlefield under ")
+            append(player.possessive)
+            append(" control this turn")
+        }
+    }
+
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnnieFlashTheVeteran.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnnieFlashTheVeteran.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Annie Flash, the Veteran
+ * {3}{R}{G}{W}
+ * Legendary Creature — Human Rogue
+ * 4/5
+ *
+ * Flash
+ * When Annie Flash enters, if you cast it, return target permanent card with mana value 3 or
+ * less from your graveyard to the battlefield tapped.
+ * Whenever Annie Flash becomes tapped, exile the top two cards of your library. You may play
+ * those cards this turn.
+ *
+ * - The reanimation ETB is gated by [Conditions.WasCast] (intervening-if "if you cast it"), so it
+ *   does not trigger when Annie is put onto the battlefield by another effect (per the 2024-04-12
+ *   ruling). The target is a single printed "permanent card with mana value 3 or less" you own in
+ *   your graveyard ([GameObjectFilter.Permanent].ownedByYou().manaValueAtMost(3)); it enters the
+ *   battlefield tapped via [Effects.PutOntoBattlefield] with `tapped = true`.
+ * - The "becomes tapped" trigger is the impulse-draw facade [Patterns.Exile.impulse] for two cards
+ *   (gather top two → exile → grant "may play until end of turn"), the same shape as Irascible
+ *   Wolverine but for two cards. It fires on any tap (attacking, abilities, opponents' effects)
+ *   since it has no qualifier.
+ */
+val AnnieFlashTheVeteran = card("Annie Flash, the Veteran") {
+    manaCost = "{3}{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Creature — Human Rogue"
+    power = 4
+    toughness = 5
+    oracleText = "Flash\n" +
+        "When Annie Flash enters, if you cast it, return target permanent card with mana value 3 " +
+        "or less from your graveyard to the battlefield tapped.\n" +
+        "Whenever Annie Flash becomes tapped, exile the top two cards of your library. You may " +
+        "play those cards this turn."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        val card = target(
+            "permanent card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.ownedByYou().manaValueAtMost(3),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.PutOntoBattlefield(card, tapped = true)
+        description = "When Annie Flash enters, if you cast it, return target permanent card with " +
+            "mana value 3 or less from your graveyard to the battlefield tapped."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        effect = Patterns.Exile.impulse(2)
+        description = "Whenever Annie Flash becomes tapped, exile the top two cards of your " +
+            "library. You may play those cards this turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "190"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg?1712356036"
+
+        ruling("2024-04-12", "Annie Flash's second ability triggers if you cast it from any zone. It doesn't trigger if you put Annie Flash onto the battlefield without casting it.")
+        ruling("2024-04-12", "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card.")
+        ruling("2024-04-12", "If the mana cost of a card in your graveyard includes {X}, X is 0 for the purpose of determining its mana value.")
+        ruling("2024-04-12", "You pay all costs and follow all normal timing rules for cards played from exile with Annie Flash's last ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BaronBertramGraywater.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BaronBertramGraywater.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Baron Bertram Graywater
+ * {2}{W}{B}
+ * Legendary Creature — Vampire Noble
+ * 3/4
+ *
+ * Whenever one or more tokens you control enter, create a 1/1 black Vampire Rogue creature token
+ * with lifelink. This ability triggers only once each turn.
+ * {1}{B}, Sacrifice another creature or artifact: Draw a card.
+ *
+ * - The first ability is the batched you-scoped token-ETB trigger
+ *   ([Triggers.OneOrMorePermanentsEnter] on [GameObjectFilter.Token], which defaults to "you
+ *   control") with `oncePerTurn = true` for "This ability triggers only once each turn"
+ *   (CR 603.3 / engine-tracked once-per-turn). It fires once per batch, no matter how many tokens
+ *   entered.
+ * - The activated ability composes a mana + sacrifice-another cost over the
+ *   [GameObjectFilter.CreatureOrArtifact] filter ("creature or artifact", excluding Baron himself)
+ *   and draws a card.
+ */
+val BaronBertramGraywater = card("Baron Bertram Graywater") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Vampire Noble"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever one or more tokens you control enter, create a 1/1 black Vampire Rogue " +
+        "creature token with lifelink. This ability triggers only once each turn.\n" +
+        "{1}{B}, Sacrifice another creature or artifact: Draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMorePermanentsEnter(GameObjectFilter.Token)
+        oncePerTurn = true
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(1),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Vampire", "Rogue"),
+            keywords = setOf(Keyword.LIFELINK),
+            imageUri = "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg?1712316236"
+        )
+        description = "Whenever one or more tokens you control enter, create a 1/1 black Vampire " +
+            "Rogue creature token with lifelink. This ability triggers only once each turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.CreatureOrArtifact)
+        )
+        effect = Effects.DrawCards(1)
+        description = "{1}{B}, Sacrifice another creature or artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Johan Grenier"
+        flavorText = "\"Of course the law's on my side. I wrote it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg?1712356055"
+
+        ruling("2024-04-12", "If Baron Bertram Graywater enters under your control and is itself a token, its own ability will trigger and you'll create a Vampire Rogue token. If you also control a nontoken Baron Bertram Graywater, that one's ability will also trigger, netting you another Vampire Rogue.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GeralfTheFleshwright.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GeralfTheFleshwright.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Geralf, the Fleshwright
+ * {2}{U}
+ * Legendary Creature — Human Warlock
+ * 2/3
+ *
+ * Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2
+ * blue and black Zombie Rogue creature token.
+ * Whenever a Zombie you control enters, put a +1/+1 counter on it for each other Zombie that
+ * entered the battlefield under your control this turn.
+ *
+ * - First ability: "a spell during your turn other than your first spell that turn" → the spell-cast
+ *   trigger [Triggers.YouCastSpell] gated by an intervening "if" that it is your turn and you have
+ *   already cast a spell this turn. The triggering spell is itself counted in
+ *   `spellsCastThisTurnByPlayer` at the time the cast trigger is checked (cf. Inventive Wingsmith /
+ *   Outlaw Stitcher), so [Conditions.YouCastSpellsThisTurn](atLeast = 2) is true exactly for the
+ *   2nd and every later spell. Spells cast before Geralf was on the battlefield count
+ *   (2024-04-12 ruling); the gate just compares the running cast count.
+ * - Second ability: "a Zombie you control enters" → an ETB trigger (ANY binding so it sees Geralf
+ *   himself were he ever a Zombie) filtered to Zombies you control. The counter goes on the entering
+ *   Zombie ([EffectTarget.TriggeringEntity]); the count is
+ *   [DynamicAmounts.subtypeEnteredUnderControlThisTurn](Zombie, excludeTriggeringEntity = true) —
+ *   "each *other* Zombie that entered the battlefield under your control this turn". This is a turn
+ *   history count (it counts Zombies that have since left or changed type) and, per the 2024-04-12
+ *   ruling, simultaneous Zombie entrants each see the others.
+ */
+val GeralfTheFleshwright = card("Geralf, the Fleshwright") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast a spell during your turn other than your first spell that turn, " +
+        "create a 2/2 blue and black Zombie Rogue creature token.\n" +
+        "Whenever a Zombie you control enters, put a +1/+1 counter on it for each other Zombie that " +
+        "entered the battlefield under your control this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        triggerCondition = Conditions.All(
+            Conditions.IsYourTurn,
+            Conditions.YouCastSpellsThisTurn(atLeast = 2),
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE, Color.BLACK),
+            creatureTypes = setOf("Zombie", "Rogue"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777",
+        )
+        description = "Whenever you cast a spell during your turn other than your first spell that " +
+            "turn, create a 2/2 blue and black Zombie Rogue creature token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmounts.subtypeEnteredUnderControlThisTurn(
+                subtype = Subtype.ZOMBIE,
+                excludeTriggeringEntity = true,
+            ),
+            target = EffectTarget.TriggeringEntity,
+        )
+        description = "Whenever a Zombie you control enters, put a +1/+1 counter on it for each " +
+            "other Zombie that entered the battlefield under your control this turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "50"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg?1712355427"
+
+        ruling("2024-04-12", "Geralf's first ability will consider spells you cast before it was on the battlefield. For example, if Geralf is the first spell you cast during your turn, each subsequent spell you cast that turn after it's on the battlefield will cause its first ability to trigger.")
+        ruling("2024-04-12", "If multiple Zombies enter the battlefield under your control at the same time, Geralf's last ability will trigger for each of those Zombies. Each of those triggered abilities will see each of those other Zombies that entered the battlefield plus any other Zombies that entered the battlefield under your control so far this turn.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GisaTheHellraiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GisaTheHellraiser.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gisa, the Hellraiser
+ * {3}{B}{B}
+ * Legendary Creature — Human Warlock
+ * 4/4
+ *
+ * Ward—{2}, Pay 2 life.
+ * Skeletons and Zombies you control get +1/+1 and have menace.
+ * Whenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens.
+ * This ability triggers only once each turn. (Targeting opponents, anything they control, and/or
+ * cards in their graveyards is a crime.)
+ *
+ * - Ward—{2}, Pay 2 life is a single composite ward cost ([WardCost.Composite] of a mana part and a
+ *   life part). When an opponent targets Gisa, they must pay both components or their spell/ability
+ *   is countered (CR 702.21a).
+ * - The lord is two static abilities over `Skeletons and Zombies you control`
+ *   ([GameObjectFilter.Creature].withAnyOfSubtypes(Skeleton, Zombie).youControl()): a +1/+1
+ *   [ModifyStats] (layer 7c) and a [GrantKeyword] of menace (layer 6). Gisa is a Human Warlock, so
+ *   she doesn't buff herself; the filter carries no excludeSelf because the printed text says
+ *   "Skeletons and Zombies you control", not "other".
+ * - The crime payoff is the standard [Triggers.YouCommitCrime] trigger with `oncePerTurn = true`,
+ *   creating two tapped 2/2 blue-black Zombie Rogue tokens (the canonical OTJ Zombie Rogue, cf.
+ *   Outlaw Stitcher).
+ */
+val GisaTheHellraiser = card("Gisa, the Hellraiser") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 4
+    toughness = 4
+    oracleText = "Ward—{2}, Pay 2 life.\n" +
+        "Skeletons and Zombies you control get +1/+1 and have menace.\n" +
+        "Whenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature " +
+        "tokens. This ability triggers only once each turn. (Targeting opponents, anything they " +
+        "control, and/or cards in their graveyards is a crime.)"
+
+    keywordAbility(
+        KeywordAbility.wardComposite(WardCost.Mana("{2}"), WardCost.Life(2))
+    )
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(listOf(Subtype.SKELETON, Subtype.ZOMBIE))
+                    .youControl()
+            )
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.MENACE,
+            GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(listOf(Subtype.SKELETON, Subtype.ZOMBIE))
+                    .youControl()
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCommitCrime
+        oncePerTurn = true
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(2),
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE, Color.BLACK),
+            creatureTypes = setOf("Zombie", "Rogue"),
+            tapped = true,
+            imageUri = "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+        )
+        description = "Whenever you commit a crime, create two tapped 2/2 blue and black Zombie " +
+            "Rogue creature tokens. This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "89"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg?1712355592"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "The spell or ability that constituted a crime doesn't have to have resolved yet or at all. As soon as you're finished casting the spell, activating the ability, or putting the triggered ability on the stack, you've committed a crime.")
+        ruling("2024-04-12", "A player can commit only one crime per spell or ability they control. Targeting multiple opponents, permanents, spells, abilities, and/or cards with the same spell or ability doesn't constitute committing multiple crimes.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IrascibleWolverine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/IrascibleWolverine.kt
@@ -1,18 +1,10 @@
 package com.wingedsheep.mtg.sets.definitions.otj.cards
 
-import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.KeywordAbility
-import com.wingedsheep.sdk.scripting.effects.CardDestination
-import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
-import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
-import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Irascible Wolverine
@@ -35,19 +27,7 @@ val IrascibleWolverine = card("Irascible Wolverine") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Composite(
-            listOf(
-                GatherCardsEffect(
-                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
-                    storeAs = "exiledCard",
-                ),
-                MoveCollectionEffect(
-                    from = "exiledCard",
-                    destination = CardDestination.ToZone(Zone.EXILE),
-                ),
-                GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.EndOfTurn),
-            ),
-        )
+        effect = Patterns.Exile.impulse(1)
     }
 
     metadata {

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -236,6 +236,113 @@
     ]
 }
 
+// Annie Flash, the Veteran
+{
+    "name": "Annie Flash, the Veteran",
+    "manaCost": "{3}{R}{G}{W}",
+    "typeLine": "Legendary Creature — Human Rogue",
+    "oracleText": "Flash\nWhen Annie Flash enters, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\nWhenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "permanent card with mana value 3 or less from your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "placement": "Tapped"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "permanent card with mana value 3 or less from your graveyard"
+                },
+                "triggerCondition": "WasCast",
+                "descriptionOverride": "When Annie Flash enters, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "TapEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "MYTHIC",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg?1712356036",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Annie Flash's second ability triggers if you cast it from any zone. It doesn't trigger if you put Annie Flash onto the battlefield without casting it."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If the mana cost of a card in your graveyard includes {X}, X is 0 for the purpose of determining its mana value."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You pay all costs and follow all normal timing rules for cards played from exile with Annie Flash's last ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Annie Joins Up
 {
     "name": "Annie Joins Up",
@@ -1045,6 +1152,98 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/8/68b2e74b-933b-4285-963b-dda3a986a914.jpg?1712356248"
     },
     "colorIdentityOverride": []
+}
+
+// Baron Bertram Graywater
+{
+    "name": "Baron Bertram Graywater",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Legendary Creature — Vampire Noble",
+    "oracleText": "Whenever one or more tokens you control enter, create a 1/1 black Vampire Rogue creature token with lifelink. This ability triggers only once each turn.\n{1}{B}, Sacrifice another creature or artifact: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsEnteredEvent",
+                    "filter": "token"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Vampire",
+                        "Rogue"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg?1712316236"
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever one or more tokens you control enter, create a 1/1 black Vampire Rogue creature token with lifelink. This ability triggers only once each turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{1}{B}, Sacrifice another creature or artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "Johan Grenier",
+        "flavorText": "\"Of course the law's on my side. I wrote it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg?1712356055",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "If Baron Bertram Graywater enters under your control and is itself a token, its own ability will trigger and you'll create a Vampire Rogue token. If you also control a nontoken Baron Bertram Graywater, that one's ability will also trigger, netting you another Vampire Rogue."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
 }
 
 // Beastbond Outcaster
@@ -6383,6 +6582,92 @@
     ]
 }
 
+// Geralf, the Fleshwright
+{
+    "name": "Geralf, the Fleshwright",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie you control enters, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLUE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie",
+                        "Rogue"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777"
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        "IsYourTurn",
+                        {
+                            "type": "PlayerCastSpellsThisTurn",
+                            "atLeast": 2
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Zombie ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "SubtypeEnteredUnderControlThisTurn",
+                        "player": "You",
+                        "subtype": "Zombie",
+                        "excludeTriggeringEntity": true
+                    },
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Whenever a Zombie you control enters, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg?1712355427",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Geralf's first ability will consider spells you cast before it was on the battlefield. For example, if Geralf is the first spell you cast during your turn, each subsequent spell you cast that turn after it's on the battlefield will cause its first ability to trigger."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If multiple Zombies enter the battlefield under your control at the same time, Geralf's last ability will trigger for each of those Zombies. Each of those triggered abilities will see each of those other Zombies that entered the battlefield plus any other Zombies that entered the battlefield under your control so far this turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Getaway Glamer
 {
     "name": "Getaway Glamer",
@@ -6713,6 +6998,133 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gisa, the Hellraiser
+{
+    "name": "Gisa, the Hellraiser",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Ward—{2}, Pay 2 life.\nSkeletons and Zombies you control get +1/+1 and have menace.\nWhenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Composite",
+                "parts": [
+                    {
+                        "type": "WardCost.Mana",
+                        "manaCost": "{2}"
+                    },
+                    {
+                        "type": "WardCost.Life",
+                        "amount": 2
+                    }
+                ]
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CommitCrimeEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLUE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie",
+                        "Rogue"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1712316777",
+                    "tapped": true
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Skeleton",
+                                    "Zombie"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Skeleton",
+                                    "Zombie"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg?1712355592",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "The spell or ability that constituted a crime doesn't have to have resolved yet or at all. As soon as you're finished casting the spell, activating the ability, or putting the triggered ability on the stack, you've committed a crime."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "A player can commit only one crime per spell or ability they control. Targeting multiple opponents, permanents, spells, abilities, and/or cards with the same spell or ability doesn't constitute committing multiple crimes."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -8383,11 +8795,11 @@
                                     "amount": 1
                                 }
                             },
-                            "storeAs": "exiledCard"
+                            "storeAs": "impulseExiled"
                         },
                         {
                             "type": "MoveCollection",
-                            "from": "exiledCard",
+                            "from": "impulseExiled",
                             "destination": {
                                 "type": "ToZone",
                                 "zone": "Exile"
@@ -8395,7 +8807,7 @@
                         },
                         {
                             "type": "GrantMayPlayFromExile",
-                            "from": "exiledCard"
+                            "from": "impulseExiled"
                         }
                     ]
                 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -230,9 +230,10 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         }
         // "Until end of turn / end of your next turn, you may play that card." — the second half of the
         // impulse-draw idiom (Irascible Wolverine, Alania's Pathmaker). The grant reads the card the paired
-        // `ExileTopCardOfLibrary` action stashed under "exiledCard". Only the controller-scoped grant on the
-        // card-exiled-this-way renders, and only for the two expirations the MayPlayExpiry facade names;
-        // any other player scope or expiration declines (-> SCAFFOLD) rather than emit a wrong window.
+        // `ExileTopCardOfLibrary` action stashed under "impulseExiled" (matching `Patterns.Exile.impulse`'s
+        // default storeAs key). Only the controller-scoped grant on the card-exiled-this-way renders, and
+        // only for the two expirations the MayPlayExpiry facade names; any other player scope or expiration
+        // declines (-> SCAFFOLD) rather than emit a wrong window.
         if (jsonContains(node, "_PlayerEffect", "MayPlayExiledCard") &&
             jsonContains(node, "_CardInExile", "TheCardExiledThisWay") &&
             jsonContains(node, "_Player", "You")
@@ -242,7 +243,7 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
                 "UntilEndOfNextTurn" -> "MayPlayExpiry.UntilEndOfNextTurn"
                 else -> return@on null
             }
-            return@on call("GrantMayPlayFromExileEffect", arg("\"exiledCard\""), arg(Lit(expiry)))
+            return@on call("GrantMayPlayFromExileEffect", arg("\"impulseExiled\""), arg(Lit(expiry)))
         }
         null
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -91,14 +91,15 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     }
 
     // "Exile the top card of your library." (the first half of the impulse-draw idiom — Irascible
-    // Wolverine, Alania's Pathmaker). The exiled card is stored under the shared "exiledCard" key that
+    // Wolverine, Alania's Pathmaker). The exiled card is stored under the shared "impulseExiled" key that
     // the paired `CreatePlayerEffectUntil{MayPlayExiledCard(TheCardExiledThisWay)}` action reads to grant
     // the may-play window (see TapLayerStateHandlers' CreatePlayerEffectUntil branch). The exile itself is
-    // the gather + move-to-exile atomic pair.
+    // the gather + move-to-exile atomic pair, matching `Patterns.Exile.impulse(1)`'s default storeAs key
+    // so the emitted tree is gameplay-equivalent to the hand-authored facade call.
     on("ExileTopCardOfLibrary") { _, _, _ ->
         Composite(listOf(
-            Lit("GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = \"exiledCard\")"),
-            Lit("MoveCollectionEffect(from = \"exiledCard\", destination = CardDestination.ToZone(Zone.EXILE))"),
+            Lit("GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = \"impulseExiled\")"),
+            Lit("MoveCollectionEffect(from = \"impulseExiled\", destination = CardDestination.ToZone(Zone.EXILE))"),
         ))
     }
 

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -8520,9 +8520,9 @@ val StromkirkOccultist = card("Stromkirk Occultist") {
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
         effect = Effects.Composite(
-            GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = "exiledCard"),
-            MoveCollectionEffect(from = "exiledCard", destination = CardDestination.ToZone(Zone.EXILE)),
-            GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.EndOfTurn)
+            GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = "impulseExiled"),
+            MoveCollectionEffect(from = "impulseExiled", destination = CardDestination.ToZone(Zone.EXILE)),
+            GrantMayPlayFromExileEffect("impulseExiled", MayPlayExpiry.EndOfTurn)
         )
     }
     // STRUCTURE needs human wiring: Madness

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -36,6 +36,7 @@ import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnCompone
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
@@ -475,6 +476,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<LandsEnteredUnderControlThisTurnComponent>()) {
                     result = result.without<LandsEnteredUnderControlThisTurnComponent>()
+                }
+                if (result.has<PermanentsEnteredUnderControlThisTurnComponent>()) {
+                    result = result.without<PermanentsEnteredUnderControlThisTurnComponent>()
                 }
                 if (result.has<PutCounterOnCreatureThisTurnComponent>()) {
                     result = result.without<PutCounterOnCreatureThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.effects.WardCost
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import kotlinx.serialization.Serializable
 
@@ -152,7 +153,15 @@ data class CounterUnlessPaysManaSelectionContinuation(
     /** See [CounterUnlessPaysContinuation.onPaid]. */
     val onPaid: Effect? = null,
     /** See [CounterUnlessPaysContinuation.sourceId]. Carried for the rider's [EffectContext]. */
-    val sourceId: EntityId? = null
+    val sourceId: EntityId? = null,
+    /**
+     * Not-yet-paid components of an enclosing [WardCost.Composite] (e.g. the "Pay 2 life" part of
+     * "Ward—{2}, Pay 2 life" while the mana part is being paid). When this is paid and the list is
+     * non-empty, the resumer charges the next component instead of letting the spell resolve.
+     */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** The ward source permanent, carried so a composite cost can re-prompt its next component. */
+    val wardSourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -199,7 +208,11 @@ data class CounterUnlessPaysLifeContinuation(
     val spellEntityId: EntityId,
     val lifeCost: Int,
     val exileOnCounter: Boolean = false,
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    /** See [CounterUnlessPaysManaSelectionContinuation.remainingWardParts]. */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** See [CounterUnlessPaysManaSelectionContinuation.wardSourceId]. */
+    val wardSourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -222,7 +235,11 @@ data class CounterUnlessDiscardContinuation(
     val count: Int,
     val random: Boolean = false,
     val exileOnCounter: Boolean = false,
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    /** See [CounterUnlessPaysManaSelectionContinuation.remainingWardParts]. */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** See [CounterUnlessPaysManaSelectionContinuation.wardSourceId]. */
+    val wardSourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -248,7 +265,11 @@ data class CounterUnlessSacrificeContinuation(
     val filter: GameObjectFilter,
     val count: Int = 1,
     val exileOnCounter: Boolean = false,
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    /** See [CounterUnlessPaysManaSelectionContinuation.remainingWardParts]. */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** See [CounterUnlessPaysManaSelectionContinuation.wardSourceId]. */
+    val wardSourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -305,7 +326,12 @@ data class WardTapPermanentsSubCostContinuation(
      *  spell's controller finishes paying through a tap-permanents sub-cost source. */
     val onPaid: Effect? = null,
     /** See [CounterUnlessPaysContinuation.sourceId]. Carried for the rider's [EffectContext]. */
-    val sourceId: EntityId? = null
+    val sourceId: EntityId? = null,
+    /** See [CounterUnlessPaysManaSelectionContinuation.remainingWardParts] — the not-yet-paid
+     *  components of an enclosing composite ward cost, charged once this mana part is fully paid. */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** See [CounterUnlessPaysManaSelectionContinuation.wardSourceId]. */
+    val wardSourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -448,6 +448,7 @@ val engineSerializersModule = SerializersModule {
         subclass(SacrificedFoodThisTurnComponent::class)
         subclass(PermanentTypesEnteredBattlefieldThisTurnComponent::class)
         subclass(LandsEnteredUnderControlThisTurnComponent::class)
+        subclass(PermanentsEnteredUnderControlThisTurnComponent::class)
         subclass(SpellsCantBeCounteredComponent::class)
         subclass(FlashGrantsThisTurnComponent::class)
         subclass(PutCounterOnCreatureThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -454,6 +454,22 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            is DynamicAmount.SubtypeEnteredUnderControlThisTurn -> {
+                val playerIds = resolveUnifiedPlayerIds(state, amount.player, context)
+                val wanted = amount.subtype.value
+                val excludeId = if (amount.excludeTriggeringEntity) context.triggeringEntityId else null
+                playerIds.sumOf { playerId ->
+                    val entries = state.getEntity(playerId)
+                        ?.get<com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent>()
+                        ?.entries
+                        ?: emptyList()
+                    entries.count { rec ->
+                        rec.entityId != excludeId &&
+                            rec.subtypes.any { it.equals(wanted, ignoreCase = true) }
+                    }
+                }
+            }
+
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -208,6 +208,14 @@ class ManaPaymentContinuationResumer(
             val events = listOf<GameEvent>(
                 LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)
             )
+            // If this life cost was one component of a composite ward cost, charge the next
+            // component before the spell is allowed to resolve.
+            chargeNextWardPartOrNull(
+                newState, events,
+                continuation.remainingWardParts, continuation.spellEntityId,
+                continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+                checkForMore
+            )?.let { return it }
             return checkForMore(newState, events)
         } else {
             val counterResult = if (continuation.exileOnCounter) {
@@ -288,6 +296,12 @@ class ManaPaymentContinuationResumer(
         if (discardResult.error != null) return discardResult
         if (discardResult.isPaused) return discardResult
 
+        chargeNextWardPartOrNull(
+            discardResult.newState, discardResult.events.toList(),
+            continuation.remainingWardParts, continuation.spellEntityId,
+            continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+            checkForMore
+        )?.let { return it }
         return checkForMore(discardResult.newState, discardResult.events.toList())
     }
 
@@ -350,6 +364,12 @@ class ManaPaymentContinuationResumer(
             events.addAll(transitionResult.events)
         }
 
+        chargeNextWardPartOrNull(
+            newState, events.toList(),
+            continuation.remainingWardParts, continuation.spellEntityId,
+            continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+            checkForMore
+        )?.let { return it }
         return checkForMore(newState, events)
     }
 
@@ -459,7 +479,9 @@ class ManaPaymentContinuationResumer(
                         pendingSubCostSources = subCostSources,
                         availableSources = continuation.availableSources,
                         onPaid = continuation.onPaid,
-                        sourceId = continuation.sourceId
+                        sourceId = continuation.sourceId,
+                        remainingWardParts = continuation.remainingWardParts,
+                        wardSourceId = continuation.wardSourceId
                     )
                 }
             }
@@ -489,6 +511,15 @@ class ManaPaymentContinuationResumer(
             )
         }
 
+        // If this mana cost was one component of a composite ward cost, charge the next
+        // component before the spell is allowed to resolve.
+        chargeNextWardPartOrNull(
+            currentState, events,
+            continuation.remainingWardParts, continuation.spellEntityId,
+            continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+            checkForMore
+        )?.let { return it }
+
         // Spell resolves normally — don't counter it.
         return runOnPaidThenCheckForMore(
             currentState,
@@ -498,6 +529,54 @@ class ManaPaymentContinuationResumer(
             continuation.sourceId,
             checkForMore
         )
+    }
+
+    /**
+     * If [remainingWardParts] is non-empty, charge the next component of a composite ward cost
+     * (CR 702.21a — "Ward—{2}, Pay 2 life") and return the resulting [ExecutionResult] (a new
+     * pause for the next component's decision, or a resolved/countered result). Returns `null`
+     * when there are no further ward components, so the caller proceeds with the spell resolving.
+     *
+     * [priorEvents] (e.g. the LifeChangedEvent / tap events from the just-paid component) are
+     * prepended to the next component's events so nothing is dropped across the chain.
+     */
+    private fun chargeNextWardPartOrNull(
+        state: GameState,
+        priorEvents: List<GameEvent>,
+        remainingWardParts: List<com.wingedsheep.sdk.scripting.effects.WardCost>,
+        spellEntityId: EntityId,
+        payingPlayerId: EntityId,
+        wardSourceId: EntityId?,
+        controllerId: EntityId?,
+        checkForMore: CheckForMore
+    ): ExecutionResult? {
+        if (remainingWardParts.isEmpty()) return null
+
+        // The spell/ability must still be on the stack; if it left, there's nothing left to pay for.
+        val container = state.getEntity(spellEntityId)
+        if (container == null || !state.stack.contains(spellEntityId)) {
+            return checkForMore(state, priorEvents)
+        }
+
+        val next = com.wingedsheep.engine.handlers.effects.stack.WardCounterEffectExecutor
+            .chargeWardCost(
+                state = state,
+                cardRegistry = services.cardRegistry,
+                cost = remainingWardParts.first(),
+                remainingParts = remainingWardParts.drop(1),
+                spellEntityId = spellEntityId,
+                container = container,
+                payingPlayerId = payingPlayerId,
+                wardSourceId = wardSourceId,
+                controllerId = controllerId
+            ).toExecutionResult()
+
+        if (next.error != null) return next
+        return if (next.isPaused) {
+            ExecutionResult.paused(next.state, next.pendingDecision!!, priorEvents + next.events)
+        } else {
+            checkForMore(next.state, priorEvents + next.events)
+        }
     }
 
     /**
@@ -1185,7 +1264,9 @@ class ManaPaymentContinuationResumer(
         pendingSubCostSources: List<EntityId>,
         availableSources: List<ManaSourceOption>,
         onPaid: com.wingedsheep.sdk.scripting.effects.Effect? = null,
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        remainingWardParts: List<com.wingedsheep.sdk.scripting.effects.WardCost> = emptyList(),
+        wardSourceId: EntityId? = null
     ): ExecutionResult {
         val headSourceId = pendingSubCostSources.first()
         val sourceName = availableSources.firstOrNull { it.entityId == headSourceId }?.name
@@ -1236,7 +1317,9 @@ class ManaPaymentContinuationResumer(
             pendingSubCostSources = pendingSubCostSources,
             availableSources = availableSources,
             onPaid = onPaid,
-            sourceId = sourceId
+            sourceId = sourceId,
+            remainingWardParts = remainingWardParts,
+            wardSourceId = wardSourceId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -1353,7 +1436,9 @@ class ManaPaymentContinuationResumer(
                 pendingSubCostSources = remaining,
                 availableSources = continuation.availableSources,
                 onPaid = continuation.onPaid,
-                sourceId = continuation.sourceId
+                sourceId = continuation.sourceId,
+                remainingWardParts = continuation.remainingWardParts,
+                wardSourceId = continuation.wardSourceId
             )
         }
 
@@ -1380,6 +1465,15 @@ class ManaPaymentContinuationResumer(
                 )
             )
         }
+        // If this mana component was one part of a composite ward cost, charge the next
+        // component before the spell is allowed to resolve.
+        chargeNextWardPartOrNull(
+            currentState, events,
+            continuation.remainingWardParts, continuation.spellEntityId,
+            continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+            checkForMore
+        )?.let { return it }
+
         // Payment fully resolved through the sub-cost source — fire the "If they do, …"
         // rider (no-op when null), with the counter's controller as "you".
         return runOnPaidThenCheckForMore(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
@@ -1,8 +1,10 @@
 package com.wingedsheep.engine.handlers.effects
 
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.model.EntityId
 
@@ -43,6 +45,7 @@ object PermanentEntryTracker {
     fun record(state: GameState, controllerId: EntityId, entityId: EntityId): GameState {
         val cardTypes = projectedCardTypes(state, entityId)
         if (cardTypes.isEmpty()) return state
+        val subtypes = state.projectedState.getSubtypes(entityId)
         return state.updateEntity(controllerId) { container ->
             val typeMerged = run {
                 val existing = container.get<PermanentTypesEnteredBattlefieldThisTurnComponent>()
@@ -51,16 +54,28 @@ object PermanentEntryTracker {
                 if (merged == existing.cardTypes) container
                 else container.with(PermanentTypesEnteredBattlefieldThisTurnComponent(merged))
             }
+            // Per-permanent entry list, keyed by entityId so a (theoretical) double-record is
+            // idempotent. Backs subtype-keyed "for each [type] that entered this turn" counts.
+            val perPermanentMerged = run {
+                val existing = typeMerged.get<PermanentsEnteredUnderControlThisTurnComponent>()
+                    ?: PermanentsEnteredUnderControlThisTurnComponent()
+                if (existing.entries.any { it.entityId == entityId }) typeMerged
+                else typeMerged.with(
+                    PermanentsEnteredUnderControlThisTurnComponent(
+                        existing.entries + EnteredPermanentRecord(entityId, subtypes)
+                    )
+                )
+            }
             // Lands need a *count*, not just presence, for "for each land that entered
             // this turn" dynamic amounts (Bioengineered Future). Two unrelated lands
             // entering both bump the counter; the set-based type tracker above sees them
             // as a single LAND entry.
             if (CardType.LAND in cardTypes) {
-                val landExisting = typeMerged.get<LandsEnteredUnderControlThisTurnComponent>()
+                val landExisting = perPermanentMerged.get<LandsEnteredUnderControlThisTurnComponent>()
                     ?: LandsEnteredUnderControlThisTurnComponent()
-                typeMerged.with(LandsEnteredUnderControlThisTurnComponent(landExisting.count + 1))
+                perPermanentMerged.with(LandsEnteredUnderControlThisTurnComponent(landExisting.count + 1))
             } else {
-                typeMerged
+                perPermanentMerged
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -45,7 +45,16 @@ import kotlin.reflect.KClass
  *      standard discard pipeline (random or player's choice).
  *    - WardCost.Sacrifice → SelectCardsDecision over the controller's matching permanents
  *      (min 0, max N); selecting N pays and the spell resolves, declining counters it.
+ *    - WardCost.Composite → pay each component cost in order (CR 702.21a; "Ward—{2}, Pay 2
+ *      life"). Each component reuses the per-component flow above and carries the remaining
+ *      components so the resumer charges the next one after a successful payment. Declining or
+ *      being unable to pay any component counters the spell/ability immediately.
  *    If the controller can't possibly pay, counter immediately.
+ *
+ * The per-component handlers are reusable from
+ * [com.wingedsheep.engine.handlers.continuations.ManaPaymentContinuationResumer] (via
+ * [chargeWardCost]) so a composite cost can resume into its next component after each payment
+ * without re-deriving the ward source/controller context.
  */
 class WardCounterEffectExecutor(
     private val cardRegistry: CardRegistry
@@ -72,269 +81,345 @@ class WardCounterEffectExecutor(
             ?: container.get<TriggeredAbilityOnStackComponent>()?.controllerId
             ?: return EffectResult.success(state)
 
-        return when (val cost = effect.cost) {
-            is WardCost.Mana -> handleManaCost(state, context, spellEntityId, container, payingPlayerId, cost.manaCost)
-            is WardCost.Life -> handleLifeCost(state, context, spellEntityId, container, payingPlayerId, cost.amount)
-            is WardCost.Discard -> handleDiscardCost(state, context, spellEntityId, container, payingPlayerId, cost.count, cost.random)
-            is WardCost.Sacrifice -> handleSacrificeCost(state, context, spellEntityId, container, payingPlayerId, cost.filter)
-        }
-    }
-
-    /**
-     * Ward—Sacrifice [filter] (e.g. "Sacrifice a Food").
-     *
-     * Valid sacrifice fodder is computed against projected state via
-     * [BattlefieldFilterUtils.findMatchingOnBattlefield], so subtypes granted by continuous
-     * effects (Ygra, Eater of All making every other creature a Food) count. If the paying
-     * player controls no qualifying permanent they cannot pay, so the spell is countered
-     * immediately. Otherwise they pick which permanent(s) to sacrifice (declining → counter).
-     */
-    private fun handleSacrificeCost(
-        state: GameState,
-        context: EffectContext,
-        spellEntityId: EntityId,
-        container: ComponentContainer,
-        payingPlayerId: EntityId,
-        filter: GameObjectFilter
-    ): EffectResult {
-        val count = 1
-        val validPermanents = BattlefieldFilterUtils.findMatchingOnBattlefield(
-            state, filter.youControl(), PredicateContext(controllerId = payingPlayerId)
-        )
-
-        // Can't possibly pay → counter immediately.
-        if (validPermanents.size < count) {
-            return counterSpellOrAbility(state, spellEntityId, container)
-        }
-
-        val fodderLabel = filter.description
-        val prompt = "Sacrifice ${if (count == 1) "a" else "$count"} $fodderLabel or your spell will be countered"
-
-        val decisionResult = DecisionHandler().createCardSelectionDecision(
+        return chargeWardCost(
             state = state,
-            playerId = payingPlayerId,
-            sourceId = context.sourceId,
-            sourceName = "Ward",
-            prompt = prompt,
-            options = validPermanents,
-            minSelections = 0,
-            maxSelections = count,
-            ordered = false,
-            phase = DecisionPhase.RESOLUTION,
-            useTargetingUI = true
-        )
-
-        val continuation = CounterUnlessSacrificeContinuation(
-            decisionId = decisionResult.pendingDecision!!.id,
-            payingPlayerId = payingPlayerId,
+            cardRegistry = cardRegistry,
+            cost = effect.cost,
+            remainingParts = emptyList(),
             spellEntityId = spellEntityId,
-            filter = filter,
-            count = count,
+            container = container,
+            payingPlayerId = payingPlayerId,
+            wardSourceId = context.sourceId,
             controllerId = context.controllerId
-        )
-
-        val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
-
-        return EffectResult.paused(
-            stateWithContinuation,
-            decisionResult.pendingDecision,
-            decisionResult.events
         )
     }
 
-    private fun handleDiscardCost(
-        state: GameState,
-        context: EffectContext,
-        spellEntityId: EntityId,
-        container: ComponentContainer,
-        payingPlayerId: EntityId,
-        count: Int,
-        random: Boolean
-    ): EffectResult {
-        // Not enough cards in hand → counter immediately.
-        // (The caster spends the spell as part of casting, so the spell itself is not in hand here.)
-        if (state.getHand(payingPlayerId).size < count) {
-            return counterSpellOrAbility(state, spellEntityId, container)
+    companion object {
+        /**
+         * Charge a single ward [cost] against [payingPlayerId], carrying [remainingParts] (the
+         * not-yet-paid components of an enclosing [WardCost.Composite]) so the continuation
+         * resumer can charge the next component once this one is paid. Pass `emptyList()` for an
+         * atomic (non-composite) ward cost.
+         *
+         * A [WardCost.Composite] unrolls into "charge `parts.first()` with `remainingParts =
+         * parts.drop(1)`". The components themselves must be atomic ward costs (the SDK forbids
+         * nesting another Composite).
+         */
+        fun chargeWardCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            cost: WardCost,
+            remainingParts: List<WardCost>,
+            spellEntityId: EntityId,
+            container: ComponentContainer,
+            payingPlayerId: EntityId,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            return when (cost) {
+                is WardCost.Mana -> handleManaCost(
+                    state, cardRegistry, spellEntityId, container, payingPlayerId,
+                    cost.manaCost, remainingParts, wardSourceId, controllerId
+                )
+                is WardCost.Life -> handleLifeCost(
+                    state, cardRegistry, spellEntityId, container, payingPlayerId,
+                    cost.amount, remainingParts, wardSourceId, controllerId
+                )
+                is WardCost.Discard -> handleDiscardCost(
+                    state, cardRegistry, spellEntityId, container, payingPlayerId,
+                    cost.count, cost.random, remainingParts, wardSourceId, controllerId
+                )
+                is WardCost.Sacrifice -> handleSacrificeCost(
+                    state, cardRegistry, spellEntityId, container, payingPlayerId,
+                    cost.filter, remainingParts, wardSourceId, controllerId
+                )
+                is WardCost.Composite -> {
+                    require(cost.parts.isNotEmpty()) { "WardCost.Composite must have at least one part" }
+                    chargeWardCost(
+                        state, cardRegistry, cost.parts.first(), cost.parts.drop(1) + remainingParts,
+                        spellEntityId, container, payingPlayerId, wardSourceId, controllerId
+                    )
+                }
+            }
         }
 
-        val cardsLabel = if (count == 1) "a card" else "$count cards"
-        val randomSuffix = if (random) " at random" else ""
-        val decisionId = java.util.UUID.randomUUID().toString()
-        val decision = YesNoDecision(
-            id = decisionId,
-            playerId = payingPlayerId,
-            prompt = "Discard $cardsLabel$randomSuffix or your spell will be countered",
-            context = DecisionContext(
-                sourceId = context.sourceId,
+        /**
+         * Ward—Sacrifice [filter] (e.g. "Sacrifice a Food").
+         *
+         * Valid sacrifice fodder is computed against projected state via
+         * [BattlefieldFilterUtils.findMatchingOnBattlefield], so subtypes granted by continuous
+         * effects (Ygra, Eater of All making every other creature a Food) count. If the paying
+         * player controls no qualifying permanent they cannot pay, so the spell is countered
+         * immediately. Otherwise they pick which permanent(s) to sacrifice (declining → counter).
+         */
+        private fun handleSacrificeCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            spellEntityId: EntityId,
+            container: ComponentContainer,
+            payingPlayerId: EntityId,
+            filter: GameObjectFilter,
+            remainingParts: List<WardCost>,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            val count = 1
+            val validPermanents = BattlefieldFilterUtils.findMatchingOnBattlefield(
+                state, filter.youControl(), PredicateContext(controllerId = payingPlayerId)
+            )
+
+            // Can't possibly pay → counter immediately.
+            if (validPermanents.size < count) {
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+            }
+
+            val fodderLabel = filter.description
+            val prompt = "Sacrifice ${if (count == 1) "a" else "$count"} $fodderLabel or your spell will be countered"
+
+            val decisionResult = DecisionHandler().createCardSelectionDecision(
+                state = state,
+                playerId = payingPlayerId,
+                sourceId = wardSourceId,
                 sourceName = "Ward",
-                phase = DecisionPhase.RESOLUTION
-            ),
-            yesText = "Discard $cardsLabel$randomSuffix",
-            noText = "Counter spell"
-        )
+                prompt = prompt,
+                options = validPermanents,
+                minSelections = 0,
+                maxSelections = count,
+                ordered = false,
+                phase = DecisionPhase.RESOLUTION,
+                useTargetingUI = true
+            )
 
-        val continuation = CounterUnlessDiscardContinuation(
-            decisionId = decisionId,
-            payingPlayerId = payingPlayerId,
-            spellEntityId = spellEntityId,
-            count = count,
-            random = random,
-            controllerId = context.controllerId
-        )
+            val continuation = CounterUnlessSacrificeContinuation(
+                decisionId = decisionResult.pendingDecision!!.id,
+                payingPlayerId = payingPlayerId,
+                spellEntityId = spellEntityId,
+                filter = filter,
+                count = count,
+                controllerId = controllerId,
+                remainingWardParts = remainingParts,
+                wardSourceId = wardSourceId
+            )
 
-        val stateWithDecision = state.withPendingDecision(decision)
-        val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+            val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
 
-        return EffectResult.paused(
-            stateWithContinuation,
-            decision,
-            listOf(
-                DecisionRequestedEvent(
-                    decisionId = decisionId,
-                    playerId = payingPlayerId,
-                    decisionType = "YES_NO",
-                    prompt = decision.prompt
+            return EffectResult.paused(
+                stateWithContinuation,
+                decisionResult.pendingDecision,
+                decisionResult.events
+            )
+        }
+
+        private fun handleDiscardCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            spellEntityId: EntityId,
+            container: ComponentContainer,
+            payingPlayerId: EntityId,
+            count: Int,
+            random: Boolean,
+            remainingParts: List<WardCost>,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            // Not enough cards in hand → counter immediately.
+            // (The caster spends the spell as part of casting, so the spell itself is not in hand here.)
+            if (state.getHand(payingPlayerId).size < count) {
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+            }
+
+            val cardsLabel = if (count == 1) "a card" else "$count cards"
+            val randomSuffix = if (random) " at random" else ""
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val decision = YesNoDecision(
+                id = decisionId,
+                playerId = payingPlayerId,
+                prompt = "Discard $cardsLabel$randomSuffix or your spell will be countered",
+                context = DecisionContext(
+                    sourceId = wardSourceId,
+                    sourceName = "Ward",
+                    phase = DecisionPhase.RESOLUTION
+                ),
+                yesText = "Discard $cardsLabel$randomSuffix",
+                noText = "Counter spell"
+            )
+
+            val continuation = CounterUnlessDiscardContinuation(
+                decisionId = decisionId,
+                payingPlayerId = payingPlayerId,
+                spellEntityId = spellEntityId,
+                count = count,
+                random = random,
+                controllerId = controllerId,
+                remainingWardParts = remainingParts,
+                wardSourceId = wardSourceId
+            )
+
+            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+
+            return EffectResult.paused(
+                stateWithContinuation,
+                decision,
+                listOf(
+                    DecisionRequestedEvent(
+                        decisionId = decisionId,
+                        playerId = payingPlayerId,
+                        decisionType = "YES_NO",
+                        prompt = decision.prompt
+                    )
                 )
             )
-        )
-    }
-
-    private fun handleManaCost(
-        state: GameState,
-        context: EffectContext,
-        spellEntityId: EntityId,
-        container: ComponentContainer,
-        payingPlayerId: EntityId,
-        manaCostString: String
-    ): EffectResult {
-        val manaCost = ManaCost.parse(manaCostString)
-
-        val manaSolver = ManaSolver(cardRegistry)
-        if (!manaSolver.canPay(state, payingPlayerId, manaCost)) {
-            return counterSpellOrAbility(state, spellEntityId, container)
         }
 
-        val sources = manaSolver.findAvailableManaSources(state, payingPlayerId)
-        val sourceOptions = sources.map { source ->
-            ManaSourceOption(
-                entityId = source.entityId,
-                name = source.name,
-                producesColors = source.producesColors,
-                producesColorless = source.producesColorless,
-                requiresSacrifice = source.requiresSacrifice,
-                requiresTappingAnotherPermanent = source.tapPermanentsSubCost != null
+        private fun handleManaCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            spellEntityId: EntityId,
+            container: ComponentContainer,
+            payingPlayerId: EntityId,
+            manaCostString: String,
+            remainingParts: List<WardCost>,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            val manaCost = ManaCost.parse(manaCostString)
+
+            val manaSolver = ManaSolver(cardRegistry)
+            if (!manaSolver.canPay(state, payingPlayerId, manaCost)) {
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+            }
+
+            val sources = manaSolver.findAvailableManaSources(state, payingPlayerId)
+            val sourceOptions = sources.map { source ->
+                ManaSourceOption(
+                    entityId = source.entityId,
+                    name = source.name,
+                    producesColors = source.producesColors,
+                    producesColorless = source.producesColorless,
+                    requiresSacrifice = source.requiresSacrifice,
+                    requiresTappingAnotherPermanent = source.tapPermanentsSubCost != null
+                )
+            }
+
+            val solution = manaSolver.solve(state, payingPlayerId, manaCost)
+            val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
+
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val decision = SelectManaSourcesDecision(
+                id = decisionId,
+                playerId = payingPlayerId,
+                prompt = "Pay $manaCost for ward or your spell will be countered",
+                context = DecisionContext(
+                    sourceId = wardSourceId,
+                    sourceName = "Ward",
+                    phase = DecisionPhase.RESOLUTION
+                ),
+                availableSources = sourceOptions,
+                requiredCost = manaCost.toString(),
+                autoPaySuggestion = autoPaySuggestion,
+                canDecline = true
             )
-        }
 
-        val solution = manaSolver.solve(state, payingPlayerId, manaCost)
-        val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
+            val continuation = CounterUnlessPaysManaSelectionContinuation(
+                decisionId = decisionId,
+                payingPlayerId = payingPlayerId,
+                spellEntityId = spellEntityId,
+                manaCost = manaCost,
+                availableSources = sourceOptions,
+                autoPaySuggestion = autoPaySuggestion,
+                controllerId = controllerId,
+                remainingWardParts = remainingParts,
+                wardSourceId = wardSourceId
+            )
 
-        val decisionId = java.util.UUID.randomUUID().toString()
-        val decision = SelectManaSourcesDecision(
-            id = decisionId,
-            playerId = payingPlayerId,
-            prompt = "Pay $manaCost for ward or your spell will be countered",
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = "Ward",
-                phase = DecisionPhase.RESOLUTION
-            ),
-            availableSources = sourceOptions,
-            requiredCost = manaCost.toString(),
-            autoPaySuggestion = autoPaySuggestion,
-            canDecline = true
-        )
+            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
-        val continuation = CounterUnlessPaysManaSelectionContinuation(
-            decisionId = decisionId,
-            payingPlayerId = payingPlayerId,
-            spellEntityId = spellEntityId,
-            manaCost = manaCost,
-            availableSources = sourceOptions,
-            autoPaySuggestion = autoPaySuggestion,
-            controllerId = context.controllerId
-        )
-
-        val stateWithDecision = state.withPendingDecision(decision)
-        val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
-
-        return EffectResult.paused(
-            stateWithContinuation,
-            decision,
-            listOf(
-                DecisionRequestedEvent(
-                    decisionId = decisionId,
-                    playerId = payingPlayerId,
-                    decisionType = "SELECT_MANA_SOURCES",
-                    prompt = decision.prompt
+            return EffectResult.paused(
+                stateWithContinuation,
+                decision,
+                listOf(
+                    DecisionRequestedEvent(
+                        decisionId = decisionId,
+                        playerId = payingPlayerId,
+                        decisionType = "SELECT_MANA_SOURCES",
+                        prompt = decision.prompt
+                    )
                 )
             )
-        )
-    }
-
-    private fun handleLifeCost(
-        state: GameState,
-        context: EffectContext,
-        spellEntityId: EntityId,
-        container: ComponentContainer,
-        payingPlayerId: EntityId,
-        lifeCost: Int
-    ): EffectResult {
-        val currentLife = state.lifeTotal(payingPlayerId) // CR 810.9a — team's shared total
-        if (currentLife < lifeCost) {
-            // Can't pay — counter immediately.
-            return counterSpellOrAbility(state, spellEntityId, container)
         }
 
-        val decisionId = java.util.UUID.randomUUID().toString()
-        val decision = YesNoDecision(
-            id = decisionId,
-            playerId = payingPlayerId,
-            prompt = "Pay $lifeCost life or your spell will be countered",
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = "Ward",
-                phase = DecisionPhase.RESOLUTION
-            ),
-            yesText = "Pay $lifeCost life",
-            noText = "Counter spell"
-        )
+        private fun handleLifeCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            spellEntityId: EntityId,
+            container: ComponentContainer,
+            payingPlayerId: EntityId,
+            lifeCost: Int,
+            remainingParts: List<WardCost>,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            val currentLife = state.lifeTotal(payingPlayerId) // CR 810.9a — team's shared total
+            if (currentLife < lifeCost) {
+                // Can't pay — counter immediately.
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+            }
 
-        val continuation = CounterUnlessPaysLifeContinuation(
-            decisionId = decisionId,
-            payingPlayerId = payingPlayerId,
-            spellEntityId = spellEntityId,
-            lifeCost = lifeCost,
-            controllerId = context.controllerId
-        )
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val decision = YesNoDecision(
+                id = decisionId,
+                playerId = payingPlayerId,
+                prompt = "Pay $lifeCost life or your spell will be countered",
+                context = DecisionContext(
+                    sourceId = wardSourceId,
+                    sourceName = "Ward",
+                    phase = DecisionPhase.RESOLUTION
+                ),
+                yesText = "Pay $lifeCost life",
+                noText = "Counter spell"
+            )
 
-        val stateWithDecision = state.withPendingDecision(decision)
-        val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+            val continuation = CounterUnlessPaysLifeContinuation(
+                decisionId = decisionId,
+                payingPlayerId = payingPlayerId,
+                spellEntityId = spellEntityId,
+                lifeCost = lifeCost,
+                controllerId = controllerId,
+                remainingWardParts = remainingParts,
+                wardSourceId = wardSourceId
+            )
 
-        return EffectResult.paused(
-            stateWithContinuation,
-            decision,
-            listOf(
-                DecisionRequestedEvent(
-                    decisionId = decisionId,
-                    playerId = payingPlayerId,
-                    decisionType = "YES_NO",
-                    prompt = decision.prompt
+            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+
+            return EffectResult.paused(
+                stateWithContinuation,
+                decision,
+                listOf(
+                    DecisionRequestedEvent(
+                        decisionId = decisionId,
+                        playerId = payingPlayerId,
+                        decisionType = "YES_NO",
+                        prompt = decision.prompt
+                    )
                 )
             )
-        )
-    }
+        }
 
-    private fun counterSpellOrAbility(
-        state: GameState,
-        entityId: EntityId,
-        container: ComponentContainer
-    ): EffectResult {
-        val resolver = StackResolver(cardRegistry = cardRegistry)
-        return EffectResult.from(if (container.has<SpellOnStackComponent>()) {
-            resolver.counterSpell(state, entityId)
-        } else {
-            resolver.counterAbility(state, entityId)
-        })
+        private fun counterSpellOrAbility(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            entityId: EntityId,
+            container: ComponentContainer
+        ): EffectResult {
+            val resolver = StackResolver(cardRegistry = cardRegistry)
+            return EffectResult.from(if (container.has<SpellOnStackComponent>()) {
+                resolver.counterSpell(state, entityId)
+            } else {
+                resolver.counterAbility(state, entityId)
+            })
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -724,6 +724,36 @@ data class PermanentTypesEnteredBattlefieldThisTurnComponent(
 data class LandsEnteredUnderControlThisTurnComponent(val count: Int = 0) : Component
 
 /**
+ * One permanent that entered the battlefield under a player's control this turn, captured for
+ * subtype-keyed "for each [creature type] that entered the battlefield under your control this
+ * turn" counts (Geralf, the Fleshwright). [subtypes] is snapshotted from the **projected** state
+ * at the instant of entry, so a permanent that was a Zombie when it entered still counts even
+ * after it leaves the battlefield or loses the type (CR 603.10 last-known style — the entry event
+ * is what matters, not current state). [entityId] lets a triggered ability exclude the permanent
+ * that caused it to trigger ("each *other* Zombie", and simultaneous entries per the 2024-04-12
+ * ruling).
+ */
+@Serializable
+data class EnteredPermanentRecord(
+    val entityId: EntityId,
+    val subtypes: Set<String> = emptySet()
+)
+
+/**
+ * Tracks every permanent that entered the battlefield under this player's control during the
+ * current turn, with the subtypes each had at entry. Populated by `PermanentEntryTracker.record`
+ * (exactly once per ETB) and cleared at end of turn by [CleanupPhaseManager].
+ *
+ * Backs `DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity)`
+ * — "for each [other] [subtype] that entered the battlefield under your control this turn"
+ * (Geralf, the Fleshwright). Counts entries even if the permanent has since left or changed type.
+ */
+@Serializable
+data class PermanentsEnteredUnderControlThisTurnComponent(
+    val entries: List<EnteredPermanentRecord> = emptyList()
+) : Component
+
+/**
  * Marker component indicating that this player has put a counter on a creature this turn.
  * Cleared at end of turn by CleanupPhaseManager.
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnieFlashTheVeteranScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnieFlashTheVeteranScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.AnnieFlashTheVeteran
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Annie Flash, the Veteran (OTJ #190) — {3}{R}{G}{W} 4/5 Legendary Human Rogue, Flash.
+ *
+ *  - "Whenever Annie Flash becomes tapped, exile the top two cards of your library. You may play
+ *    those cards this turn."
+ *
+ * Exercises the impulse-draw becomes-tapped ability (now composed via `Patterns.Exile.impulse(2)`):
+ * tapping Annie exiles the top two cards and grants permission to play them this turn.
+ */
+class AnnieFlashTheVeteranScenarioTest : FunSpec({
+
+    // Minimal instant that taps a target creature so we can make Annie "become tapped".
+    val tapThatThing = card("Tap That Thing") {
+        manaCost = "{U}"
+        colorIdentity = "U"
+        typeLine = "Instant"
+        oracleText = "Tap target creature."
+        spell {
+            target = Targets.Creature
+            effect = Effects.Tap(EffectTarget.ContextTarget(0))
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AnnieFlashTheVeteran + tapThatThing)
+        return driver
+    }
+
+    test("becoming tapped exiles the top two cards and grants permission to play them this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val annie = driver.putCreatureOnBattlefield(player, "Annie Flash, the Veteran")
+        driver.putCardOnTopOfLibrary(player, "Mountain")
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val tapSpell = driver.putCardInHand(player, "Tap That Thing")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.castSpell(player, tapSpell, listOf(annie))
+        driver.bothPass() // resolve the tap spell — Annie becomes tapped
+        if (driver.stackSize > 0) driver.bothPass() // resolve the becomes-tapped trigger
+
+        driver.isTapped(annie) shouldBe true
+        // The two top cards are exiled and flagged playable.
+        driver.getExileCardNames(player).sorted() shouldBe listOf("Forest", "Mountain")
+        driver.getExile(player).all { exiled ->
+            driver.state.mayPlayPermissions.any { exiled in it.cardIds }
+        } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BaronBertramGraywaterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BaronBertramGraywaterScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BaronBertramGraywater
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Baron Bertram Graywater — {2}{W}{B} 3/4 Legendary Creature — Vampire Noble
+ *
+ * 1. "Whenever one or more tokens you control enter, create a 1/1 black Vampire Rogue creature
+ *     token with lifelink. This ability triggers only once each turn."
+ * 2. "{1}{B}, Sacrifice another creature or artifact: Draw a card."
+ */
+class BaronBertramGraywaterScenarioTest : FunSpec({
+
+    val drawAbilityId = BaronBertramGraywater.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BaronBertramGraywater))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun vampireTokens(driver: GameTestDriver, playerId: EntityId): List<EntityId> =
+        driver.getCreatures(playerId).filter {
+            val e = driver.state.getEntity(it)
+            e?.get<CardComponent>()?.name == "Vampire Rogue Token" && e.has<TokenComponent>()
+        }
+
+    fun mercenaryTokens(driver: GameTestDriver, playerId: EntityId): List<EntityId> =
+        driver.getCreatures(playerId).filter {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Mercenary Token"
+        }
+
+    fun castFormAPosse(driver: GameTestDriver, playerId: EntityId, x: Int) {
+        driver.giveMana(playerId, Color.RED, 1)
+        driver.giveMana(playerId, Color.WHITE, 1)
+        driver.giveColorlessMana(playerId, x)
+        val posse = driver.putCardInHand(playerId, "Form a Posse")
+        driver.castXSpell(playerId, posse, xValue = x).error shouldBe null
+        // Resolve Form a Posse and the Baron trigger(s) it created, but stop once the stack is empty
+        // so we stay in the precombat main phase (Form a Posse is a sorcery; a later cast needs it).
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) {
+            driver.bothPass()
+        }
+    }
+
+    test("one or more tokens entering creates a single Vampire Rogue — once per turn") {
+        val driver = createDriver()
+        val me = driver.player1
+        driver.putCreatureOnBattlefield(me, "Baron Bertram Graywater")
+
+        // Make two Mercenary tokens — the trigger fires once for the batch, making ONE Vampire.
+        castFormAPosse(driver, me, x = 2)
+        vampireTokens(driver, me).size shouldBe 1
+
+        // A second batch the same turn does not make another Vampire (once per turn).
+        castFormAPosse(driver, me, x = 1)
+        vampireTokens(driver, me).size shouldBe 1
+    }
+
+    test("activated ability: sacrifice another creature to draw a card") {
+        val driver = createDriver()
+        val me = driver.player1
+        val baron = driver.putCreatureOnBattlefield(me, "Baron Bertram Graywater")
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+        val handBefore = driver.getHandSize(me)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = baron,
+                abilityId = drawAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder)),
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass() // resolve the draw
+
+        driver.findPermanent(me, "Grizzly Bears") shouldBe null
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+
+    test("activated ability cannot sacrifice Baron himself (\"another\")") {
+        val driver = createDriver()
+        val me = driver.player1
+        val baron = driver.putCreatureOnBattlefield(me, "Baron Bertram Graywater")
+
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = baron,
+                abilityId = drawAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(baron)),
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeralfTheFleshwrightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeralfTheFleshwrightScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GeralfTheFleshwright
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Geralf, the Fleshwright — {2}{U} 2/3 Legendary Creature — Human Warlock
+ *
+ * 1) "Whenever you cast a spell during your turn other than your first spell that turn, create a
+ *    2/2 blue and black Zombie Rogue creature token."
+ * 2) "Whenever a Zombie you control enters, put a +1/+1 counter on it for each other Zombie that
+ *    entered the battlefield under your control this turn."
+ *
+ * The two abilities feed each other: each 2nd+ spell makes a Zombie token, whose entry then
+ * triggers the counter ability seeing the Zombies that entered earlier this turn. This exercises
+ * the new `DynamicAmount.SubtypeEnteredUnderControlThisTurn` (turn-history count with
+ * excludeTriggeringEntity).
+ */
+class GeralfTheFleshwrightScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GeralfTheFleshwright)
+        return driver
+    }
+
+    fun zombieTokens(driver: GameTestDriver, me: EntityId): List<EntityId> =
+        driver.getCreatures(me).filter { driver.getCardName(it) == "Zombie Rogue Token" }
+
+    fun counters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Cast a Lightning Bolt at the opponent (a spell) and resolve the whole stack (spell + triggers). */
+    fun castBolt(driver: GameTestDriver, me: EntityId, opp: EntityId) {
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(opp))
+        // Resolve the whole stack (the spell, then Geralf's token trigger, then that token's enters
+        // trigger), but stop once the stack is empty so we stay in the precombat main phase.
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) {
+            driver.bothPass()
+        }
+    }
+
+    test("first spell of the turn makes no token; second spell makes one Zombie Rogue") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Geralf, the Fleshwright")
+
+        // First spell — no token.
+        castBolt(driver, me, opp)
+        zombieTokens(driver, me).size shouldBe 0
+
+        // Second spell — one token (its entry triggers ability 2 with 0 other Zombies → 0 counters).
+        castBolt(driver, me, opp)
+        val tokens = zombieTokens(driver, me)
+        tokens.size shouldBe 1
+        counters(driver, tokens.single()) shouldBe 0
+    }
+
+    test("each later Zombie token gets +1/+1 for each other Zombie that entered this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Geralf, the Fleshwright")
+
+        // Spell 1: no token.
+        castBolt(driver, me, opp)
+        // Spell 2: token A enters, 0 other Zombies this turn → 0 counters.
+        castBolt(driver, me, opp)
+        // Spell 3: token B enters, 1 other Zombie (A) this turn → 1 counter.
+        castBolt(driver, me, opp)
+        // Spell 4: token C enters, 2 other Zombies (A, B) this turn → 2 counters.
+        castBolt(driver, me, opp)
+
+        val tokens = zombieTokens(driver, me)
+        tokens.size shouldBe 3
+        // Counters across the three tokens are {0, 1, 2} in creation order.
+        tokens.map { counters(driver, it) }.sorted() shouldBe listOf(0, 1, 2)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GisaTheHellraiserScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GisaTheHellraiserScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GisaTheHellraiser
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Gisa, the Hellraiser — composite ward "Ward—{2}, Pay 2 life." (CR 702.21a).
+ *
+ * An opponent targeting Gisa must pay BOTH components — {2} mana, then 2 life — in order, or
+ * their spell is countered. The two components are charged one at a time: a mana-source decision
+ * first, then a yes/no life decision; only paying both lets the spell resolve.
+ */
+class GisaTheHellraiserScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GisaTheHellraiser)
+        return driver
+    }
+
+    test("paying both ward components (mana then life) lets the targeting spell resolve") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gisa = driver.putCreatureOnBattlefield(opponent, "Gisa, the Hellraiser")
+
+        // Three Mountains: {R} for Bolt, {2} for the mana ward component.
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(gisa)))
+
+        // Resolve ward trigger — first component is the {2} mana cost.
+        driver.bothPass()
+        val manaDecision = driver.pendingDecision
+        manaDecision.shouldNotBeNull()
+        manaDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        manaDecision.requiredCost shouldBe "{2}"
+
+        val lifeBefore = driver.getLifeTotal(activePlayer)
+        driver.submitManaAutoPayOrDecline(activePlayer, autoPay = true)
+
+        // Second component is the 2-life yes/no decision.
+        val lifeDecision = driver.pendingDecision
+        lifeDecision.shouldNotBeNull()
+        lifeDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(activePlayer, true)
+
+        // Both paid → Bolt resolves (3 damage to a 4/4 — Gisa survives but the spell was not countered).
+        repeat(3) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        driver.getLifeTotal(activePlayer) shouldBe (lifeBefore - 2)
+        driver.getGraveyardCardNames(activePlayer).contains("Lightning Bolt") shouldBe true
+        driver.findPermanent(opponent, "Gisa, the Hellraiser").shouldNotBeNull()
+    }
+
+    test("declining the second component (life) after paying mana still counters the spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gisa = driver.putCreatureOnBattlefield(opponent, "Gisa, the Hellraiser")
+
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(gisa)))
+
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        driver.submitManaAutoPayOrDecline(activePlayer, autoPay = true)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        // Decline the life component — even though mana was paid, the spell is countered.
+        driver.submitYesNo(activePlayer, false)
+
+        repeat(2) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        driver.findPermanent(opponent, "Gisa, the Hellraiser") shouldNotBe null
+        driver.getGraveyardCardNames(activePlayer).contains("Lightning Bolt") shouldBe true
+    }
+
+    test("declining the first component (mana) counters immediately without a life prompt") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gisa = driver.putCreatureOnBattlefield(opponent, "Gisa, the Hellraiser")
+
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(gisa)))
+
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        val lifeBefore = driver.getLifeTotal(activePlayer)
+        driver.submitManaAutoPayOrDecline(activePlayer, autoPay = false)
+
+        // No life prompt — the spell is already countered.
+        driver.pendingDecision shouldBe null
+        repeat(2) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        driver.findPermanent(opponent, "Gisa, the Hellraiser") shouldNotBe null
+        driver.getLifeTotal(activePlayer) shouldBe lifeBefore
+    }
+
+    test("ward counters immediately when the caster cannot pay the mana component") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gisa = driver.putCreatureOnBattlefield(opponent, "Gisa, the Hellraiser")
+
+        // Only {R} for Bolt — nothing left to pay the {2} ward component.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(gisa)))
+
+        driver.bothPass()
+        driver.pendingDecision shouldBe null
+        driver.findPermanent(opponent, "Gisa, the Hellraiser") shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Cards

Four Outlaws of Thunder Junction legends, each with a scenario test:

- **Annie Flash, the Veteran** ({3}{R}{G}{W}, mythic) — Flash; cast-gated ETB (`Conditions.WasCast`) reanimates a target MV≤3 permanent card from your graveyard tapped; "becomes tapped" impulse-draws two cards.
- **Baron Bertram Graywater** ({2}{W}{B}, uncommon) — once-per-turn batched "tokens you control enter" payoff making a Vampire Rogue; `{1}{B}, Sacrifice another creature or artifact: Draw a card`.
- **Geralf, the Fleshwright** ({2}{U}, mythic) — second-and-later spell each turn makes a Zombie Rogue; entering Zombies get a +1/+1 counter per *other* Zombie that entered under your control this turn.
- **Gisa, the Hellraiser** ({3}{B}{B}, mythic) — composite Ward; Skeleton/Zombie lord (+1/+1 and menace); once-per-turn commit-a-crime makes two tapped Zombie Rogues.

## SDK / engine features

- **Composite Ward** (CR 702.21a) — `WardCost.Composite` + `KeywordAbility.wardComposite(...)` for "Ward—{2}, Pay 2 life". Components are charged one at a time via `WardCounterEffectExecutor.chargeWardCost`; `ManaPaymentContinuationResumer` chains the next component after each payment (life/mana/discard/sacrifice all carry `remainingWardParts`). Declining or being unable to pay any component counters the spell.
- **`DynamicAmount.SubtypeEnteredUnderControlThisTurn`** + `DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` — turn-history count backed by a new `PermanentsEnteredUnderControlThisTurnComponent` (snapshots each entrant's subtypes at entry, cleared at cleanup). `excludeTriggeringEntity` gives "each *other*" and lets simultaneous entrants see each other (2024-04-12 ruling).
- **`Patterns.Exile.impulse(count, expiry)`** — named impulse-draw facade (gather top N → exile → grant may-play). Irascible Wolverine migrated onto it; Annie Flash uses `impulse(2)`.

## Tooling (mtgish-tooling)

- Aligned the emitter's impulse-draw idiom `storeAs` key to the facade default (`impulseExiled`) so the auto-gen tree matches the golden, removing the Irascible Wolverine `coverage-verify` mismatch. Re-blessed the INR emitter fixture (one card: Stromkirk Occultist).
- The four new cards correctly **decline to SCAFFOLD** (NOT EMITTED) rather than emit a lossy approximation.

## Verification

- 4 scenario tests: pass.
- `CardLintTest`, `CardDefinitionSnapshotTest` (re-blessed OTJ golden), `EmitterGoldenTest`: pass.
- Full `:rules-engine` suite: pass.
- `coverage-verify`: **OTJ = 7** mismatches (exactly the pre-existing list — Cactusfolk Sureshot, Freestrider Lookout, High Noon, Mirage Mesa, One Last Job, The Key to the Vault, Thunder Lasso; no new ones), **POR = 0 (GATE PASS)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)