### PR TITLE
OTJ batch A: Obeka, Ertha Jo, Bruse Tarl, Tinybones the Pickpocket

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -241,8 +241,9 @@ power via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DR
    stack-object kind the single target resolved to — instant/sorcery spell, **activated ability**, or
    triggered ability — via `Targets.InstantSorcerySpellOrAbility`; STACK targeting enumeration was
    widened so an ability becomes a legal target when the filter names an ability predicate. This
-   closed the **Return the Favor** copy mode. Still open for **Ertha Jo, Frontier Mentor**: a trigger
-   predicate for "an ability that targets a creature or player."
+   closed the **Return the Favor** copy mode. ~~Still open for **Ertha Jo, Frontier Mentor**: a trigger
+   predicate for "an ability that targets a creature or player."~~ **DONE** — added
+   `Triggers.youActivateAbilityTargeting(AbilityTargetMatch)`; Ertha Jo implemented.
 
 8. **Aura "becomes attached" trigger + control-for-as-long-as-attached + MV-on-attach condition.**
    No "becomes attached" trigger event, no MV-comparison-on-attachment condition, and no control
@@ -256,9 +257,11 @@ power via `dynamicPower = CharacteristicValue.dynamic(TurnTracking(You, CARDS_DR
    `SetBasePowerToughnessDynamicStatic` (Layer 7b SET_VALUES) + `Modification.SetPowerToughnessDynamic`;
    Bonny Pall implemented.
 
-10. **Additional upkeep steps inserted into the current turn.** Extra *combat* phases and extra
+10. ~~**Additional upkeep steps inserted into the current turn.** Extra *combat* phases and extra
     *turns* are supported, but not inserting N extra upkeep steps after the current phase.
-    → **Obeka, Splitter of Seconds**.
+    → **Obeka, Splitter of Seconds**.~~ **DONE** — added `Effects.AddAdditionalUpkeepSteps` +
+    `AdditionalUpkeepStepsComponent`; TurnManager drains the queue after the postcombat main phase.
+    Obeka implemented.
 
 11. **"Tap an artifact (token) for mana" trigger + reflexive same-type mana.** The tap-for-mana
     trigger is land-only (`LandTappedForMana`); needs generalization to artifact/permanent-tapped-for-mana

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -425,7 +425,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ReturnLinkedExileUnderOwnersControl()` — return under each card's owner.
 - `ReturnLinkedExileToHand()` — return all from linked exile to hand.
 - `ReturnOneFromLinkedExile()` — return one chosen card.
-- `GrantMayPlayFromExile(from, expiry?, withAnyManaType?, condition?, landEntersTapped?)` — controller may play matching cards from exile. `landEntersTapped=true` forces a played land tapped regardless of its own ETB script (Lightstall Inquisitor); PlayLandHandler reads the flag off the active `MayPlayPermission` at play time and stamps `TappedComponent` before the card's intrinsic `EntersTapped` branch runs.
+- `GrantMayPlayFromExile(from, expiry?, withAnyManaType?, condition?, landEntersTapped?)` — controller may play matching cards from exile. `withAnyManaType=true` relaxes the colored pips so mana of any type can pay them (Laughing Jasper Flint, Cruelclaw's Heist); the grant works whether the card stays in exile *or* in a graveyard (Tinybones, the Pickpocket grants over a card the trigger gathered straight from a graveyard via `CardSource.ChosenTargets`), and the relaxation is applied both in the legal-action enumerator and in the cast handler's payment. `landEntersTapped=true` forces a played land tapped regardless of its own ETB script (Lightstall Inquisitor); PlayLandHandler reads the flag off the active `MayPlayPermission` at play time and stamps `TappedComponent` before the card's intrinsic `EntersTapped` branch runs.
 - `GrantPlayWithoutPayingCost(from)` — same, without paying mana costs.
 - `GrantPlayWithCostIncrease(from, amount)` — stamp `PlayWithCostIncreaseComponent(controllerId, amount)` on every card in the collection, so the next cast pays `{amount}` extra generic. Pair with `GrantMayPlayFromExile` for "each spell cast this way costs {N} more" clauses (Lightstall Inquisitor); for target-based "exile this permanent, owner may play it, opponents tax" effects use `Effects.ExileAndGrantOwnerPlayPermission` instead.
 - `GrantFreeCastTargetFromExile(target)` — cast specific exiled card for free.
@@ -744,6 +744,18 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `PhaseOutEffect(target = Self)` — phase the target permanent out (Rule 702.26); facade `Effects.PhaseOut(target)`. While phased out it's treated as though it doesn't exist (excluded from `getBattlefield`, so from projection, triggers, combat, targeting, and SBAs) and phases back in before its controller's next untap step. Indirect phasing (attached Auras/Equipment) is handled automatically. Used as the `suffer` branch of a pay-or-phase trigger (Vaporous Djinn: "phases out unless you pay {U}{U}" = `PayOrSufferEffect(Costs.pay.Mana(...), Effects.PhaseOut())`).
 - `PhaseOutUntilLeavesEffect(target, tapOnPhaseIn)` / `Effects.PhaseOutUntilLeaves(target, tapOnPhaseIn)` — phase the target out **indefinitely, linked to the effect's source** (the phasing analogue of `ExileUntilLeaves`): it skips its untap-step phase-in and stays out until the source leaves the battlefield. Pair with `Effects.PhaseInLinkedToSource()` on the source's `LeavesBattlefield` trigger, which phases everything the source phased out this way back in (tapping those flagged `tapOnPhaseIn`). The link lives on the phased-out permanent (`PhasedOutComponent.phaseInOnSourceLeaves`); indirect phasing carries Auras/Equipment out with the creature. This is Oubliette (ETB phase-out + leaves-trigger phase-in, tapped).
 - `MarkExileOnDeathEffect(target)` — replace next "to graveyard" with "to exile".
+- `Effects.AddAdditionalUpkeepSteps(amount)` (`amount: DynamicAmount` or `Int`) — give the
+  controller `amount` additional upkeep steps after the current phase (Obeka, Splitter of Seconds:
+  "you get that many additional upkeep steps after this phase"). Per CR 500.10, each added upkeep
+  step creates the *beginning phase* that normally contains it, with the untap and draw steps
+  skipped; per CR 500.8 the phases are inserted after the current phase, and after any additional
+  combat phases added to the same point (most-recently-created phase first). "At the beginning of
+  [your] upkeep" abilities trigger in each inserted step (CR 503.1a). Steps are always added to the
+  controller's own turn (CR 500.10a). Implemented by accumulating an `AdditionalUpkeepStepsComponent`
+  count on the active player, drained by `TurnManager.advanceStep` after the postcombat main phase
+  (after the additional-combat-phase check), each remaining count redirecting into a fresh upkeep
+  step in the beginning phase. Read "that many" from the triggering combat damage with
+  `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)`.
 - `GatedEffect(gate, then, otherwise?, decisionMaker?)` — **the unified resolution frame for the
   optional / gated-effect cluster** (phase-rs Lesson 1). A `Gate` decides whether `then` runs; if it
   fails, `otherwise` runs. One executor + one continuation/resumer own the canonical unwind order, so
@@ -1766,6 +1778,17 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   abilities don't use the stack, so they never fire this; loyalty abilities (which are activated abilities) do. Pair
   with `Effects.DealDamage(n, EffectTarget.PlayerRef(Player.TriggeringPlayer))` to punish the activator (Flamescroll
   Celebrant). Backed by `EventPattern.AbilityActivatedEvent(player)`.
+- `YouActivateAbility` — you activate an ability that isn't a mana ability (the `Player.You` form of the above).
+- `youActivateAbilityTargeting(targetMatch)` — you activate an ability whose **chosen targets** satisfy
+  `targetMatch`. Backed by `EventPattern.AbilityActivatedEvent(player, targetMatch)`: when `targetMatch != null`, the
+  activated ability on the stack must have at least one chosen target matching it, so a non-targeting ability (e.g.
+  tap-for-mana) never fires. `targetMatch` is an `AbilityTargetMatch` (in `scripting.events`): `ObjectMatching(filter)`
+  matches an object target against a `GameObjectFilter`, `AnyPlayer` matches a player target, and `AnyOf(list)` is a
+  heterogeneous OR (the match space is wider than `GameObjectFilter` because an ability can target a player too).
+  `AbilityTargetMatch.CreatureOrPlayer` is the prebuilt "targets a creature or player" used by Ertha Jo, Frontier
+  Mentor, whose payoff is `Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)` (for an
+  `AbilityActivatedEvent` the triggering entity is the activated ability on the stack; the copy executor reprompts for
+  new targets, CR 707.10/707.10c).
 
 **Other casters.** The same shape, scoped to a different caster via the runtime
 `Player.Each` / `Player.EachOpponent` matching on `SpellCastEvent`. Bind the payoff to the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2476,6 +2476,20 @@ object Effects {
     fun ForceBlock(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
         com.wingedsheep.sdk.scripting.effects.ForceBlockEffect(target)
 
+    /**
+     * Give the controller [amount] additional upkeep steps after the current phase
+     * (Obeka, Splitter of Seconds). Each is a beginning phase containing only an upkeep step
+     * (untap and draw skipped, CR 500.10); they occur after any additional combat phases (CR 500.8).
+     */
+    fun AddAdditionalUpkeepSteps(amount: DynamicAmount): Effect =
+        com.wingedsheep.sdk.scripting.effects.AddAdditionalUpkeepStepsEffect(amount)
+
+    /**
+     * Give the controller a fixed number of additional upkeep steps after the current phase.
+     */
+    fun AddAdditionalUpkeepSteps(amount: Int): Effect =
+        com.wingedsheep.sdk.scripting.effects.AddAdditionalUpkeepStepsEffect(DynamicAmount.Fixed(amount))
+
     // -------------------------------------------------------------------------
     // Damage Prevention (unified via PreventDamageEffect)
     // -------------------------------------------------------------------------

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.scripting.EventPattern.*
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.events.AbilityTargetMatch
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.sdk.scripting.events.AttackPredicate
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
@@ -947,6 +948,25 @@ object Triggers {
      */
     val OpponentActivatesAbility: TriggerSpec = TriggerSpec(
         event = AbilityActivatedEvent(player = Player.EachOpponent),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you activate an ability that isn't a mana ability (CR 605 / 606).
+     */
+    val YouActivateAbility: TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(player = Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you activate an ability whose chosen targets satisfy [targetMatch] — e.g.
+     * [AbilityTargetMatch.CreatureOrPlayer] for Ertha Jo, Frontier Mentor's
+     * "Whenever you activate an ability that targets a creature or player". A non-targeting
+     * ability (a tap-for-mana, etc.) never matches.
+     */
+    fun youActivateAbilityTargeting(targetMatch: AbilityTargetMatch): TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(player = Player.You, targetMatch = targetMatch),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1202,14 +1202,29 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      *
      * Used by Flamescroll Celebrant: "Whenever an opponent activates an ability that isn't a mana
      * ability, this creature deals 1 damage to that player."
+     *
+     * [targetMatch] optionally narrows the trigger to abilities that target a particular kind of
+     * object or player. When non-null, the activated ability must have at least one chosen target
+     * satisfying it — a non-targeting ability never fires. Ertha Jo, Frontier Mentor uses
+     * [com.wingedsheep.sdk.scripting.events.AbilityTargetMatch.CreatureOrPlayer] for
+     * "Whenever you activate an ability that targets a creature or player".
      */
     @SerialName("AbilityActivatedEvent")
     @Serializable
     data class AbilityActivatedEvent(
-        val player: Player = Player.You
+        val player: Player = Player.You,
+        val targetMatch: com.wingedsheep.sdk.scripting.events.AbilityTargetMatch? = null
     ) : EventPattern {
-        override val description: String =
-            "${player.description} activates an ability that isn't a mana ability"
+        override val description: String = buildString {
+            append(player.description)
+            append(" activates an ability that ")
+            if (targetMatch != null) {
+                append("targets a ")
+                append(targetMatch.description)
+            } else {
+                append("isn't a mana ability")
+            }
+        }
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -92,6 +93,29 @@ data class PlayAdditionalLandsEffect(
 data object AddCombatPhaseEffect : Effect {
     override val description: String =
         "After this main phase, there is an additional combat phase followed by an additional main phase"
+}
+
+/**
+ * Give the controller additional upkeep steps after the current phase
+ * (Obeka, Splitter of Seconds: "you get that many additional upkeep steps after this phase").
+ *
+ * Per CR 500.10, adding an upkeep step after a phase creates the beginning phase that normally
+ * contains the upkeep step, with its untap and draw steps skipped. The phases are inserted after
+ * the current phase (CR 500.8), and after any additional combat phases added to the same point
+ * (CR 500.8: most recently created phase occurs first), so any extra combat happens before the
+ * extra upkeeps. "At the beginning of [your] upkeep" abilities trigger in each (CR 503.1a).
+ *
+ * Always added to the controller of the effect (CR 500.10a — "you get" steps are never added to
+ * another player's turn).
+ *
+ * @param amount The number of additional upkeep steps to add (e.g. the combat damage dealt).
+ */
+@SerialName("AddAdditionalUpkeepSteps")
+@Serializable
+data class AddAdditionalUpkeepStepsEffect(
+    val amount: DynamicAmount
+) : Effect {
+    override val description: String = "You get ${amount.description} additional upkeep step(s) after this phase"
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -428,3 +428,53 @@ sealed interface AttackPredicate {
         override val description = "with $n or more attackers"
     }
 }
+
+// =============================================================================
+// Ability Target Match - constrains an activated ability by its chosen targets
+// =============================================================================
+
+/**
+ * A predicate over the set of targets an activated ability on the stack was given.
+ *
+ * Used by [com.wingedsheep.sdk.scripting.EventPattern.AbilityActivatedEvent.targetMatch] to express
+ * "Whenever you activate an ability that targets X" (Ertha Jo, Frontier Mentor — "...that targets a
+ * creature or player"). A constraint is satisfied when **at least one** of the ability's chosen
+ * targets matches it; a non-targeting ability (e.g. a tap-for-mana) never matches, so it doesn't
+ * fire the trigger.
+ *
+ * The match space is wider than [GameObjectFilter] because an ability can target a *player* as well
+ * as an object, and `GameObjectFilter` only describes objects. [AnyPlayer] covers the player half;
+ * [ObjectMatching] covers the object half; [AnyOf] composes them into heterogeneous unions such as
+ * "creature or player".
+ */
+@Serializable
+sealed interface AbilityTargetMatch {
+    val description: String
+
+    /** At least one chosen target is a player. */
+    @SerialName("AbilityTargetAnyPlayer")
+    @Serializable
+    data object AnyPlayer : AbilityTargetMatch {
+        override val description = "player"
+    }
+
+    /** At least one chosen target is an object matching [filter] (creature, permanent, …). */
+    @SerialName("AbilityTargetObjectMatching")
+    @Serializable
+    data class ObjectMatching(val filter: GameObjectFilter) : AbilityTargetMatch {
+        override val description = filter.description
+    }
+
+    /** At least one chosen target matches any of [options] (heterogeneous OR). */
+    @SerialName("AbilityTargetAnyOf")
+    @Serializable
+    data class AnyOf(val options: List<AbilityTargetMatch>) : AbilityTargetMatch {
+        override val description = options.joinToString(" or ") { it.description }
+    }
+
+    companion object {
+        /** "...that targets a creature or player." */
+        val CreatureOrPlayer: AbilityTargetMatch =
+            AnyOf(listOf(ObjectMatching(GameObjectFilter.Creature), AnyPlayer))
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BruseTarlRovingRancher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BruseTarlRovingRancher.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bruse Tarl, Roving Rancher
+ * {2}{R}{W}
+ * Legendary Creature — Human Warrior
+ * 4/3
+ *
+ * Oxen you control have double strike.
+ * Whenever Bruse Tarl enters or attacks, exile the top card of your library. If it's a
+ * land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the
+ * end of your next turn.
+ *
+ * Implementation:
+ * - Lord: [GrantKeyword] of double strike to Oxen you control (mirrors Mobile Homestead's
+ *   keyword-grant lord shape).
+ * - "Enters or attacks" → two triggered abilities (per Sentinel of the Nameless City),
+ *   sharing one composite body.
+ * - The body gathers the top card, exiles it, then splits land vs. non-land
+ *   ([FilterCollectionEffect]). A land leg (gated by [Conditions.CollectionContainsMatch])
+ *   creates an Ox token and leaves the land sitting in exile. The non-land leg grants a
+ *   may-play window until the end of the controller's next turn (impulse, mirroring Gila
+ *   Courser / Alania's Pathmaker). Oracle says "cast"; the engine's may-play permission
+ *   only lets you cast a nonland card anyway, so the window is faithful.
+ */
+private const val OX_TOKEN_IMAGE =
+    "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg?1712316060"
+
+private val bruseTarlBody = Effects.Composite(
+    listOf(
+        GatherCardsEffect(
+            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+            storeAs = "exiledCard",
+        ),
+        MoveCollectionEffect(
+            from = "exiledCard",
+            destination = CardDestination.ToZone(Zone.EXILE),
+        ),
+        // Split the exiled card into land vs. non-land.
+        FilterCollectionEffect(
+            from = "exiledCard",
+            filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
+            storeMatching = "landCards",
+            storeNonMatching = "nonLandCards",
+        ),
+        // Land: create a 2/2 white Ox token (the land stays in exile, unused).
+        ConditionalEffect(
+            condition = Conditions.CollectionContainsMatch("landCards", GameObjectFilter.Land),
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Ox"),
+                imageUri = OX_TOKEN_IMAGE,
+            ),
+        ),
+        // Otherwise: you may cast the non-land card until the end of your next turn.
+        GrantMayPlayFromExileEffect("nonLandCards", MayPlayExpiry.UntilEndOfNextTurn),
+    )
+)
+
+val BruseTarlRovingRancher = card("Bruse Tarl, Roving Rancher") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Oxen you control have double strike.\n" +
+        "Whenever Bruse Tarl enters or attacks, exile the top card of your library. If it's " +
+        "a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until " +
+        "the end of your next turn."
+
+    // Oxen you control have double strike.
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DOUBLE_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Ox").youControl()),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = bruseTarlBody
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = bruseTarlBody
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "198"
+        artist = "Forrest Imel"
+        flavorText = "\"I find a world where the herds finally listen to me, but now the " +
+            "plants have an attitude?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg?1712356070"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ErthaJoFrontierMentor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ErthaJoFrontierMentor.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.events.AbilityTargetMatch
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ertha Jo, Frontier Mentor
+ * {2}{R}{W}
+ * Legendary Creature — Kor Advisor
+ * 2/4
+ *
+ * When Ertha Jo enters, create a 1/1 red Mercenary creature token with "{T}: Target creature you
+ * control gets +1/+0 until end of turn. Activate only as a sorcery."
+ * Whenever you activate an ability that targets a creature or player, copy that ability. You may
+ * choose new targets for the copy.
+ *
+ * The copy clause reuses [Effects.CopyTargetSpellOrAbility] against
+ * [EffectTarget.TriggeringEntity] — for an `AbilityActivatedEvent` the triggering entity is the
+ * activated ability already on the stack, and the copy executor prompts for new targets (CR 707.10
+ * / 707.10c). Ertha Jo's own triggered ability is not an activated ability, so it doesn't recurse;
+ * the Mercenary token's `{T}:` ability does, so activating it copies the pump onto a second creature.
+ *
+ * The "targets a creature or player" restriction is enforced by
+ * [AbilityTargetMatch.CreatureOrPlayer] on the trigger — a non-targeting ability (tap-for-mana,
+ * etc.) never fires it.
+ */
+val ErthaJoFrontierMentor = card("Ertha Jo, Frontier Mentor") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Kor Advisor"
+    power = 2
+    toughness = 4
+    oracleText = "When Ertha Jo enters, create a 1/1 red Mercenary creature token with " +
+        "\"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n" +
+        "Whenever you activate an ability that targets a creature or player, copy that ability. " +
+        "You may choose new targets for the copy."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youActivateAbilityTargeting(AbilityTargetMatch.CreatureOrPlayer)
+        effect = Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Michal Ivan"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg?1712356089"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ObekaSplitterOfSeconds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ObekaSplitterOfSeconds.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Obeka, Splitter of Seconds
+ * {1}{U}{B}{R}
+ * Legendary Creature — Ogre Warlock
+ * 2/5
+ *
+ * Menace
+ * Whenever Obeka deals combat damage to a player, you get that many additional upkeep
+ * steps after this phase.
+ *
+ * Implementation:
+ * - The combat-damage trigger reads "that many" as
+ *   [DynamicAmount.ContextProperty]`(TRIGGER_DAMAGE_AMOUNT)` — the amount of combat damage
+ *   Obeka just dealt (mirrors The Key to the Vault).
+ * - "You get that many additional upkeep steps after this phase" →
+ *   [Effects.AddAdditionalUpkeepSteps]. Per CR 500.10, each added upkeep step creates the
+ *   beginning phase that normally contains it, with the untap and draw steps skipped; per
+ *   CR 500.8 these phases are inserted after the current phase (and after any additional
+ *   combat phases added to the same point). "At the beginning of upkeep" abilities trigger in
+ *   each (CR 503.1a). The TurnManager drains the queued count after the postcombat main phase.
+ */
+val ObekaSplitterOfSeconds = card("Obeka, Splitter of Seconds") {
+    manaCost = "{1}{U}{B}{R}"
+    colorIdentity = "UBR"
+    typeLine = "Legendary Creature — Ogre Warlock"
+    power = 2
+    toughness = 5
+    oracleText = "Menace\n" +
+        "Whenever Obeka deals combat damage to a player, you get that many additional upkeep " +
+        "steps after this phase."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.SELF
+        )
+        effect = Effects.AddAdditionalUpkeepSteps(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Ryan Pancoast"
+        flavorText = "\"You're living on borrowed time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg?1712356168"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TinybonesThePickpocket.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TinybonesThePickpocket.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Tinybones, the Pickpocket
+ * {B}
+ * Legendary Creature — Skeleton Rogue
+ * 1/1
+ *
+ * Deathtouch
+ * Whenever Tinybones deals combat damage to a player, you may cast target nonland permanent
+ * card from that player's graveyard, and mana of any type can be spent to cast that spell.
+ *
+ * Implementation:
+ * - The combat-damage trigger (binding SELF, `RecipientFilter.AnyPlayer`) puts the ability on
+ *   the stack, choosing a target nonland permanent card in an opponent's graveyard. Tinybones can
+ *   only deal combat damage to an opponent, so "that player" is the (sole) opponent whose graveyard
+ *   is scanned — modelled as a graveyard [TargetFilter] scoped to `ownedByOpponent()`.
+ * - On resolution the body gathers the chosen target ([CardSource.ChosenTargets]) and grants a
+ *   may-play-from-graveyard permission with `withAnyManaType = true`. The permission *is* the
+ *   "you may cast" optionality (the player chooses whether to cast it), and `withAnyManaType`
+ *   relaxes the spell's colored costs so mana of any type pays them — the same primitive Laughing
+ *   Jasper Flint / Cruelclaw's Heist use. The card is not moved out of the graveyard; the
+ *   enumerator already honours a `MayPlayPermission` on a graveyard card (Malcolm-style).
+ * - Per the Scryfall ruling, the cast happens as the ability resolves and can't be deferred to
+ *   later in the turn; the engine's established convention (Daring Waverider) models this
+ *   "cast during resolution" window as a may-play permission expiring at end of turn.
+ */
+val TinybonesThePickpocket = card("Tinybones, the Pickpocket") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Skeleton Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch\n" +
+        "Whenever Tinybones deals combat damage to a player, you may cast target nonland " +
+        "permanent card from that player's graveyard, and mana of any type can be spent to " +
+        "cast that spell."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.SELF,
+        )
+        target(
+            "target nonland permanent card from that player's graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent.ownedByOpponent(),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.ChosenTargets,
+                    storeAs = "stolenCard",
+                ),
+                GrantMayPlayFromExileEffect(
+                    from = "stolenCard",
+                    expiry = MayPlayExpiry.EndOfTurn,
+                    withAnyManaType = true,
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "109"
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg?1712355685"
+
+        ruling("2024-04-12", "You choose whether to cast the target nonland permanent card as " +
+            "Tinybones's triggered ability resolves. If you do, you do so as part of the resolution " +
+            "of that ability. You can't wait to cast it later in the turn. Timing restrictions based " +
+            "on the card's types are ignored.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2500,6 +2500,185 @@
     ]
 }
 
+// Bruse Tarl, Roving Rancher
+{
+    "name": "Bruse Tarl, Roving Rancher",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Oxen you control have double strike.\nWhenever Bruse Tarl enters or attacks, exile the top card of your library. If it's a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the end of your next turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "exiledCard",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "landCards",
+                            "storeNonMatching": "nonLandCards"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "landCards",
+                                    "filter": "land"
+                                }
+                            },
+                            "then": {
+                                "type": "CreateToken",
+                                "power": 2,
+                                "toughness": 2,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Ox"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg?1712316060"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "nonLandCards",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "CLEANUP",
+                                "includeCurrentTurn": false
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "exiledCard",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "landCards",
+                            "storeNonMatching": "nonLandCards"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "landCards",
+                                    "filter": "land"
+                                }
+                            },
+                            "then": {
+                                "type": "CreateToken",
+                                "power": 2,
+                                "toughness": 2,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Ox"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg?1712316060"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "nonLandCards",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "CLEANUP",
+                                "includeCurrentTurn": false
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Ox ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "RARE",
+        "artist": "Forrest Imel",
+        "flavorText": "\"I find a world where the herds finally listen to me, but now the plants have an attitude?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg?1712356070"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Bucolic Ranch
 {
     "name": "Bucolic Ranch",
@@ -5066,6 +5245,102 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Ertha Jo, Frontier Mentor
+{
+    "name": "Ertha Jo, Frontier Mentor",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Kor Advisor",
+    "oracleText": "When Ertha Jo enters, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever you activate an ability that targets a creature or player, copy that ability. You may choose new targets for the copy.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "targetMatch": {
+                        "type": "AbilityTargetAnyOf",
+                        "options": [
+                            {
+                                "type": "AbilityTargetObjectMatching",
+                                "filter": "creature"
+                            },
+                            "AbilityTargetAnyPlayer"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CopyTargetSpellOrAbility",
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Michal Ivan",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg?1712356089"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -11065,6 +11340,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1712356276"
     },
     "colorIdentityOverride": []
+}
+
+// Obeka, Splitter of Seconds
+{
+    "name": "Obeka, Splitter of Seconds",
+    "manaCost": "{1}{U}{B}{R}",
+    "typeLine": "Legendary Creature — Ogre Warlock",
+    "oracleText": "Menace\nWhenever Obeka deals combat damage to a player, you get that many additional upkeep steps after this phase.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddAdditionalUpkeepSteps",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "flavorText": "\"You're living on borrowed time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg?1712356168"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
 }
 
 // Omenport Vigilante
@@ -17817,6 +18138,71 @@
         "artist": "Wylie Beckert",
         "flavorText": "It was going to be the greatest heist of his unlife.",
         "imageUri": "https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg?1712355685"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Tinybones, the Pickpocket
+{
+    "name": "Tinybones, the Pickpocket",
+    "manaCost": "{B}",
+    "typeLine": "Legendary Creature — Skeleton Rogue",
+    "oracleText": "Deathtouch\nWhenever Tinybones deals combat damage to a player, you may cast target nonland permanent card from that player's graveyard, and mana of any type can be spent to cast that spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "stolenCard"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "stolenCard",
+                            "withAnyManaType": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent own:opponent",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target nonland permanent card from that player's graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "MYTHIC",
+        "artist": "Ekaterina Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg?1712355685",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You choose whether to cast the target nonland permanent card as Tinybones's triggered ability resolves. If you do, you do so as part of the resolution of that ability. You can't wait to cast it later in the turn. Timing restrictions based on the card's types are ignored."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -426,6 +426,8 @@ val engineSerializersModule = SerializersModule {
         subclass(EquipActivationsThisTurnComponent::class)
         subclass(WasDealtCombatDamageThisTurnComponent::class)
         subclass(AdditionalCombatPhasesComponent::class)
+        subclass(AdditionalUpkeepStepsComponent::class)
+        subclass(InAdditionalUpkeepStepComponent::class)
         subclass(CantCastSpellsComponent::class)
         subclass(CantActivateLoyaltyAbilitiesComponent::class)
         subclass(CardsLeftGraveyardThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -12,6 +12,8 @@ import com.wingedsheep.engine.state.components.combat.BlockingComponent
 import com.wingedsheep.engine.state.components.combat.MustAttackPlayerComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
+import com.wingedsheep.engine.state.components.player.AdditionalUpkeepStepsComponent
+import com.wingedsheep.engine.state.components.player.InAdditionalUpkeepStepComponent
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
 import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
 import com.wingedsheep.engine.state.components.player.ManaSpentOnSpellsThisTurnComponent
@@ -183,6 +185,30 @@ class TurnManager(
             return endTurn(state)
         }
 
+        // Leaving an inserted additional upkeep step (Obeka, Splitter of Seconds). Per CR 500.10
+        // the extra beginning phase has only its upkeep step (its untap and draw steps are
+        // skipped), and the game then returns to the phase after which the steps were added — the
+        // postcombat main phase. The active player gets priority there; when they pass, the
+        // POSTCOMBAT_MAIN drain below inserts the next remaining additional upkeep step (if any).
+        if (currentStep == Step.UPKEEP &&
+            state.getEntity(activePlayer)?.has<InAdditionalUpkeepStepComponent>() == true
+        ) {
+            var redirectedState = state.updateEntity(activePlayer) { container ->
+                container.without<InAdditionalUpkeepStepComponent>()
+            }
+            redirectedState = redirectedState.copy(
+                step = Step.POSTCOMBAT_MAIN,
+                phase = Phase.POSTCOMBAT_MAIN,
+                priorityPassedBy = emptySet()
+            )
+            val events = mutableListOf<GameEvent>(
+                PhaseChangedEvent(Phase.POSTCOMBAT_MAIN),
+                StepChangedEvent(Step.POSTCOMBAT_MAIN)
+            )
+            redirectedState = redirectedState.withPriority(activePlayer)
+            return ExecutionResult.success(redirectedState, events)
+        }
+
         // Check for additional combat phases (Aggravated Assault, etc.)
         if (currentStep == Step.POSTCOMBAT_MAIN) {
             val additionalPhases = state.getEntity(activePlayer)?.get<AdditionalCombatPhasesComponent>()
@@ -204,6 +230,41 @@ class TurnManager(
                 val events = mutableListOf<GameEvent>(
                     PhaseChangedEvent(Phase.COMBAT),
                     StepChangedEvent(Step.BEGIN_COMBAT)
+                )
+
+                redirectedState = redirectedState.withPriority(activePlayer)
+                return ExecutionResult.success(redirectedState, events)
+            }
+
+            // No more additional combat phases — now drain any additional upkeep steps
+            // (Obeka, Splitter of Seconds). Per the card's rulings, extra combat phases (created
+            // earlier) happen before the extra beginning phases, which is why this check follows
+            // the combat-phase check above. Each remaining count inserts one fresh beginning phase
+            // whose only step is the upkeep step (untap and draw skipped); the
+            // InAdditionalUpkeepStepComponent marker makes the redirect at the top of advanceStep
+            // send the game back here after that upkeep step, draining the next one until the
+            // count is exhausted, after which the turn proceeds to the postcombat main phase.
+            val additionalUpkeeps = state.getEntity(activePlayer)?.get<AdditionalUpkeepStepsComponent>()
+            if (additionalUpkeeps != null && additionalUpkeeps.count > 0) {
+                var redirectedState = if (additionalUpkeeps.count <= 1) {
+                    state.updateEntity(activePlayer) { it.without<AdditionalUpkeepStepsComponent>() }
+                } else {
+                    state.updateEntity(activePlayer) { container ->
+                        container.with(AdditionalUpkeepStepsComponent(additionalUpkeeps.count - 1))
+                    }
+                }
+
+                redirectedState = redirectedState
+                    .updateEntity(activePlayer) { it.with(InAdditionalUpkeepStepComponent) }
+                    .copy(
+                        step = Step.UPKEEP,
+                        phase = Phase.BEGINNING,
+                        priorityPassedBy = emptySet()
+                    )
+
+                val events = mutableListOf<GameEvent>(
+                    PhaseChangedEvent(Phase.BEGINNING),
+                    StepChangedEvent(Step.UPKEEP)
                 )
 
                 redirectedState = redirectedState.withPriority(activePlayer)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -36,8 +36,10 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.sdk.scripting.events.AbilityTargetMatch
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -241,8 +243,15 @@ class TriggerMatcher(
                 // The engine only emits AbilityActivatedEvent for non-mana activated abilities
                 // (mana abilities resolve without the stack), so this naturally matches
                 // "activates an ability that isn't a mana ability". Loyalty abilities qualify.
-                event is AbilityActivatedEvent &&
-                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+                if (event !is AbilityActivatedEvent) return false
+                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                val targetMatch = trigger.targetMatch
+                if (targetMatch != null) {
+                    // "...that targets a creature or player": the activated ability on the stack
+                    // must have at least one chosen target satisfying the constraint. A
+                    // non-targeting ability has no TargetsComponent and therefore never matches.
+                    matchesAbilityTargetConstraint(event.abilityEntityId, targetMatch, sourceId, controllerId, state)
+                } else true
             }
             is EventPattern.CycleEvent -> {
                 event is CardCycledEvent &&
@@ -1137,6 +1146,56 @@ class TriggerMatcher(
      * the mana-pool tracker is generalized to a `Set<Subtype>`; card
      * definitions can already declare them forward-compatibly.
      */
+    /**
+     * "Whenever you activate an ability that targets [a creature or player]" — true when the
+     * activated ability on the stack ([abilityEntityId]) has at least one chosen target satisfying
+     * [match]. The ability's chosen targets live on its [TargetsComponent]; a non-targeting ability
+     * has no such component, so this returns false (the trigger doesn't fire).
+     */
+    private fun matchesAbilityTargetConstraint(
+        abilityEntityId: EntityId?,
+        match: AbilityTargetMatch,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        state: GameState
+    ): Boolean {
+        if (abilityEntityId == null) return false
+        val targets = state.getEntity(abilityEntityId)?.get<TargetsComponent>()?.targets ?: return false
+        return targets.any { target -> matchesAbilityTarget(target, match, sourceId, controllerId, state) }
+    }
+
+    /** True if a single chosen target satisfies the [match] constraint. */
+    private fun matchesAbilityTarget(
+        target: ChosenTarget,
+        match: AbilityTargetMatch,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        state: GameState
+    ): Boolean = when (match) {
+        is AbilityTargetMatch.AnyPlayer -> target is ChosenTarget.Player
+        is AbilityTargetMatch.AnyOf -> match.options.any {
+            matchesAbilityTarget(target, it, sourceId, controllerId, state)
+        }
+        is AbilityTargetMatch.ObjectMatching -> {
+            val objectId = when (target) {
+                is ChosenTarget.Permanent -> target.entityId
+                is ChosenTarget.Card -> target.cardId
+                is ChosenTarget.Spell -> target.spellEntityId
+                is ChosenTarget.Player -> null
+            }
+            if (objectId == null) false
+            else {
+                val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
+                    controllerId = controllerId,
+                    sourceId = sourceId
+                )
+                predicateEvaluator.matches(
+                    state, state.projectedState, objectId, match.filter, predicateContext
+                )
+            }
+        }
+    }
+
     /**
      * Resolve one [AttackPredicate] against the runtime [AttackersDeclaredEvent].
      *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -766,16 +766,21 @@ class CastSpellHandler(
     }
 
     /**
-     * True if the spell is being cast from exile via a [com.wingedsheep.engine.state.permissions.MayPlayPermission]
-     * that allows mana of any type to be spent. The card must currently be in some exile
-     * zone (the card's owner's, which may be an opponent — e.g. Taster of Wares leaves the
-     * exiled card in the revealing player's exile), an active permission must be granted
-     * to the casting player with its condition gate open, and the `withAnyManaType` flag
-     * must be set on at least one of those active permissions.
+     * True if the spell is being cast via a [com.wingedsheep.engine.state.permissions.MayPlayPermission]
+     * that allows mana of any type to be spent. The card must currently be in a zone a may-play
+     * permission can grant casting from — exile (the card's owner's, which may be an opponent —
+     * e.g. Taster of Wares leaves the exiled card in the revealing player's exile) or a graveyard
+     * (per-card grants that leave the card in the graveyard — e.g. Tinybones, the Pickpocket lets
+     * you cast a targeted nonland permanent card from the damaged player's graveyard). An active
+     * permission must be granted to the casting player with its condition gate open, and the
+     * `withAnyManaType` flag must be set on at least one of those active permissions.
      */
     private fun isCastWithAnyManaType(state: GameState, action: CastSpell): Boolean {
-        val inExile = state.turnOrder.any { ownerId -> action.cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) }
-        if (!inExile) return false
+        val inGrantableZone = state.turnOrder.any { ownerId ->
+            action.cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) ||
+                action.cardId in state.getZone(ZoneKey(ownerId, Zone.GRAVEYARD))
+        }
+        if (!inGrantableZone) return false
         return state.activeMayPlayFor(action.cardId, action.playerId, conditionEvaluator)
             .any { it.withAnyManaType }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -99,7 +99,10 @@ class MiscContinuationResumer(
             state = state,
             ability = copy,
             targets = selectedTargets,
-            targetRequirements = continuation.targetRequirements
+            targetRequirements = continuation.targetRequirements,
+            // CR 707.10: a copy isn't activated — suppress the AbilityActivatedEvent so the copy
+            // doesn't itself re-trigger "whenever you activate an ability" abilities.
+            emitActivationEvent = false
         )
         if (!stackResult.isSuccess) return stackResult
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AddAdditionalUpkeepStepsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AddAdditionalUpkeepStepsExecutor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.AdditionalUpkeepStepsComponent
+import com.wingedsheep.sdk.scripting.effects.AddAdditionalUpkeepStepsEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [AddAdditionalUpkeepStepsEffect] (Obeka, Splitter of Seconds).
+ *
+ * "You get that many additional upkeep steps after this phase." Per CR 500.10a, the steps are
+ * always added to the controller's turn (the active player when this resolves — these effects only
+ * ever trigger off the controller's own combat damage, on the controller's turn). Accumulates the
+ * resolved amount onto an [AdditionalUpkeepStepsComponent] on the active player; the TurnManager
+ * drains it after the postcombat main phase, redirecting into a fresh beginning phase whose only
+ * step is the upkeep step (untap and draw skipped, CR 500.10).
+ */
+class AddAdditionalUpkeepStepsExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<AddAdditionalUpkeepStepsEffect> {
+
+    override val effectType: KClass<AddAdditionalUpkeepStepsEffect> =
+        AddAdditionalUpkeepStepsEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: AddAdditionalUpkeepStepsEffect,
+        context: EffectContext
+    ): EffectResult {
+        val activePlayer = state.activePlayerId
+            ?: return EffectResult.error(state, "No active player for AddAdditionalUpkeepStepsEffect")
+
+        val amount = amountEvaluator.evaluate(state, effect.amount, context)
+        if (amount <= 0) {
+            return EffectResult.success(state)
+        }
+
+        val existing = state.getEntity(activePlayer)?.get<AdditionalUpkeepStepsComponent>()
+        val newCount = (existing?.count ?: 0) + amount
+
+        val newState = state.updateEntity(activePlayer) { container ->
+            container.with(AdditionalUpkeepStepsComponent(count = newCount))
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -39,6 +39,7 @@ class PlayerExecutors(
 
     override fun executors(): List<EffectExecutor<*>> = listOf(
         AmassExecutor(effectExecutor),
+        AddAdditionalUpkeepStepsExecutor(),
         AddCombatPhaseExecutor(),
         AnyPlayerMayPayExecutor(executeEffect = effectExecutor),
         CantActivateLoyaltyAbilitiesExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellOrAbilityExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellOrAbilityExecutor.kt
@@ -86,7 +86,11 @@ class CopyTargetSpellOrAbilityExecutor(
         if (targetRequirements.isEmpty()) {
             val copy = source.copy(controllerId = context.controllerId)
             val stackResolver = StackResolver(cardRegistry = cardRegistry)
-            return EffectResult.from(stackResolver.putActivatedAbility(state, copy))
+            // CR 707.10: a copy isn't activated, so don't emit an AbilityActivatedEvent (it would
+            // re-fire "whenever you activate an ability" triggers off the copy).
+            return EffectResult.from(
+                stackResolver.putActivatedAbility(state, copy, emitActivationEvent = false)
+            )
         }
 
         // The source has targets — prompt the copier to choose new ones.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -561,12 +561,20 @@ class StackResolver(
 
     /**
      * Put an activated ability on the stack.
+     *
+     * [emitActivationEvent] is true for a genuine activation. A **copy** of an activated ability is
+     * *not* activated (CR 707.10), so the copy paths pass false to suppress the
+     * [AbilityActivatedEvent] — otherwise placing the copy would itself re-fire
+     * "whenever you activate an ability" triggers (e.g. Ertha Jo, Frontier Mentor would copy its own
+     * copies endlessly). The copy still becomes a stack object with its own targets, so
+     * `BecomesTargetEvent`/`TargetsChosenEvent` are still emitted below.
      */
     fun putActivatedAbility(
         state: GameState,
         ability: ActivatedAbilityOnStackComponent,
         targets: List<ChosenTarget> = emptyList(),
-        targetRequirements: List<TargetRequirement> = emptyList()
+        targetRequirements: List<TargetRequirement> = emptyList(),
+        emitActivationEvent: Boolean = true
     ): ExecutionResult {
         val (abilityId, stateWithId) = state.newEntity()
 
@@ -579,14 +587,17 @@ class StackResolver(
         newState = newState.pushToStack(abilityId)
             .copy(priorityPassedBy = emptySet())
 
-        val events = mutableListOf<GameEvent>(
-            AbilityActivatedEvent(
-                ability.sourceId,
-                ability.sourceName,
-                ability.controllerId,
-                abilityEntityId = abilityId
+        val events = mutableListOf<GameEvent>()
+        if (emitActivationEvent) {
+            events.add(
+                AbilityActivatedEvent(
+                    ability.sourceId,
+                    ability.sourceName,
+                    ability.controllerId,
+                    abilityEntityId = abilityId
+                )
             )
-        )
+        }
 
         if (CrimeDetector.isCrime(newState, ability.controllerId, targets)) {
             events.add(CommitCrimeEvent(ability.controllerId, abilityId, ability.sourceName))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -276,6 +276,35 @@ data class AdditionalCombatPhasesComponent(
 ) : Component
 
 /**
+ * Component tracking additional upkeep steps to be inserted into the current turn
+ * (Obeka, Splitter of Seconds). Per CR 500.10, adding a step after a phase creates the
+ * beginning phase that normally contains that step directly after the specified phase, with
+ * its other steps (untap and draw) skipped. Per CR 500.8, these extra phases occur after the
+ * current phase, and after any extra combat phases added to the same point (CR 500.8: the most
+ * recently created phase occurs first — combat phases are created before the upkeep phases here,
+ * so combat happens first).
+ *
+ * The TurnManager drains this at the postcombat-main → end transition, *after* the
+ * additional-combat-phase check, redirecting into a fresh beginning phase whose only step is the
+ * upkeep step. The count is decremented each time an additional upkeep step begins.
+ *
+ * @param count Number of additional upkeep steps (beginning phases) remaining to insert
+ */
+@Serializable
+data class AdditionalUpkeepStepsComponent(
+    val count: Int = 1
+) : Component
+
+/**
+ * Marker placed on the active player while the game is inside an inserted additional upkeep step
+ * (see [AdditionalUpkeepStepsComponent]). It tells the TurnManager that advancing out of this
+ * upkeep step must skip the draw step and return to the postcombat main phase (CR 500.10), rather
+ * than following the normal upkeep → draw progression. Consumed when that redirect happens.
+ */
+@Serializable
+data object InAdditionalUpkeepStepComponent : Component
+
+/**
  * Marker component indicating that a player should skip all combat phases
  * during their next turn. Applied by effects like False Peace.
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BruseTarlRovingRancherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BruseTarlRovingRancherScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.BruseTarlRovingRancher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bruse Tarl, Roving Rancher (OTJ) — {2}{R}{W} Legendary Creature — Human Warrior 4/3
+ *
+ * "Oxen you control have double strike.
+ *  Whenever Bruse Tarl enters or attacks, exile the top card of your library. If it's a
+ *  land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the
+ *  end of your next turn."
+ *
+ * Composes existing primitives (no new SDK surface): a [GrantKeyword] lord scoped to Oxen,
+ * two triggered abilities (enters / attacks) sharing a gather → exile → split body, a
+ * conditional Ox token on the land leg, and a may-play window on the non-land leg.
+ */
+class BruseTarlRovingRancherScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A vanilla Ox to check the double-strike lord.
+    val testOx = card("Test Ox") {
+        manaCost = "{2}"
+        typeLine = "Creature — Ox"
+        power = 2
+        toughness = 2
+        oracleText = ""
+    }
+
+    fun newDriver(deck: Deck): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BruseTarlRovingRancher)
+        driver.registerCard(testOx)
+        driver.initMirrorMatch(deck, skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Oxen you control have double strike") {
+        val driver = newDriver(Deck.of("Mountain" to 40))
+        val me = driver.player1
+
+        val ox = driver.putCreatureOnBattlefield(me, "Test Ox")
+        // No double strike before Bruse Tarl is in play.
+        projector.project(driver.state).hasKeyword(ox, Keyword.DOUBLE_STRIKE) shouldBe false
+
+        driver.putCreatureOnBattlefield(me, "Bruse Tarl, Roving Rancher")
+        projector.project(driver.state).hasKeyword(ox, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+
+    test("enters: land on top creates a 2/2 white Ox token") {
+        val driver = newDriver(Deck.of("Mountain" to 40))
+        val me = driver.player1
+
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+        val oxBefore = driver.getPermanents(me).count { driver.getCardName(it) == "Ox Token" }
+        val exileBefore = driver.getExile(me).size
+
+        // Cast Bruse Tarl so the enters trigger fires.
+        val bruse = driver.putCardInHand(me, "Bruse Tarl, Roving Rancher")
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, bruse)
+        driver.bothPass() // resolve Bruse -> enters trigger on stack
+        driver.bothPass() // resolve enters trigger
+
+        // The land was exiled (and stays there) and a 2/2 white Ox token was created.
+        driver.getExile(me).size shouldBe exileBefore + 1
+        val oxen = driver.getPermanents(me).filter { driver.getCardName(it) == "Ox Token" }
+        oxen.size shouldBe oxBefore + 1
+        driver.state.projectedState.getPower(oxen.single()) shouldBe 2
+        driver.state.projectedState.getToughness(oxen.single()) shouldBe 2
+    }
+
+    test("attacks: non-land on top is exiled and may be cast") {
+        val driver = newDriver(Deck.of("Centaur Courser" to 40))
+        val me = driver.player1
+
+        val bruse = driver.putCreatureOnBattlefield(me, "Bruse Tarl, Roving Rancher")
+        driver.removeSummoningSickness(bruse)
+
+        driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+        val exileBefore = driver.getExile(me).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(bruse), driver.player2)
+        driver.bothPass() // resolve attack trigger
+
+        driver.getExile(me).size shouldBe exileBefore + 1
+        val exiled = driver.getExile(me).last()
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ErthaJoFrontierMentorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ErthaJoFrontierMentorScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ErthaJoFrontierMentor
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ertha Jo, Frontier Mentor — {2}{R}{W} Legendary Creature — Kor Advisor 2/4
+ *
+ * "When Ertha Jo enters, create a 1/1 red Mercenary creature token with '{T}: Target creature you
+ *  control gets +1/+0 until end of turn. Activate only as a sorcery.'
+ *  Whenever you activate an ability that targets a creature or player, copy that ability. You may
+ *  choose new targets for the copy."
+ *
+ * Exercises the new `Triggers.youActivateAbilityTargeting(AbilityTargetMatch.CreatureOrPlayer)`
+ * trigger + matcher: the copy fires only when the activated ability targets a creature or player,
+ * and the copy reprompts for new targets (CR 707.10 / 707.10c) so a second creature can be hit.
+ */
+class ErthaJoFrontierMentorScenarioTest : FunSpec({
+
+    // Helper: a creature with a creature-targeting activated ability ("{T}: target creature you
+    // control gets +1/+0"). Used to drive Ertha Jo's copy trigger deterministically.
+    val pumpBuddy = card("Pump Buddy") {
+        manaCost = "{1}"
+        typeLine = "Creature — Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+            target = Targets.CreatureYouControl
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    // Helper: a creature with a NON-targeting activated ability ("{T}: you gain 1 life").
+    // Activating it must NOT fire Ertha Jo's copy trigger.
+    val lifeBuddy = card("Life Buddy") {
+        manaCost = "{1}"
+        typeLine = "Creature — Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: You gain 1 life."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.GainLife(1)
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ErthaJoFrontierMentor)
+        driver.registerCard(pumpBuddy)
+        driver.registerCard(lifeBuddy)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Ertha Jo's ETB creates a 1/1 red Mercenary token") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Cast Ertha Jo so the enters-the-battlefield trigger actually fires.
+        val ertha = driver.putCardInHand(me, "Ertha Jo, Frontier Mentor")
+        driver.giveColorlessMana(me, 2)
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 1)
+        driver.castSpell(me, ertha)
+        driver.bothPass() // resolve Ertha Jo -> ETB trigger on stack
+        driver.bothPass() // resolve ETB trigger -> create token
+
+        val mercenaries = driver.getCreatures(me).filter { driver.getCardName(it) == "Mercenary Token" }
+        mercenaries.size shouldBe 1
+        val merc = mercenaries.single()
+        driver.state.projectedState.getPower(merc) shouldBe 1
+        driver.state.projectedState.getToughness(merc) shouldBe 1
+    }
+
+    test("activating a creature-targeting ability copies it and a second creature can be pumped") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        // Ertha Jo's copy trigger is a battlefield triggered ability, so she just needs to be in
+        // play — no ETB needed here (the Mercenary token is irrelevant; Pump Buddy drives the test).
+        driver.putCreatureOnBattlefield(me, "Ertha Jo, Frontier Mentor")
+
+        val buddy = driver.putCreatureOnBattlefield(me, "Pump Buddy")
+        driver.removeSummoningSickness(buddy)
+
+        // Two other creatures to pump: creatureA (original target) and creatureB (copy's new target).
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val creatureB = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val pumpAbilityId = driver.cardRegistry.requireCard("Pump Buddy").activatedAbilities[0].id
+
+        // Activate "{T}: target creature you control gets +1/+0" targeting creatureA.
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = buddy,
+                abilityId = pumpAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+
+        // Ertha Jo's trigger goes on the stack above the original ability and copies it; the copy
+        // executor pauses for the "choose new targets" prompt. Aim the copy at creatureB.
+        var guard = 0
+        while (driver.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+            driver.bothPass()
+            guard++
+        }
+        (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(me, listOf(creatureB)).isSuccess shouldBe true
+
+        // Resolve everything (the copy, then the original ability).
+        guard = 0
+        while (driver.state.stack.isNotEmpty() && guard < 20) {
+            driver.bothPass()
+            guard++
+        }
+
+        // Both creatures got +1/+0 (original ability -> A, copy -> B).
+        driver.state.projectedState.getPower(creatureA) shouldBe 3
+        driver.state.projectedState.getPower(creatureB) shouldBe 3
+        driver.state.projectedState.getToughness(creatureA) shouldBe 2
+        driver.state.projectedState.getToughness(creatureB) shouldBe 2
+    }
+
+    test("activating a non-targeting ability does NOT trigger the copy") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putCreatureOnBattlefield(me, "Ertha Jo, Frontier Mentor")
+
+        val lifeGuy = driver.putCreatureOnBattlefield(me, "Life Buddy")
+        driver.removeSummoningSickness(lifeGuy)
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val gainAbilityId = driver.cardRegistry.requireCard("Life Buddy").activatedAbilities[0].id
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = lifeGuy,
+                abilityId = gainAbilityId
+            )
+        )
+
+        // No copy trigger should appear; resolve the stack.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard < 20) {
+            (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe false
+            driver.bothPass()
+            guard++
+        }
+
+        // The ability resolved exactly once: +1 life, not +2.
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ObekaSplitterOfSecondsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ObekaSplitterOfSecondsScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ObekaSplitterOfSeconds
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Obeka, Splitter of Seconds (OTJ) — {1}{U}{B}{R} Legendary Creature — Ogre Warlock 2/5
+ *
+ * "Menace
+ *  Whenever Obeka deals combat damage to a player, you get that many additional upkeep
+ *  steps after this phase."
+ *
+ * Exercises the new [Effects.AddAdditionalUpkeepSteps] / `AdditionalUpkeepStepsComponent` path:
+ * after Obeka (power 2) deals 2 combat damage, the controller gets two additional beginning
+ * phases each containing an upkeep step (untap/draw skipped, CR 500.10). We prove this with an
+ * "at the beginning of your upkeep" life-gain trigger on a witness permanent — it fires once in
+ * the normal upkeep and twice more in the two inserted upkeep steps (CR 503.1a).
+ */
+class ObekaSplitterOfSecondsScenarioTest : FunSpec({
+
+    // Witness permanent: gains 1 life at the beginning of each of its controller's upkeeps.
+    val upkeepWitness = card("Upkeep Witness") {
+        manaCost = "{1}"
+        typeLine = "Enchantment"
+        oracleText = "At the beginning of your upkeep, you gain 1 life."
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ObekaSplitterOfSeconds)
+        driver.registerCard(upkeepWitness)
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("dealing 2 combat damage grants two additional upkeep steps after combat") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val obeka = driver.putCreatureOnBattlefield(me, "Obeka, Splitter of Seconds")
+        driver.removeSummoningSickness(obeka)
+        driver.putPermanentOnBattlefield(me, "Upkeep Witness")
+
+        val lifeBefore = driver.getLifeTotal(me)
+
+        // Attack the opponent. Obeka is 2/2 -> deals 2 combat damage.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(obeka), driver.player2)
+        driver.bothPass() // first-strike / combat damage
+        // Resolve the Obeka combat-damage trigger (queues 2 additional upkeep steps).
+        driver.bothPass()
+
+        // Advance through the rest of the turn. The two additional beginning phases (each an
+        // upkeep step) are inserted after combat; the Upkeep Witness trigger fires in each, so the
+        // controller gains 2 life beyond the normal upkeep before reaching the end step.
+        driver.passPriorityUntil(Step.END)
+
+        // 2 extra upkeep steps => +2 life from the witness (the normal upkeep already passed
+        // before combat this turn, so these are purely the inserted ones).
+        driver.getLifeTotal(me) shouldBe lifeBefore + 2
+    }
+
+    test("no combat damage means no additional upkeep steps") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.putCreatureOnBattlefield(me, "Obeka, Splitter of Seconds")
+        driver.putPermanentOnBattlefield(me, "Upkeep Witness")
+
+        val lifeBefore = driver.getLifeTotal(me)
+
+        // Never attack; just move to the end step.
+        driver.passPriorityUntil(Step.END)
+
+        driver.getLifeTotal(me) shouldBe lifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TinybonesThePickpocketScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TinybonesThePickpocketScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TinybonesThePickpocket
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tinybones, the Pickpocket (OTJ) — {B} Legendary Creature — Skeleton Rogue 1/1.
+ *
+ * "Deathtouch
+ *  Whenever Tinybones deals combat damage to a player, you may cast target nonland permanent
+ *  card from that player's graveyard, and mana of any type can be spent to cast that spell."
+ *
+ * Exercises the graveyard `withAnyManaType` may-play grant: after Tinybones connects, the
+ * controller targets a nonland permanent card in the opponent's graveyard and gains permission to
+ * cast it paying its (color-relaxed) cost from the graveyard. A land/instant in that graveyard is
+ * not a legal target.
+ */
+class TinybonesThePickpocketScenarioTest : FunSpec({
+
+    // A green creature card to be stolen from the opponent's graveyard. Its {G}{G} cost proves the
+    // "mana of any type can be spent" relaxation — we pay it from Swamps (black mana).
+    val greenCreature = card("Pickpocket Test Bear") {
+        manaCost = "{G}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    // An instant — a nonpermanent card; must NOT be a legal target.
+    val cheapInstant = card("Pickpocket Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        oracleText = "Pickpocket Test Bolt deals 3 damage to any target."
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TinybonesThePickpocket)
+        driver.registerCard(greenCreature)
+        driver.registerCard(cheapInstant)
+        driver.initMirrorMatch(Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castActionsFor(playerId: EntityId, cardId: EntityId): List<CastSpell> =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, playerId)
+            .mapNotNull { it.action as? CastSpell }
+            .filter { it.cardId == cardId }
+
+    test("combat damage lets you cast a targeted nonland permanent card from the opponent's graveyard with any mana") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        // Tinybones (mine) attacks; a green creature sits in the opponent's graveyard.
+        val tinybones = driver.putCreatureOnBattlefield(me, "Tinybones, the Pickpocket")
+        driver.removeSummoningSickness(tinybones)
+        val stolenCard = driver.putCardInGraveyard(opponent, "Pickpocket Test Bear")
+        // Off-color (black) mana sources: tapping these for the {G}{G} cost proves "mana of any
+        // type can be spent" — the permission relaxes the colored pips.
+        repeat(2) { driver.putLandOnBattlefield(me, "Swamp") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(tinybones), opponent)
+
+        // Drive combat damage + the Tinybones trigger to resolution. The trigger's target is the
+        // green creature in the opponent's graveyard; choose it when the targeting decision appears.
+        // Stop once the may-play permission has been granted.
+        run {
+            repeat(20) {
+                if (driver.state.mayPlayPermissions.any { stolenCard in it.cardIds }) return@run
+                when (driver.pendingDecision) {
+                    is ChooseTargetsDecision -> driver.submitTargetSelection(me, listOf(stolenCard))
+                    null -> driver.bothPass()
+                    else -> driver.autoResolveDecision()
+                }
+            }
+        }
+
+        // The trigger granted a may-play permission for the stolen card (still in the graveyard).
+        driver.state.mayPlayPermissions.any { stolenCard in it.cardIds } shouldBe true
+
+        // Advance to my postcombat main phase, where this sorcery-speed creature can be cast.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // The granted permission relaxes the colored cost so any mana type pays it.
+        driver.state.mayPlayPermissions.single { stolenCard in it.cardIds }.withAnyManaType shouldBe true
+
+        // The card is now castable from the opponent's graveyard via the granted permission.
+        driver.castActionsFor(me, stolenCard).isNotEmpty().shouldBeTrue()
+
+        // Tap the Swamps (black mana) to pay the {G}{G} cost — possible only because mana of any
+        // type can be spent to cast it.
+        driver.castSpell(me, stolenCard).isSuccess shouldBe true
+        repeat(4) {
+            if (driver.pendingDecision != null) driver.autoResolveDecision() else driver.bothPass()
+            if (driver.state.getZone(me, Zone.BATTLEFIELD).contains(stolenCard)) return@repeat
+        }
+
+        // The stolen creature resolved onto my battlefield (I control it).
+        driver.state.getZone(me, Zone.BATTLEFIELD).contains(stolenCard).shouldBeTrue()
+        driver.state.getEntity(stolenCard)?.get<CardComponent>()?.name shouldBe "Pickpocket Test Bear"
+    }
+
+    test("a nonpermanent card in the opponent's graveyard is not a legal target") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        val tinybones = driver.putCreatureOnBattlefield(me, "Tinybones, the Pickpocket")
+        driver.removeSummoningSickness(tinybones)
+        // Only an instant in the opponent's graveyard — no nonland permanent card.
+        driver.putCardInGraveyard(opponent, "Pickpocket Test Bolt")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(tinybones), opponent)
+        driver.bothPass() // combat damage
+
+        // With no legal target, the triggered ability is removed (no target-selection decision
+        // surfaces) and nothing becomes castable from the opponent's graveyard.
+        driver.passPriorityUntil(Step.END)
+
+        val instantId = driver.getGraveyard(opponent).first { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == "Pickpocket Test Bolt"
+        }
+        driver.castActionsFor(me, instantId) shouldBe emptyList()
+    }
+})


### PR DESCRIPTION
Implements four Outlaws of Thunder Junction legendary creatures, building the engine/SDK each needed.

## Cards
- **Obeka, Splitter of Seconds** ({1}{U}{B}{R}, 2/5) — Menace; combat-damage trigger grants "that many additional upkeep steps after this phase." New `Effects.AddAdditionalUpkeepSteps` + `AdditionalUpkeepStepsComponent`; `TurnManager` drains the queued count after the postcombat main phase (each added upkeep step makes the beginning phase that contains it, untap/draw skipped — CR 500.8 / 500.10).
- **Ertha Jo, Frontier Mentor** ({2}{R}{W}, 2/4) — ETB makes a 1/1 red Mercenary with a sorcery-speed pump; "whenever you activate an ability that targets a creature or player, copy that ability." New `Triggers.youActivateAbilityTargeting(AbilityTargetMatch.CreatureOrPlayer)` feeding `Effects.CopyTargetSpellOrAbility(TriggeringEntity)`.
- **Bruse Tarl, Roving Rancher** ({2}{R}{W}, 4/3) — Oxen-you-control lord (double strike); enters/attacks impulse: exile top card, land → 2/2 white Ox token, else may-cast until end of your next turn.
- **Tinybones, the Pickpocket** ({B}, 1/1) — Deathtouch; combat-damage trigger lets you cast a targeted nonland permanent card from the damaged player's graveyard with mana of any type. Reuses the `GrantMayPlayFromExile(withAnyManaType)` primitive over `CardSource.ChosenTargets`; the card stays in the graveyard (Malcolm-style grant).

## Engine fix (Tinybones)
`CastSpellHandler.isCastWithAnyManaType` was gated to EXILE only, so a graveyard-located may-play permission relaxed colored pips in the legal-action enumerator but not in the cast handler's payment. Widened it to also accept a graveyard zone, so "mana of any type can be spent" works end-to-end for graveyard grants. Small, general correction — not card-specific.

## Verification
- Four passing scenario tests; full `:rules-engine` + `:mtg-sets` suites green (CardLintTest, FacadeBoundaryTest, CardDefinitionSnapshotTest re-blessed).
- mtgish: all four cards correctly **decline to SCAFFOLD** (no lossy auto-emit). OTJ `coverage-verify` stays at the 7 pre-existing mismatches (Cactusfolk Sureshot, Freestrider Lookout, High Noon, Mirage Mesa, One Last Job, The Key to the Vault, Thunder Lasso) — **no new mismatches**. POR stays **GATE PASS / 0-mismatch (158/158)**.
- SDK reference (`withAnyManaType` graveyard note) and OTJ engine-gaps notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)