### PR TITLE
Add OTJ batch 2: Ghired, Jace Reawakened, Kellan, Kraum

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1816,6 +1816,12 @@ matcher branch — `SpellCastEvent` does not grow a new field per axis.
 - `SpellCastPredicate.CastFromZone(zone)` — spell was cast from this zone. Used for Sunbird's
   Invocation (`Zone.HAND`), Goliath Daydreamer's instant/sorcery-from-hand trigger,
   Wildsear's enchantment-from-hand cascade.
+- `SpellCastPredicate.CastFromZoneOtherThan(zone)` — the negation: spell was cast from a known
+  zone that is *not* [zone]. Fires only on an actual cast from a different recorded zone (a spell
+  with no recorded cast zone does not satisfy it). Used by Kellan, the Kid — "Whenever you cast a
+  spell from anywhere other than your hand" (`CastFromZoneOtherThan(Zone.HAND)`): casts from
+  exile (Adventure / plotted), graveyard (flashback), or the top of library all match; hand casts
+  don't.
 - `SpellCastPredicate.WasKicked` — spell was cast with kicker (CR 702.32). Used for
   Hallar / Bloodstone Goblin.
 - `SpellCastPredicate.PaidWithManaFromSubtype(subtype)` — mana from a permanent of this
@@ -3346,6 +3352,13 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
     `DynamicAmount.TotalManaSpent`, which reads the *current resolving object's own* cast — this
     reads the **triggering** spell's cast (the payoff lives on a separate permanent). Populated
     from `SpellCastEvent.totalManaSpent`; `0` for non-cast triggers.
+  - `TRIGGERING_SPELL_MANA_VALUE` — mana value (CR 202.3) of the spell that fired the trigger
+    (Kellan, the Kid — "a permanent spell with equal or lesser mana value"). Distinct from
+    `MANA_SPENT_ON_TRIGGERING_SPELL` (mana actually paid): this is the spell's printed mana
+    value, unaffected by cost reductions / alternative costs / X. Populated from
+    `SpellCastEvent.manaValue`; `0` for non-cast triggers. Pair with
+    `CollectionFilter.ManaValueAtMost(ContextProperty(TRIGGERING_SPELL_MANA_VALUE))` to bound a
+    gathered collection by the triggering spell's mana value.
   - `TRIGGER_SCRY_COUNT` — cards looked at by the scry that fired the trigger (Celeborn the
     Wise, Elrond Master of Healing). Equals the scry N parameter.
   - `TRIGGER_EXCESS_DAMAGE_AMOUNT` — damage past lethal in the trigger payload (CR 120.4a).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1950,10 +1950,14 @@ object Effects {
 
     /**
      * Cast the (0..1) card stored under [from] without paying its mana cost. The card must
-     * already be in a zone where casting is legal (e.g. exile after a move/copy step).
+     * already be in a zone where casting is legal (e.g. exile after a move/copy step, or the
+     * hand for "you may cast … from your hand without paying its mana cost"). When [storeCastTo]
+     * is set, the cast card's id is published to that pipeline collection on a successful cast,
+     * so an enclosing [IfYouDo] with [SuccessCriterion.CollectionNonEmpty] can gate the
+     * "if you don't, …" branch (Kellan, the Kid).
      */
-    fun CastFromCollectionWithoutPayingCost(from: String): Effect =
-        CastFromCollectionWithoutPayingCostEffect(from = from)
+    fun CastFromCollectionWithoutPayingCost(from: String, storeCastTo: String? = null): Effect =
+        CastFromCollectionWithoutPayingCostEffect(from = from, storeCastTo = storeCastTo)
 
     /**
      * Cast the (0..1) card stored under [from], **paying its normal mana cost** (the "you may

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -357,6 +357,22 @@ sealed interface SpellCastPredicate {
         }
     }
 
+    /**
+     * The spell was cast from a zone *other than* [zone] — the negation of [CastFromZone].
+     * Used for "whenever you cast a spell from anywhere other than your hand" (Kellan, the Kid):
+     * `CastFromZoneOtherThan(Zone.HAND)`. A spell with no recorded cast zone (synthetic / put
+     * directly on the stack) does not satisfy this — only an actual cast from a different known
+     * zone counts.
+     */
+    @SerialName("SpellCastFromZoneOtherThan")
+    @Serializable
+    data class CastFromZoneOtherThan(val zone: Zone) : SpellCastPredicate {
+        override val description = when (zone) {
+            Zone.HAND -> "from anywhere other than your hand"
+            else -> "from anywhere other than your ${zone.displayName.lowercase()}"
+        }
+    }
+
     /** The spell was cast with kicker (CR 702.32). */
     @SerialName("SpellWasKicked")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -156,6 +156,14 @@ enum class ContextPropertyKey(val description: String) {
      */
     MANA_SPENT_ON_TRIGGERING_SPELL("the amount of mana spent to cast that spell"),
     /**
+     * Mana value (CR 202.3) of the spell that fired this trigger. Distinct from
+     * [MANA_SPENT_ON_TRIGGERING_SPELL] (mana actually paid) — this reads the spell's printed
+     * mana value, unaffected by cost reductions / alternative costs. Populated from
+     * `SpellCastEvent.manaValue`; `0` when the trigger was not driven by a spell cast. Used by
+     * Kellan, the Kid — "a permanent spell with equal or lesser mana value."
+     */
+    TRIGGERING_SPELL_MANA_VALUE("the mana value of that spell"),
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Equals the
      * scry N parameter unless the library held fewer cards. Read by "Whenever you scry,
      * ... for each card looked at" payoffs (Celeborn the Wise, Elrond Master of Healing).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GhiredMirrorOfTheWilds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GhiredMirrorOfTheWilds.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ghired, Mirror of the Wilds
+ * {R}{G}{W}
+ * Legendary Creature — Human Shaman
+ * 3/3
+ *
+ * Haste
+ * Nontoken creatures you control have "{T}: Create a token that's a copy of target token
+ * you control that entered this turn."
+ *
+ * The granted ability is a lord-style [GrantActivatedAbility] over `nontoken creatures you
+ * control`. Each granted instance taps its own bearer ([Costs.Tap]) and targets a *token*
+ * permanent the controller owns that entered the battlefield this turn
+ * (`GameObjectFilter.Token.youControl().enteredThisTurn()`), then makes a copy of it via
+ * [Effects.CreateTokenCopyOfTarget].
+ */
+val GhiredMirrorOfTheWilds = card("Ghired, Mirror of the Wilds") {
+    manaCost = "{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Creature — Human Shaman"
+    power = 3
+    toughness = 3
+    oracleText = "Haste\n" +
+        "Nontoken creatures you control have \"{T}: Create a token that's a copy of " +
+        "target token you control that entered this turn.\""
+
+    keywords(Keyword.HASTE)
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.CreateTokenCopyOfTarget(EffectTarget.ContextTarget(0)),
+                targetRequirement = TargetPermanent(
+                    filter = TargetFilter(
+                        GameObjectFilter.Token.youControl().enteredThisTurn(),
+                    ),
+                ),
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().nontoken()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "205"
+        artist = "Diego Gisbert"
+        flavorText = "\"The Conclave was soft. The Clans were trapped beasts. Here in this " +
+            "untamed wilderness, nature can truly roam free.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg?1712356098"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/JaceReawakened.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/JaceReawakened.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MakePlottedEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Jace Reawakened
+ * {U}{U}
+ * Legendary Planeswalker — Jace
+ * Starting Loyalty: 3
+ *
+ * You can't cast Jace Reawakened during your first, second, or third turns of the game.
+ * +1: Draw a card, then discard a card.
+ * +1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.
+ * −6: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.
+ *
+ * The cast restriction is expressed as `castOnlyIf(NOT controller-turns-taken ≤ 3)` — i.e. it can
+ * only be cast once the controller has taken at least four turns. The +1 plot mode reuses the OTJ
+ * gather → choose-up-to-one (nonland, MV ≤ 3) → exile → [MakePlottedEffect] pipeline (CR 718); the
+ * `ChooseUpTo(1)` over the filtered hand is the "you may" fork, and `MakePlottedEffect` no-ops on an
+ * empty selection so declining is safe. The −6 ultimate installs a copy-each-spell-cast effect over
+ * *any* spell (not just instants/sorceries) for the turn; the engine's copy creation already offers
+ * "you may choose new targets for the copy."
+ */
+val JaceReawakened = card("Jace Reawakened") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Planeswalker — Jace"
+    startingLoyalty = 3
+    oracleText = "You can't cast Jace Reawakened during your first, second, or third turns of the game.\n" +
+        "+1: Draw a card, then discard a card.\n" +
+        "+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n" +
+        "−6: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy."
+
+    // "You can't cast Jace Reawakened during your first, second, or third turns of the game."
+    spell {
+        castOnlyIf(Conditions.Not(Conditions.ControllerTurnsTakenAtMost(3)))
+    }
+
+    // +1: Draw a card, then discard a card.
+    loyaltyAbility(+1) {
+        effect = Effects.DrawCards(1).then(Patterns.Hand.discardCards(1))
+    }
+
+    // +1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.
+    loyaltyAbility(+1) {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                CardSource.FromZone(Zone.HAND, filter = GameObjectFilter.Nonland.manaValueAtMost(3)),
+                storeAs = "handCards",
+            ),
+            SelectFromCollectionEffect(
+                from = "handCards",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Nonland.manaValueAtMost(3),
+                storeSelected = "toPlot",
+                selectedLabel = "Exile and plot",
+            ),
+            MoveCollectionEffect(from = "toPlot", destination = CardDestination.ToZone(Zone.EXILE)),
+            MakePlottedEffect(from = "toPlot"),
+        )
+    }
+
+    // −6: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.
+    loyaltyAbility(-6) {
+        effect = Effects.CopyEachSpellCast(copies = 1, spellFilter = GameObjectFilter.Any)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "271"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg?1712356388"
+
+        ruling("2024-04-12", "Jace Reawakened's last ability copies any spell you cast, not just instant and sorcery spells. The copy is created on the stack, so it's not \"cast.\"")
+        ruling("2024-04-12", "A plotted card is exiled face up. You may cast it as a sorcery on a later turn without paying its mana cost, but not on the turn it became plotted.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/KellanTheKid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/KellanTheKid.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kellan, the Kid
+ * {G}{W}{U}
+ * Legendary Creature — Human Faerie Rogue
+ * 3/3
+ *
+ * Flying, lifelink
+ * Whenever you cast a spell from anywhere other than your hand, you may cast a permanent spell
+ * with equal or lesser mana value from your hand without paying its mana cost. If you don't,
+ * you may put a land card from your hand onto the battlefield.
+ *
+ * The trigger uses the negated cast-source predicate [SpellCastPredicate.CastFromZoneOtherThan]
+ * (Zone.HAND) — it fires only on casts from a known zone that is not the hand (Adventure/exile,
+ * plotted cards, flashback, top of library, …).
+ *
+ * The payoff is an [Effects.IfYouDo]: the *action* gathers permanent cards from hand, filters
+ * them to mana value ≤ the triggering spell's mana value
+ * ([ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE]), lets you choose up to one, and casts it for
+ * free (publishing the cast id to `kellanCast`). Success is gated on that collection being
+ * non-empty; "if you don't" (no permanent cast) offers the optional "put a land from your hand
+ * onto the battlefield" via the choose-up-to-one [Patterns.Hand.putFromHand].
+ */
+val KellanTheKid = card("Kellan, the Kid") {
+    manaCost = "{G}{W}{U}"
+    colorIdentity = "GWU"
+    typeLine = "Legendary Creature — Human Faerie Rogue"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, lifelink\n" +
+        "Whenever you cast a spell from anywhere other than your hand, you may cast a permanent " +
+        "spell with equal or lesser mana value from your hand without paying its mana cost. If " +
+        "you don't, you may put a land card from your hand onto the battlefield."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            requires = setOf(SpellCastPredicate.CastFromZoneOtherThan(Zone.HAND)),
+        )
+        effect = Effects.IfYouDo(
+            action = Effects.Composite(
+                GatherCardsEffect(
+                    CardSource.FromZone(Zone.HAND, filter = GameObjectFilter.Permanent),
+                    storeAs = "kellanCandidates",
+                ),
+                FilterCollectionEffect(
+                    from = "kellanCandidates",
+                    filter = CollectionFilter.ManaValueAtMost(
+                        DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE),
+                    ),
+                    storeMatching = "kellanEligible",
+                ),
+                SelectFromCollectionEffect(
+                    from = "kellanEligible",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "kellanChosen",
+                    selectedLabel = "Cast without paying its mana cost",
+                ),
+                Effects.CastFromCollectionWithoutPayingCost("kellanChosen", storeCastTo = "kellanCast"),
+            ),
+            ifYouDo = Effects.Composite(emptyList()),
+            ifYouDont = Patterns.Hand.putFromHand(GameObjectFilter.Land),
+            successCriterion = SuccessCriterion.CollectionNonEmpty("kellanCast"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "213"
+        artist = "Magali Villeneuve"
+        flavorText = "\"I found out who I was. Now it's time to discover who I am.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg?1712356134"
+
+        ruling("2024-04-12", "Kellan's ability resolves before the spell that caused it to trigger.")
+        ruling("2024-04-12", "If you cast a permanent spell this way, you don't get to put a land onto the battlefield, even if you couldn't cast a spell with equal or lesser mana value.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/KraumViolentCacophony.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/KraumViolentCacophony.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kraum, Violent Cacophony
+ * {2}{U}{R}
+ * Legendary Creature — Zombie Horror
+ * 2/3
+ *
+ * Flying
+ * Whenever you cast your second spell each turn, put a +1/+1 counter on Kraum and draw a card.
+ *
+ * The trigger uses the per-player Nth-spell tracker scoped to [Player.You] (it watches *your*
+ * spell count, not any player's). Only the second spell each turn fires it.
+ */
+val KraumViolentCacophony = card("Kraum, Violent Cacophony") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Zombie Horror"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever you cast your second spell each turn, put a +1/+1 counter on Kraum and draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Artur Nakhodkin"
+        flavorText = "Concerned for his apprentice's welfare, Ludevic sent his greatest creation " +
+            "to make sure Geralf got into the right kind of trouble."
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg?1712356134"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -7124,6 +7124,70 @@
     ]
 }
 
+// Ghired, Mirror of the Wilds
+{
+    "name": "Ghired, Mirror of the Wilds",
+    "manaCost": "{R}{G}{W}",
+    "typeLine": "Legendary Creature — Human Shaman",
+    "oracleText": "Haste\nNontoken creatures you control have \"{T}: Create a token that's a copy of target token you control that entered this turn.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "CreateTokenCopyOfTarget",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsToken"
+                                    ],
+                                    "statePredicates": [
+                                        "EnteredThisTurn"
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "creature nontoken ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "MYTHIC",
+        "artist": "Diego Gisbert",
+        "flavorText": "\"The Conclave was soft. The Clans were trapped beasts. Here in this untamed wilderness, nature can truly roam free.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg?1712356098"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Giant Beaver
 {
     "name": "Giant Beaver",
@@ -9218,6 +9282,168 @@
     ]
 }
 
+// Jace Reawakened
+{
+    "name": "Jace Reawakened",
+    "manaCost": "{U}{U}",
+    "typeLine": "Legendary Planeswalker — Jace",
+    "oracleText": "You can't cast Jace Reawakened during your first, second, or third turns of the game.\n+1: Draw a card, then discard a card.\n+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n−6: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "nonland mv<=3"
+                            },
+                            "storeAs": "handCards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "handCards",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "nonland mv<=3",
+                            "storeSelected": "toPlot",
+                            "selectedLabel": "Exile and plot"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toPlot",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "MakePlotted",
+                            "from": "toPlot"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -6
+                },
+                "effect": {
+                    "type": "CopyEachSpellCast",
+                    "spellFilter": {}
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "ControllerTurnsTakenAtMost",
+                        "threshold": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "MYTHIC",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg?1712356388",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Jace Reawakened's last ability copies any spell you cast, not just instant and sorcery spells. The copy is created on the stack, so it's not \"cast.\""
+            },
+            {
+                "date": "2024-04-12",
+                "text": "A plotted card is exiled face up. You may cast it as a sorcery on a later turn without paying its mana cost, but not on the turn it became plotted."
+            }
+        ]
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Jagged Barrens
 {
     "name": "Jagged Barrens",
@@ -9839,6 +10065,210 @@
         "GREEN",
         "BLUE",
         "WHITE"
+    ]
+}
+
+// Kellan, the Kid
+{
+    "name": "Kellan, the Kid",
+    "manaCost": "{G}{W}{U}",
+    "typeLine": "Legendary Creature — Human Faerie Rogue",
+    "oracleText": "Flying, lifelink\nWhenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellCastFromZoneOtherThan",
+                            "zone": "Hand"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand",
+                                        "filter": "permanent"
+                                    },
+                                    "storeAs": "kellanCandidates"
+                                },
+                                {
+                                    "type": "FilterCollection",
+                                    "from": "kellanCandidates",
+                                    "filter": {
+                                        "type": "ManaValueAtMost",
+                                        "max": {
+                                            "type": "ContextProperty",
+                                            "key": "TRIGGERING_SPELL_MANA_VALUE"
+                                        }
+                                    },
+                                    "storeMatching": "kellanEligible"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "kellanEligible",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "kellanChosen",
+                                    "selectedLabel": "Cast without paying its mana cost"
+                                },
+                                {
+                                    "type": "CastFromCollectionWithoutPayingCost",
+                                    "from": "kellanChosen",
+                                    "storeCastTo": "kellanCast"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "kellanCast"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": []
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "land"
+                                },
+                                "storeAs": "put_candidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "put_candidates",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "putting"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "putting",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"I found out who I was. Now it's time to discover who I am.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg?1712356134",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Kellan's ability resolves before the spell that caused it to trigger."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you cast a permanent spell this way, you don't get to put a land onto the battlefield, even if you couldn't cast a spell with equal or lesser mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Kraum, Violent Cacophony
+{
+    "name": "Kraum, Violent Cacophony",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Legendary Creature — Zombie Horror",
+    "oracleText": "Flying\nWhenever you cast your second spell each turn, put a +1/+1 counter on Kraum and draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Nakhodkin",
+        "flavorText": "Concerned for his apprentice's welfare, Ludevic sent his greatest creation to make sure Geralf got into the right kind of trouble.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg?1712356134"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -78,6 +78,10 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // loot, rendered by the emitter as MayEffect(IfYouDoEffect(...)). Universal condition vocabulary.
     supported("CostWasPaid", "condition: the optional cost was paid (IfYouDoEffect linkage)")
     supported("WasCastFromTheirHand", "predicate: spell cast from the player's hand (fromZone = HAND)")
+    // The negation — "a spell from anywhere other than your hand" (Kellan, the Kid). Backed by
+    // SpellCastPredicate.CastFromZoneOtherThan(Zone.HAND). The trigger itself is coverable even
+    // though Kellan's free-cast-or-play-land body declines to SCAFFOLD in the emitter.
+    supported("WasntCastFromTheirHand", "predicate: spell cast from a zone other than the player's hand (CastFromZoneOtherThan(HAND))")
     // Source-relative Mount/Vehicle payoff filter: "a creature that crewed/saddled it this turn"
     // (Giant Beaver) -> GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn().
     supported("SaddledPermanentThisTurn", "filter: a creature that saddled this permanent this turn (crewedOrSaddledSourceThisTurn)")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -66,6 +66,11 @@ internal fun BridgeBuilder.zoneMovement() {
     // mid-resolution CastFromCollectionWithoutPayingCostEffect over a card just exiled by the look
     // pipeline (Sunbird's Invocation / Goliath Daydreamer shape).
     composed("CastExiledCardWithoutPaying", "CastFromCollectionWithoutPayingCost over the exiled card", composes = listOf("CastFromCollectionWithoutPayingCost"))
+    // "You may cast a [filtered] spell from your hand without paying its mana cost" (Kellan, the
+    // Kid). Gather hand -> FilterCollection(ManaValueAtMost(...)) -> CastFromCollectionWithoutPayingCost.
+    // Coverable as a composition even though Kellan's full free-cast-or-play-land body declines to
+    // SCAFFOLD in the emitter.
+    composed("CastASpellFromHandWithoutPaying", "CastFromCollectionWithoutPayingCost over a hand-gathered, MV-bounded collection", composes = listOf("CastFromCollectionWithoutPayingCost"))
     // "Exile target spell" (CR 718 — Aven Interrupter). Not a counter (ignores can't-be-countered);
     // the spell leaves the stack and fails to resolve. Maps to ExileTargetSpellEffect; the paired
     // `CreateExiledCardEffect[IsPlotted]` sub-action sets `makePlotted = true` (the exiled card

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -78,7 +78,10 @@ data class TriggeredAbilityContinuation(
     val triggerRecipientToughness: Int? = null,
     /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
      *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
-    val triggerManaSpentOnTriggeringSpell: Int? = null
+    val triggerManaSpentOnTriggeringSpell: Int? = null,
+    /** Mana value of the spell that fired this trigger (Kellan, the Kid). Read via
+     *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
+    val triggerManaValueOfTriggeringSpell: Int? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -336,7 +336,15 @@ data class SpellCastEvent(
      * `ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL` for cards like Riku of Many
      * Paths whose triggered ability scales by the cast's mode count.
      */
-    val chosenModesCount: Int = 0
+    val chosenModesCount: Int = 0,
+    /**
+     * Mana value of the cast spell (CR 202.3), captured at cast time. Distinct from
+     * [totalManaSpent] (actual mana paid, which can differ with cost reductions, alternative
+     * costs, or X). Feeds `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE` so payoffs that key
+     * off "a spell with equal or lesser mana value" (Kellan, the Kid) read the printed value of
+     * the spell that fired the trigger, not the mana spent on it.
+     */
+    val manaValue: Int = 0
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -77,6 +77,13 @@ data class TriggerContext(
      */
     val manaSpentOnTriggeringSpell: Int? = null,
     /**
+     * For SpellCastEvent triggers — mana value (CR 202.3) of the triggering spell. `null` when
+     * the trigger was not driven by a spell cast. Read by
+     * `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE` so abilities like Kellan, the Kid can
+     * gate "a permanent spell with equal or lesser mana value."
+     */
+    val manaValueOfTriggeringSpell: Int? = null,
+    /**
      * Power of the creature the trigger's source (an Aura/Equipment) was attached to, captured
      * when the trigger fired. Carried as last-known information (CR 608.2h) so that an
      * "enchanted creature deals damage equal to its power" ability still uses the right power
@@ -155,7 +162,8 @@ data class TriggerContext(
                     triggeringEntityId = event.spellEntityId,
                     triggeringPlayerId = event.casterId,
                     modesChosenCount = event.chosenModesCount.takeIf { it > 0 },
-                    manaSpentOnTriggeringSpell = event.totalManaSpent.takeIf { it > 0 }
+                    manaSpentOnTriggeringSpell = event.totalManaSpent.takeIf { it > 0 },
+                    manaValueOfTriggeringSpell = event.manaValue.takeIf { it > 0 }
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is com.wingedsheep.engine.core.ScriedEvent -> TriggerContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1220,6 +1220,11 @@ class TriggerMatcher(
             val spellComponent = state.getEntity(event.spellEntityId)?.get<SpellOnStackComponent>()
             spellComponent?.castFromZone == predicate.zone
         }
+        is SpellCastPredicate.CastFromZoneOtherThan -> {
+            val spellComponent = state.getEntity(event.spellEntityId)?.get<SpellOnStackComponent>()
+            val from = spellComponent?.castFromZone
+            from != null && from != predicate.zone
+        }
         SpellCastPredicate.WasKicked -> event.wasKicked
         is SpellCastPredicate.PaidWithManaFromSubtype -> when (predicate.subtype) {
             Subtype.TREASURE -> event.paidWithTreasureMana
@@ -1252,7 +1257,8 @@ class TriggerMatcher(
                 triggerScryCount = trigger.triggerContext.scryCount,
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
-                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
+                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
             )
             conditionEvaluator.evaluate(state, condition, context)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -571,7 +571,8 @@ class TriggerProcessor(
                 triggerScryCount = trigger.triggerContext.scryCount,
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
-                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
+                triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
             )
             ability.effect.runtimeDescription { amount -> evaluator.evaluate(state, amount, context) }
         } catch (_: Exception) {
@@ -620,7 +621,8 @@ class TriggerProcessor(
             triggerScryCount = trigger.triggerContext.scryCount,
             triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
-            triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell
+            triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+            triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
         )
 
         // Push the continuation onto the stack
@@ -676,6 +678,7 @@ class TriggerProcessor(
             triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
             triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+            triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
             capturedEntityIds = trigger.triggerContext.capturedEntityIds ?: emptyList()
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -506,6 +506,8 @@ class DynamicAmountEvaluator(
 
         ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL -> context.triggerManaSpentOnTriggeringSpell ?: 0
 
+        ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE -> context.triggerManaValueOfTriggeringSpell ?: 0
+
         ContextPropertyKey.TRIGGER_SCRY_COUNT -> context.triggerScryCount ?: 0
 
         ContextPropertyKey.TRIGGER_EXCESS_DAMAGE_AMOUNT -> context.triggerExcessDamageAmount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -179,6 +179,12 @@ data class EffectContext(
      */
     val triggerManaSpentOnTriggeringSpell: Int? = null,
     /**
+     * Mana value (CR 202.3) of the spell that fired this trigger. Read by
+     * `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE` (Kellan, the Kid). Distinct from
+     * [triggerManaSpentOnTriggeringSpell], which is the mana actually paid.
+     */
+    val triggerManaValueOfTriggeringSpell: Int? = null,
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Read by
      * `ContextPropertyKey.TRIGGER_SCRY_COUNT` (Celeborn the Wise, Elrond Master of Healing).
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -101,7 +101,8 @@ class EffectAndTriggerContinuationResumer(
                 triggerScryCount = continuation.triggerScryCount,
                 triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
                 triggerRecipientToughness = continuation.triggerRecipientToughness,
-                triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell
+                triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
+                triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
             )
             val stackResult = services.stackResolver.putTriggeredAbility(state, elseComponent, emptyList())
             if (!stackResult.isSuccess) return stackResult
@@ -150,7 +151,8 @@ class EffectAndTriggerContinuationResumer(
             triggerScryCount = continuation.triggerScryCount,
             triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
             triggerRecipientToughness = continuation.triggerRecipientToughness,
-            triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell
+            triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
+            triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
         )
 
         val stackResult = services.stackResolver.putTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -326,7 +326,8 @@ class StackResolver(
                 wasKicked = wasKicked,
                 totalManaSpent = totalManaSpent,
                 paidWithTreasureMana = paidWithTreasureMana,
-                chosenModesCount = reportedChosenModesCount
+                chosenModesCount = reportedChosenModesCount,
+                manaValue = cardComponent.manaValue
             )
         )
 
@@ -1912,6 +1913,7 @@ class StackResolver(
             triggerExcessDamageAmount = abilityComponent.triggerExcessDamageAmount,
             triggerRecipientToughness = abilityComponent.triggerRecipientToughness,
             triggerManaSpentOnTriggeringSpell = abilityComponent.triggerManaSpentOnTriggeringSpell,
+            triggerManaValueOfTriggeringSpell = abilityComponent.triggerManaValueOfTriggeringSpell,
             xValue = abilityComponent.xValue,
             damageDistribution = abilityComponent.damageDistribution,
             chosenModes = abilityComponent.chosenModes,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -138,6 +138,9 @@ data class TriggeredAbilityOnStackComponent(
     /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
      *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
     val triggerManaSpentOnTriggeringSpell: Int? = null,
+    /** Mana value (CR 202.3) of the spell that fired this trigger (Kellan, the Kid). Read via
+     *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
+    val triggerManaValueOfTriggeringSpell: Int? = null,
     // Modal fields — populated when this triggered ability is a copy of a modal spell (700.2g).
     // Copies inherit the original's chosen modes; targets either inherit too (StormCopy default)
     // or are re-chosen by the copy controller while modes stay fixed.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1540,7 +1540,8 @@ class ClientStateTransformer(
         triggerScryCount = triggered.triggerScryCount,
         triggerExcessDamageAmount = triggered.triggerExcessDamageAmount,
         triggerRecipientToughness = triggered.triggerRecipientToughness,
-        triggerManaSpentOnTriggeringSpell = triggered.triggerManaSpentOnTriggeringSpell
+        triggerManaSpentOnTriggeringSpell = triggered.triggerManaSpentOnTriggeringSpell,
+        triggerManaValueOfTriggeringSpell = triggered.triggerManaValueOfTriggeringSpell
     )
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhiredMirrorOfTheWildsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhiredMirrorOfTheWildsScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Ghired, Mirror of the Wilds.
+ *
+ * Ghired, Mirror of the Wilds ({R}{G}{W}): Legendary Creature — Human Shaman, 3/3, Haste.
+ * "Nontoken creatures you control have '{T}: Create a token that's a copy of target token
+ * you control that entered this turn.'"
+ */
+class GhiredMirrorOfTheWildsScenarioTest : ScenarioTestBase() {
+
+    private fun grantedAbilityId() =
+        cardRegistry.getCard("Ghired, Mirror of the Wilds")!!.staticAbilities
+            .filterIsInstance<GrantActivatedAbility>().first().ability.id
+
+    init {
+        context("Ghired grants nontoken creatures the token-copy ability") {
+
+            test("a nontoken creature can tap to copy a token that entered this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ghired, Mirror of the Wilds")
+                    // A nontoken creature that receives the granted ability.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // A token that "entered this turn" — the legal target.
+                    .withCardOnBattlefield(1, "Grizzly Bears", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ghired = game.findPermanent("Ghired, Mirror of the Wilds")!!
+                // Distinguish the nontoken bears from the token bears.
+                val bearsIds = game.getClientState(1).cards.values
+                    .filter { it.name == "Grizzly Bears" }
+                    .map { it.id }
+                val nontokenBears = bearsIds.first { id ->
+                    game.state.getEntity(id)?.has<TokenComponent>() != true
+                }
+                val tokenBears = bearsIds.first { id ->
+                    game.state.getEntity(id)?.has<TokenComponent>() == true
+                }
+
+                // Mark the token as having entered this turn.
+                game.state = game.state.updateEntity(tokenBears) { c ->
+                    c.with(EnteredThisTurnComponent)
+                }
+
+                // The nontoken bears (not Ghired itself the only one — but any nontoken
+                // creature you control) must have the granted ability available.
+                val tokenCountBefore = game.state.getZone(game.player1Id, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)
+                    .count { game.state.getEntity(it)?.has<TokenComponent>() == true }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = nontokenBears,
+                        abilityId = grantedAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(tokenBears)),
+                    ),
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val tokenCountAfter = game.state.getZone(game.player1Id, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)
+                    .count { game.state.getEntity(it)?.has<TokenComponent>() == true }
+
+                withClue("A new token copy should have been created") {
+                    tokenCountAfter shouldBe tokenCountBefore + 1
+                }
+                // Ghired is unrelated to whether it taps — make sure it wasn't consumed.
+                game.state.getEntity(ghired) shouldNotBe null
+            }
+
+            test("a token that did NOT enter this turn is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ghired, Mirror of the Wilds")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsIds = game.getClientState(1).cards.values
+                    .filter { it.name == "Grizzly Bears" }
+                    .map { it.id }
+                val nontokenBears = bearsIds.first { id ->
+                    game.state.getEntity(id)?.has<TokenComponent>() != true
+                }
+                val tokenBears = bearsIds.first { id ->
+                    game.state.getEntity(id)?.has<TokenComponent>() == true
+                }
+
+                // Note: we deliberately do NOT stamp EnteredThisTurnComponent on the token.
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = nontokenBears,
+                        abilityId = grantedAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(tokenBears)),
+                    ),
+                )
+                withClue("Activation should fail: token did not enter this turn") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JaceReawakenedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JaceReawakenedScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.PlottedComponent
+import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.JaceReawakened
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Jace Reawakened.
+ *
+ * Jace Reawakened ({U}{U}): Legendary Planeswalker — Jace, starting loyalty 3.
+ * - Can't be cast during your first/second/third turns of the game.
+ * - +1: Draw a card, then discard a card.
+ * - +1: You may exile a nonland card with mana value 3 or less from your hand; it becomes plotted.
+ * - −6: Until end of turn, whenever you cast a spell, copy it. You may choose new targets.
+ */
+class JaceReawakenedScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JaceReawakened))
+        return driver
+    }
+
+    /** Force the active player's "turns taken this game" so the cast-restriction condition flips. */
+    fun GameTestDriver.setTurnsTaken(playerId: com.wingedsheep.sdk.model.EntityId, count: Int) {
+        replaceState(state.updateEntity(playerId) { c -> c.with(PlayerTurnsTakenComponent(count = count)) })
+    }
+
+    test("cannot be cast during the first three turns of the game") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Player has taken their first turn — casting Jace must be illegal.
+        driver.setTurnsTaken(player, 1)
+        val jace = driver.putCardInHand(player, "Jace Reawakened")
+        driver.giveMana(player, Color.BLUE, 2)
+
+        val result = driver.submit(CastSpell(playerId = player, cardId = jace))
+        result.error shouldNotBe null
+        // Still in hand.
+        (jace in driver.state.getZone(ZoneKey(player, Zone.HAND))) shouldBe true
+    }
+
+    test("can be cast once the controller has taken four or more turns") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setTurnsTaken(player, 4)
+        val jace = driver.putCardInHand(player, "Jace Reawakened")
+        driver.giveMana(player, Color.BLUE, 2)
+
+        val result = driver.submit(CastSpell(playerId = player, cardId = jace))
+        result.error shouldBe null
+        driver.bothPass() // resolve onto the battlefield
+
+        driver.state.getBattlefield().any {
+            driver.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?.name == "Jace Reawakened"
+        } shouldBe true
+    }
+
+    test("+1 plot: exile a nonland MV<=3 card from hand and it becomes plotted") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val jace = driver.putPermanentOnBattlefield(player, "Jace Reawakened")
+        // An MV-3 nonland creature, eligible to plot (MV <= 3).
+        val courser = driver.putCardInHand(player, "Centaur Courser")
+        // A high-MV card that must NOT be eligible (MV 12).
+        driver.putCardInHand(player, "Ghalta, Primal Hunger")
+
+        val plotAbility = driver.cardRegistry.requireCard("Jace Reawakened")
+            .script.activatedAbilities.first { it.description.contains("plotted", ignoreCase = true) }
+
+        driver.submit(ActivateAbility(player, jace, plotAbility.id))
+        driver.bothPass() // resolve the loyalty ability
+
+        // Resolution pauses to let the controller choose the card to exile and plot.
+        driver.submitCardSelection(player, listOf(courser))
+
+        (courser in driver.state.getZone(ZoneKey(player, Zone.EXILE))) shouldBe true
+        driver.state.getEntity(courser)?.get<PlottedComponent>() shouldNotBe null
+    }
+
+    test("+1 loot: draw a card, then discard a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val jace = driver.putPermanentOnBattlefield(player, "Jace Reawakened")
+        val discardFodder = driver.putCardInHand(player, "Island")
+        val handBefore = driver.state.getZone(ZoneKey(player, Zone.HAND)).size
+
+        // The first loyalty ability (index 0) is the +1 "draw a card, then discard a card" loot.
+        val lootAbility = driver.cardRegistry.requireCard("Jace Reawakened")
+            .script.activatedAbilities[0]
+
+        driver.submit(ActivateAbility(player, jace, lootAbility.id))
+        driver.bothPass() // resolve: draw, then a discard selection pauses
+
+        driver.submitCardSelection(player, listOf(discardFodder))
+
+        // Net hand size: +1 draw, -1 discard = unchanged.
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).size shouldBe handBefore
+        (discardFodder in driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD))) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanTheKidScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanTheKidScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.KellanTheKid
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Kellan, the Kid.
+ *
+ * Kellan, the Kid ({G}{W}{U}): Legendary Creature — Human Faerie Rogue, 3/3, Flying, lifelink.
+ * "Whenever you cast a spell from anywhere other than your hand, you may cast a permanent spell
+ *  with equal or lesser mana value from your hand without paying its mana cost. If you don't, you
+ *  may put a land card from your hand onto the battlefield."
+ *
+ * Exercises the new SpellCastPredicate.CastFromZoneOtherThan trigger predicate and the
+ * TRIGGERING_SPELL_MANA_VALUE dynamic amount.
+ */
+class KellanTheKidScenarioTest : FunSpec({
+
+    // A {2}{R} sorcery (mana value 3) castable from the graveyard — the "cast from anywhere
+    // other than your hand" enabler.
+    val graveyardSpell = card("Kellan Test Graveyard Spell") {
+        manaCost = "{2}{R}"
+        typeLine = "Sorcery"
+        oracleText = "Test sorcery castable from the graveyard."
+        spell { effect = Effects.GainLife(1) }
+        staticAbility { ability = MayCastSelfFromZones(zones = listOf(Zone.GRAVEYARD)) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KellanTheKid))
+        driver.registerCard(graveyardSpell)
+        return driver
+    }
+
+    test("casting a spell from the graveyard lets you free-cast a permanent of equal or lesser MV") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 10))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Kellan, the Kid")
+
+        // Centaur Courser is a {2}{G} (MV 3) permanent — eligible (3 <= 3).
+        driver.putCardInHand(player, "Centaur Courser")
+        val gySpell = driver.putCardInGraveyard(player, "Kellan Test Graveyard Spell")
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        val creaturesBefore = driver.getCreatures(player).size
+
+        // Cast the sorcery from the graveyard — Kellan's trigger fires.
+        driver.submit(
+            CastSpell(playerId = player, cardId = gySpell, paymentStrategy = PaymentStrategy.AutoPay),
+        )
+        // Resolve the trigger (it goes on top of the sorcery).
+        driver.passPriority(player)
+        driver.passPriority(opponent)
+
+        // Trigger resolution pauses to choose the permanent to free-cast.
+        driver.submitCardSelection(player, listOf(driver.findCardInHand(player, "Centaur Courser")!!))
+        // Let any free-cast / follow-up settle.
+        driver.bothPass()
+
+        // Centaur Courser was cast for free and is now a creature on the battlefield.
+        driver.getCreatures(player).any {
+            driver.state.getEntity(it)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Centaur Courser"
+        } shouldBe true
+        driver.getCreatures(player).size shouldBe creaturesBefore + 1
+    }
+
+    test("declining the free cast lets you put a land from hand instead") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 10))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Kellan, the Kid")
+
+        driver.putCardInHand(player, "Centaur Courser")
+        val forest = driver.putCardInHand(player, "Forest")
+        val gySpell = driver.putCardInGraveyard(player, "Kellan Test Graveyard Spell")
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        driver.submit(
+            CastSpell(playerId = player, cardId = gySpell, paymentStrategy = PaymentStrategy.AutoPay),
+        )
+        driver.passPriority(player)
+        driver.passPriority(opponent)
+
+        // Decline the free cast (choose no permanent).
+        driver.submitCardSelection(player, emptyList())
+        // Now the "if you don't" branch offers putting a land — choose the Forest.
+        driver.submitCardSelection(player, listOf(forest))
+        driver.bothPass()
+
+        (forest in driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))) shouldBe true
+    }
+
+    test("casting a spell from hand does NOT trigger Kellan") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 10))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Kellan, the Kid")
+        driver.putCardInHand(player, "Centaur Courser")
+        val handSpell = driver.putCardInHand(player, "Kellan Test Graveyard Spell")
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        val creaturesBefore = driver.getCreatures(player).size
+
+        // Cast the sorcery from hand — no trigger, so no free cast.
+        driver.submit(
+            CastSpell(playerId = player, cardId = handSpell, paymentStrategy = PaymentStrategy.AutoPay),
+        )
+        driver.bothPass()
+
+        // No new permanent entered from a free cast.
+        driver.getCreatures(player).size shouldBe creaturesBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KraumViolentCacophonyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KraumViolentCacophonyScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.KraumViolentCacophony
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Kraum, Violent Cacophony.
+ *
+ * Kraum, Violent Cacophony: {2}{U}{R}
+ * Legendary Creature — Zombie Horror
+ * 2/3
+ * Flying
+ * Whenever you cast your second spell each turn, put a +1/+1 counter on Kraum and draw a card.
+ */
+class KraumViolentCacophonyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KraumViolentCacophony))
+        return driver
+    }
+
+    test("your second spell each turn grows Kraum and draws a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Lightning Bolt" to 30),
+            startingLife = 20,
+        )
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kraum = driver.putCreatureOnBattlefield(player1, "Kraum, Violent Cacophony")
+
+        // First spell — no trigger.
+        val bolt1 = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt1, listOf(player2))
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+
+        driver.state.projectedState.getPower(kraum) shouldBe 2
+        driver.state.projectedState.getToughness(kraum) shouldBe 3
+
+        // Second spell — trigger fires.
+        val bolt2 = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt2, listOf(player2))
+        // bolt2 is on the stack; hand size here is the baseline before the trigger draw.
+        val handOnStack = driver.getHandSize(player1)
+
+        // Resolve the trigger (top of stack).
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+
+        // Kraum grew and controller drew a card.
+        driver.state.projectedState.getPower(kraum) shouldBe 3
+        driver.state.projectedState.getToughness(kraum) shouldBe 4
+        driver.getHandSize(player1) shouldBe handOnStack + 1
+
+        // Resolve the bolt.
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+    }
+
+    test("does not trigger on the first spell, nor on the third spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Lightning Bolt" to 30),
+            startingLife = 20,
+        )
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kraum = driver.putCreatureOnBattlefield(player1, "Kraum, Violent Cacophony")
+
+        // First spell.
+        val bolt1 = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt1, listOf(player2))
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+        driver.state.projectedState.getPower(kraum) shouldBe 2
+
+        // Second spell — fires once.
+        val bolt2 = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt2, listOf(player2))
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+        driver.state.projectedState.getPower(kraum) shouldBe 3
+
+        // Third spell — no further trigger.
+        val bolt3 = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt3, listOf(player2))
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+
+        driver.state.projectedState.getPower(kraum) shouldBe 3
+        driver.state.projectedState.getToughness(kraum) shouldBe 4
+    }
+
+    test("opponent casting their second spell does not trigger Kraum") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Lightning Bolt" to 30),
+            startingLife = 20,
+        )
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kraum = driver.putCreatureOnBattlefield(player1, "Kraum, Violent Cacophony")
+
+        driver.passPriority(player1)
+
+        val bolt1 = driver.putCardInHand(player2, "Lightning Bolt")
+        driver.giveMana(player2, Color.RED, 1)
+        driver.castSpell(player2, bolt1, listOf(player1))
+        driver.passPriority(player2)
+        driver.passPriority(player1)
+
+        driver.passPriority(player1)
+
+        val bolt2 = driver.putCardInHand(player2, "Lightning Bolt")
+        driver.giveMana(player2, Color.RED, 1)
+        driver.castSpell(player2, bolt2, listOf(player1))
+        driver.passPriority(player2)
+        driver.passPriority(player1)
+        driver.passPriority(player1)
+        driver.passPriority(player2)
+
+        // Kraum belongs to player1; player2's second spell does not grow it.
+        driver.state.projectedState.getPower(kraum) shouldBe 2
+        driver.state.projectedState.getToughness(kraum) shouldBe 3
+    }
+})


### PR DESCRIPTION
Implements four **Outlaws of Thunder Junction** cards.

## Cards

| Card | Type | New SDK? |
|------|------|----------|
| **Kraum, Violent Cacophony** | {2}{U}{R} Legendary Creature, 2/3, Flying | No — pure composition |
| **Ghired, Mirror of the Wilds** | {R}{G}{W} Legendary Creature, 3/3, Haste | No — existing lord/grant + token-copy |
| **Jace Reawakened** | {U}{U} Legendary Planeswalker, loyalty 3 | No — existing primitives composed |
| **Kellan, the Kid** | {G}{W}{U} Legendary Creature, 3/3, Flying/Lifelink | Yes — see below |

### Kraum, Violent Cacophony
"Whenever you cast your second spell each turn, put a +1/+1 counter on Kraum and draw a card." — `Triggers.NthSpellCast(2, Player.You)` + `Composite(AddCounters(+1/+1, Self), DrawCards(1))`.

### Ghired, Mirror of the Wilds
"Nontoken creatures you control have '{T}: Create a token that's a copy of target token you control that entered this turn.'" — `GrantActivatedAbility` over `Creature.youControl().nontoken()`, granting `{T}` + `CreateTokenCopyOfTarget` targeting `Token.youControl().enteredThisTurn()`.

### Jace Reawakened
- Cast restriction: `spell { castOnlyIf(Not(ControllerTurnsTakenAtMost(3))) }` (can't cast turns 1–3).
- +1: loot (`DrawCards(1).then(Patterns.Hand.discardCards(1))`).
- +1: plot a nonland MV≤3 from hand (gather → choose-up-to-1 → exile → `MakePlotted`).
- −6: `CopyEachSpellCast(spellFilter = Any)` for the turn.

### Kellan, the Kid (needed `add-feature`)
"Whenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield."

Two new, reusable SDK primitives:
- **`SpellCastPredicate.CastFromZoneOtherThan(zone)`** — the negation of `CastFromZone`; fires only on a cast from a known zone that isn't the given one (+ `TriggerMatcher` branch).
- **`ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`** — the triggering spell's mana value (CR 202.3), threaded `SpellCastEvent.manaValue` → `TriggerContext` → stack component → `EffectContext` → `DynamicAmountEvaluator`, parallel to the existing `MANA_SPENT_ON_TRIGGERING_SPELL`.

Payoff modeled as `IfYouDo(free-cast a permanent with MV ≤ triggering-spell MV from hand, ifYouDont = put a land from hand)`, gated on `SuccessCriterion.CollectionNonEmpty`. Also added an optional `storeCastTo` to the `CastFromCollectionWithoutPayingCost` facade.

## mtgish-tooling
- Bridge: `WasntCastFromTheirHand` → `CastFromZoneOtherThan(HAND)`, and `CastASpellFromHandWithoutPaying` → composed over `CastFromCollectionWithoutPayingCost`. Kellan now scores **COVERABLE-NOW**.
- Kraum already auto-emits (**AUTO**); Ghired/Jace/Kellan correctly stay declined (SCAFFOLD / NOT-EMITTED) — no lossy approximation emitted.
- `coverage-verify POR` stays **0-mismatch (158/158)**. OTJ's pre-existing 7 gameplay-tree mismatches are unrelated (not in the CI gate; none are these cards).

## Tests
- New scenario tests for all four cards in `rules-engine` (all green), covering the cast restriction, plot, the new trigger predicate, the MV-bounded free cast, and the "if you don't, play a land" branch.
- Full `rules-engine` + `mtg-sets` + `mtgish-tooling` suites pass.
- OTJ card snapshot re-blessed — only the four new cards added, no other card moved.
- `CardLintTest` passes.
- `docs/card-sdk-language-reference.md` updated for both new SDK building blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)