### PR TITLE
Fix landing-page disclaimer overlapping content on mobile

### DIFF
--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -2995,12 +2995,16 @@
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    font-size: 11px;
-    line-height: 1.45;
-    padding: 10px 14px;
+    gap: 2px;
+    font-size: 10px;
+    line-height: 1.35;
+    padding: 7px 12px;
+    border-radius: 10px;
+    background: rgba(8, 8, 16, 0.45);
+    border-color: rgba(255, 255, 255, 0.06);
   }
 
   .attributionDisclaimer {
-    font-size: 10px;
+    font-size: 9px;
   }
 }

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -2980,3 +2980,27 @@
   color: #cfe7ff;
   text-decoration-color: rgba(207, 231, 255, 0.9);
 }
+
+/*
+ * On narrow screens the overlay scrolls and the absolutely-pinned attribution
+ * floats over the content (it overlapped the public-lobby panel). Drop it back
+ * into normal flow so it sits below the content as a full-width footer.
+ * Placed after the base rules so these overrides win at equal specificity.
+ */
+@media (max-width: 639px) {
+  .attribution {
+    position: static;
+    transform: none;
+    margin: var(--space-2) auto 0;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    font-size: 11px;
+    line-height: 1.45;
+    padding: 10px 14px;
+  }
+
+  .attributionDisclaimer {
+    font-size: 10px;
+  }
+}


### PR DESCRIPTION
## Problem

On mobile, the attribution/disclaimer footer on the landing page overlapped the **Public Lobbies** panel (and the *online* badge), making both unreadable.

The footer is `position: absolute; bottom: 12px`, pinning it to the bottom of the scrollable connection overlay. On narrow screens the menu content is tall enough to scroll, so the pinned footer floated *over* the content rather than sitting below it.

## Fix

On screens ≤639px:
- Drop the attribution back into normal document flow as a full-width footer below the content (kills the overlap).
- Make it more compact for the small viewport — smaller font (10px / 9px disclaimer), tighter line-height, padding and gap, and lighter background/border so it reads as a subtle footer rather than a heavy card.

Desktop (the centered pill pinned to the bottom) is unchanged — the override lives in a `max-width: 639px` media query placed after the base rules so it wins at equal specificity.

Single-file CSS change in `GameUI.module.css`. `npm run typecheck` passes.

## Screenshots

**Mobile — before (disclaimer overlaps the Public Lobbies panel):**

![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/92b664b0da8baf34e8c78fca0c7a1444e8f3b977/mobile-before.png)

**Mobile — after (compact footer flows below the content):**

![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/92b664b0da8baf34e8c78fca0c7a1444e8f3b977/mobile-after.png)

**Desktop — unchanged:**

![desktop](https://raw.githubusercontent.com/wingedsheep/argentum-engine/92b664b0da8baf34e8c78fca0c7a1444e8f3b977/desktop-after.png)

> Screenshots are hosted on the throwaway `mobile-disclaimer-screenshots` branch (not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)