### PR TITLE
Fix saddle action menu not appearing in UI

### DIFF
--- a/web-client/src/hooks/useLegalActions.ts
+++ b/web-client/src/hooks/useLegalActions.ts
@@ -108,6 +108,8 @@ export function useCardActions(cardId: EntityId | null): LegalActionInfo[] {
           return a.sourceId === cardId
         case 'CrewVehicle':
           return a.vehicleId === cardId
+        case 'SaddleMount':
+          return a.mountId === cardId
         case 'UnlockRoomDoor':
           return a.roomId === cardId
         default:
@@ -176,6 +178,8 @@ function getActionCardId(action: GameAction): EntityId | null {
       return action.sourceId
     case 'CrewVehicle':
       return action.vehicleId
+    case 'SaddleMount':
+      return action.mountId
     case 'UnlockRoomDoor':
       return action.roomId
     default:


### PR DESCRIPTION
## Problem

The saddle ability didn't work in the UI: the server correctly reported the saddle action as legal, but clicking the Mount card never opened the action menu, so there was no way to select it.

## Root cause

`useCardActions` in `web-client/src/hooks/useLegalActions.ts` filters the server's `legalActions` down to those belonging to the clicked card. It had a `case 'CrewVehicle'` matching `vehicleId`, but **no `case 'SaddleMount'`** — so a `SaddleMount` action fell through to `default: return false`. Clicking a Mount therefore returned zero actions, and `ActionMenu` (which only renders when `cardActions.length > 0`) never opened.

The parallel grouping helper `getActionCardId` in the same file had the same omission.

Notably, every *other* part of the saddle flow was already wired up and shared with crew — the action-menu button (`ActionMenu.tsx`), the tap-for-power selection HUD (`TapForPowerSelector.tsx`), and the confirm/submit path (`selectionSlice.ts`) all handle `SaddleMount`. Only this card→action mapping was missing, which is why "a legal action exists but no menu appears" was the exact symptom.

## Fix

Add the missing `SaddleMount` → `mountId` cases in both switches, mirroring the existing `CrewVehicle` handling.

## Testing

- `npm run typecheck` passes.
- Saddle reuses the identical client flow as crew (same `TapForPowerSelectionState`, same HUD, same submit), which already works — this change just makes the menu open when a Mount is clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)