### PR TITLE
Add QR code to join a lobby from another device

### DIFF
--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "keyrune": "^3.19.0",
         "mana-font": "^1.18.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-router-dom": "^7.16.0",
@@ -1607,6 +1608,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "keyrune": "^3.19.0",
     "mana-font": "^1.18.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.16.0",

--- a/web-client/src/components/lobby/JoinLobbyPage.tsx
+++ b/web-client/src/components/lobby/JoinLobbyPage.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useGameStore } from '@/store/gameStore.ts'
+
+/**
+ * Entry point for the `/join/:lobbyId` deep link — the target of a lobby's QR code / share link.
+ *
+ * Lobby-kind agnostic: it always joins via `joinQuickGameLobby`, whose server handler delegates to
+ * the tournament join handler when the id is a tournament lobby. So one link/QR covers Quick Game,
+ * sealed/draft and tournament lobbies alike.
+ *
+ * Two cases, mirroring {@link TournamentEntryPage}:
+ * 1. Not connected: show a name entry, connect, then auto-join once connected.
+ * 2. Already connected (returning user with a stored name): auto-join immediately.
+ *
+ * Once any lobby state arrives, navigate to "/" where the normal lobby UI takes over.
+ */
+export function JoinLobbyPage() {
+  const { lobbyId } = useParams<{ lobbyId: string }>()
+  const navigate = useNavigate()
+
+  const connectionStatus = useGameStore((state) => state.connectionStatus)
+  const connect = useGameStore((state) => state.connect)
+  const joinAnyLobby = useGameStore((state) => state.joinQuickGameLobby)
+  const lobbyState = useGameStore((state) => state.lobbyState)
+  const quickGameLobbyState = useGameStore((state) => state.quickGameLobbyState)
+  const tournamentState = useGameStore((state) => state.tournamentState)
+  const lastError = useGameStore((state) => state.lastError)
+  const sessionReplaced = useGameStore((state) => state.sessionReplaced)
+
+  const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
+  const [joining, setJoining] = useState(false)
+  const hasJoinedRef = useRef(false)
+  const hasConnectedRef = useRef(false)
+
+  // Auto-connect a returning user (stored name). Never while another tab/device owns the session —
+  // reconnecting would steal it back (mirrors App.tsx / TournamentEntryPage).
+  useEffect(() => {
+    if (sessionReplaced) return
+    const storedName = localStorage.getItem('argentum-player-name')
+    if (storedName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+      hasConnectedRef.current = true
+      connect(storedName)
+    }
+  }, [connectionStatus, connect, sessionReplaced])
+
+  // Auto-join once connected (fires for both the returning user and the fresh name-entry path).
+  useEffect(() => {
+    if (connectionStatus === 'connected' && lobbyId && !hasJoinedRef.current) {
+      hasJoinedRef.current = true
+      setJoining(true)
+      joinAnyLobby(lobbyId)
+    }
+  }, [connectionStatus, lobbyId, joinAnyLobby])
+
+  // Navigate home once any lobby/tournament state is received.
+  useEffect(() => {
+    if (lobbyState || quickGameLobbyState || tournamentState) {
+      navigate('/', { replace: true })
+    }
+  }, [lobbyState, quickGameLobbyState, tournamentState, navigate])
+
+  const handleConnect = () => {
+    if (playerName.trim()) {
+      localStorage.setItem('argentum-player-name', playerName.trim())
+      connect(playerName.trim())
+    }
+  }
+
+  const errorMessage = lastError?.message?.toLowerCase().includes('lobby')
+    || lastError?.message?.toLowerCase().includes('not found')
+    ? lastError?.message
+    : null
+
+  return (
+    <div style={pageStyles.container}>
+      <div style={pageStyles.card}>
+        <h1 style={pageStyles.title}>Argentum Engine</h1>
+
+        {errorMessage && <p style={pageStyles.error}>{errorMessage}</p>}
+
+        {!errorMessage && connectionStatus === 'disconnected' && (
+          <div style={pageStyles.form}>
+            <label style={pageStyles.label}>Enter your name to join the lobby</label>
+            <input
+              type="text"
+              value={playerName}
+              onChange={(e) => setPlayerName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}
+              placeholder="Your name"
+              autoFocus
+              maxLength={20}
+              style={pageStyles.input}
+            />
+            <button
+              onClick={handleConnect}
+              disabled={!playerName.trim()}
+              style={{ ...pageStyles.button, opacity: playerName.trim() ? 1 : 0.5 }}
+            >
+              Join Lobby
+            </button>
+          </div>
+        )}
+
+        {(connectionStatus === 'connecting' || joining) && !errorMessage && (
+          <div style={pageStyles.loading}>
+            <div style={pageStyles.spinner} />
+            <p style={pageStyles.loadingText}>
+              {connectionStatus === 'connecting' ? 'Connecting...' : 'Joining lobby...'}
+            </p>
+            <style>{`@keyframes join-spin { to { transform: rotate(360deg); } }`}</style>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const pageStyles: Record<string, React.CSSProperties> = {
+  container: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#0a0a0f',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  },
+  card: {
+    backgroundColor: '#1a1a2e',
+    borderRadius: 12,
+    padding: '40px 48px',
+    maxWidth: 420,
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 24,
+    border: '1px solid #2a2a3e',
+  },
+  title: { margin: 0, fontSize: 28, color: '#e0e0e0', fontWeight: 600 },
+  error: { color: '#ff6b6b', fontSize: 14, margin: 0, textAlign: 'center' },
+  form: { width: '100%', display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center' },
+  label: { color: '#888', fontSize: 14 },
+  input: {
+    width: '100%',
+    padding: '10px 14px',
+    fontSize: 16,
+    backgroundColor: '#12121e',
+    color: '#e0e0e0',
+    border: '1px solid #3a3a4e',
+    borderRadius: 6,
+    outline: 'none',
+    boxSizing: 'border-box',
+  },
+  button: {
+    width: '100%',
+    padding: '12px 24px',
+    fontSize: 16,
+    fontWeight: 600,
+    backgroundColor: '#9b59b6',
+    color: 'white',
+    border: 'none',
+    borderRadius: 6,
+    cursor: 'pointer',
+  },
+  loading: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 },
+  spinner: {
+    width: 32,
+    height: 32,
+    border: '3px solid #333',
+    borderTopColor: '#888',
+    borderRadius: '50%',
+    animation: 'join-spin 1s linear infinite',
+  },
+  loadingText: { color: '#888', fontSize: 14, margin: 0 },
+}

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -14,6 +14,8 @@ import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/sto
 import { DeckPicker } from './DeckPicker'
 import { BanListEditor } from './BanListEditor'
 import { SetPickerModal } from './SetPickerModal'
+import { JoinQrModal } from './JoinQrModal'
+import { buildJoinUrl } from '@/utils/joinLink'
 import { labelForFormat } from '@/utils/deckLegality'
 import styles from './GameUI.module.css'
 
@@ -876,23 +878,26 @@ function LobbyOverlay({
           </p>
         </div>
 
-        {/* Invite code */}
-        <div
-          onClick={copyLobbyId}
-          className={`${styles.inviteBox} ${copied ? styles.inviteBoxCopied : ''}`}
-          style={{ alignSelf: 'stretch', justifyContent: 'space-between' }}
-        >
-          <div>
-            <div style={{ color: 'var(--text-disabled)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 3 }}>
-              Invite Code
+        {/* Invite code + scannable QR to pull another device straight into the lobby */}
+        <div style={{ alignSelf: 'stretch', display: 'flex', alignItems: 'stretch', gap: 8 }}>
+          <div
+            onClick={copyLobbyId}
+            className={`${styles.inviteBox} ${copied ? styles.inviteBoxCopied : ''}`}
+            style={{ flex: 1, marginBottom: 0, justifyContent: 'space-between' }}
+          >
+            <div>
+              <div style={{ color: 'var(--text-disabled)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 3 }}>
+                Invite Code
+              </div>
+              <div className={styles.inviteCode} data-testid="invite-code">
+                {lobbyState.lobbyId}
+              </div>
             </div>
-            <div className={styles.inviteCode} data-testid="invite-code">
-              {lobbyState.lobbyId}
-            </div>
+            <span className={`${styles.inviteCopyLabel} ${copied ? styles.inviteCopyLabelCopied : ''}`} style={{ flexShrink: 0, marginLeft: 12 }}>
+              {copied ? 'Copied!' : 'Copy'}
+            </span>
           </div>
-          <span className={`${styles.inviteCopyLabel} ${copied ? styles.inviteCopyLabelCopied : ''}`} style={{ flexShrink: 0, marginLeft: 12 }}>
-            {copied ? 'Copied!' : 'Copy'}
-          </span>
+          <JoinQrModal url={buildJoinUrl(lobbyState.lobbyId)} />
         </div>
 
         {/* Settings (host only) */}

--- a/web-client/src/components/ui/JoinQrModal.tsx
+++ b/web-client/src/components/ui/JoinQrModal.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+
+/**
+ * A compact "QR" button that opens a modal showing a scannable QR code for a lobby join link.
+ *
+ * Meant to sit beside the textual invite code in a lobby. Scanning the code opens the
+ * `/join/:lobbyId` deep link on the other device, which auto-connects and joins the lobby — the
+ * fast path for pulling a phone into your game. The button is self-contained (owns its own open
+ * state) so any lobby overlay can drop it in next to its invite box.
+ */
+export function JoinQrModal({ url }: { url: string }) {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  // Close on Escape while open — standard modal affordance.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Show QR code to join"
+        title="Show QR code to join"
+        data-testid="lobby-qr-button"
+        style={styles.iconButton}
+      >
+        <QrGlyph />
+      </button>
+
+      {open && (
+        <div
+          style={styles.backdrop}
+          onClick={() => setOpen(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Scan to join lobby"
+          data-testid="lobby-qr-modal"
+        >
+          <div style={styles.panel} onClick={(e) => e.stopPropagation()}>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              style={styles.close}
+            >
+              ×
+            </button>
+            <h2 style={styles.title}>Scan to join</h2>
+            <p style={styles.subtitle}>Point another phone's camera at the code to jump into this lobby.</p>
+            <div style={styles.qrCard}>
+              <QRCodeSVG value={url} size={232} level="M" marginSize={2} bgColor="#ffffff" fgColor="#0a0a0f" />
+            </div>
+            <div style={styles.urlRow}>
+              <span style={styles.url}>{url}</span>
+              <button type="button" onClick={copyLink} style={styles.copyButton}>
+                {copied ? 'Copied!' : 'Copy link'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+/** Minimalist QR-code glyph (three finder squares + a few modules) drawn inline so we ship no icon asset. */
+function QrGlyph() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zM3 13h8v8H3v-8zm2 2v4h4v-4H5zM13 3h8v8h-8V3zm2 2v4h4V5h-4z" />
+      <path d="M13 13h3v3h-3v-3zm5 0h3v3h-3v-3zm-5 5h3v3h-3v-3zm5 0h3v3h-3v-3z" />
+    </svg>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  iconButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 40,
+    height: 40,
+    flexShrink: 0,
+    color: 'var(--text-secondary)',
+    backgroundColor: 'var(--bg-panel-light)',
+    border: '1px solid var(--border-light)',
+    borderRadius: 'var(--radius-xl)',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+  },
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.78)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 3000,
+    padding: 16,
+  },
+  panel: {
+    position: 'relative',
+    backgroundColor: '#1a1a2e',
+    border: '1px solid #2a2a3e',
+    borderRadius: 16,
+    padding: '28px 28px 24px',
+    width: '100%',
+    maxWidth: 340,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 12,
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  },
+  close: {
+    position: 'absolute',
+    top: 10,
+    right: 14,
+    background: 'none',
+    border: 'none',
+    color: '#888',
+    fontSize: 26,
+    lineHeight: 1,
+    cursor: 'pointer',
+  },
+  title: {
+    margin: 0,
+    fontSize: 20,
+    fontWeight: 600,
+    color: '#e0e0e0',
+  },
+  subtitle: {
+    margin: 0,
+    fontSize: 13,
+    color: '#9a9aae',
+    textAlign: 'center',
+  },
+  qrCard: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 14,
+    lineHeight: 0,
+    marginTop: 4,
+  },
+  urlRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    width: '100%',
+    marginTop: 4,
+  },
+  url: {
+    flex: 1,
+    minWidth: 0,
+    fontFamily: 'monospace',
+    fontSize: 12,
+    color: '#9a9aae',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  copyButton: {
+    flexShrink: 0,
+    padding: '8px 14px',
+    fontSize: 13,
+    fontWeight: 600,
+    color: 'white',
+    backgroundColor: '#9b59b6',
+    border: 'none',
+    borderRadius: 8,
+    cursor: 'pointer',
+  },
+}

--- a/web-client/src/components/ui/QuickGameLobbyOverlay.tsx
+++ b/web-client/src/components/ui/QuickGameLobbyOverlay.tsx
@@ -16,6 +16,8 @@ import type { DeckFormat, QuickGameLobbyPlayerView } from '@/types'
 import { randomBackground } from '@/utils/background.ts'
 import momirVigUrl from '@/assets/momir-vig.svg'
 import { DeckPicker } from './DeckPicker'
+import { JoinQrModal } from './JoinQrModal'
+import { buildJoinUrl } from '@/utils/joinLink'
 import styles from './GameUI.module.css'
 
 const FORMAT_OPTIONS: Array<{ value: DeckFormat; label: string }> = [
@@ -146,22 +148,25 @@ export function QuickGameLobbyOverlay() {
         </div>
 
         {!lobby.vsAi && (
-          <div
-            onClick={copyLobbyId}
-            className={`${styles.inviteBox} ${copied ? styles.inviteBoxCopied : ''}`}
-            style={{ alignSelf: 'stretch', justifyContent: 'space-between' }}
-          >
-            <div>
-              <div style={{ color: 'var(--text-disabled)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 3 }}>
-                Invite Code
+          <div style={{ alignSelf: 'stretch', display: 'flex', alignItems: 'stretch', gap: 8 }}>
+            <div
+              onClick={copyLobbyId}
+              className={`${styles.inviteBox} ${copied ? styles.inviteBoxCopied : ''}`}
+              style={{ flex: 1, marginBottom: 0, justifyContent: 'space-between' }}
+            >
+              <div>
+                <div style={{ color: 'var(--text-disabled)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 3 }}>
+                  Invite Code
+                </div>
+                <div className={styles.inviteCode} data-testid="quick-game-invite-code">
+                  {lobby.lobbyId}
+                </div>
               </div>
-              <div className={styles.inviteCode} data-testid="quick-game-invite-code">
-                {lobby.lobbyId}
-              </div>
+              <span className={`${styles.inviteCopyLabel} ${copied ? styles.inviteCopyLabelCopied : ''}`} style={{ flexShrink: 0, marginLeft: 12 }}>
+                {copied ? 'Copied!' : 'Copy'}
+              </span>
             </div>
-            <span className={`${styles.inviteCopyLabel} ${copied ? styles.inviteCopyLabelCopied : ''}`} style={{ flexShrink: 0, marginLeft: 12 }}>
-              {copied ? 'Copied!' : 'Copy'}
-            </span>
+            <JoinQrModal url={buildJoinUrl(lobby.lobbyId)} />
           </div>
         )}
 

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -7,6 +7,7 @@ import 'mana-font/css/mana.min.css'
 import 'keyrune/css/keyrune.min.css'
 import App from './App'
 import { TournamentEntryPage } from './components/tournament/TournamentEntryPage'
+import { JoinLobbyPage } from './components/lobby/JoinLobbyPage'
 import { AdminPage } from './components/admin/AdminPage'
 import { ReplayPage } from './components/replay/ReplayPage'
 import { DeckbuilderPage } from './components/deckbuilder/DeckbuilderPage'
@@ -27,6 +28,7 @@ createRoot(rootElement).render(
     <BrowserRouter>
       <Routes>
         <Route path="/tournament/:lobbyId" element={<TournamentEntryPage />} />
+        <Route path="/join/:lobbyId" element={<JoinLobbyPage />} />
         <Route path="/replay/:gameId" element={<ReplayPage />} />
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/deckbuilder" element={<DeckbuilderPage />} />

--- a/web-client/src/utils/joinLink.test.ts
+++ b/web-client/src/utils/joinLink.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { buildJoinUrl } from './joinLink'
+
+describe('buildJoinUrl', () => {
+  it('builds a /join/:lobbyId link from the given origin', () => {
+    expect(buildJoinUrl('abc-123', 'https://play.example.com')).toBe(
+      'https://play.example.com/join/abc-123'
+    )
+  })
+
+  it('does not emit a double slash when the origin has a trailing slash', () => {
+    expect(buildJoinUrl('abc', 'https://play.example.com/')).toBe(
+      'https://play.example.com/join/abc'
+    )
+  })
+
+  it('url-encodes a lobby id so odd characters survive the round trip', () => {
+    expect(buildJoinUrl('a b/c', 'https://x.io')).toBe('https://x.io/join/a%20b%2Fc')
+  })
+})

--- a/web-client/src/utils/joinLink.ts
+++ b/web-client/src/utils/joinLink.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds the shareable deep-link a player scans / clicks to join a lobby.
+ *
+ * The `/join/:lobbyId` route (see `main.tsx` → `JoinLobbyPage`) is lobby-kind agnostic: the server's
+ * quick-game join handler delegates to the tournament join handler when the id is a tournament lobby,
+ * so one link works for Quick Game lobbies, sealed/draft lobbies and tournaments alike.
+ */
+export function buildJoinUrl(lobbyId: string, origin: string = window.location.origin): string {
+  // Strip any trailing slash so we never emit a double slash for a root-hosted origin.
+  return `${origin.replace(/\/$/, '')}/join/${encodeURIComponent(lobbyId)}`
+}


### PR DESCRIPTION
## What

Every lobby (Quick Game **and** tournament / sealed / draft) now shows a small **QR button** next to its invite code. Tapping it opens a modal with a scannable code — point another phone's camera at it to drop straight into the lobby. This is the fast path for pulling a second device into a game on mobile, instead of typing a UUID invite code by hand.

| Lobby + QR button | Scan-to-join modal | Deep-link landing |
|---|---|---|
| ![lobby](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-join-qr-screenshots/qr-lobby.png) | ![modal](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-join-qr-screenshots/qr-modal.png) | ![join](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-join-qr-screenshots/qr-join-page.png) |

## How it fits together

The QR encodes a new **`/join/:lobbyId`** deep link. That route is **lobby-kind agnostic**: it joins via `joinQuickGameLobby`, whose server handler already delegates to the tournament join handler when the id turns out to be a tournament lobby (`QuickGameLobbyHandler.handleJoin`). So **one link/QR covers every lobby type with zero server changes** — no new endpoint, no second route, no `pendingTournamentId`-style plumbing.

- **`JoinQrModal`** (`components/ui/JoinQrModal.tsx`) — a self-contained QR button + modal (Esc / backdrop to close, copy-link button). Renders an SVG QR via `qrcode.react`. Dropped into both the Quick Game and tournament lobby invite boxes, so the invite row reads *code → copy → QR*.
- **`JoinLobbyPage`** (`components/lobby/JoinLobbyPage.tsx`) — the `/join/:lobbyId` entry, mirroring the existing `TournamentEntryPage` pattern: auto-connect a returning user (stored name), or show a name-entry form for a fresh device, then auto-join once connected and redirect to `/`.
- **`buildJoinUrl`** (`utils/joinLink.ts`) — pure URL helper, unit-tested.

## Testing

- `npm run typecheck`, `npm run build`, full `npm test` (158 tests) all green; added `joinLink.test.ts`.
- **End-to-end manually verified** against the running stack: created a Quick Game lobby in one browser, opened `/join/<lobbyId>` in a second fresh context (no stored name → name-entry path), and confirmed the guest landed in the *same* lobby and the host saw them join. Screenshots above are from the live app at a mobile viewport.

## Notes

- Adds one dependency: `qrcode.react` (^4) — a tiny, dependency-light SVG/canvas QR renderer. Hand-rolling QR encoding (Reed–Solomon, masking) wasn't worth it.
- The existing `/tournament/:lobbyId` shareable link and URL-bar sync are untouched; `/join/:lobbyId` is purely additive.
- Screenshots live on the throwaway `lobby-join-qr-screenshots` branch (not in this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)