### PR TITLE
Honor optional+elseEffect on no-target triggered abilities

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -772,10 +772,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   targets on `then`/`otherwise` lock at trigger time (CR 603.3d) and the gate is resolved at
   resolution time (CR 117.3a) by `decisionMaker` (defaults to the controller) — the may-vs-target
   timing is correct by construction rather than re-encoded per wrapper. Gates:
-  - `Gate.MayDecide(prompt?, hint?, sourceRequiredZone?, inlineOnTrigger?)` — pure yes/no
+  - `Gate.MayDecide(prompt?, hint?, sourceRequiredZone?, inlineOnTrigger?, feasibility?)` — pure yes/no
     ("You may [then]."). Replaces `MayEffect` (see the `MayEffect` facade below). `sourceRequiredZone`
     skips the gate silently when the source has left that zone by resolution; `inlineOnTrigger`
-    renders the yes/no on the triggering permanent rather than as a modal.
+    renders the yes/no on the triggering permanent rather than as a modal. `feasibility` (a
+    `FeasibilityCheck`) — when set and **unmet** at resolution, the may-action is impossible, so the
+    player "doesn't": the prompt is skipped and `otherwise` runs directly. Lets "you may sacrifice an
+    artifact. If you don't, …" apply its else automatically when the controller has no artifact (the
+    no-target analogue of a targeted "may" with no legal targets falling to its else branch).
   - `Gate.MayPay(cost)` — "You may [cost]. If you do, [then]." `cost` is a cost **effect**
     (`PayManaCostEffect`, `PayDynamicManaCostEffect`, `PayLifeEffect`, `SacrificeEffect`, or a
     `CompositeEffect` of them). An unaffordable cost (fixed mana, dynamic mana, and life are
@@ -1540,7 +1544,19 @@ work for abilities-on-stack (which carry no `CardComponent`).
 
 ## 8. Triggered abilities (`Triggers.*`)
 
-`triggeredAbility { trigger; effect; target?; triggerCondition?; optional?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController? }`.
+`triggeredAbility { trigger; effect; target?; triggerCondition?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController? }`.
+
+**`optional` + `elseEffect` = "you may [effect]. If you don't, [elseEffect]."** For a **targeted**
+trigger, `optional` lets the player choose 0 targets to decline, and `elseEffect` runs on decline or
+when no legal targets exist (Entrails Feaster: "you may exile a creature card from a graveyard … if
+you don't, tap this"). For a **no-target** trigger the same pair lowers to a
+`GatedEffect(Gate.MayDecide, then = effect, otherwise = elseEffect)` resolved by the unified gated
+executor — a resolution-time yes/no whose "no" runs `elseEffect`. The may-action's feasibility is
+derived from `effect` (a `SacrificeEffect` needs the controller to control a matching permanent), so
+an impossible "may" skips the prompt and runs `elseEffect` directly — the no-target analogue of "no
+legal targets → else" (Yawgmoth Demon: "you may sacrifice an artifact. If you don't, tap this
+creature and it deals 2 damage to you" — with no artifact the tax just applies). Always-feasible
+bodies (gain life, draw, add a counter) always prompt.
 
 ### Zone change
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
@@ -125,6 +125,11 @@ sealed interface Gate {
      * @property inlineOnTrigger When true, the yes/no is rendered inline on the triggering
      *   permanent rather than as a centered modal (the Dragon Shadow / "may" trigger UX); flows
      *   into `DecisionContext.inlineOnTrigger`.
+     * @property feasibility If set and unmet at resolution, the may-action is impossible — so the
+     *   player "doesn't": the yes/no prompt is skipped and [GatedEffect.otherwise] runs directly
+     *   (the no-target analogue of a targeted "may" with no legal targets falling to its else
+     *   branch). Lets a "you may sacrifice an artifact. If you don't, …" trigger apply its else
+     *   automatically when the controller has no artifact, with no pointless "sacrifice?" prompt.
      */
     @SerialName("Gate.MayDecide")
     @Serializable
@@ -132,7 +137,8 @@ sealed interface Gate {
         val prompt: String? = null,
         val hint: String? = null,
         val sourceRequiredZone: Zone? = null,
-        val inlineOnTrigger: Boolean = false
+        val inlineOnTrigger: Boolean = false,
+        val feasibility: FeasibilityCheck? = null
     ) : Gate {
         override fun applyTextReplacement(replacer: TextReplacer): Gate = this
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/YawgmothDemon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/YawgmothDemon.kt
@@ -1,13 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.atq.cards
 
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -19,11 +18,12 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * At the beginning of your upkeep, you may sacrifice an artifact. If you don't, tap this
  * creature and it deals 2 damage to you.
  *
- * Modeled with the curated punisher primitive [PayOrSufferEffect] ("do [suffer] unless you
- * [cost]"): the avoidable cost is sacrificing an artifact, and the `suffer` is the upkeep tax —
- * tap this creature and deal 2 damage to its controller. When the controller has an artifact they
- * choose whether to sacrifice one (decline → suffer); with no artifact the cost is unpayable and
- * the tax applies automatically. This is the "you may sacrifice …; if you don't, …" reading.
+ * The literal "you may [action]. If you don't, [consequence]" reading: an optional triggered
+ * ability whose body is "sacrifice an artifact" and whose `elseEffect` is the upkeep tax — tap
+ * this creature and deal 2 damage to its controller. With an artifact the controller is asked
+ * whether to sacrifice one (decline → tax); with no artifact the sacrifice is impossible, so the
+ * engine skips the prompt and applies the tax automatically (the no-target may-action's feasibility
+ * is derived from the [SacrificeEffect], so an impossible "may" falls straight to its else branch).
  */
 val YawgmothDemon = card("Yawgmoth Demon") {
     manaCost = "{4}{B}{B}"
@@ -39,13 +39,12 @@ val YawgmothDemon = card("Yawgmoth Demon") {
 
     triggeredAbility {
         trigger = Triggers.YourUpkeep
-        effect = PayOrSufferEffect(
-            cost = Costs.pay.Sacrifice(GameObjectFilter.Artifact),
-            suffer = Effects.Composite(
-                listOf(
-                    Effects.Tap(EffectTarget.Self),
-                    Effects.DealDamage(2, EffectTarget.Controller, damageSource = EffectTarget.Self)
-                )
+        optional = true
+        effect = SacrificeEffect(GameObjectFilter.Artifact)
+        elseEffect = Effects.Composite(
+            listOf(
+                Effects.Tap(EffectTarget.Self),
+                Effects.DealDamage(2, EffectTarget.Controller, damageSource = EffectTarget.Self)
             )
         )
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -2348,32 +2348,27 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "PayOrSuffer",
-                    "cost": {
-                        "type": "PayAtom",
-                        "atom": {
-                            "type": "AtomSacrifice",
-                            "filter": "artifact"
-                        }
-                    },
-                    "suffer": {
-                        "type": "Composite",
-                        "effects": [
-                            {
-                                "type": "TapUntap",
-                                "target": "Self"
+                    "type": "Sacrifice",
+                    "filter": "artifact"
+                },
+                "optional": true,
+                "elseEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
                             },
-                            {
-                                "type": "DealDamage",
-                                "amount": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "target": "Controller",
-                                "damageSource": "Self"
-                            }
-                        ]
-                    }
+                            "target": "Controller",
+                            "damageSource": "Self"
+                        }
+                    ]
                 }
             }
         ]

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -15,6 +15,10 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.engine.handlers.effects.composite.asMayDecide
 import com.wingedsheep.engine.handlers.effects.composite.asOptionalManaPayment
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
@@ -286,8 +290,38 @@ class TriggerProcessor(
             return processTargetedTrigger(currentState, trigger, targetRequirement)
         }
 
+        // A no-target "you may X. If you don't, Y" (optional + elseEffect) has no target-selection
+        // step to carry the decline through, so the targeted path's may/else handling never runs and
+        // both fields were silently dropped (the latent bug that made Yawgmoth Demon do nothing).
+        // Lower it into the unified GatedEffect(Gate.MayDecide) frame so GatedEffectExecutor owns the
+        // resolution-time yes/no and runs `elseEffect` on decline. Feasibility derived from the
+        // may-action lets an impossible "may" (e.g. "you may sacrifice an artifact" with no artifact)
+        // fall straight to the else with no prompt — the no-target analogue of "no legal targets → else".
+        val elseEffect = ability.elseEffect
+        if (ability.optional && elseEffect != null) {
+            val gated = GatedEffect(
+                gate = Gate.MayDecide(feasibility = impliedMayFeasibility(ability.effect)),
+                then = ability.effect,
+                otherwise = elseEffect
+            )
+            return putTriggerOnStack(currentState, trigger, emptyList(), gated)
+        }
+
         // No targets required - put directly on stack
         return putTriggerOnStack(currentState, trigger, emptyList())
+    }
+
+    /**
+     * The feasibility a no-target "may" action implies, so a "you may [action]. If you don't, …"
+     * trigger skips the prompt and runs its else branch when the action is impossible (the player
+     * can't, so they "don't"). A [SacrificeEffect] is always controller-self and needs the
+     * controller to control enough matching permanents; other actions (draw, gain life, add a
+     * counter) are always feasible (`null` → always prompt). Extend as further
+     * impossible-when-empty may-actions appear.
+     */
+    private fun impliedMayFeasibility(effect: Effect): FeasibilityCheck? = when (effect) {
+        is SacrificeEffect -> FeasibilityCheck.ControlsPermanentMatching(effect.filter, effect.count)
+        else -> null
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -112,6 +112,17 @@ class GatedEffectExecutor(
             ) {
                 return EffectResult.success(state)
             }
+            // A declared feasibility that isn't met means the may-action is impossible — the player
+            // "doesn't", so skip the prompt and run `otherwise` directly. This is the no-target
+            // analogue of a targeted "may" with no legal targets falling to its else branch (e.g.
+            // "you may sacrifice an artifact. If you don't, …" with no artifact taps you out).
+            gate.feasibility?.let { check ->
+                if (!checkFeasibility(state, context.controllerId, check)) {
+                    return effect.otherwise
+                        ?.let { effectExecutor(state, it, context) }
+                        ?: EffectResult.success(state)
+                }
+            }
         }
 
         val playerId = effect.decisionMaker

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoTargetMayElseTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoTargetMayElseTriggerScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for a *no-target* "you may X. If you don't, Y" triggered ability — the latent
+ * gap that made Yawgmoth Demon do nothing: the no-target trigger path used to silently drop both
+ * `optional` and `elseEffect` (only the targeted path honored them, via target-decline → else).
+ *
+ * This test pins the general fix with an always-feasible may-action (gain life), so it exercises
+ * the lowering into `GatedEffect(Gate.MayDecide, then, otherwise)` independently of the
+ * sacrifice-style feasibility skip that Yawgmoth's test covers: the may question is always asked,
+ * "yes" runs the body, "no" runs the else branch.
+ */
+class NoTargetMayElseTriggerScenarioTest : ScenarioTestBase() {
+
+    // "At the beginning of your upkeep, you may gain 2 life. If you don't, you lose 1 life."
+    // No target, optional, with an else branch — gaining life is always feasible, so no feasibility
+    // skip applies and the may question is always presented.
+    private val penitent = card("May-Else Penitent") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Human Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "At the beginning of your upkeep, you may gain 2 life. If you don't, you lose 1 life."
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            optional = true
+            effect = Effects.GainLife(2)
+            elseEffect = Effects.LoseLife(1, EffectTarget.Controller)
+        }
+    }
+
+    init {
+        cardRegistry.register(penitent)
+
+        context("no-target you-may-X / if-you-don't-Y trigger") {
+
+            fun atPlayer1Upkeep(): TestGame {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "May-Else Penitent", summoningSickness = false)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                return game
+            }
+
+            test("the may question is always asked even though the body is always feasible") {
+                val game = atPlayer1Upkeep()
+                withClue("Gaining life can't be infeasible → the player is always prompted") {
+                    game.hasPendingDecision() shouldBe true
+                }
+            }
+
+            test("saying yes runs the body (gain 2 life)") {
+                val game = atPlayer1Upkeep()
+                game.answerYesNo(true)
+                game.resolveStack()
+                withClue("Body ran: 20 → 22") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+
+            test("saying no runs the else branch (lose 1 life)") {
+                val game = atPlayer1Upkeep()
+                game.answerYesNo(false)
+                game.resolveStack()
+                withClue("Else branch ran: 20 → 19") {
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YawgmothDemonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YawgmothDemonScenarioTest.kt
@@ -14,19 +14,20 @@ import io.kotest.matchers.shouldBe
  * "At the beginning of your upkeep, you may sacrifice an artifact. If you don't, tap this
  *  creature and it deals 2 damage to you."
  *
- * Modeled with [com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect] ("do [suffer] unless you
- * [cost]"). The upkeep trigger only fires on a real step transition into UPKEEP, so each scenario
- * starts on the opponent's turn (precombat main) and passes around to player 1's upkeep. The
- * punisher flow: with no artifact the sacrifice cost is unpayable and the tax applies with no
- * decision; with an artifact the controller is offered a card selection — picking one pays the
- * cost (no tax), picking none declines (tax applies).
+ * Modeled as the literal "you may [action]. If you don't, [consequence]" — an optional triggered
+ * ability (no target) whose body is "sacrifice an artifact" and whose `elseEffect` is the upkeep
+ * tax. The upkeep trigger only fires on a real step transition into UPKEEP, so each scenario starts
+ * on the opponent's turn (precombat main) and passes around to player 1's upkeep. The flow exercises
+ * the no-target may/else engine path: with no artifact the sacrifice is impossible, so the may
+ * prompt is skipped and the tax applies automatically; with an artifact the controller is asked
+ * yes/no — yes sacrifices one (no tax), no declines (tax applies).
  */
 class YawgmothDemonScenarioTest : ScenarioTestBase() {
 
     private fun isTapped(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Boolean =
         game.state.getEntity(id)?.get<TappedComponent>() != null
 
-    private fun atPlayer1Upkeep(withArtifact: Boolean): TestGame {
+    private fun atPlayer1Upkeep(artifacts: List<String>): TestGame {
         var builder = scenario()
             .withPlayers("Player", "Opponent")
             .withCardOnBattlefield(1, "Yawgmoth Demon", summoningSickness = false)
@@ -34,7 +35,7 @@ class YawgmothDemonScenarioTest : ScenarioTestBase() {
             // Start on the opponent's turn so we transition into player 1's upkeep.
             .withActivePlayer(2)
             .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
-        if (withArtifact) builder = builder.withCardOnBattlefield(1, "Ornithopter")
+        for (artifact in artifacts) builder = builder.withCardOnBattlefield(1, artifact)
         // Library fuel so neither player decks out during step advances.
         repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
         repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
@@ -48,11 +49,11 @@ class YawgmothDemonScenarioTest : ScenarioTestBase() {
     init {
         context("Yawgmoth Demon upkeep tax") {
 
-            test("with no artifact the cost is unpayable and the tax applies (tap + 2 to controller)") {
-                val game = atPlayer1Upkeep(withArtifact = false)
+            test("with no artifact the may is infeasible: no prompt, the tax applies (tap + 2 to controller)") {
+                val game = atPlayer1Upkeep(artifacts = emptyList())
                 val demonId = game.findPermanent("Yawgmoth Demon")!!
 
-                withClue("No payable sacrifice cost → no decision is offered") {
+                withClue("No artifact to sacrifice → the may is skipped, no decision offered") {
                     game.hasPendingDecision() shouldBe false
                 }
                 withClue("The tax taps Yawgmoth Demon") {
@@ -63,37 +64,62 @@ class YawgmothDemonScenarioTest : ScenarioTestBase() {
                 }
             }
 
-            test("sacrificing an artifact pays the cost and avoids the tax") {
-                val game = atPlayer1Upkeep(withArtifact = true)
+            test("choosing to sacrifice the only artifact avoids the tax (auto-sacrificed)") {
+                val game = atPlayer1Upkeep(artifacts = listOf("Ornithopter"))
                 val demonId = game.findPermanent("Yawgmoth Demon")!!
 
-                withClue("With an artifact, the punisher offers a sacrifice selection") {
+                withClue("With an artifact, the ability asks the may question") {
                     game.hasPendingDecision() shouldBe true
                 }
-                val artifactId = game.findPermanent("Ornithopter")!!
-                game.selectCards(listOf(artifactId))
+                // Say yes — with a single artifact it is sacrificed without a further "which?" prompt.
+                game.answerYesNo(true)
                 game.resolveStack()
 
                 withClue("The sacrificed artifact should be gone from the battlefield") {
                     game.isOnBattlefield("Ornithopter") shouldBe false
                 }
-                withClue("Paying the cost spares Yawgmoth Demon — it is NOT tapped") {
+                withClue("Sacrificing spares Yawgmoth Demon — it is NOT tapped") {
                     isTapped(game, demonId) shouldBe false
                 }
-                withClue("Paying the cost spares the controller — no life loss (stays at 20)") {
+                withClue("Sacrificing spares the controller — no life loss (stays at 20)") {
                     game.getLifeTotal(1) shouldBe 20
                 }
             }
 
-            test("declining to sacrifice an available artifact still triggers the tax") {
-                val game = atPlayer1Upkeep(withArtifact = true)
+            test("with multiple artifacts, saying yes lets the controller choose which to sacrifice") {
+                val game = atPlayer1Upkeep(artifacts = listOf("Ornithopter", "Su-Chi"))
                 val demonId = game.findPermanent("Yawgmoth Demon")!!
 
-                withClue("With an artifact, the punisher offers a sacrifice selection") {
+                withClue("The ability asks the may question") {
                     game.hasPendingDecision() shouldBe true
                 }
-                // Decline by selecting no artifact to sacrifice.
-                game.skipSelection()
+                game.answerYesNo(true)
+                // Now choose which single artifact to sacrifice.
+                val ornithopterId = game.findPermanent("Ornithopter")!!
+                game.selectCards(listOf(ornithopterId))
+                game.resolveStack()
+
+                withClue("Only the chosen artifact is sacrificed") {
+                    game.isOnBattlefield("Ornithopter") shouldBe false
+                    game.isOnBattlefield("Su-Chi") shouldBe true
+                }
+                withClue("Sacrificing spares Yawgmoth Demon — it is NOT tapped") {
+                    isTapped(game, demonId) shouldBe false
+                }
+                withClue("Sacrificing spares the controller — no life loss (stays at 20)") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("declining the may with an artifact available triggers the tax") {
+                val game = atPlayer1Upkeep(artifacts = listOf("Ornithopter"))
+                val demonId = game.findPermanent("Yawgmoth Demon")!!
+
+                withClue("With an artifact, the ability asks the may question") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Say no — decline the optional sacrifice.
+                game.answerYesNo(false)
                 game.resolveStack()
 
                 withClue("Declining keeps the artifact on the battlefield") {


### PR DESCRIPTION
## Summary

Fixes a latent engine bug surfaced in #788: a **no-target** "you may X. If you don't, Y" triggered ability silently dropped both `optional` and `elseEffect`. Only the *targeted* path honored them (via target-decline → else), so the no-target path put the bare effect on the stack and the may question and else branch never ran. That's why **Yawgmoth Demon** originally did nothing and was worked around with `PayOrSufferEffect`.

The next no-target "you may X; if you don't, Y" card would have hit the same silent no-op — this closes the gap and proves it with Yawgmoth.

## The fix

- A no-target `optional + elseEffect` trigger now **lowers into the unified `GatedEffect(Gate.MayDecide, then, otherwise)` frame**, so the existing `GatedEffectExecutor` owns the resolution-time yes/no and runs the else branch on decline — no new decision/continuation plumbing.
- `Gate.MayDecide` gains an optional `feasibility: FeasibilityCheck?`. When set and **unmet** at resolution, the may-action is impossible — the player "doesn't", so the prompt is skipped and `otherwise` runs directly. This is the no-target analogue of a targeted "may" with no legal targets falling to its else branch.
- `TriggerProcessor.impliedMayFeasibility` derives that check from the body (a `SacrificeEffect` needs the controller to control a matching permanent); always-feasible bodies (draw, gain life, add a counter) stay `null` → always prompt.

## Yawgmoth Demon, the correct way

Reimplemented with the literal oracle shape instead of the `PayOrSuffer` workaround:

```kotlin
triggeredAbility {
    trigger = Triggers.YourUpkeep
    optional = true
    effect = SacrificeEffect(GameObjectFilter.Artifact)
    elseEffect = Effects.Composite(listOf(
        Effects.Tap(EffectTarget.Self),
        Effects.DealDamage(2, EffectTarget.Controller, damageSource = EffectTarget.Self),
    ))
}
```

With no artifact the sacrifice is infeasible, so the prompt is skipped and the tax applies automatically (matches the existing test). With an artifact the controller is asked yes/no — yes sacrifices one (multiple → choose which), no declines and takes the tax.

## Tests

- **`NoTargetMayElseTriggerScenarioTest`** (new) — pins the general lowering with an always-feasible body ("you may gain 2 life. If you don't, lose 1 life"): the may is always asked, "yes" runs the body, "no" runs the else.
- **`YawgmothDemonScenarioTest`** — rewritten for the yes/no flow: no-artifact (no prompt → tax), sacrifice the only artifact (auto), choose-which with two artifacts, and decline → tax.
- Full `rules-engine`, `mtg-sets` (incl. snapshot + lint), and `mtg-sdk` suites pass; `ai` / `game-server` compile. ATQ snapshot re-blessed (only Yawgmoth's trigger changed). `Gate.MayDecide`'s new field defaults to `null` and `encodeDefaults = false`, so no other card snapshots churn.

## Scope notes

- **No client/server work**: the lowering reuses the existing `YesNoDecision` / `DecisionRequestedEvent("YES_NO")` path — no new GameEvent, DTO branch, or decision component.
- **No mtgish change**: this adds a trigger-authoring shape, not a new IR tag; the punisher cards it serves are already coverable via the existing emitter path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)