### PR TITLE
SOS cards (agent 1): Heated Argument, Mana Sculpt, Erode + emitter support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2057,6 +2057,16 @@ Triggers.youCastSpell(
     effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE))` — "whenever you cast a noncreature spell
     this turn, target creature you control gains double strike". Works on both event-based and
     step-based delayed triggers; null (default) for non-targeting delayed triggers.
+  - **Amount snapshot at creation time.** When `effect` is an `AddManaEffect` / `AddColorlessManaEffect`
+    carrying a non-`Fixed` `DynamicAmount` that reads from the *current* resolution context — e.g.
+    `DynamicAmounts.targetManaSpent(0)` (`EntityProperty(Target(0), ManaSpent)`) — the executor
+    evaluates that amount **now** and bakes it into a `DynamicAmount.Fixed` literal, exactly as it
+    bakes `ContextTarget(n)` target references into `SpecificEntity`. This is required for "at the
+    beginning of your next main phase, add an amount of {C} equal to the amount of mana spent to cast
+    that spell" (**Mana Sculpt**): the referenced spell is gone by the time the delayed trigger fires,
+    so a lazy read would yield 0 — author the gated delayed-trigger creation *before* the counter so
+    the target spell is still on the stack when the snapshot is taken. Already-`Fixed` amounts pass
+    through untouched.
 
 ---
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Erode.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Erode.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Erode
+ * {W}
+ * Instant
+ * Destroy target creature or planeswalker. Its controller may search their library for a basic land
+ * card, put it onto the battlefield tapped, then shuffle.
+ *
+ * A Path-to-Exile-shaped compensation effect. The destroy resolves first, then the destroyed
+ * permanent's controller — not Erode's controller — gets the optional search, so the [MayEffect]
+ * gate is delegated to [EffectTarget.TargetController] and the whole search pipeline is scoped to
+ * [Player.ControllerOf] (library to gather from, battlefield to put the land onto tapped, and the
+ * library to shuffle). "Its controller" is resolved from the targeted permanent at resolution;
+ * since the permanent has just left the battlefield, the controller falls back to its owner (the
+ * standard last-known controller for a permanent that left play).
+ */
+val Erode = card("Erode") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature or planeswalker. Its controller may search their library " +
+        "for a basic land card, put it onto the battlefield tapped, then shuffle."
+
+    spell {
+        val permanent = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Destroy(permanent) then MayEffect(
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            zone = Zone.LIBRARY,
+                            player = Player.ControllerOf("target"),
+                            filter = GameObjectFilter.BasicLand,
+                        ),
+                        storeAs = "searchable",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "searchable",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                        storeSelected = "found",
+                    ),
+                    MoveCollectionEffect(
+                        from = "found",
+                        destination = CardDestination.ToZone(
+                            zone = Zone.BATTLEFIELD,
+                            player = Player.ControllerOf("target"),
+                            placement = ZonePlacement.Tapped,
+                        ),
+                    ),
+                    ShuffleLibraryEffect(target = EffectTarget.TargetController),
+                ),
+            ),
+            decisionMaker = EffectTarget.TargetController,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Florian Herold"
+        flavorText = "\"Our lives are built upon our pasts. What happens, then, if we are cut off from them?\"\n" +
+            "—Augusta, dean of order"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32e670da-7563-4f6a-a7db-4c126a440eb8.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/HeatedArgument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/HeatedArgument.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Heated Argument
+ * {4}{R}
+ * Instant
+ * Heated Argument deals 6 damage to target creature. You may exile a card from your graveyard.
+ * If you do, Heated Argument also deals 2 damage to that creature's controller.
+ *
+ * The optional graveyard exile is modeled as a [MayEffect] + [IfYouDoEffect] gate: gather your
+ * graveyard, choose exactly one card, exile it, and only deal the 2 extra damage when a card was
+ * actually exiled ([SuccessCriterion.CollectionNonEmpty] on the moved pile). With an empty graveyard
+ * the player can't complete the exile, so the rider never happens. The rider's damage hits
+ * [EffectTarget.TargetController] — the controller of the targeted creature — and is dealt by this
+ * spell ("Heated Argument also deals ..."), matching the targeted creature's damage source.
+ */
+val HeatedArgument = card("Heated Argument") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Heated Argument deals 6 damage to target creature. You may exile a card from your " +
+        "graveyard. If you do, Heated Argument also deals 2 damage to that creature's controller."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(6, creature) then MayEffect(
+            IfYouDoEffect(
+                action = Effects.Composite(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(zone = Zone.GRAVEYARD),
+                            storeAs = "graveyardCards",
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "graveyardCards",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                            storeSelected = "toExile",
+                            selectedLabel = "Exile",
+                        ),
+                        MoveCollectionEffect(
+                            from = "toExile",
+                            destination = CardDestination.ToZone(Zone.EXILE),
+                        ),
+                    ),
+                ),
+                ifYouDo = Effects.DealDamage(2, EffectTarget.TargetController),
+                successCriterion = SuccessCriterion.CollectionNonEmpty("toExile", min = 1),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Aleksi Briclot"
+        flavorText = "\"I don't want to hurt you, Ajani, but whatever Jace is planning needs to be stopped!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/0038d212-3d95-4f98-8c2e-7b2404d0ced7.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ManaSculpt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ManaSculpt.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mana Sculpt
+ * {1}{U}{U}
+ * Instant
+ * Counter target spell. If you control a Wizard, add an amount of {C} equal to the amount of mana
+ * spent to cast that spell at the beginning of your next main phase.
+ *
+ * The Wizard rider creates a delayed triggered ability ("at the beginning of your next main phase,
+ * add an amount of {C} equal to the amount of mana spent to cast that spell"). "That spell" is the
+ * countered spell — gone from the stack by the time the delayed trigger fires — so the amount must
+ * be captured at resolution. The delayed-trigger payoff is authored as
+ * `AddColorlessMana(targetManaSpent(0))`; [CreateDelayedTriggerExecutor] snapshots that dynamic
+ * amount into a [com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed] literal while the target
+ * spell is still on the stack. For that snapshot to read the real amount, the gated delayed-trigger
+ * creation is sequenced **before** the counter (the target spell still carries its
+ * `SpellOnStackComponent` payment buckets at that point).
+ *
+ * "Your next main phase" is modeled as the controller's next precombat main phase
+ * ([Step.PRECOMBAT_MAIN] gated to [Player.You] via [DelayedTriggerTiming.CURRENT_TURN_OR_LATER]) —
+ * the common reading for a "next main phase" mana payoff.
+ */
+val ManaSculpt = card("Mana Sculpt") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. If you control a Wizard, add an amount of {C} equal to the " +
+        "amount of mana spent to cast that spell at the beginning of your next main phase."
+
+    spell {
+        target = Targets.Spell
+        effect = ConditionalEffect(
+            condition = Conditions.YouControl(GameObjectFilter.Creature.withSubtype("Wizard")),
+            effect = CreateDelayedTriggerEffect(
+                step = Step.PRECOMBAT_MAIN,
+                fireOnPlayer = EffectTarget.PlayerRef(Player.You),
+                timing = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+                effect = Effects.AddColorlessMana(DynamicAmounts.targetManaSpent(0)),
+            ),
+        ) then Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "Cristi Balanescu"
+        flavorText = "The harder a foe strikes, the stronger a Dragonsguard's defenses become."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/200c8e3d-c53b-40c7-a29a-fccc1281bfc6.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1483,6 +1483,98 @@
     ]
 }
 
+// Erode
+{
+    "name": "Erode",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature or planeswalker. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "player": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "target"
+                                    },
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "player": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "target"
+                                    },
+                                    "placement": "Tapped"
+                                }
+                            },
+                            {
+                                "type": "ShuffleLibrary",
+                                "target": "TargetController"
+                            }
+                        ]
+                    },
+                    "decisionMaker": "TargetController"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Florian Herold",
+        "flavorText": "\"Our lives are built upon our pasts. What happens, then, if we are cut off from them?\"\n—Augusta, dean of order",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32e670da-7563-4f6a-a7db-4c126a440eb8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Expressive Firedancer
 {
     "name": "Expressive Firedancer",
@@ -2507,6 +2599,106 @@
     ]
 }
 
+// Heated Argument
+{
+    "name": "Heated Argument",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Heated Argument deals 6 damage to target creature. You may exile a card from your graveyard. If you do, Heated Argument also deals 2 damage to that creature's controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "storeAs": "graveyardCards"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "graveyardCards",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "toExile",
+                                        "selectedLabel": "Exile"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "toExile",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    }
+                                ]
+                            },
+                            "successCriterion": {
+                                "type": "SuccessCriterion.CollectionNonEmpty",
+                                "name": "toExile"
+                            }
+                        },
+                        "then": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "TargetController"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Aleksi Briclot",
+        "flavorText": "\"I don't want to hurt you, Ajani, but whatever Jace is planning needs to be stopped!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/0038d212-3d95-4f98-8c2e-7b2404d0ced7.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hungry Graffalon
 {
     "name": "Hungry Graffalon",
@@ -3274,6 +3466,69 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Mana Sculpt
+{
+    "name": "Mana Sculpt",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. If you control a Wizard, add an amount of {C} equal to the amount of mana spent to cast that spell at the beginning of your next main phase.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature Wizard"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateDelayedTrigger",
+                        "step": "PRECOMBAT_MAIN",
+                        "effect": {
+                            "type": "AddColorlessMana",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "ManaSpent"
+                            }
+                        },
+                        "fireOnPlayer": {
+                            "type": "PlayerRef",
+                            "player": "You"
+                        }
+                    }
+                },
+                "Counter"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "Cristi Balanescu",
+        "flavorText": "The harder a foe strikes, the stronger a Dragonsguard's defenses become.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/200c8e3d-c53b-40c7-a29a-fccc1281bfc6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -132,6 +132,9 @@ internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): Dsl? =
 internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): Dsl? {
     echoEffect(actions)?.let { return it }
     counterUnlessPaysEffect(actions)?.let { return it }
+    erodeDestroyControllerFetchEffect(actions)?.let { return it }
+    heatedArgumentExileRiderEffect(actions)?.let { return it }
+    manaSculptCounterWizardManaEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
     chooseAbilityGrantEffect(actions, tvar)?.let { return it }
     chooseTypeModifyStatsEffect(actions)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
@@ -1,0 +1,226 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.Composite
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.Raw
+import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.call
+import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.strField
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Multi-action composite recognizers for a few "Secrets of Strixhaven" spell shapes where the mtgish IR
+ * splits one engine effect into sibling actions the per-action handlers can't fuse on their own. Each
+ * matches an EXACT action-list shape and renders the same gameplay tree as the hand-authored card, or
+ * returns null (→ SCAFFOLD) — never a lossy approximation.
+ *
+ * These live with the other named composite recognizers tried first in [renderEffectList].
+ */
+
+/**
+ * Erode: `[DestroyPermanent(Ref_TargetPermanent),
+ *          PlayerMayAction(ControllerOfTargetPermanent, SearchLibrary(basic land → battlefield tapped, shuffle))]`
+ * → `Effects.Destroy(t) then MayEffect(<controller-of-target basic-land fetch pipeline>)`.
+ *
+ * "Destroy target creature or planeswalker. Its controller may search their library for a basic land
+ * card, put it onto the battlefield tapped, then shuffle." The searcher is the *destroyed permanent's
+ * controller*, not the spell's controller, so `Patterns.Library.searchLibrary` (always controller-scoped)
+ * can't express it — the fetch pipeline is scoped to `Player.ControllerOf("target")` and the gate is
+ * delegated to `EffectTarget.TargetController`. Renders only this exact shape (a bare basic-land tutor to
+ * the battlefield tapped, then shuffle); any other search arm declines.
+ */
+internal fun EmitCtx.erodeDestroyControllerFetchEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (destroy, mayAction) = actions
+    if (destroy.strField("_Action") != "DestroyPermanent") return null
+    if (!jsonContains(destroy, "_Permanent", "Ref_TargetPermanent")) return null
+    if (mayAction.strField("_Action") != "PlayerMayAction") return null
+    // The optional searcher must be the controller of the targeted permanent.
+    if (!jsonContains(mayAction, "_Player", "ControllerOfTargetPermanent")) return null
+    val search = innerAction(mayAction)?.takeIf { it.strField("_Action") == "SearchLibrary" } ?: return null
+    val blob = compact(search)
+    // Exactly: find a basic land card, put it onto the battlefield tapped, then shuffle.
+    val basicLand = "IsSupertype" in blob && "\"Basic\"" in blob &&
+        "IsCardtype" in blob && "\"Land\"" in blob
+    val toBattlefieldTapped = "PutFoundCardsOntoBattlefield" in blob && "EntersTapped" in blob
+    val shuffles = "Shuffle" in blob
+    if (!basicLand || !toBattlefieldTapped || !shuffles) return null
+    // Decline any extra search arm (reveal, conditional, choice, etc.) we don't render here.
+    if ("ChooseAnAction" in blob || "If" in blob || "MayPut" in blob || "ExileFoundCards" in blob) return null
+
+    val destroyEffect = call("Effects.Destroy", arg(Lit("EffectTarget.BoundVariable(\"target\")")))
+    val fetch = Composite(
+        listOf(
+            Raw(
+                "GatherCardsEffect(\n" +
+                    "                source = CardSource.FromZone(\n" +
+                    "                    zone = Zone.LIBRARY,\n" +
+                    "                    player = Player.ControllerOf(\"target\"),\n" +
+                    "                    filter = GameObjectFilter.BasicLand,\n" +
+                    "                ),\n" +
+                    "                storeAs = \"searchable\",\n" +
+                    "            )",
+            ),
+            Raw(
+                "SelectFromCollectionEffect(\n" +
+                    "                from = \"searchable\",\n" +
+                    "                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),\n" +
+                    "                storeSelected = \"found\",\n" +
+                    "            )",
+            ),
+            Raw(
+                "MoveCollectionEffect(\n" +
+                    "                from = \"found\",\n" +
+                    "                destination = CardDestination.ToZone(\n" +
+                    "                    zone = Zone.BATTLEFIELD,\n" +
+                    "                    player = Player.ControllerOf(\"target\"),\n" +
+                    "                    placement = ZonePlacement.Tapped,\n" +
+                    "                ),\n" +
+                    "            )",
+            ),
+            Lit("ShuffleLibraryEffect(target = EffectTarget.TargetController)"),
+        ),
+    )
+    val may = call(
+        "MayEffect",
+        arg("effect", fetch),
+        arg("decisionMaker", "EffectTarget.TargetController"),
+    )
+    return Composite(listOf(destroyEffect, may))
+}
+
+/**
+ * Heated Argument: `[SpellDealsDamage(6, Ref_TargetPermanent),
+ *                    MayCost(Exile a card from your graveyard),
+ *                    If(CostWasPaid)[SpellDealsDamage(2, ControllerOfPermanent Ref_TargetPermanent)]]`
+ * → `Effects.DealDamage(6, t) then MayEffect(IfYouDoEffect(<exile-one-from-graveyard pipeline>,
+ *      ifYouDo = Effects.DealDamage(2, TargetController), CollectionNonEmpty))`.
+ *
+ * The optional graveyard exile + "if you do" rider fuse into one gate: the IR's `MayCost(Exile)` becomes
+ * the choose-and-exile pipeline, and `If(CostWasPaid)` becomes the `SuccessCriterion.CollectionNonEmpty`
+ * gate on the moved pile. Only the exact "exile a card from YOUR graveyard, then deal N to the targeted
+ * creature's controller" shape renders; any other cost / condition / recipient declines.
+ */
+internal fun EmitCtx.heatedArgumentExileRiderEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 3) return null
+    val (damage, mayCost, ifPaid) = actions
+    if (damage.strField("_Action") != "SpellDealsDamage") return null
+    if (!jsonContains(damage, "_Permanent", "Ref_TargetPermanent")) return null
+    val firstAmt = findInteger(damage["args"]) as? Int ?: return null
+
+    if (mayCost.strField("_Action") != "MayCost") return null
+    // The optional cost is "exile a card from your graveyard".
+    val costBlob = compact(mayCost["args"])
+    val exilesOwnGraveyardCard = "\"Exile\"" in costBlob && "AGraveyardCard" in costBlob &&
+        "InAPlayersGraveyard" in costBlob && "\"You\"" in costBlob
+    if (!exilesOwnGraveyardCard) return null
+
+    if (ifPaid.strField("_Action") != "If") return null
+    val ifArgs = ifPaid["args"].asArr ?: return null
+    val cond = ifArgs.getOrNull(0) as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "CostWasPaid") return null
+    val riderActions = (ifArgs.getOrNull(1) as? JsonArray)
+        ?.filterIsInstance<JsonObject>() ?: return null
+    val rider = riderActions.singleOrNull()?.takeIf { it.strField("_Action") == "SpellDealsDamage" } ?: return null
+    // The rider hits the targeted creature's controller ("...also deals N damage to that creature's controller").
+    if (!jsonContains(rider, "_DamageRecipient", "Player") ||
+        !jsonContains(rider, "_Player", "ControllerOfPermanent") ||
+        !jsonContains(rider, "_Permanent", "Ref_TargetPermanent")
+    ) return null
+    val riderAmt = findInteger(rider["args"]) as? Int ?: return null
+
+    val firstDamage = call(
+        "Effects.DealDamage",
+        arg("$firstAmt"),
+        arg(Lit("EffectTarget.BoundVariable(\"target\")")),
+    )
+    val exilePipeline = Composite(
+        listOf(
+            Lit("GatherCardsEffect(source = CardSource.FromZone(zone = Zone.GRAVEYARD), storeAs = \"graveyardCards\")"),
+            Raw(
+                "SelectFromCollectionEffect(\n" +
+                    "                    from = \"graveyardCards\",\n" +
+                    "                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),\n" +
+                    "                    storeSelected = \"toExile\",\n" +
+                    "                    selectedLabel = \"Exile\",\n" +
+                    "                )",
+            ),
+            Lit("MoveCollectionEffect(from = \"toExile\", destination = CardDestination.ToZone(Zone.EXILE))"),
+        ),
+    )
+    val ifYouDo = call(
+        "IfYouDoEffect",
+        arg("action", exilePipeline),
+        arg("ifYouDo", call("Effects.DealDamage", arg("$riderAmt"), arg("EffectTarget.TargetController"))),
+        arg("successCriterion", "SuccessCriterion.CollectionNonEmpty(\"toExile\", min = 1)"),
+    )
+    return Composite(listOf(firstDamage, call("MayEffect", arg(ifYouDo))))
+}
+
+/**
+ * Mana Sculpt: `[CounterSpell(Ref_TargetSpell),
+ *                If(PlayerPassesFilter(You, ControlsA(Wizard)))
+ *                  [CreateFutureTrigger(AtTheBeginningOfPlayersNextMainPhase(You),
+ *                     [AddManaRepeated(C, AmountOfManaSpentToCastSpell(Ref_TargetSpell))])]]`
+ * → `ConditionalEffect(YouControl(Wizard), CreateDelayedTriggerEffect(PRECOMBAT_MAIN, fireOnPlayer = You,
+ *      AddColorlessManaEffect(targetManaSpent(0)))) then Effects.CounterSpell()`.
+ *
+ * "Counter target spell. If you control a Wizard, add an amount of {C} equal to the amount of mana spent
+ * to cast that spell at the beginning of your next main phase." The delayed trigger fires at the
+ * controller's next precombat main phase; the mana-spent amount references the (now-countered) target
+ * spell — the engine snapshots it at delayed-trigger creation time, so the gated trigger creation is
+ * sequenced before the counter. Renders only this exact shape (control-a-Wizard gate, your-next-main-
+ * phase timing, {C} = mana spent to cast the target spell); any other condition / timing / mana declines.
+ */
+internal fun EmitCtx.manaSculptCounterWizardManaEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (counter, ifWizard) = actions
+    if (counter.strField("_Action") != "CounterSpell") return null
+    if (!jsonContains(counter, "_Spell", "Ref_TargetSpell")) return null
+
+    if (ifWizard.strField("_Action") != "If") return null
+    val ifArgs = ifWizard["args"].asArr ?: return null
+    val cond = ifArgs.getOrNull(0) as? JsonObject ?: return null
+    // "if you control a Wizard".
+    val condBlob = compact(cond)
+    val controlsWizard = cond.strField("_Condition") == "PlayerPassesFilter" &&
+        "\"You\"" in condBlob && "ControlsA" in condBlob &&
+        "IsCreatureType" in condBlob && "\"Wizard\"" in condBlob
+    if (!controlsWizard) return null
+
+    val thenActions = (ifArgs.getOrNull(1) as? JsonArray)
+        ?.filterIsInstance<JsonObject>() ?: return null
+    val future = thenActions.singleOrNull()?.takeIf { it.strField("_Action") == "CreateFutureTrigger" } ?: return null
+    val futureArgs = future["args"].asArr ?: return null
+    val timing = futureArgs.getOrNull(0) as? JsonObject ?: return null
+    // "at the beginning of your next main phase".
+    if (timing.strField("_FutureTrigger") != "AtTheBeginningOfPlayersNextMainPhase") return null
+    if (!jsonContains(timing, "_Player", "You")) return null
+    val futureBody = (futureArgs.getOrNull(1) as? JsonObject)?.get("args").asArr
+        ?.filterIsInstance<JsonObject>() ?: return null
+    val addMana = futureBody.singleOrNull()?.takeIf { it.strField("_Action") == "AddManaRepeated" } ?: return null
+    val addBlob = compact(addMana)
+    // {C} equal to the amount of mana spent to cast THAT (countered) spell.
+    val colorlessManaSpent = "ManaProduceC" in addBlob &&
+        "AmountOfManaSpentToCastSpell" in addBlob && "Ref_TargetSpell" in addBlob
+    if (!colorlessManaSpent) return null
+
+    val delayedTrigger = call(
+        "CreateDelayedTriggerEffect",
+        arg("step", "Step.PRECOMBAT_MAIN"),
+        arg("fireOnPlayer", "EffectTarget.PlayerRef(Player.You)"),
+        arg("effect", call("Effects.AddColorlessMana", arg(Lit("DynamicAmounts.targetManaSpent(0)")))),
+    )
+    val gated = call(
+        "ConditionalEffect",
+        arg("condition", "Conditions.YouControl(GameObjectFilter.Creature.withSubtype(\"Wizard\"))"),
+        arg("effect", delayedTrigger),
+    )
+    return Composite(listOf(gated, call("Effects.CounterSpell")))
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -2,11 +2,14 @@ package com.wingedsheep.engine.handlers.effects.composite
 
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.event.DelayedTriggeredAbility
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
@@ -24,6 +27,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -41,6 +45,8 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
 
     override val effectType: KClass<CreateDelayedTriggerEffect> = CreateDelayedTriggerEffect::class
 
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
+
     override fun execute(
         state: GameState,
         effect: CreateDelayedTriggerEffect,
@@ -53,7 +59,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
 
         // Bake in any context-dependent target references so the delayed trigger
         // has concrete entity IDs when it fires later.
-        val resolvedEffect = resolveContextTargets(effect.effect, context)
+        val resolvedEffect = resolveContextTargets(effect.effect, context, state)
 
         // Bake any chosen-value references in the trigger's filter into concrete predicates.
         // Long List of the Ents (LTR) needs "when you cast a creature spell of the type just
@@ -166,13 +172,29 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
     }
 
     /**
+     * Capture a [DynamicAmount] that reads from the *current* context (a target spell/permanent,
+     * the mana spent to cast it, etc.) into a [DynamicAmount.Fixed] literal, so the delayed
+     * trigger's effect carries the value forward to a later step when the originating context —
+     * and any referenced object — no longer exists. Already-fixed amounts are returned unchanged.
+     */
+    private fun snapshotAmount(
+        amount: DynamicAmount,
+        context: EffectContext,
+        state: GameState
+    ): DynamicAmount {
+        if (amount is DynamicAmount.Fixed) return amount
+        val value = dynamicAmountEvaluator.evaluate(state, amount, context)
+        return DynamicAmount.Fixed(value)
+    }
+
+    /**
      * Recursively substitute context-dependent target references with concrete SpecificEntity
      * references using the current execution context.
      *
      * This covers ContextTarget(n), Self, TriggeringEntity, and any other non-persistent
      * target types that won't be resolvable when the delayed trigger fires later.
      */
-    private fun resolveContextTargets(effect: Effect, context: EffectContext): Effect {
+    private fun resolveContextTargets(effect: Effect, context: EffectContext, state: GameState): Effect {
         return when (effect) {
             is MoveToZoneEffect -> {
                 val resolvedId = context.resolveTarget(effect.target)
@@ -200,6 +222,19 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
                 val resolvedId = context.resolveTarget(effect.target)
                 if (resolvedId != null) effect.copy(target = EffectTarget.SpecificEntity(resolvedId)) else effect
             }
+            // A delayed trigger that adds mana "equal to" a value read from a context entity
+            // (e.g. Mana Sculpt: "{C} equal to the amount of mana spent to cast that spell, at the
+            // beginning of your next main phase") must capture that value NOW — the referenced
+            // spell/permanent is gone by the time the trigger fires, so a lazy read would yield 0.
+            // Snapshot the amount against the current context into a Fixed literal.
+            is AddManaEffect -> {
+                val snapshot = snapshotAmount(effect.amount, context, state)
+                if (snapshot !== effect.amount) effect.copy(amount = snapshot) else effect
+            }
+            is AddColorlessManaEffect -> {
+                val snapshot = snapshotAmount(effect.amount, context, state)
+                if (snapshot !== effect.amount) effect.copy(amount = snapshot) else effect
+            }
             is DealDamagePerEntityInZoneEffect -> {
                 // Resolve collection name to concrete entity IDs from the pipeline
                 val resolvedIds = effect.collectionName?.let { name ->
@@ -215,14 +250,14 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
                 )
             }
             is CompositeEffect -> effect.copy(
-                effects = effect.effects.map { resolveContextTargets(it, context) }
+                effects = effect.effects.map { resolveContextTargets(it, context, state) }
             )
             is GatedEffect -> {
                 // Former MayEffect shape: resolve ContextTargets inside the optional `then` payoff,
                 // exactly as MayEffect did. Other gate shapes (MayPay / WhenCondition) were never
                 // resolved here, so leave them untouched.
                 if (effect.gate is Gate.MayDecide && effect.otherwise == null) {
-                    val inner = resolveContextTargets(effect.then, context)
+                    val inner = resolveContextTargets(effect.then, context, state)
                     if (inner !== effect.then) effect.copy(then = inner) else effect
                 } else {
                     effect

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ErodeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ErodeScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Erode (SOS #15).
+ *
+ * "{W} Instant. Destroy target creature or planeswalker. Its controller may search their library
+ *  for a basic land card, put it onto the battlefield tapped, then shuffle."
+ *
+ * Verifies the destroy always happens, and that the optional basic-land search is performed by the
+ * *destroyed permanent's controller* (the opponent here), who may decline.
+ */
+class ErodeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Erode") {
+
+            test("destroys the creature; its controller may fetch a tapped basic land") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Erode")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Erode", bears)
+                game.resolveStack()
+
+                // Its controller (player 2) may search — accept.
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                // Select the Forest from player 2's library.
+                if (game.hasPendingDecision()) {
+                    val forest = game.state.getLibrary(game.player2Id).first { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    }
+                    game.selectCards(listOf(forest))
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears should be destroyed") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                val forestOnBf = game.state.getBattlefield().firstOrNull { id ->
+                    val e = game.state.getEntity(id)
+                    e?.get<CardComponent>()?.name == "Forest" &&
+                        e.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+                withClue("Player 2 should have fetched a Forest onto the battlefield") {
+                    (forestOnBf != null) shouldBe true
+                }
+                withClue("The fetched Forest should be tapped") {
+                    game.state.getEntity(forestOnBf!!)?.get<TappedComponent>() shouldBe TappedComponent
+                }
+            }
+
+            test("the controller may decline the search") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Erode")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Erode", bears)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Grizzly Bears should still be destroyed") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("No land should have entered the battlefield") {
+                    game.state.getBattlefield().none { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeatedArgumentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeatedArgumentScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Heated Argument (SOS #118).
+ *
+ * "{4}{R} Instant. Heated Argument deals 6 damage to target creature. You may exile a card from
+ *  your graveyard. If you do, Heated Argument also deals 2 damage to that creature's controller."
+ *
+ * Verifies the 6 damage to the targeted creature always happens; the 2 damage to that creature's
+ * controller only happens when the caster actually exiles a graveyard card (MayEffect + IfYouDo).
+ */
+class HeatedArgumentScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Heated Argument") {
+
+            test("exiling a graveyard card deals 2 extra damage to the creature's controller") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Heated Argument")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Heated Argument", bears)
+                game.resolveStack()
+
+                // MayEffect: accept and exile the graveyard card.
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val gy = game.state.getGraveyard(game.player1Id)
+                    game.selectCards(gy.take(1))
+                    game.resolveStack()
+                }
+
+                // 6 damage destroys the 2/2 Grizzly Bears.
+                withClue("Grizzly Bears should be destroyed by 6 damage") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+
+                withClue("Victim should take 2 damage to face (20 -> 18)") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("declining the exile deals no extra damage") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Heated Argument")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Heated Argument", bears)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Grizzly Bears should still be destroyed by 6 damage") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Victim should be untouched when the exile is declined") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+                withClue("The Mountain should remain in the graveyard (not exiled)") {
+                    val names = game.state.getGraveyard(game.player1Id).mapNotNull {
+                        game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name
+                    }
+                    names.contains("Mountain") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaSculptScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaSculptScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ManaSculpt
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Mana Sculpt (SOS #57).
+ *
+ * "{1}{U}{U} Instant. Counter target spell. If you control a Wizard, add an amount of {C} equal to
+ *  the amount of mana spent to cast that spell at the beginning of your next main phase."
+ *
+ * Exercises the delayed-trigger mana-spent snapshot: the countered spell is gone by the time the
+ * delayed trigger fires, so [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor]
+ * captures "the amount of mana spent to cast that spell" into a fixed amount while the spell is still
+ * on the stack. The Wizard rider only happens when the caster controls a Wizard.
+ */
+class ManaSculptScenarioTest : FunSpec({
+
+    // A 1/1 Wizard for {U} so the controller "controls a Wizard".
+    val Apprentice = CardDefinition.creature(
+        name = "Apprentice Wizard",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Wizard")),
+        power = 1,
+        toughness = 1
+    )
+
+    // A 3/3 for {2}{G} — total mana spent = 3 — to be the countered spell.
+    val Bear = CardDefinition.creature(
+        name = "Big Bear",
+        manaCost = ManaCost.parse("{2}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 3,
+        toughness = 3
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ManaSculpt, Apprentice, Bear))
+        return driver
+    }
+
+    fun colorlessInPool(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getEntity(playerId)?.get<ManaPoolComponent>()?.colorless ?: 0
+
+    fun advanceToPlayersPrecombatMain(driver: GameTestDriver, playerId: EntityId, maxSteps: Int = 200) {
+        var steps = 0
+        while (!(driver.state.activePlayerId == playerId && driver.state.step == Step.PRECOMBAT_MAIN) &&
+            steps++ < maxSteps
+        ) {
+            if (driver.state.pendingDecision != null) {
+                driver.autoResolveDecision()
+            } else if (driver.state.priorityPlayerId != null) {
+                driver.passPriority(driver.state.priorityPlayerId!!)
+            }
+        }
+        check(driver.state.activePlayerId == playerId && driver.state.step == Step.PRECOMBAT_MAIN) {
+            "Failed to reach player's precombat main (active=${driver.state.activePlayerId}, step=${driver.state.step})"
+        }
+    }
+
+    test("controlling a Wizard adds {C} equal to the mana spent, at the next main phase") {
+        val driver = createDriver()
+        // Player 2 starts so player 1 (the counterer) gets the next precombat main.
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20, startingPlayer = 1)
+
+        val player2 = driver.activePlayer!!
+        val player1 = driver.getOpponent(player2)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Player 1 controls a Wizard.
+        driver.putCreatureOnBattlefield(player1, "Apprentice Wizard")
+
+        // Player 2 casts Big Bear, paying {2}{G} from pool so 3 mana is recorded as spent.
+        val bear = driver.putCardInHand(player2, "Big Bear")
+        driver.giveMana(player2, Color.GREEN, 1)
+        driver.giveColorlessMana(player2, 2)
+        driver.castSpell(player2, bear)
+        driver.getTopOfStackName() shouldBe "Big Bear"
+
+        // Player 2 passes priority; player 1 responds with Mana Sculpt, countering Big Bear.
+        driver.passPriority(player2)
+        val sculpt = driver.putCardInHand(player1, "Mana Sculpt")
+        driver.giveMana(player1, Color.BLUE, 2)
+        driver.giveColorlessMana(player1, 1)
+        val cast = driver.castSpellWithTargets(player1, sculpt, listOf(ChosenTarget.Spell(bear)))
+        cast.isSuccess shouldBe true
+
+        // Resolve the stack: Mana Sculpt counters Big Bear.
+        driver.bothPass()
+        driver.bothPass()
+        driver.stackSize shouldBe 0
+
+        // No mana added yet — it waits for the next main phase.
+        colorlessInPool(driver, player1) shouldBe 0
+
+        // Advance to player 1's next precombat main; the delayed trigger fires and resolves.
+        advanceToPlayersPrecombatMain(driver, player1)
+        driver.bothPass()
+
+        // {C}{C}{C} added (3 mana was spent to cast Big Bear).
+        colorlessInPool(driver, player1) shouldBe 3
+    }
+
+    test("no Wizard means no mana rider — the spell is still countered") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30), startingLife = 20, startingPlayer = 1)
+
+        val player2 = driver.activePlayer!!
+        val player1 = driver.getOpponent(player2)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Player 2 casts Big Bear.
+        val bear = driver.putCardInHand(player2, "Big Bear")
+        driver.giveMana(player2, Color.GREEN, 1)
+        driver.giveColorlessMana(player2, 2)
+        driver.castSpell(player2, bear)
+
+        // Player 2 passes priority; player 1 counters with Mana Sculpt but controls no Wizard.
+        driver.passPriority(player2)
+        val sculpt = driver.putCardInHand(player1, "Mana Sculpt")
+        driver.giveMana(player1, Color.BLUE, 2)
+        driver.giveColorlessMana(player1, 1)
+        driver.castSpellWithTargets(player1, sculpt, listOf(ChosenTarget.Spell(bear)))
+
+        driver.bothPass()
+        driver.bothPass()
+        driver.stackSize shouldBe 0
+
+        advanceToPlayersPrecombatMain(driver, player1)
+        driver.bothPass()
+
+        // No Wizard → no delayed trigger → no mana.
+        colorlessInPool(driver, player1) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements three **Secrets of Strixhaven** (SOS) instants as data-driven `cardDef`s, each with a passing scenario test, plus mtgish-emitter support so they auto-generate at **AUTO** tier.

## Cards
- **Heated Argument** `{4}{R}` — 6 damage to target creature, then `MayEffect` + `IfYouDoEffect` exile-one-from-graveyard pipeline gating 2 damage to that creature's controller.
- **Mana Sculpt** `{1}{U}{U}` — counter target spell; if you control a Wizard, a delayed trigger at your next precombat main adds `{C}` equal to the mana spent to cast that (now-countered) spell.
- **Erode** `{W}` — destroy target creature or planeswalker; its controller (delegated `decisionMaker`) may fetch a basic land onto the battlefield tapped, then shuffle. A Path-to-Exile-shaped fetch scoped to `Player.ControllerOf("target")`.

## Engine change
`CreateDelayedTriggerExecutor` now **snapshots** a non-`Fixed` `DynamicAmount` inside an `AddMana`/`AddColorlessMana` delayed-trigger effect into a `Fixed` literal at creation time (same mechanism it already uses to bake `ContextTarget` refs). This is required for Mana Sculpt: "add `{C}` equal to the mana spent to cast that spell" must read the still-on-stack target spell before it leaves — the gated trigger creation is sequenced before the counter so the snapshot is accurate. Documented in `docs/card-sdk-language-reference.md`.

## mtgish tooling
`SosRecognizers.kt` adds three exact-shape composite recognizers wired into `renderEffectList`, rendering each card whole (matching the hand-authored gameplay tree) or declining — no lossy approximation. The `MayCost`/`PlayerMayAction`/`If` bridge envelopes already existed, so no bridge change was needed.

## Verification
- New `ManaSculpt`/`HeatedArgument`/`Erode` scenario tests pass.
- `CardDefinitionSnapshotTest` re-blessed — SOS diff is only the 3 new cards.
- `CardLintTest`, `EmitterGoldenTest`, and the full `:mtgish-tooling` suite pass.
- `coverage-verify POR`: **GATE PASS, 158/158, 0 mismatch**.
- `coverage-verify SOS`: all 3 new cards now **AUTO-emit, compile, and match golden**. The remaining 3 `GAMEPLAY TREE MISMATCH`es (Lorehold/Prismari/Silverquill Charm) are **pre-existing and unrelated** to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)