### PR TITLE
Fix AI infinite loop on sacrifice-cost activated abilities

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -1159,11 +1159,24 @@ class GamePlayHandler(
         aiPlayerId: EntityId
     ): List<com.wingedsheep.engine.core.GameAction> {
         val pass = com.wingedsheep.engine.core.PassPriority(aiPlayerId)
+        // If PassPriority is currently a legal action, we're in a priority window (e.g. after
+        // blockers/attackers were already declared), not the actual declare-step decision. In that
+        // case a do-nothing DeclareBlockers/DeclareAttackers can succeed as a no-op and hand
+        // priority straight back to the AI → infinite loop. Pass FIRST so the loop breaks; keep the
+        // do-nothing declaration only as a fallback for the genuine declare-step decision (where
+        // PassPriority is NOT yet legal).
+        val passIsLegal = gameSession.getLegalActions(aiPlayerId).any {
+            it.action is com.wingedsheep.engine.core.PassPriority
+        }
         return when (gameSession.getStateForTesting()?.step) {
-            com.wingedsheep.sdk.core.Step.DECLARE_BLOCKERS ->
-                listOf(com.wingedsheep.engine.core.DeclareBlockers(aiPlayerId, emptyMap()), pass)
-            com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS ->
-                listOf(com.wingedsheep.engine.core.DeclareAttackers(aiPlayerId, emptyMap()), pass)
+            com.wingedsheep.sdk.core.Step.DECLARE_BLOCKERS -> {
+                val declare = com.wingedsheep.engine.core.DeclareBlockers(aiPlayerId, emptyMap())
+                if (passIsLegal) listOf(pass, declare) else listOf(declare, pass)
+            }
+            com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS -> {
+                val declare = com.wingedsheep.engine.core.DeclareAttackers(aiPlayerId, emptyMap())
+                if (passIsLegal) listOf(pass, declare) else listOf(declare, pass)
+            }
             else -> listOf(pass)
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -487,3 +487,31 @@ data class ActivateAbilityOpponentTargetContinuation(
     val fullRequirements: List<com.wingedsheep.sdk.scripting.targets.TargetRequirement>,
     val deciderId: EntityId
 ) : ContinuationFrame
+
+/**
+ * Resume after a player picks which permanents to sacrifice to satisfy a
+ * [com.wingedsheep.sdk.scripting.costs.CostAtom.Sacrifice] cost on an activated ability.
+ *
+ * Surfaces the cost-choice the original engine path used to fail on: when an activation's
+ * `Sacrifice(filter, count, excludeSelf)` cost has more matching battlefield permanents than
+ * `count`, the handler raises a [SelectCardsDecision] and pushes this frame so the resumer can
+ * re-enter the handler with the player's chosen permanents filled into
+ * `costPayment.sacrificedPermanents`.
+ *
+ * Skipped (no pause) when `sacrificedPermanents` is already pre-filled (engine-direct path /
+ * resumed replay) or when candidate count ≤ required count (no real choice — CostHandler
+ * auto-picks). Sage of Lat-Nam ({T}, Sacrifice an artifact: Draw a card) is the canonical case.
+ *
+ * @property action The original [ActivateAbility] (`costPayment.sacrificedPermanents` still empty),
+ *   so the resumer can re-enter the handler with the chosen sacrifice victims filled in.
+ * @property sacrificeCandidates The matching battlefield permanents offered to the player as
+ *   options; used to validate the response is a subset of the originally legal candidates.
+ * @property sacrificeCount Exact number of permanents the player must pick (`count` from the cost).
+ */
+@Serializable
+data class ActivateAbilitySacrificeContinuation(
+    override val decisionId: String,
+    val action: ActivateAbility,
+    val sacrificeCandidates: List<EntityId>,
+    val sacrificeCount: Int
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -296,6 +296,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ActivateAbilityTapXTargetsContinuation::class)
         subclass(ActivateAbilityExileFromGraveyardContinuation::class)
         subclass(ActivateAbilityOpponentTargetContinuation::class)
+        subclass(ActivateAbilitySacrificeContinuation::class)
     }
 
     // Component hierarchy (for GameState persistence)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -656,7 +656,26 @@ class CostHandler(
         controllerId: EntityId,
         manaPool: ManaPool,
     ): CostPaymentResult {
-        val toSacrificeList = sacrificeChoices.take(requiredCount)
+        // When no choice was supplied, auto-pick from the legal candidates — but ONLY when the
+        // choice is forced (candidates <= requiredCount). When candidates > requiredCount it's a
+        // real choice that ActivateAbilityHandler pauses for; we should never silently take the
+        // first N. This mirrors exileCardsFromZone's auto-pick for empty exile choices, and lets
+        // the forced case (e.g. exactly one artifact) resolve without a decision while breaking the
+        // AI's infinite "Not enough sacrifice targets chosen" loop.
+        val toSacrificeList = if (sacrificeChoices.isEmpty()) {
+            val candidates = findMatchingCardsUnified(state, state.getBattlefield(controllerId), filter, controllerId)
+                .let { if (excludeSelf) it.filter { id -> id != sourceId } else it }
+            if (candidates.size < requiredCount) {
+                return CostPaymentResult.failure("Not enough sacrifice targets chosen (need $requiredCount, got ${candidates.size})")
+            }
+            if (candidates.size > requiredCount) {
+                // A real choice reached the cost path with no selection — fail rather than guess.
+                return CostPaymentResult.failure("Not enough sacrifice targets chosen (need $requiredCount, got 0)")
+            }
+            candidates.take(requiredCount)
+        } else {
+            sacrificeChoices.take(requiredCount)
+        }
         if (toSacrificeList.size < requiredCount) {
             return CostPaymentResult.failure("Not enough sacrifice targets chosen (need $requiredCount, got ${toSacrificeList.size})")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -578,6 +578,63 @@ class ActivateAbilityHandler(
             }
         }
 
+        // -------------------------------------------------------------------
+        // Sacrifice cost-choice pause (legal-actions submission path).
+        //
+        // When the cost is `Sacrifice(filter, count, excludeSelf)` (Sage of
+        // Lat-Nam: "{T}, Sacrifice an artifact: Draw a card", Atog, Ashnod's
+        // Altar, …) and the player controls more matching permanents than the
+        // count, this is a real choice — the engine must pause and ask which
+        // permanent(s) to sacrifice, not fail with "Not enough sacrifice
+        // targets chosen" (an AI submitting a bare ActivateAbility with no
+        // sacrifice chosen would otherwise spin forever).
+        //
+        // Skipped when `sacrificedPermanents` is already pre-filled
+        // (engine-direct path and resumed-replay case) or when candidates <=
+        // count (no real choice — Part 2 / CostHandler auto-picks). Mirrors the
+        // ExileFromGraveyard pause block above.
+        // -------------------------------------------------------------------
+        val sacrificeCost = extractSacrificeCost(effectiveCost)
+        val alreadySacrificing = (action.costPayment?.sacrificedPermanents?.isNotEmpty() == true)
+        if (sacrificeCost != null && !alreadySacrificing) {
+            val sacrificeCandidates = costHandler
+                .findMatchingCardsUnified(state, state.getBattlefield(action.playerId), sacrificeCost.filter, action.playerId)
+                .let { if (sacrificeCost.excludeSelf) it.filter { id -> id != action.sourceId } else it }
+            if (sacrificeCandidates.size > sacrificeCost.count) {
+                val decisionId = java.util.UUID.randomUUID().toString()
+                val prompt = "Select ${sacrificeCost.count} permanent${if (sacrificeCost.count > 1) "s" else ""} to sacrifice for ${cardComponent.name}"
+                val decision = com.wingedsheep.engine.core.SelectCardsDecision(
+                    id = decisionId,
+                    playerId = action.playerId,
+                    prompt = prompt,
+                    context = com.wingedsheep.engine.core.DecisionContext(
+                        sourceId = action.sourceId,
+                        sourceName = cardComponent.name,
+                        phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
+                    ),
+                    options = sacrificeCandidates,
+                    minSelections = sacrificeCost.count,
+                    maxSelections = sacrificeCost.count
+                )
+                val continuation = com.wingedsheep.engine.core.ActivateAbilitySacrificeContinuation(
+                    decisionId = decisionId,
+                    action = action,
+                    sacrificeCandidates = sacrificeCandidates,
+                    sacrificeCount = sacrificeCost.count
+                )
+                val pausedState = state
+                    .withPendingDecision(decision)
+                    .pushContinuation(continuation)
+                val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = action.playerId,
+                    decisionType = "SELECT_CARDS",
+                    prompt = prompt
+                )
+                return ExecutionResult.paused(pausedState, decision, listOf(event))
+            }
+        }
+
         val executeAbilityContext = buildAbilityPaymentContext(cardComponent, state.projectedState, action.sourceId)
 
         var currentState = state
@@ -2183,6 +2240,20 @@ class ActivateAbilityHandler(
         is AbilityCost.Atom -> (cost.atom as? CostAtom.ExileFrom)?.takeIf { it.zone == Zone.GRAVEYARD }
         is AbilityCost.Composite -> cost.costs.firstNotNullOfOrNull {
             ((it as? AbilityCost.Atom)?.atom as? CostAtom.ExileFrom)?.takeIf { ex -> ex.zone == Zone.GRAVEYARD }
+        }
+        else -> null
+    }
+
+    /**
+     * Pull the [CostAtom.Sacrifice] sub-cost out of an ability cost (top-level [AbilityCost.Atom] or
+     * inside a [AbilityCost.Composite]), or null if none. Used by the legal-actions submission path
+     * to detect that an activation needs to pause for a sacrifice-target selection when the player
+     * controls more matching permanents than the cost requires (Sage of Lat-Nam, Atog, …).
+     */
+    private fun extractSacrificeCost(cost: AbilityCost): CostAtom.Sacrifice? = when (cost) {
+        is AbilityCost.Atom -> cost.atom as? CostAtom.Sacrifice
+        is AbilityCost.Composite -> cost.costs.firstNotNullOfOrNull {
+            (it as? AbilityCost.Atom)?.atom as? CostAtom.Sacrifice
         }
         else -> null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation
 import com.wingedsheep.engine.core.ActivateAbilityExileFromGraveyardContinuation
+import com.wingedsheep.engine.core.ActivateAbilitySacrificeContinuation
 import com.wingedsheep.engine.core.ActivateAbilityTapXTargetsContinuation
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.ChooseNumberDecision
@@ -45,7 +46,8 @@ class ActivateAbilityXCostContinuationResumer(
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(ActivateAbilityChooseXContinuation::class, ::resumeChooseX),
         resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets),
-        resumer(ActivateAbilityExileFromGraveyardContinuation::class, ::resumeExileFromGraveyard)
+        resumer(ActivateAbilityExileFromGraveyardContinuation::class, ::resumeExileFromGraveyard),
+        resumer(ActivateAbilitySacrificeContinuation::class, ::resumeSacrifice)
     )
 
     private fun resumeChooseX(
@@ -139,6 +141,38 @@ class ActivateAbilityXCostContinuationResumer(
         val replay = action.copy(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(exiledCards = response.selectedCards)
+        )
+        return handler.execute(state, replay)
+    }
+
+    /**
+     * Resume after the player picks which permanents to sacrifice for a `Sacrifice` activated-ability
+     * cost (Sage of Lat-Nam etc.). Re-enters the handler with the chosen permanents filled into
+     * `costPayment.sacrificedPermanents`; CostHandler then sacrifices exactly those.
+     */
+    private fun resumeSacrifice(
+        state: GameState,
+        continuation: ActivateAbilitySacrificeContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card-selection response for ActivateAbility Sacrifice")
+        }
+        if (response.selectedCards.size != continuation.sacrificeCount) {
+            return ExecutionResult.error(
+                state,
+                "Expected ${continuation.sacrificeCount} permanents to sacrifice, got ${response.selectedCards.size}"
+            )
+        }
+        if (response.selectedCards.any { it !in continuation.sacrificeCandidates }) {
+            return ExecutionResult.error(state, "Selected permanent is not in the list of valid sacrifice candidates")
+        }
+
+        val action = continuation.action
+        val replay = action.copy(
+            costPayment = (action.costPayment ?: AdditionalCostPayment())
+                .copy(sacrificedPermanents = response.selectedCards)
         )
         return handler.execute(state, replay)
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SacrificeCostActivationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SacrificeCostActivationScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dom.cards.SageOfLatNam
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Covers activating an ability with a "Sacrifice an artifact/creature" additional cost
+ * (Sage of Lat-Nam: "{T}, Sacrifice an artifact: Draw a card").
+ *
+ * Three behaviours are pinned:
+ *   1. Forced case (exactly one legal sacrifice candidate) — the engine auto-sacrifices it and
+ *      draws a card with no decision and no failure.
+ *   2. Choice case (two+ candidates) — the engine pauses with a SelectCards decision; after the
+ *      player chooses one, that one is sacrificed and a card drawn.
+ *   3. AI / loop regression — a bare ActivateAbility (empty costPayment) with exactly one candidate
+ *      resolves successfully (previously the cost path failed "Not enough sacrifice targets chosen"
+ *      forever, spinning the server's AI fallback loop).
+ */
+class SacrificeCostActivationScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SageOfLatNam))
+        return driver
+    }
+
+    val abilityId = SageOfLatNam.activatedAbilities.first().id
+
+    fun GameTestDriver.readySage(playerId: com.wingedsheep.sdk.model.EntityId): com.wingedsheep.sdk.model.EntityId {
+        val sage = putCreatureOnBattlefield(playerId, "Sage of Lat-Nam")
+        replaceState(state.updateEntity(sage) { it.without<SummoningSicknessComponent>() })
+        return sage
+    }
+
+    test("Forced case: exactly one artifact auto-sacrifices and draws, no decision needed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sage = driver.readySage(alice)
+        val artifact = driver.putPermanentOnBattlefield(alice, "Artifact Creature")
+
+        val handBefore = driver.getHandSize(alice)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = sage,
+                abilityId = abilityId,
+                costPayment = null,
+            )
+        )
+
+        result.error shouldBe null
+        driver.pendingDecision.shouldBeNull()
+        // The single artifact was sacrificed (cost paid on activation, no longer on battlefield).
+        driver.state.getBattlefield(alice) shouldNotContain artifact
+        // Resolve Sage's ability off the stack so "Draw a card" happens.
+        driver.bothPass()
+        driver.getHandSize(alice) shouldBe handBefore + 1
+    }
+
+    test("Choice case: two artifacts pause for a SelectCards decision; chosen one is sacrificed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sage = driver.readySage(alice)
+        val artifactA = driver.putPermanentOnBattlefield(alice, "Artifact Creature")
+        val artifactB = driver.putPermanentOnBattlefield(alice, "Artifact Creature")
+
+        val handBefore = driver.getHandSize(alice)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = sage,
+                abilityId = abilityId,
+                costPayment = null,
+            )
+        )
+        result.error shouldBe null
+
+        val pending = driver.pendingDecision
+        pending.shouldNotBeNull()
+        val selection = pending.shouldBeInstanceOf<SelectCardsDecision>()
+        selection.playerId shouldBe alice
+        selection.minSelections shouldBe 1
+        selection.maxSelections shouldBe 1
+        selection.options shouldContainAll listOf(artifactA, artifactB)
+
+        // Choose artifactA to sacrifice.
+        val resumed = driver.submitCardSelection(alice, listOf(artifactA))
+        resumed.error shouldBe null
+
+        driver.state.getBattlefield(alice) shouldNotContain artifactA
+        driver.state.getBattlefield(alice) shouldContain artifactB
+        // Resolve Sage's ability off the stack so "Draw a card" happens.
+        driver.bothPass()
+        driver.getHandSize(alice) shouldBe handBefore + 1
+    }
+
+    test("AI / loop regression: bare activation with one candidate succeeds (no infinite failure)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sage = driver.readySage(alice)
+        val artifact = driver.putPermanentOnBattlefield(alice, "Artifact Creature")
+
+        val handBefore = driver.getHandSize(alice)
+
+        // Simulate the AI submitting a bare action with no sacrifice chosen.
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = sage,
+                abilityId = abilityId,
+                costPayment = com.wingedsheep.sdk.scripting.AdditionalCostPayment(),
+            )
+        )
+
+        result.error shouldBe null
+        driver.pendingDecision.shouldBeNull()
+        driver.state.getBattlefield(alice) shouldNotContain artifact
+        // Resolve Sage's ability off the stack so "Draw a card" happens.
+        driver.bothPass()
+        driver.getHandSize(alice) shouldBe handBefore + 1
+    }
+})


### PR DESCRIPTION
The engine AI repeatedly activated an ability with a 'Sacrifice an artifact/creature' additional cost (Sage of Lat-Nam, Atog, Orcish Mechanics, Ashnod's Altar) but submitted a bare ActivateAbility with no sacrifice chosen. CostHandler.paySacrificeList then hard-failed 'Not enough sacrifice targets chosen (need 1, got 0)', the server's safeFallbackActions did not break the loop, and it spun forever.

Mirrors the existing exile-from-graveyard cost-choice pattern:
- ActivateAbilityHandler pauses for a SelectCards decision when a Sacrifice cost has more matching permanents than its count (a real choice), pushing a new ActivateAbilitySacrificeContinuation. The AI's existing respondToDecision path and the client's existing decision UI handle it (same as exile-from-graveyard).
- CostHandler.paySacrificeList auto-picks when the choice is forced (candidates <= required count) instead of failing, so the common case (e.g. exactly one artifact) resolves with no decision.
- ActivateAbilitySacrificeContinuation + resumer fill costPayment.sacrificedPermanents and re-dispatch; registered for serialization.
- GamePlayHandler.safeFallbackActions passes priority FIRST in a declare-step priority window (where PassPriority is legal), so a failed AI action can't loop on a do-nothing DeclareBlockers/Attackers no-op.

Adds SacrificeCostActivationScenarioTest (forced auto-pick, real choice pause+respond, AI bare-action regression).