### PR TITLE
SOS: Molten-Core Maestro, Magmablood Archaic, Resonating Lute + mtgish auto-gen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3403,6 +3403,13 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
     `DynamicAmount.TotalManaSpent`, which reads the *current resolving object's own* cast — this
     reads the **triggering** spell's cast (the payoff lives on a separate permanent). Populated
     from `SpellCastEvent.totalManaSpent`; `0` for non-cast triggers.
+  - `COLORS_SPENT_ON_TRIGGERING_SPELL` — number of distinct *colors* of mana spent to cast the
+    spell that fired the trigger (0–5; colorless is not a color, CR 105.1). The triggering-spell
+    analogue of `DistinctColorsManaSpent` (which reads the resolving object's own cast, i.e.
+    Converge): this reads the **triggering** spell's payment for a payoff on a separate permanent
+    (Magmablood Archaic's "creatures you control get +1/+0 ... for each color of mana spent to cast
+    that spell"). Populated from `SpellCastEvent.distinctColorsSpent`; `0` for non-cast triggers.
+    Facade: `DynamicAmounts.colorsSpentOnTriggeringSpell()`.
   - `TRIGGERING_SPELL_MANA_VALUE` — mana value (CR 202.3) of the spell that fired the trigger
     (Kellan, the Kid — "a permanent spell with equal or lesser mana value"). Distinct from
     `MANA_SPENT_ON_TRIGGERING_SPELL` (mana actually paid): this is the spell's printed mana

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -132,6 +132,16 @@ object DynamicAmounts {
      */
     fun colorsOfManaSpent(): DynamicAmount = DynamicAmount.DistinctColorsManaSpent
 
+    /**
+     * The number of distinct colors of mana spent to cast the spell that fired this trigger
+     * (0–5). The triggering-spell analogue of [colorsOfManaSpent] (which reads the resolving
+     * object's own cast, i.e. Converge). Used by "Whenever you cast an instant or sorcery spell,
+     * … for each color of mana spent to cast that spell" payoffs on a separate permanent
+     * (Magmablood Archaic).
+     */
+    fun colorsSpentOnTriggeringSpell(): DynamicAmount =
+        DynamicAmount.ContextProperty(ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL)
+
     fun creaturesYouControl(): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Creature).count()
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -156,6 +156,16 @@ enum class ContextPropertyKey(val description: String) {
      */
     MANA_SPENT_ON_TRIGGERING_SPELL("the amount of mana spent to cast that spell"),
     /**
+     * Number of distinct *colors* of mana spent to cast the spell that fired this trigger (0–5).
+     * Distinct from [DynamicAmount.DistinctColorsManaSpent], which reads the *current resolving
+     * object's* own cast (Converge) — this reads the **triggering** spell's payment (a "Whenever
+     * you cast an instant or sorcery spell, … for each color of mana spent to cast that spell"
+     * payoff living on a separate permanent). Colorless is not a color (CR 105.1) and never
+     * contributes. Populated from `SpellCastEvent.distinctColorsSpent`; `0` when the trigger was
+     * not driven by a spell cast. Used by Magmablood Archaic.
+     */
+    COLORS_SPENT_ON_TRIGGERING_SPELL("the number of colors of mana spent to cast that spell"),
+    /**
      * Mana value (CR 202.3) of the spell that fired this trigger. Distinct from
      * [MANA_SPENT_ON_TRIGGERING_SPELL] (mana actually paid) — this reads the spell's printed
      * mana value, unaffected by cost reductions / alternative costs. Populated from

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MagmabloodArchaic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MagmabloodArchaic.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.convergeEntersWithCounters
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Magmablood Archaic
+ * {2/R}{2/R}{2/R}
+ * Creature — Avatar
+ * 2/2
+ *
+ * Trample, reach
+ * Converge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.
+ * Whenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end of turn
+ * for each color of mana spent to cast that spell.
+ *
+ * The {2/R} hybrid cost makes the colour count entirely a function of how you pay: all generic/red
+ * still counts as (at most) one colour, but multicolour payment pushes the Converge counters and the
+ * spell-trigger pump higher. The enter-with-counters part is [convergeEntersWithCounters] (reads this
+ * creature's own cast via [DynamicAmount.DistinctColorsManaSpent]); the spell-cast pump reads the
+ * *triggering* spell's colour count via [DynamicAmounts.colorsSpentOnTriggeringSpell] (the
+ * `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL` captured from `SpellCastEvent`).
+ */
+val MagmabloodArchaic = card("Magmablood Archaic") {
+    manaCost = "{2/R}{2/R}{2/R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Avatar"
+    power = 2
+    toughness = 2
+    oracleText = "Trample, reach\n" +
+        "Converge — This creature enters with a +1/+1 counter on it for each color of mana spent " +
+        "to cast it.\n" +
+        "Whenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end " +
+        "of turn for each color of mana spent to cast that spell."
+
+    keywords(Keyword.TRAMPLE, Keyword.REACH)
+
+    convergeEntersWithCounters()
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Patterns.Group.modifyStatsForAll(
+            power = DynamicAmounts.colorsSpentOnTriggeringSpell(),
+            toughness = DynamicAmount.Fixed(0),
+            filter = Filters.Group.creaturesYouControl,
+        )
+        description = "Whenever you cast an instant or sorcery spell, creatures you control get " +
+            "+1/+0 until end of turn for each color of mana spent to cast that spell."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d611278-9948-4345-b4dd-aa6eaf21b233.jpg?1775937816"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoltenCoreMaestro.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoltenCoreMaestro.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Molten-Core Maestro
+ * {1}{R}
+ * Creature — Goblin Bard
+ * 2/2
+ * Menace
+ * Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature.
+ * If five or more mana was spent to cast that spell, add an amount of {R} equal to this
+ * creature's power.
+ *
+ * "Opus" is an ability word (flavor only). The `opus { }` builder wires the spell-cast trigger
+ * and the 5+ mana tier (`ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5`). The mana
+ * production is `alsoIfFiveOrMore`, so it runs in addition to the unconditional +1/+1 counter.
+ * The {R} amount reads the creature's (already-incremented) power via [DynamicAmounts.sourcePower].
+ */
+val MoltenCoreMaestro = card("Molten-Core Maestro") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Bard"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\nOpus — Whenever you cast an instant or sorcery spell, put a +1/+1 " +
+        "counter on this creature. If five or more mana was spent to cast that spell, add an " +
+        "amount of {R} equal to this creature's power."
+    keywords(Keyword.MENACE)
+
+    opus {
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        alsoIfFiveOrMore = Effects.AddMana(Color.RED, DynamicAmounts.sourcePower())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Aleksi Briclot"
+        flavorText = "\"My media? Fury and flame.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/326dfe32-3674-4a11-acd8-5ba62371235a.jpg?1775937832"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ResonatingLute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ResonatingLute.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Resonating Lute
+ * {2}{U}{R}
+ * Artifact
+ * Lands you control have "{T}: Add two mana of any one color. Spend this mana only to cast instant
+ * and sorcery spells."
+ * {T}: Draw a card. Activate only if you have seven or more cards in your hand.
+ *
+ * The static ability grants every land you control a [ManaRestriction.InstantOrSorceryOnly] mana
+ * ability that adds two mana of one chosen colour (Add **any one** colour — [Effects.AddAnyColorMana]
+ * with `amount = 2`, not a free combination). The card's own `{T}: Draw a card` is gated by
+ * [ActivationRestriction.OnlyIfCondition] on [Conditions.CardsInHandAtLeast] (7) — a "loot when
+ * flooded" payoff that turns excess cards into more draws.
+ */
+val ResonatingLute = card("Resonating Lute") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact"
+    oracleText = "Lands you control have \"{T}: Add two mana of any one color. Spend this mana only " +
+        "to cast instant and sorcery spells.\"\n" +
+        "{T}: Draw a card. Activate only if you have seven or more cards in your hand."
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddAnyColorMana(
+                    amount = 2,
+                    restriction = ManaRestriction.InstantOrSorceryOnly,
+                ),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            ),
+            filter = GroupFilter(GameObjectFilter.Land.youControl()),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.DrawCards(1)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(Conditions.CardsInHandAtLeast(7)),
+        )
+        description = "{T}: Draw a card. Activate only if you have seven or more cards in your hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "221"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "School styluses are just tools. Passion is a Prismari's true instrument."
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ef168d6-28f2-4c24-9bfa-82c35663b729.jpg?1775938538"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -4063,6 +4063,81 @@
     ]
 }
 
+// Magmablood Archaic
+{
+    "name": "Magmablood Archaic",
+    "manaCost": "{2/R}{2/R}{2/R}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Trample, reach\nConverge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end of turn for each color of mana spent to cast that spell.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "ContextProperty",
+                            "key": "COLORS_SPENT_ON_TRIGGERING_SPELL"
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end of turn for each color of mana spent to cast that spell."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "DistinctColorsManaSpent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d611278-9948-4345-b4dd-aa6eaf21b233.jpg?1775937816"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mana Sculpt
 {
     "name": "Mana Sculpt",
@@ -4320,6 +4395,92 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Molten-Core Maestro
+{
+    "name": "Molten-Core Maestro",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Bard",
+    "oracleText": "Menace\nOpus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If five or more mana was spent to cast that spell, add an amount of {R} equal to this creature's power.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "AddMana",
+                                "color": "RED",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Source",
+                                    "numericProperty": "Power"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Opus — Whenever you cast an instant or sorcery spell, put 1 +1/+1 counter on this creature. If five or more mana was spent to cast that spell, add {R} for each it's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "flavorText": "\"My media? Fury and flame.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/326dfe32-3674-4a11-acd8-5ba62371235a.jpg?1775937832"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5980,6 +6141,81 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Resonating Lute
+{
+    "name": "Resonating Lute",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "Lands you control have \"{T}: Add two mana of any one color. Spend this mana only to cast instant and sorcery spells.\"\n{T}: Draw a card. Activate only if you have seven or more cards in your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Hand"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "{T}: Draw a card. Activate only if you have seven or more cards in your hand."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddManaOfChoice",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "restriction": "InstantOrSorceryOnly"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "RARE",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "School styluses are just tools. Passion is a Prismari's true instrument.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6ef168d6-28f2-4c24-9bfa-82c35663b729.jpg?1775938538"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2671,6 +2671,16 @@ private fun EmitCtx.activationRestrictionLines(rule: JsonObject): List<String>? 
     ) {
         return listOf("        restrictions = listOf(ActivationRestriction.OnlyIfCondition(Conditions.EmptyHand))")
     }
+    // "Activate only if you have seven or more cards in your hand" (Resonating Lute): the sole modifier
+    // is an ActivateOnlyIf whose condition is "you have >= N cards in hand" ->
+    // ActivationRestriction.OnlyIfCondition(Conditions.CardsInHandAtLeast(N)). Match the precise shape
+    // (the You player + NumCardsInHandIs GreaterThanOrEqualTo Integer N) so any other comparator or
+    // player still scaffolds.
+    handSizeAtLeastModifier(rule)?.let { n ->
+        return listOf(
+            "        restrictions = listOf(ActivationRestriction.OnlyIfCondition(Conditions.CardsInHandAtLeast($n)))",
+        )
+    }
     // "Activate only if it's not your turn" (Ghost Town): the sole modifier is an ActivateOnlyIf whose
     // condition is IsAPlayersTurn over a player Other than you -> ActivationRestriction.OnlyIfCondition(
     // IsNotYourTurn). Match the exact shape so any other ActivateOnlyIf condition still scaffolds.
@@ -2722,4 +2732,19 @@ private fun EmitCtx.emptyHandModifier(rule: JsonObject): Boolean {
     if (!jsonContains(mod, "_Players", "NumCardsInHandIs")) return false
     // The compared count must be the literal Integer 0 — not X, not another number.
     return (findInteger(mod.field("args")) as? Int) == 0
+}
+
+/** The threshold N when the rule's only `_ActivateModifier` is an `ActivateOnlyIf` gating on "you have
+ *  N or more cards in hand" (`NumCardsInHandIs(GreaterThanOrEqualTo, Integer N)` over the You player),
+ *  else null. Guards `CardsInHandAtLeast` so a different comparator (less-than, exactly), a different
+ *  player, an X count, or an extra modifier still scaffolds. */
+private fun EmitCtx.handSizeAtLeastModifier(rule: JsonObject): Int? {
+    val modifiers = (rule["args"].asArr ?: emptyList()).filterIsInstance<JsonObject>()
+        .filter { it.strField("_ActivateModifier") != null }
+    val mod = modifiers.singleOrNull() ?: return null
+    if (mod.strField("_ActivateModifier") != "ActivateOnlyIf") return null
+    if (!jsonContains(mod, "_Player", "You")) return null
+    if (!jsonContains(mod, "_Players", "NumCardsInHandIs")) return null
+    if (!jsonContains(mod, "_Comparison", "GreaterThanOrEqualTo")) return null
+    return findInteger(mod.field("args")) as? Int
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -421,6 +421,12 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // the flat type/subtype/controller filter below — emitting the aggregate without it would silently
         // over-count, so decline (-> SCAFFOLD) rather than misrender.
         if ("SharesACreatureTypeWithPermanent" in compact(node)) return null
+        // "for each creature blocking it" — an IsBlockingAttacker combat-relationship predicate scoped to
+        // the triggering attacker (Elvish Berserker's "+1/+1 for each creature blocking it"). A flat
+        // battlefield aggregate has no notion of "blocking <that creature>"; the search filter would
+        // silently drop the predicate and tally EVERY creature on the battlefield. Decline -> SCAFFOLD
+        // rather than misrender.
+        if ("IsBlockingAttacker" in compact(node)) return null
         // "for each creature that crewed it this turn" — a CrewedVehicleThisTurn predicate scoped to the
         // source Vehicle (Luxurious Locomotive). This is a per-source set-tracker count, not a flat
         // battlefield aggregate; the search filter below would silently drop the CrewedVehicleThisTurn

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -263,6 +263,19 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
             return if (jsonContains(node["args"], "_Spell", "Trigger_ThatSpell"))
                 call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL"))
             else null
+        // Converge — "the number of colors of mana spent to cast it" reading the entering/resolving
+        // permanent's own cast (the dominant Converge "Archaic" shape, also Sunburst). Maps to the
+        // source-relative facade `DynamicAmounts.colorsOfManaSpent()` (DistinctColorsManaSpent).
+        "NumColorsManaSpentToCastEnteringPermanent" ->
+            return call("DynamicAmounts.colorsOfManaSpent")
+        // "the number of colors of mana spent to cast that spell" on a `WhenAPlayerCastsASpell`
+        // trigger (Magmablood Archaic's "+1/+0 ... for each color of mana spent to cast that spell").
+        // Only the triggering-spell subject (`Trigger_ThatSpell`) maps to the context key; any other
+        // spell subject declines -> SCAFFOLD rather than misread a different cast's colors.
+        "NumColorsManaSpentToCastSpell" ->
+            return if (jsonContains(node["args"], "_Spell", "Trigger_ThatSpell"))
+                call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL"))
+            else null
         "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
         // "the number of [filter] cards in your graveyard" (Rise of the Varmints' Varmint count). The
         // count's args are a `_CardsInGraveyard` filter — typically `And(IsCardtype Creature,

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -427,15 +427,17 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
                 inner.add(call("Effects.ModifyStats", arg(power), arg(toughness), arg(Lit(target))))
             }
             "AdjustPTForEach" -> {
-                // "+P/+T for each <count>" (Goblin Piledriver +2/+0 per other attacking Goblin). The base
-                // P/T are fixed ints scaled by the dynamic count; only the "other attacking <subtype>" count
-                // renders exactly (see adjustForEachCount), anything else scaffolds.
+                // "+P/+T for each <count>" (Goblin Piledriver +2/+0 per other attacking Goblin; Magmablood
+                // Archaic +1/+0 per color of mana spent to cast the triggering spell). The base P/T are
+                // fixed ints scaled by the dynamic count: the "other attacking <subtype>" battlefield count
+                // (adjustForEachCount) is tried first, then any other count dynamicAmountExpr can render
+                // exactly (e.g. NumColorsManaSpentToCastSpell). Anything else scaffolds.
                 if (duration.isNotEmpty()) return null
                 val a = leObj["args"].asArr
                 if (a == null || a.size != 3) return null
                 val pBase = a.getOrNull(0).asInt() ?: return null
                 val tBase = a.getOrNull(1).asInt() ?: return null
-                val count = adjustForEachCount(a.getOrNull(2)) ?: return null
+                val count = adjustForEachCount(a.getOrNull(2)) ?: dynamicAmountExpr(a.getOrNull(2)) ?: return null
                 inner.add(call("Effects.ModifyStats", arg(scaleByBase(count, pBase)), arg(scaleByBase(count, tBase)), arg(Lit(target))))
             }
             "AddAbility" -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -79,6 +79,9 @@ data class TriggeredAbilityContinuation(
     /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
      *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
     val triggerManaSpentOnTriggeringSpell: Int? = null,
+    /** Distinct colors of mana spent to cast the spell that fired this trigger (Magmablood Archaic).
+     *  Read via `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
+    val triggerColorsSpentOnTriggeringSpell: Int? = null,
     /** Mana value of the spell that fired this trigger (Kellan, the Kid). Read via
      *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
     val triggerManaValueOfTriggeringSpell: Int? = null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -323,6 +323,14 @@ data class SpellCastEvent(
     /** Total mana spent to cast this spell (for Expend trigger detection) */
     val totalManaSpent: Int = 0,
     /**
+     * Number of distinct colors of mana spent to cast this spell (0–5); colorless is not a
+     * color (CR 105.1) and never contributes. Feeds
+     * `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL` so a "Whenever you cast an instant
+     * or sorcery spell, … for each color of mana spent to cast that spell" payoff on a separate
+     * permanent (Magmablood Archaic) scales by the triggering spell's color count.
+     */
+    val distinctColorsSpent: Int = 0,
+    /**
      * True when any of the mana spent on this cast was tagged as Treasure
      * mana (see [com.wingedsheep.engine.state.components.player.ManaPoolComponent.treasureMana]).
      * Drives SDK triggers built with

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -77,6 +77,13 @@ data class TriggerContext(
      */
     val manaSpentOnTriggeringSpell: Int? = null,
     /**
+     * For SpellCastEvent triggers — number of distinct colors of mana spent to cast the
+     * triggering spell (0–5). `null` when the trigger was not driven by a spell cast. Read by
+     * `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL` so abilities like Magmablood Archaic
+     * can scale by "for each color of mana spent to cast that spell."
+     */
+    val colorsSpentOnTriggeringSpell: Int? = null,
+    /**
      * For SpellCastEvent triggers — mana value (CR 202.3) of the triggering spell. `null` when
      * the trigger was not driven by a spell cast. Read by
      * `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE` so abilities like Kellan, the Kid can
@@ -171,6 +178,7 @@ data class TriggerContext(
                     triggeringPlayerId = event.casterId,
                     modesChosenCount = event.chosenModesCount.takeIf { it > 0 },
                     manaSpentOnTriggeringSpell = event.totalManaSpent.takeIf { it > 0 },
+                    colorsSpentOnTriggeringSpell = event.distinctColorsSpent.takeIf { it > 0 },
                     manaValueOfTriggeringSpell = event.manaValue.takeIf { it > 0 }
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1289,6 +1289,7 @@ class TriggerMatcher(
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
                 triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+                triggerColorsSpentOnTriggeringSpell = trigger.triggerContext.colorsSpentOnTriggeringSpell,
                 triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
             )
             conditionEvaluator.evaluate(state, condition, context)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -606,6 +606,7 @@ class TriggerProcessor(
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
                 triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+                triggerColorsSpentOnTriggeringSpell = trigger.triggerContext.colorsSpentOnTriggeringSpell,
                 triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
             )
             ability.effect.runtimeDescription { amount -> evaluator.evaluate(state, amount, context) }
@@ -656,6 +657,7 @@ class TriggerProcessor(
             triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
             triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+            triggerColorsSpentOnTriggeringSpell = trigger.triggerContext.colorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
         )
 
@@ -712,6 +714,7 @@ class TriggerProcessor(
             triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
             triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
+            triggerColorsSpentOnTriggeringSpell = trigger.triggerContext.colorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
             capturedEntityIds = trigger.triggerContext.capturedEntityIds ?: emptyList()
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -506,6 +506,8 @@ class DynamicAmountEvaluator(
 
         ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL -> context.triggerManaSpentOnTriggeringSpell ?: 0
 
+        ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL -> context.triggerColorsSpentOnTriggeringSpell ?: 0
+
         ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE -> context.triggerManaValueOfTriggeringSpell ?: 0
 
         ContextPropertyKey.TRIGGER_SCRY_COUNT -> context.triggerScryCount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -179,6 +179,13 @@ data class EffectContext(
      */
     val triggerManaSpentOnTriggeringSpell: Int? = null,
     /**
+     * Number of distinct colors of mana spent to cast the spell that fired this trigger. Read by
+     * `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL` (Magmablood Archaic). Distinct from
+     * [com.wingedsheep.sdk.scripting.values.DynamicAmount.DistinctColorsManaSpent] (Converge),
+     * which reads the *resolving object's own* cast.
+     */
+    val triggerColorsSpentOnTriggeringSpell: Int? = null,
+    /**
      * Mana value (CR 202.3) of the spell that fired this trigger. Read by
      * `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE` (Kellan, the Kid). Distinct from
      * [triggerManaSpentOnTriggeringSpell], which is the mana actually paid.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -102,6 +102,7 @@ class EffectAndTriggerContinuationResumer(
                 triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
                 triggerRecipientToughness = continuation.triggerRecipientToughness,
                 triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
+                triggerColorsSpentOnTriggeringSpell = continuation.triggerColorsSpentOnTriggeringSpell,
                 triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
             )
             val stackResult = services.stackResolver.putTriggeredAbility(state, elseComponent, emptyList())
@@ -152,6 +153,7 @@ class EffectAndTriggerContinuationResumer(
             triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
             triggerRecipientToughness = continuation.triggerRecipientToughness,
             triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
+            triggerColorsSpentOnTriggeringSpell = continuation.triggerColorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -325,6 +325,8 @@ class StackResolver(
                 xValue = xValue,
                 wasKicked = wasKicked,
                 totalManaSpent = totalManaSpent,
+                distinctColorsSpent =
+                    com.wingedsheep.engine.handlers.ManaSpentReader.distinctColorsSpent(newState, cardId),
                 paidWithTreasureMana = paidWithTreasureMana,
                 chosenModesCount = reportedChosenModesCount,
                 manaValue = cardComponent.manaValue
@@ -1933,6 +1935,7 @@ class StackResolver(
             triggerExcessDamageAmount = abilityComponent.triggerExcessDamageAmount,
             triggerRecipientToughness = abilityComponent.triggerRecipientToughness,
             triggerManaSpentOnTriggeringSpell = abilityComponent.triggerManaSpentOnTriggeringSpell,
+            triggerColorsSpentOnTriggeringSpell = abilityComponent.triggerColorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = abilityComponent.triggerManaValueOfTriggeringSpell,
             xValue = abilityComponent.xValue,
             damageDistribution = abilityComponent.damageDistribution,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -138,6 +138,9 @@ data class TriggeredAbilityOnStackComponent(
     /** Total mana spent to cast the spell that fired this trigger (Aberrant Manawurm, Expressive
      *  Firedancer). Read via `ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
     val triggerManaSpentOnTriggeringSpell: Int? = null,
+    /** Distinct colors of mana spent to cast the spell that fired this trigger (Magmablood Archaic).
+     *  Read via `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL`. Null for non-cast triggers. */
+    val triggerColorsSpentOnTriggeringSpell: Int? = null,
     /** Mana value (CR 202.3) of the spell that fired this trigger (Kellan, the Kid). Read via
      *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
     val triggerManaValueOfTriggeringSpell: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1541,6 +1541,7 @@ class ClientStateTransformer(
         triggerExcessDamageAmount = triggered.triggerExcessDamageAmount,
         triggerRecipientToughness = triggered.triggerRecipientToughness,
         triggerManaSpentOnTriggeringSpell = triggered.triggerManaSpentOnTriggeringSpell,
+        triggerColorsSpentOnTriggeringSpell = triggered.triggerColorsSpentOnTriggeringSpell,
         triggerManaValueOfTriggeringSpell = triggered.triggerManaValueOfTriggeringSpell
     )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagmabloodArchaicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagmabloodArchaicScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.MagmabloodArchaic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Magmablood Archaic (Secrets of Strixhaven #123).
+ *
+ * Magmablood Archaic ({2/R}{2/R}{2/R}, 2/2 Avatar):
+ *   Trample, reach
+ *   Converge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.
+ *   Whenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end of turn
+ *   for each color of mana spent to cast that spell.
+ *
+ * The Converge enters-with-counters part reuses `DistinctColorsManaSpent` (covered for the family by
+ * ConvergeMechanicTest); this file also pins the *spell-cast pump*, which scales by the new
+ * `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL` — the colours spent on the **triggering**
+ * spell, not on the Archaic's own cast.
+ */
+class MagmabloodArchaicScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(MagmabloodArchaic))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun projectedPower(driver: GameTestDriver, id: EntityId): Int =
+        StateProjector().getProjectedPower(driver.state, id)
+
+    // ── Converge enters-with-counters (the colors of the Archaic's OWN cast) ──
+
+    test("enters with a +1/+1 counter for each color of mana spent to cast it (2 colors → 4/4)") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val archaic = driver.putCardInHand(p, "Magmablood Archaic")
+        // {2/R}{2/R}{2/R}: two pips paid {R} (red), the third's {2} generic side paid with two
+        // green → mana spent is R, R, G, G → 2 distinct colors.
+        driver.giveMana(p, Color.RED, 2)
+        driver.giveMana(p, Color.GREEN, 2)
+
+        driver.castSpell(p, archaic).isSuccess shouldBe true
+        driver.bothPass()
+
+        plusCounters(driver, archaic) shouldBe 2
+    }
+
+    // ── Spell-cast pump scales by the colors spent on the TRIGGERING spell ──
+
+    test("a 1-color spell pumps creatures you control +1/+0") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val archaic = driver.putCreatureOnBattlefield(p, "Magmablood Archaic") // 2/2
+        val lion = driver.putCreatureOnBattlefield(p, "Savannah Lions") // 1/1
+        val opp = driver.getOpponent(p)
+        val victim = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        val bolt = driver.putCardInHand(p, "Lightning Bolt") // {R} → 1 color
+        driver.giveMana(p, Color.RED, 1)
+
+        driver.castSpell(p, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // bolt resolves
+        driver.bothPass() // Magmablood cast-trigger resolves
+
+        // 1 color spent → +1/+0. Lion 1/1 → 2/1; Magmablood 2/2 → 3/2.
+        projectedPower(driver, lion) shouldBe 2
+        projectedPower(driver, archaic) shouldBe 3
+    }
+
+    test("a 2-color spell pumps creatures you control +2/+0") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val archaic = driver.putCreatureOnBattlefield(p, "Magmablood Archaic") // 2/2
+        val lion = driver.putCreatureOnBattlefield(p, "Savannah Lions") // 1/1
+        val opp = driver.getOpponent(p)
+        val victim = driver.putCreatureOnBattlefield(opp, "Centaur Courser") // nonblack target
+
+        // Doom Blade {1}{B}: pay {B} with black, the {1} generic with red → 2 distinct colors.
+        val doomBlade = driver.putCardInHand(p, "Doom Blade")
+        driver.giveMana(p, Color.BLACK, 1)
+        driver.giveMana(p, Color.RED, 1)
+
+        driver.castSpell(p, doomBlade, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // Doom Blade resolves
+        driver.bothPass() // Magmablood cast-trigger resolves
+
+        // 2 colors spent → +2/+0. Lion 1/1 → 3/1; Magmablood 2/2 → 4/2.
+        projectedPower(driver, lion) shouldBe 3
+        projectedPower(driver, archaic) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCoreMaestroScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCoreMaestroScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Molten-Core Maestro (Secrets of Strixhaven).
+ *
+ * Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If
+ * five or more mana was spent to cast that spell, add an amount of {R} equal to this creature's
+ * power.
+ *
+ * The base effect (+1/+1 counter) always fires; the `alsoIfFiveOrMore` mana production only fires
+ * at 5+ mana, and reads the creature's power *after* the counter is added.
+ */
+class MoltenCoreMaestroScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun ManaPoolComponent.total() =
+        white + blue + black + red + green + colorless
+
+    init {
+        test("a cheap spell adds a +1/+1 counter but produces no mana (5+ tier not reached)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Molten-Core Maestro") // 2/2
+                .withCardInHand(1, "Lightning Bolt") // {R}
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val maestro = game.findPermanent("Molten-Core Maestro")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+            game.resolveStack()
+
+            withClue("1 mana spent → +1/+1 counter only → 3/3") {
+                projector.getProjectedPower(game.state, maestro) shouldBe 3
+                projector.getProjectedToughness(game.state, maestro) shouldBe 3
+            }
+            withClue("no mana added below the 5-mana threshold") {
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                (pool?.total() ?: 0) shouldBe 0
+            }
+        }
+
+        test("a 5-mana spell adds a +1/+1 counter AND produces {R} equal to power (now 3)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Molten-Core Maestro") // 2/2
+                .withCardInHand(1, "Blaze") // {X}{R}
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 5)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val maestro = game.findPermanent("Molten-Core Maestro")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            // Blaze X=4 → {4}{R} → 5 mana spent (boundary).
+            game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+            game.resolveStack()
+
+            withClue("5 mana spent → +1/+1 counter → 3/3") {
+                projector.getProjectedPower(game.state, maestro) shouldBe 3
+                projector.getProjectedToughness(game.state, maestro) shouldBe 3
+            }
+            withClue("add {R} equal to power AFTER the counter → 3 red mana") {
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                pool.red shouldBe 3
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResonatingLuteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResonatingLuteScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ResonatingLute
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Resonating Lute (Secrets of Strixhaven #221).
+ *
+ * Resonating Lute ({2}{U}{R}, Artifact):
+ *   Lands you control have "{T}: Add two mana of any one color. Spend this mana only to cast
+ *   instant and sorcery spells."
+ *   {T}: Draw a card. Activate only if you have seven or more cards in your hand.
+ *
+ * Pins (1) the static grant landing on each land you control (and adding 2 mana of the chosen
+ * colour), and (2) the hand-size activation gate on the draw ability (legal at 7+, illegal below).
+ */
+class ResonatingLuteScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(ResonatingLute))
+        return driver
+    }
+
+    val drawAbilityId = ResonatingLute.activatedAbilities.first().id
+
+    fun start(driver: GameTestDriver): com.wingedsheep.sdk.model.EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    test("grants each land you control a {T}: add two mana of one color ability") {
+        val driver = createDriver()
+        val p = start(driver)
+        val opp = driver.getOpponent(p)
+
+        driver.putPermanentOnBattlefield(p, "Resonating Lute") // artifact host
+        val myLand = driver.putLandOnBattlefield(p, "Mountain")
+        val oppLand = driver.putLandOnBattlefield(opp, "Forest")
+
+        // My land has the granted mana ability; the opponent's does not.
+        val myGrants = driver.state.grantedActivatedAbilities.filter { it.entityId == myLand }
+        myGrants.size shouldBe 1
+        driver.state.grantedActivatedAbilities.filter { it.entityId == oppLand }.size shouldBe 0
+
+        // Activating it adds two mana of one chosen color (mana ability — resolves immediately).
+        driver.submitSuccess(
+            ActivateAbility(playerId = p, sourceId = myLand, abilityId = myGrants[0].ability.id),
+        )
+        val pool = driver.state.getEntity(p)?.get<ManaPoolComponent>()!!
+        val total = pool.white + pool.blue + pool.black + pool.red + pool.green + pool.colorless
+        total shouldBe 2
+    }
+
+    test("draw ability is legal with 7+ cards in hand") {
+        val driver = createDriver()
+        val p = start(driver)
+
+        val lute = driver.putPermanentOnBattlefield(p, "Resonating Lute")
+        repeat(7) { driver.putCardInHand(p, "Island") }
+        driver.putCardOnTopOfLibrary(p, "Island")
+
+        val result = driver.submit(
+            ActivateAbility(playerId = p, sourceId = lute, abilityId = drawAbilityId),
+        )
+        result.isSuccess shouldBe true
+        driver.isTapped(lute) shouldBe true
+    }
+
+    test("draw ability is illegal with fewer than 7 cards in hand") {
+        val driver = createDriver()
+        val p = start(driver)
+
+        val lute = driver.putPermanentOnBattlefield(p, "Resonating Lute")
+        // Reduce the opening hand to exactly 6 cards (below the 7-card gate).
+        while (driver.getHandSize(p) > 6) {
+            driver.moveToGraveyard(driver.getHand(p).first())
+        }
+        while (driver.getHandSize(p) < 6) {
+            driver.putCardInHand(p, "Island")
+        }
+        driver.getHandSize(p) shouldBe 6
+
+        val result = driver.submit(
+            ActivateAbility(playerId = p, sourceId = lute, abilityId = drawAbilityId),
+        )
+        result.isSuccess shouldBe false
+        driver.isTapped(lute) shouldBe false
+    }
+})


### PR DESCRIPTION
## Cards

Three Secrets of Strixhaven (SOS) cards, all with passing scenario tests.

- **Molten-Core Maestro** `{1}{R}` 2/2 Goblin Bard — Menace; Opus — whenever you cast an instant or sorcery spell, put a +1/+1 counter on it, and if 5+ mana was spent, add {R} equal to its power. Modeled with the existing `opus { }` builder (`alsoIfFiveOrMore = AddMana(RED, sourcePower)`).
- **Magmablood Archaic** `{2/R}{2/R}{2/R}` 2/2 Avatar — Trample, reach; Converge enters-with-counters (`convergeEntersWithCounters()`), plus a spell-cast trigger that pumps creatures you control +1/+0 *for each color of mana spent to cast that spell*.
- **Resonating Lute** `{2}{U}{R}` Artifact — static grant giving lands you control "{T}: Add two mana of any one color, instant/sorcery only", plus a `{T}: Draw a card` ability gated on 7+ cards in hand (`ActivationRestriction.OnlyIfCondition(CardsInHandAtLeast(7))`).

## New SDK/engine primitive

Magmablood Archaic needed the **distinct colors of mana spent to cast the _triggering_ spell** — the triggering-spell analogue of `DistinctColorsManaSpent` (which reads the resolving object's own cast, i.e. Converge). Added `ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL`, captured on `SpellCastEvent.distinctColorsSpent` and plumbed through `TriggerContext`, the triggered-ability stack component, continuations, `EffectContext`, and `DynamicAmountEvaluator` — mirroring the existing `MANA_SPENT_ON_TRIGGERING_SPELL` path. Facade: `DynamicAmounts.colorsSpentOnTriggeringSpell()`. `docs/card-sdk-language-reference.md` updated.

## mtgish-tooling

Both SCAFFOLD cards now render whole (→ AUTOGEN), matching their hand-authored goldens:

- `dynamicAmountExpr`: `NumColorsManaSpentToCastEnteringPermanent` → `DynamicAmounts.colorsOfManaSpent()` (Converge counters, also helps the rest of the "Archaic" cycle); `NumColorsManaSpentToCastSpell` (`Trigger_ThatSpell`) → `ContextProperty(COLORS_SPENT_ON_TRIGGERING_SPELL)`.
- `AdjustPTForEach` layer effect: fall back to `dynamicAmountExpr` for the per-each count so the color-spent group pump renders.
- `ActivatedWithModifiers`: "activate only if you have N+ cards in hand" (`NumCardsInHandIs GreaterThanOrEqualTo`) → `CardsInHandAtLeast(N)` restriction.

## Verification

- Scenario tests for all three cards pass (`rules-engine`).
- `CardLintTest` and the trigger-mana regression cards (Expressive Firedancer, etc.) pass.
- SOS golden snapshot reblessed — only the 3 new cards added, nothing else changed.
- **POR `coverage-verify` stays clean** (gate `BUILD SUCCESSFUL`, 0 mismatch).
- SOS fidelity gate: the 3 cards now appear in `GAMEPLAY TREE MATCH`. The 6 remaining SOS mismatches (Forum Necroscribe, Lorehold/Prismari/Silverquill Charms, Moment of Reckoning, Primary Research) are **pre-existing** emitter debt unrelated to this change (return-from-graveyard `fromZone` and a `+1/+1` vs `+1+1` counter-name discrepancy); none are touched by the emitter changes here.

## SCAFFOLD left behind

None of the three target cards — all now auto-generate faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)