### PR TITLE
SOS: Tackle Artist, Geometer's Arthropod, Thornfist Striker + mtgish auto-gen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1861,6 +1861,12 @@ matcher branch — `SpellCastEvent` does not grow a new field per axis.
   700.2). Matches `SpellCastEvent.chosenModesCount > 0`, where the count is the size of
   `SpellOnStackComponent.chosenModes` (so Spree picking the same mode twice counts as
   two). Used by Riku of Many Paths: "Whenever you cast a modal spell, …".
+- `SpellCastPredicate.HasXInCost` — spell has `{X}` in its printed mana cost (CR 107.3).
+  A property of the cost, not the value chosen, so a spell cast with X=0 still satisfies
+  it. Matches `CardComponent.manaCost.hasX`. Read the announced X in the payoff via
+  `DynamicAmounts.xValueOfTriggeringSpell()` (→ `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL`).
+  Used by Geometer's Arthropod: "Whenever you cast a spell with {X} in its mana cost, look
+  at the top X cards of your library, …".
 
 Examples:
 
@@ -1884,6 +1890,11 @@ Triggers.youCastSpell(
 
 // "Whenever you cast a modal spell" (Riku of Many Paths)
 Triggers.youCastSpell(requires = setOf(SpellCastPredicate.IsModal))
+
+// "Whenever you cast a spell with {X} in its mana cost" (Geometer's Arthropod) —
+// then dig X cards: keep one, bottom the rest in a random order.
+Triggers.youCastSpell(requires = setOf(SpellCastPredicate.HasXInCost))
+// payoff count: DynamicAmounts.xValueOfTriggeringSpell()
 
 // "Whenever you cast a noncreature or Otter spell"
 Triggers.youCastSpell(
@@ -3410,6 +3421,12 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
     `SpellCastEvent.manaValue`; `0` for non-cast triggers. Pair with
     `CollectionFilter.ManaValueAtMost(ContextProperty(TRIGGERING_SPELL_MANA_VALUE))` to bound a
     gathered collection by the triggering spell's mana value.
+  - `X_VALUE_OF_TRIGGERING_SPELL` — value chosen for `{X}` on the spell that fired the trigger
+    (CR 601.2b) — Geometer's Arthropod's "look at the top X cards of your library." Distinct from
+    `MANA_SPENT_ON_TRIGGERING_SPELL` (total mana paid) and `TRIGGERING_SPELL_MANA_VALUE` (printed
+    mana value, where {X} counts as 0). Populated from `SpellCastEvent.xValue`; `0` for non-cast /
+    no-{X} triggers. Pair with `SpellCastPredicate.HasXInCost`. Facade:
+    `DynamicAmounts.xValueOfTriggeringSpell()`.
   - `TRIGGER_SCRY_COUNT` — cards looked at by the scry that fired the trigger (Celeborn the
     Wise, Elrond Master of Healing). Equals the scry N parameter.
   - `TRIGGER_EXCESS_DAMAGE_AMOUNT` — damage past lethal in the trigger payload (CR 120.4a).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -250,6 +250,19 @@ object DynamicAmounts {
         DynamicAmount.ContextProperty(ContextPropertyKey.ADDITIONAL_COST_EXILED_COUNT)
 
     // =========================================================================
+    // Spell-cast trigger values
+    // =========================================================================
+
+    /**
+     * "X" — the value chosen for `{X}` on the spell that fired a spell-cast trigger (CR 601.2b).
+     * Read inside the payoff of a `youCastSpell(requires = setOf(SpellCastPredicate.HasXInCost))`
+     * trigger; e.g. Geometer's Arthropod "look at the top X cards of your library." `0` outside a
+     * spell-cast trigger or when the spell had no {X}.
+     */
+    fun xValueOfTriggeringSpell(): DynamicAmount =
+        DynamicAmount.ContextProperty(ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL)
+
+    // =========================================================================
     // Prevention-reaction values
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -402,6 +402,19 @@ sealed interface SpellCastPredicate {
     data object IsModal : SpellCastPredicate {
         override val description = "modal"
     }
+
+    /**
+     * The spell has `{X}` in its printed mana cost (CR 107.3) — "Whenever you cast a spell with
+     * {X} in its mana cost, …" (Geometer's Arthropod). This is a property of the cost, not the
+     * value chosen: a spell cast with X=0 still satisfies it. Pair with
+     * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL] to
+     * read the value X was set to.
+     */
+    @SerialName("SpellHasXInCost")
+    @Serializable
+    data object HasXInCost : SpellCastPredicate {
+        override val description = "with {X} in its mana cost"
+    }
 }
 
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -164,6 +164,15 @@ enum class ContextPropertyKey(val description: String) {
      */
     TRIGGERING_SPELL_MANA_VALUE("the mana value of that spell"),
     /**
+     * The value chosen for `{X}` on the spell that fired this trigger (CR 601.2b). Distinct from
+     * [MANA_SPENT_ON_TRIGGERING_SPELL] (total mana paid) and [TRIGGERING_SPELL_MANA_VALUE] (printed
+     * mana value, which counts each {X} as 0): this reads the actual X the caster announced. `0`
+     * when the trigger was not driven by a spell cast or the spell had no {X}. Populated from
+     * `SpellCastEvent.xValue`. Pair with `SpellCastPredicate.HasXInCost`. Used by Geometer's
+     * Arthropod — "look at the top X cards of your library."
+     */
+    X_VALUE_OF_TRIGGERING_SPELL("X"),
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Equals the
      * scry N parameter unless the library held fewer cards. Read by "Whenever you scry,
      * ... for each card looked at" payoffs (Celeborn the Wise, Elrond Master of Healing).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/GeometersArthropod.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/GeometersArthropod.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Geometer's Arthropod
+ * {G}{U}
+ * Creature — Fractal Crab
+ * 1/4
+ *
+ * Whenever you cast a spell with {X} in its mana cost, look at the top X cards of your library. Put
+ * one of them into your hand and the rest on the bottom of your library in a random order.
+ *
+ * The trigger keys off the *printed cost* having `{X}` (`SpellCastPredicate.HasXInCost`), not the
+ * value chosen — a spell cast with X=0 still triggers (and then looks at zero cards, a harmless
+ * no-op). The dig count is the actual value announced for that spell's {X}, read via
+ * `DynamicAmounts.xValueOfTriggeringSpell()`. The dig itself is the standard
+ * gather → select-one → move-rest pipeline: keep one in hand, put the rest on the bottom in a
+ * random order.
+ */
+val GeometersArthropod = card("Geometer's Arthropod") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Fractal Crab"
+    power = 1
+    toughness = 4
+    oracleText = "Whenever you cast a spell with {X} in its mana cost, look at the top X cards of " +
+        "your library. Put one of them into your hand and the rest on the bottom of your library " +
+        "in a random order."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            requires = setOf(SpellCastPredicate.HasXInCost),
+        )
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = DynamicAmounts.xValueOfTriggeringSpell(),
+            keepCount = DynamicAmount.Fixed(1),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random,
+            selectedLabel = "Put in hand",
+            remainderLabel = "Put on bottom",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "191"
+        artist = "Joe Slucher"
+        flavorText = "\"Creatures that have survived blood-soaked millennia should not be " +
+            "underestimated.\"\n—Nev, dean of substance"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec0f3613-1edc-40e8-8f26-2e5ef13be55e.jpg?1775938325"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TackleArtist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TackleArtist.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tackle Artist
+ * {3}{R}
+ * Creature — Orc Sorcerer
+ * 4/3
+ *
+ * Trample
+ * Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If five
+ * or more mana was spent to cast that spell, put two +1/+1 counters on this creature instead.
+ *
+ * "Opus" is an ability word (flavor only); the `opus { }` builder wires the spell-cast trigger and the
+ * 5+ mana tier. Here the 5+ mana bonus **replaces** the base counter (`insteadIfFiveOrMore`): one
+ * +1/+1 counter normally, two when five or more mana was spent. Both counters persist (real +1/+1
+ * counters, not an until-end-of-turn buff).
+ */
+val TackleArtist = card("Tackle Artist") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Orc Sorcerer"
+    power = 4
+    toughness = 3
+    oracleText = "Trample\nOpus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter " +
+        "on this creature. If five or more mana was spent to cast that spell, put two +1/+1 counters " +
+        "on this creature instead."
+
+    keywords(Keyword.TRAMPLE)
+
+    opus {
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        insteadIfFiveOrMore = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        description = "Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on " +
+            "this creature. If five or more mana was spent to cast that spell, put two +1/+1 counters " +
+            "on this creature instead."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Ioannis Fiore"
+        flavorText = "\"Let's paint the field red!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b87e2474-98c1-4c1a-91ed-340b72d31653.jpg?1775937898"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ThornfistStriker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ThornfistStriker.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thornfist Striker
+ * {2}{G}
+ * Creature — Elf Druid
+ * 3/3
+ *
+ * Ward {1}
+ * Infusion — Creatures you control get +1/+0 and have trample as long as you gained life this turn.
+ *
+ * "Infusion" is an ability word (flavor only, CR 207.2c) — the mechanic is a conditional static
+ * lord gated on `Conditions.YouGainedLifeThisTurn`. It splits into two continuous static abilities
+ * (the +1/+0 in Layer 7c, the trample grant in Layer 6), each wrapped in `ConditionalStaticAbility`
+ * so both turn on/off together as life is gained or the turn ends.
+ */
+val ThornfistStriker = card("Thornfist Striker") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 3
+    toughness = 3
+    oracleText = "Ward {1} (Whenever this creature becomes the target of a spell or ability an " +
+        "opponent controls, counter it unless that player pays {1}.)\nInfusion — Creatures you " +
+        "control get +1/+0 and have trample as long as you gained life this turn."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    // Infusion — +1/+0 to creatures you control while you've gained life this turn.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(
+                powerBonus = 1,
+                toughnessBonus = 0,
+                filter = GroupFilter.AllCreaturesYouControl,
+            ),
+            condition = Conditions.YouGainedLifeThisTurn,
+        )
+    }
+
+    // Infusion — and they have trample under the same condition.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(
+                keyword = Keyword.TRAMPLE,
+                filter = GroupFilter.AllCreaturesYouControl,
+            ),
+            condition = Conditions.YouGainedLifeThisTurn,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Diana Franco"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6cb838e-a06a-46ae-a30f-e5192178c1cc.jpg?1775938123"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -2764,6 +2764,92 @@
     ]
 }
 
+// Geometer's Arthropod
+{
+    "name": "Geometer's Arthropod",
+    "manaCost": "{G}{U}",
+    "typeLine": "Creature — Fractal Crab",
+    "oracleText": "Whenever you cast a spell with {X} in its mana cost, look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellHasXInCost"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "X_VALUE_OF_TRIGGERING_SPELL"
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "RARE",
+        "artist": "Joe Slucher",
+        "flavorText": "\"Creatures that have survived blood-soaked millennia should not be underestimated.\"\n—Nev, dean of substance",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec0f3613-1edc-40e8-8f26-2e5ef13be55e.jpg?1775938325"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Glorious Decay
 {
     "name": "Glorious Decay",
@@ -7039,6 +7125,83 @@
     "colorIdentityOverride": []
 }
 
+// Tackle Artist
+{
+    "name": "Tackle Artist",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Orc Sorcerer",
+    "oracleText": "Trample\nOpus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If five or more mana was spent to cast that spell, put two +1/+1 counters on this creature instead.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "ContextProperty",
+                                "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 5
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 2,
+                        "target": "Self"
+                    },
+                    "otherwise": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If five or more mana was spent to cast that spell, put two +1/+1 counters on this creature instead."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Ioannis Fiore",
+        "flavorText": "\"Let's paint the field red!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b87e2474-98c1-4c1a-91ed-340b72d31653.jpg?1775937898"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Teacher's Pest
 {
     "name": "Teacher's Pest",
@@ -7229,6 +7392,90 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Thornfist Striker
+{
+    "name": "Thornfist Striker",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nInfusion — Creatures you control get +1/+0 and have trample as long as you gained life this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "UNCOMMON",
+        "artist": "Diana Franco",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6cb838e-a06a-46ae-a30f-e5192178c1cc.jpg?1775938123"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -492,6 +492,22 @@ private fun isYourTurnConditionDsl(condNode: JsonElement?): String? {
 }
 
 /**
+ * "as long as you gained life this turn" static gate — `PlayerPassesFilter(You, GainedLifeThisTurn)`
+ * with no count/amount sub-clause -> `Conditions.YouGainedLifeThisTurn`. Backs the **Infusion** ability
+ * word's static lord (Thornfist Striker). Only the bare You-scoped, no-amount shape renders; any other
+ * player scope or a quantified "gained N life" clause declines -> SCAFFOLD.
+ */
+private fun youGainedLifeConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    if (!jsonContains(cond, "_Player", "You")) return null
+    val players = (cond["args"].asArr?.getOrNull(1)) as? JsonObject ?: return null
+    // Must be exactly the bare GainedLifeThisTurn filter (no nested amount/count args).
+    if (players.strField("_Players") != "GainedLifeThisTurn" || players.size > 1) return null
+    return "Conditions.YouGainedLifeThisTurn"
+}
+
+/**
  * "you control N or more [filter]" condition (`PlayerPassesFilter(You, ControlsNum([Comparison
  * GreaterThanOrEqualTo Integer N], <filter>))`) -> `Conditions.YouControlAtLeast(N, <filter>)`, or null
  * when the player isn't You, the comparison isn't `>= N` (a fixed integer), or the filter doesn't render
@@ -734,10 +750,18 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
     //   If(IsPlayersTurn(You)) [ EachPermanentLayerEffect(<group>, [AddAbility(<keyword>) | AdjustPT]) ]
     // -> one `staticAbility { condition = Conditions.IsYourTurn; ability = <lord ability> }` per layer
     // effect, reusing the always-on lord renderer (staticLordBlock) but gated on the controller's turn.
-    // Only the "during YOUR turn" gate renders; any other turn scope declines (-> SCAFFOLD). The lord
-    // renderer itself still declines any group/ability it can't reproduce exactly.
+    // Thornfist Striker (Infusion): "Creatures you control get +1/+0 and have trample as long as you
+    // gained life this turn."
+    //   If(PlayerPassesFilter(You, GainedLifeThisTurn))
+    //     [ EachPermanentLayerEffect(creatures you control, [AdjustPT(1,0), AddAbility(Trample)]) ]
+    // -> the same gated lord, one row per layer effect, gated on Conditions.YouGainedLifeThisTurn.
+    // Only the "during YOUR turn" or "you gained life this turn" gates render; any other condition
+    // declines (-> SCAFFOLD). The lord renderer itself still declines any group/ability it can't
+    // reproduce exactly.
     if (innerRule.strField("_Rule") == "EachPermanentLayerEffect") {
-        val condDsl = isYourTurnConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        val condDsl = isYourTurnConditionDsl(cond)
+            ?: youGainedLifeConditionDsl(cond)
+            ?: run { reasons.add("If"); return null }
         return staticLordBlock(innerRule, condition = condDsl)
     }
 
@@ -1367,6 +1391,20 @@ private fun EmitCtx.opusTriggerBlock(rule: JsonObject, oncePerTurn: Boolean, tri
     val elseActions = (ifArgs.getOrNull(2) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
     if (thenActions.isEmpty() || elseActions.isEmpty()) return null
 
+    // mtgish encodes the count on an Opus 5+ `PutNumberCountersOfTypeOnPermanent` bonus arm
+    // UNRELIABLY — it reuses the literal 5-mana threshold as the counter count rather than the
+    // printed value (verified wrong: Tackle Artist's IR says 5 where the oracle prints "two";
+    // Spectacular Skywhale's says 5 where the oracle prints "three"). We can't recover the true
+    // count from the IR, so decline this shape to SCAFFOLD rather than emit a confidently-wrong
+    // counter count ("render correctly or decline — never emit a lossy approximation").
+    if ((thenActions as List<JsonObject>?).orEmpty().any {
+            it.strField("_Action") == "PutNumberCountersOfTypeOnPermanent"
+        }
+    ) {
+        reasons.add("opus-counter-count")
+        return null
+    }
+
     // A spell-cast trigger's triggering entity is the spell, so any "that …" body reference resolves
     // against the caster — match the generic path's bookkeeping while rendering the two arms.
     val prev = triggeringEntityIsSpell
@@ -1379,6 +1417,31 @@ private fun EmitCtx.opusTriggerBlock(rule: JsonObject, oncePerTurn: Boolean, tri
         Assign("effect", base),
         Assign("insteadIfFiveOrMore", bonus),
     ))))
+}
+
+/**
+ * True iff a `TriggerA` rule has the Opus *structural* shape: a `WhenAPlayerCastsASpell(You, instant|
+ * sorcery)` trigger whose sole action is an `IfElse` gated on the 5-or-more-mana-spent condition. This
+ * is the recognition net [opusTriggerBlock] uses, minus the per-arm rendering. [triggerBlock] consults
+ * it so that when a card is unmistakably Opus but [opusTriggerBlock] *declines* (e.g. the unreliable
+ * `PutNumberCountersOfTypeOnPermanent` count), the whole card downgrades to SCAFFOLD rather than
+ * falling through to the generic trigger path and re-rendering the same wrong value.
+ */
+private fun EmitCtx.isOpusShaped(rule: JsonObject): Boolean {
+    val ruleArgs = rule["args"].asArr ?: return false
+    val trig = ruleArgs.getOrNull(0) as? JsonObject ?: return false
+    if (trig.strField("_Trigger") != "WhenAPlayerCastsASpell") return false
+    if (!jsonContains(trig, "_Player", "You")) return false
+    val spellFilter = trig["args"].asArr?.getOrNull(1) as? JsonObject ?: return false
+    if (spellFilter.strField("_Spells") != "Or") return false
+    val orTypes = spellFilter["args"].asArr?.filterIsInstance<JsonObject>()
+        ?.filter { it.strField("_Spells") == "IsCardtype" }
+        ?.mapNotNull { it["args"].asStr() }?.toSet() ?: return false
+    if (orTypes != setOf("Instant", "Sorcery")) return false
+    val (_, actions) = extractEnvelope(rule)
+    val ifElse = actions?.singleOrNull()?.takeIf { it.strField("_Action") == "IfElse" } ?: return false
+    val cond = ifElse["args"].asArr?.getOrNull(0) as? JsonObject ?: return false
+    return isFiveOrMoreManaSpentCondition(cond)
 }
 
 /**
@@ -1413,8 +1476,11 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
 
     // Opus (Secrets of Strixhaven) — the `opus { }` ability-word builder. Recognise its exact structural
     // shape before the generic trigger path; "Opus" is a flavor ability word with no IR signal, so it is
-    // inferred from structure alone (then matched precisely so nothing else collapses).
+    // inferred from structure alone (then matched precisely so nothing else collapses). When the card is
+    // unmistakably Opus-shaped but the renderer declines (e.g. the unreliable counter-count arm), scaffold
+    // the whole card rather than letting the generic trigger path re-render the same wrong value.
     opusTriggerBlock(rule, oncePerTurn, triggerCondition)?.let { return it }
+    if (isOpusShaped(rule)) { reasons.add("opus"); return null }
 
     // A Mount's "while saddled" attack trigger nests the intervening-if (CR 603.4) *inside* the
     // TriggerA's trigger slot: `args[0]` is an `If { <gate> } <realTrigger>` node rather than a bare
@@ -2025,6 +2091,15 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         val argv = trig["args"].asArr
         val scope = castScope(argv?.getOrNull(0) as? JsonObject) ?: return null
         val spellsNode = argv?.getOrNull(1) as? JsonObject
+        // "a spell with {X} in its mana cost" (Geometer's Arthropod) — a bare HasXInCost filter,
+        // expressed as a cast-time `SpellCastPredicate.HasXInCost` (the X value of the triggering
+        // spell is read in the payoff via DynamicAmounts.xValueOfTriggeringSpell()). Only the You
+        // scope has the matching Triggers facade today; any other scope declines -> SCAFFOLD.
+        if (spellsNode?.strField("_Spells") == "HasXInCost") {
+            return if (scope == CastScope.YOU)
+                "Triggers.youCastSpell(requires = setOf(SpellCastPredicate.HasXInCost))"
+            else null
+        }
         // "an instant or sorcery spell that targets a creature" (Repartee — Forum Necroscribe,
         // Lecturing Scornmage): an And of the base spell-type filter + a `TargetsAPermanent`
         // clause. Recover the base category and a `targetsMatching(<filter>)` subfilter; the

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -263,6 +263,11 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
             return if (jsonContains(node["args"], "_Spell", "Trigger_ThatSpell"))
                 call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL"))
             else null
+        // "X" on a `WhenAPlayerCastsASpell(You, HasXInCost)` trigger — the value chosen for {X} on the
+        // triggering spell (Geometer's Arthropod's "look at the top X cards of your library"). Reads the
+        // triggering-spell X via the context key; the `Trigger_` prefix already scopes it to that spell.
+        "Trigger_ValueXOfThatSpell" ->
+            return call("DynamicAmounts.xValueOfTriggeringSpell")
         "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
         // "the number of [filter] cards in your graveyard" (Rise of the Varmints' Varmint count). The
         // count's args are a `_CardsInGraveyard` filter — typically `And(IsCardtype Creature,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -81,7 +81,10 @@ data class TriggeredAbilityContinuation(
     val triggerManaSpentOnTriggeringSpell: Int? = null,
     /** Mana value of the spell that fired this trigger (Kellan, the Kid). Read via
      *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
-    val triggerManaValueOfTriggeringSpell: Int? = null
+    val triggerManaValueOfTriggeringSpell: Int? = null,
+    /** Value chosen for {X} on the spell that fired this trigger (Geometer's Arthropod). Read via
+     *  `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL`. Null for non-cast / no-{X} triggers. */
+    val triggerXValueOfTriggeringSpell: Int? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -84,6 +84,13 @@ data class TriggerContext(
      */
     val manaValueOfTriggeringSpell: Int? = null,
     /**
+     * For SpellCastEvent triggers — the value chosen for `{X}` on the triggering spell (CR 601.2b).
+     * `null` when the trigger was not driven by a spell cast or the spell had no {X}. Read by
+     * `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL` so abilities like Geometer's Arthropod can
+     * scale by "the top X cards of your library."
+     */
+    val xValueOfTriggeringSpell: Int? = null,
+    /**
      * Power of the creature the trigger's source (an Aura/Equipment) was attached to, captured
      * when the trigger fired. Carried as last-known information (CR 608.2h) so that an
      * "enchanted creature deals damage equal to its power" ability still uses the right power
@@ -171,7 +178,8 @@ data class TriggerContext(
                     triggeringPlayerId = event.casterId,
                     modesChosenCount = event.chosenModesCount.takeIf { it > 0 },
                     manaSpentOnTriggeringSpell = event.totalManaSpent.takeIf { it > 0 },
-                    manaValueOfTriggeringSpell = event.manaValue.takeIf { it > 0 }
+                    manaValueOfTriggeringSpell = event.manaValue.takeIf { it > 0 },
+                    xValueOfTriggeringSpell = event.xValue
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is com.wingedsheep.engine.core.ScriedEvent -> TriggerContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1262,6 +1262,8 @@ class TriggerMatcher(
             else -> false
         }
         SpellCastPredicate.IsModal -> event.chosenModesCount > 0
+        SpellCastPredicate.HasXInCost ->
+            state.getEntity(event.spellEntityId)?.get<CardComponent>()?.manaCost?.hasX == true
     }
 
     /**
@@ -1289,7 +1291,8 @@ class TriggerMatcher(
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
                 triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
-                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
+                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
+                triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell
             )
             conditionEvaluator.evaluate(state, condition, context)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -606,7 +606,8 @@ class TriggerProcessor(
                 triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
                 triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
                 triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
-                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
+                triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
+                triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell
             )
             ability.effect.runtimeDescription { amount -> evaluator.evaluate(state, amount, context) }
         } catch (_: Exception) {
@@ -656,7 +657,8 @@ class TriggerProcessor(
             triggerExcessDamageAmount = trigger.triggerContext.excessDamageAmount,
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
             triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
-            triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell
+            triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
+            triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell
         )
 
         // Push the continuation onto the stack
@@ -713,6 +715,7 @@ class TriggerProcessor(
             triggerRecipientToughness = trigger.triggerContext.recipientToughnessAtDamage,
             triggerManaSpentOnTriggeringSpell = trigger.triggerContext.manaSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
+            triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell,
             capturedEntityIds = trigger.triggerContext.capturedEntityIds ?: emptyList()
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -508,6 +508,8 @@ class DynamicAmountEvaluator(
 
         ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE -> context.triggerManaValueOfTriggeringSpell ?: 0
 
+        ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL -> context.triggerXValueOfTriggeringSpell ?: 0
+
         ContextPropertyKey.TRIGGER_SCRY_COUNT -> context.triggerScryCount ?: 0
 
         ContextPropertyKey.TRIGGER_EXCESS_DAMAGE_AMOUNT -> context.triggerExcessDamageAmount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -185,6 +185,13 @@ data class EffectContext(
      */
     val triggerManaValueOfTriggeringSpell: Int? = null,
     /**
+     * The value chosen for `{X}` on the spell that fired this trigger (CR 601.2b). Read by
+     * `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL` (Geometer's Arthropod). Distinct from
+     * [triggerManaValueOfTriggeringSpell] (printed mana value, where {X} counts as 0) and
+     * [triggerManaSpentOnTriggeringSpell] (total mana paid).
+     */
+    val triggerXValueOfTriggeringSpell: Int? = null,
+    /**
      * Number of cards actually looked at by the scry that fired this trigger. Read by
      * `ContextPropertyKey.TRIGGER_SCRY_COUNT` (Celeborn the Wise, Elrond Master of Healing).
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -102,7 +102,8 @@ class EffectAndTriggerContinuationResumer(
                 triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
                 triggerRecipientToughness = continuation.triggerRecipientToughness,
                 triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
-                triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
+                triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell,
+                triggerXValueOfTriggeringSpell = continuation.triggerXValueOfTriggeringSpell
             )
             val stackResult = services.stackResolver.putTriggeredAbility(state, elseComponent, emptyList())
             if (!stackResult.isSuccess) return stackResult
@@ -152,7 +153,8 @@ class EffectAndTriggerContinuationResumer(
             triggerExcessDamageAmount = continuation.triggerExcessDamageAmount,
             triggerRecipientToughness = continuation.triggerRecipientToughness,
             triggerManaSpentOnTriggeringSpell = continuation.triggerManaSpentOnTriggeringSpell,
-            triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell
+            triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell,
+            triggerXValueOfTriggeringSpell = continuation.triggerXValueOfTriggeringSpell
         )
 
         val stackResult = services.stackResolver.putTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1934,6 +1934,7 @@ class StackResolver(
             triggerRecipientToughness = abilityComponent.triggerRecipientToughness,
             triggerManaSpentOnTriggeringSpell = abilityComponent.triggerManaSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = abilityComponent.triggerManaValueOfTriggeringSpell,
+            triggerXValueOfTriggeringSpell = abilityComponent.triggerXValueOfTriggeringSpell,
             xValue = abilityComponent.xValue,
             damageDistribution = abilityComponent.damageDistribution,
             chosenModes = abilityComponent.chosenModes,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -141,6 +141,9 @@ data class TriggeredAbilityOnStackComponent(
     /** Mana value (CR 202.3) of the spell that fired this trigger (Kellan, the Kid). Read via
      *  `ContextPropertyKey.TRIGGERING_SPELL_MANA_VALUE`. Null for non-cast triggers. */
     val triggerManaValueOfTriggeringSpell: Int? = null,
+    /** Value chosen for {X} on the spell that fired this trigger (Geometer's Arthropod). Read via
+     *  `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL`. Null for non-cast / no-{X} triggers. */
+    val triggerXValueOfTriggeringSpell: Int? = null,
     // Modal fields — populated when this triggered ability is a copy of a modal spell (700.2g).
     // Copies inherit the original's chosen modes; targets either inherit too (StormCopy default)
     // or are re-chosen by the copy controller while modes stay fixed.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1541,7 +1541,8 @@ class ClientStateTransformer(
         triggerExcessDamageAmount = triggered.triggerExcessDamageAmount,
         triggerRecipientToughness = triggered.triggerRecipientToughness,
         triggerManaSpentOnTriggeringSpell = triggered.triggerManaSpentOnTriggeringSpell,
-        triggerManaValueOfTriggeringSpell = triggered.triggerManaValueOfTriggeringSpell
+        triggerManaValueOfTriggeringSpell = triggered.triggerManaValueOfTriggeringSpell,
+        triggerXValueOfTriggeringSpell = triggered.triggerXValueOfTriggeringSpell
     )
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeometersArthropodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeometersArthropodScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Geometer's Arthropod {G}{U} 1/4 Fractal Crab.
+ *
+ * "Whenever you cast a spell with {X} in its mana cost, look at the top X cards of your library.
+ * Put one of them into your hand and the rest on the bottom of your library in a random order."
+ *
+ * Exercises the new `SpellCastPredicate.HasXInCost` trigger gate and
+ * `DynamicAmounts.xValueOfTriggeringSpell()` dig count: the dig only fires for spells with {X} in
+ * their cost, looks at exactly the announced X, keeps one in hand, and bottoms the rest. X=0 is a
+ * harmless no-op (look at zero), and a spell without {X} never triggers.
+ *
+ * The triggering spells here are deliberately effect-less ({X}{U} / {U} "do nothing") so the only
+ * thing that touches the library is the Arthropod's dig — keeping the assertions about library and
+ * hand contents unambiguous.
+ */
+class GeometersArthropodScenarioTest : ScenarioTestBase() {
+
+    // A targetless {X}{U} spell that does nothing on resolution, so the only library/hand change is
+    // the Arthropod's dig.
+    private val xNoop = card("X Noop Test") {
+        manaCost = "{X}{U}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(0) }
+    }
+
+    // A vanilla {U} no-op spell with NO {X} — must not fire the Arthropod's trigger.
+    private val plainNoop = card("Plain Noop Test") {
+        manaCost = "{U}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(0) }
+    }
+
+    init {
+        cardRegistry.register(xNoop)
+        cardRegistry.register(plainNoop)
+
+        context("Geometer's Arthropod") {
+
+            test("casting an {X} spell with X=2: look at top 2, keep one, bottom the rest") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Geometer's Arthropod")
+                    .withCardInHand(1, "X Noop Test") // {X}{U}
+                    .withLandsOnBattlefield(1, "Island", 3) // X=2 + {U}
+                    .withCardInLibrary(1, "Plains")    // top
+                    .withCardInLibrary(1, "Swamp")     // 2nd — both looked at with X=2
+                    .withCardInLibrary(1, "Mountain")  // 3rd — beyond X=2, untouched
+                    .withCardInLibrary(1, "Forest")    // 4th
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun libraryNames(): List<String> =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+                fun libraryIdOf(name: String): EntityId =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+                val plains = libraryIdOf("Plains")
+
+                // Cast X Noop Test with X=2. The "you cast a spell with {X}" trigger fires and asks
+                // which of the top 2 to keep.
+                game.castXSpell(1, "X Noop Test", xValue = 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("X=2 → the dig pauses for a keep-one decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.selectCards(listOf(plains)).error shouldBe null
+                game.resolveStack()
+
+                withClue("The chosen card (Plains) went to hand") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+                withClue("Swamp (2nd, rejected) is on the bottom of the library") {
+                    libraryNames().last() shouldBe "Swamp"
+                }
+                withClue("Mountain (3rd) and Forest (4th) were never looked at — still on top, in order") {
+                    libraryNames() shouldBe listOf("Mountain", "Forest", "Swamp")
+                }
+            }
+
+            test("X=0 is a harmless no-op: nothing looked at, library order preserved") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Geometer's Arthropod")
+                    .withCardInHand(1, "X Noop Test") // {X}{U}
+                    .withLandsOnBattlefield(1, "Island", 1) // just {U}, X=0
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun libraryNames(): List<String> =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+                game.castXSpell(1, "X Noop Test", xValue = 0).error shouldBe null
+                game.resolveStack()
+
+                withClue("X=0 → the dig looks at zero cards, so no keep-one decision pends") {
+                    (game.state.pendingDecision == null) shouldBe true
+                }
+                withClue("Nothing was drawn or moved — library keeps its full order") {
+                    game.isInHand(1, "Plains") shouldBe false
+                    libraryNames() shouldBe listOf("Plains", "Swamp", "Mountain")
+                }
+            }
+
+            test("a spell WITHOUT {X} in its cost does not trigger the dig") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Geometer's Arthropod")
+                    .withCardInHand(1, "Plain Noop Test") // {U}, no {X}
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun libraryNames(): List<String> =
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                        .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+                game.castSpell(1, "Plain Noop Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("No {X} in cost → no dig decision") {
+                    (game.state.pendingDecision == null) shouldBe true
+                }
+                withClue("Nothing happened — library untouched") {
+                    game.isInHand(1, "Plains") shouldBe false
+                    libraryNames() shouldBe listOf("Plains", "Swamp")
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TackleArtistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TackleArtistScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tackle Artist {3}{R} 4/3 Orc Sorcerer — Trample.
+ *
+ * "Opus — Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If
+ * five or more mana was spent to cast that spell, put two +1/+1 counters on this creature instead."
+ *
+ * The 5+ tier *replaces* the base via `insteadIfFiveOrMore`: one +1/+1 counter normally, two when
+ * five or more mana was spent (NOT three — the bonus is "instead", not additive). Exercises both
+ * sides of the 5-mana boundary; counters are permanent so they persist.
+ */
+class TackleArtistScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun plusCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Tackle Artist — Opus +1/+1 counters") {
+
+            test("a cheap instant/sorcery puts one +1/+1 counter (4/3 → 5/4)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tackle Artist") // 4/3
+                    .withCardInHand(1, "Lightning Bolt") // {R}, 1 mana
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artist = game.findPermanent("Tackle Artist")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("1 mana spent → one +1/+1 counter") {
+                    plusCounters(game, artist) shouldBe 1
+                    projector.getProjectedPower(game.state, artist) shouldBe 5
+                    projector.getProjectedToughness(game.state, artist) shouldBe 4
+                }
+            }
+
+            test("a 5+ mana spell puts TWO +1/+1 counters instead (4/3 → 6/5, not 7/6)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tackle Artist") // 4/3
+                    .withCardInHand(1, "Blaze") // {X}{R}
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artist = game.findPermanent("Tackle Artist")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Blaze X=4 → {4}{R} → 5 mana spent (boundary).
+                game.castXSpell(1, "Blaze", xValue = 4, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("5 mana spent → two +1/+1 counters instead (not one, not three)") {
+                    plusCounters(game, artist) shouldBe 2
+                    projector.getProjectedPower(game.state, artist) shouldBe 6
+                    projector.getProjectedToughness(game.state, artist) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThornfistStrikerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThornfistStrikerScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thornfist Striker {2}{G} 3/3 Elf Druid — Ward {1}.
+ *
+ * "Infusion — Creatures you control get +1/+0 and have trample as long as you gained life this
+ * turn."
+ *
+ * The Infusion lord is two `ConditionalStaticAbility` blocks (ModifyStats +1/+0 and GrantKeyword
+ * trample) both gated on `Conditions.YouGainedLifeThisTurn`: off until life is gained this turn,
+ * then both turn on for every creature the controller controls (including Thornfist Striker
+ * itself).
+ */
+class ThornfistStrikerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun hasTrample(game: TestGame, id: EntityId): Boolean =
+        projector.getProjectedKeywords(game.state, id).contains(Keyword.TRAMPLE)
+
+    init {
+        // A simple life-gain spell to turn the Infusion condition on.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Healing Salve Test",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 3 life.",
+                script = CardScript.spell(effect = GainLifeEffect(3, EffectTarget.Controller)),
+            )
+        )
+
+        context("Thornfist Striker — Infusion lord") {
+
+            test("no life gained: no buff and no trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thornfist Striker") // 3/3
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2, also controlled
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val striker = game.findPermanent("Thornfist Striker")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("No life gained → Striker stays 3/3 with no trample") {
+                    projector.getProjectedPower(game.state, striker) shouldBe 3
+                    projector.getProjectedToughness(game.state, striker) shouldBe 3
+                    hasTrample(game, striker) shouldBe false
+                }
+                withClue("No life gained → Grizzly Bears stays 2/2 with no trample") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 2
+                    hasTrample(game, bears) shouldBe false
+                }
+            }
+
+            test("after gaining life: all your creatures get +1/+0 and trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thornfist Striker") // 3/3
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2
+                    .withCardInHand(1, "Healing Salve Test")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val striker = game.findPermanent("Thornfist Striker")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Healing Salve Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("Life gained → Striker is 4/3 with trample") {
+                    projector.getProjectedPower(game.state, striker) shouldBe 4
+                    projector.getProjectedToughness(game.state, striker) shouldBe 3
+                    hasTrample(game, striker) shouldBe true
+                }
+                withClue("Life gained → Grizzly Bears is 3/2 with trample (lord hits all your creatures)") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 3
+                    projector.getProjectedToughness(game.state, bears) shouldBe 2
+                    hasTrample(game, bears) shouldBe true
+                }
+            }
+
+            test("opponent's creatures are unaffected even after you gain life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thornfist Striker")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // opponent's
+                    .withCardInHand(1, "Healing Salve Test")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oppBears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Healing Salve Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("Opponent's Grizzly Bears stays 2/2 with no trample") {
+                    projector.getProjectedPower(game.state, oppBears) shouldBe 2
+                    hasTrample(game, oppBears) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements three Secrets of Strixhaven (SOS) cards and extends the mtgish-tooling emitter so the SCAFFOLD cards render faithfully to AUTO (or correctly decline when the IR is untrustworthy).

### Cards (canonical in SOS, the earliest printing)

- **Tackle Artist** `{3}{R}` 4/3 Orc Sorcerer — Trample; Opus — whenever you cast an instant or sorcery spell, put a +1/+1 counter on it; **two** instead if 5+ mana was spent. Authored with the existing `opus { insteadIfFiveOrMore = … }` builder.
- **Geometer's Arthropod** `{G}{U}` 1/4 Fractal Crab — "Whenever you cast a spell with {X} in its mana cost, look at the top X cards of your library. Put one into your hand and the rest on the bottom in a random order." Uses the existing `Patterns.Library.lookAtTopAndKeep` dig.
- **Thornfist Striker** `{2}{G}` 3/3 Elf Druid — Ward {1}; Infusion — creatures you control get +1/+0 and have trample as long as you gained life this turn. Two `ConditionalStaticAbility` lords gated on `Conditions.YouGainedLifeThisTurn`.

Each has a passing Kotest scenario test (`*ScenarioTest`), and the SOS card snapshot golden is re-blessed (only these three card trees added).

### New SDK building blocks (for Geometer's Arthropod)

- `SpellCastPredicate.HasXInCost` — "you cast a spell with {X} in its mana cost" cast-time gate (matches `CardComponent.manaCost.hasX`; X=0 still triggers).
- `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL` + `DynamicAmounts.xValueOfTriggeringSpell()` — reads the triggering spell's chosen X, threaded from `SpellCastEvent.xValue` through `TriggerContext` → `EffectContext` → `TriggeredAbilityOnStackComponent` → continuations, alongside the existing triggering-spell mana fields.

`docs/card-sdk-language-reference.md` updated for all three (§ spell-cast predicates, dynamic amounts, context property keys).

### mtgish-tooling emitter changes

- Render the `WhenAPlayerCastsASpell(You, HasXInCost)` trigger + the `Trigger_ValueXOfThatSpell` count → promotes **Geometer's Arthropod** to AUTO.
- Recognise the Infusion `GainedLifeThisTurn` gate on an `EachPermanentLayerEffect` lord → promotes **Thornfist Striker** to AUTO.
- **Decline the Opus 5+ `PutNumberCountersOfTypeOnPermanent` bonus arm to SCAFFOLD.** The mtgish IR reuses the literal 5-mana threshold as the counter count rather than the printed value — verified wrong for Tackle Artist (IR 5 vs oracle "two") and Spectacular Skywhale (IR 5 vs oracle "three"). Per "render correctly or decline — never emit a lossy approximation", the emitter now declines this shape (and the whole Opus-shaped card scaffolds rather than falling through to the generic path's wrong count). **Tackle Artist therefore stays SCAFFOLD in the tooling and is implemented by hand** with the correct count of two.

### Verification

- All three scenario tests pass; full `:rules-engine`, `:mtg-sdk`, `:mtg-sets`, and `:mtgish-tooling` test suites pass; `:game-server`/`:ai` compile.
- `coverage-verify SOS`: my three cards introduce **no** gameplay-tree mismatch — Geometer's Arthropod and Thornfist Striker match golden (AUTO); Tackle Artist declines cleanly to "not emitted". (SOS is not a 0-mismatch gate set; its remaining mismatches — Forum Necroscribe, the charms, etc. — are pre-existing and unrelated.)
- `coverage-verify POR`: keeps its **single pre-existing** `Breath of Life` `fromZone` mismatch, which is present on a clean `main` checkout (another agent's in-flight return-from-graveyard emitter work). Not touched here. `capability MISMATCH: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
