### PR TITLE
Fix infinite-loop hang in ResonatingLuteScenarioTest (unblocks backend CI)

### DIFF
--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResonatingLuteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResonatingLuteScenarioTest.kt
@@ -1,10 +1,15 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.utils.CastPermissionUtils
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.sos.cards.ResonatingLute
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
@@ -38,27 +43,45 @@ class ResonatingLuteScenarioTest : FunSpec({
         return driver.activePlayer!!
     }
 
+    fun makeCastPermissionUtils(driver: GameTestDriver): CastPermissionUtils =
+        CastPermissionUtils(driver.cardRegistry, PredicateEvaluator(), ConditionEvaluator())
+
     test("grants each land you control a {T}: add two mana of one color ability") {
         val driver = createDriver()
         val p = start(driver)
         val opp = driver.getOpponent(p)
 
-        driver.putPermanentOnBattlefield(p, "Resonating Lute") // artifact host
+        val lute = driver.putPermanentOnBattlefield(p, "Resonating Lute") // artifact host
         val myLand = driver.putLandOnBattlefield(p, "Mountain")
         val oppLand = driver.putLandOnBattlefield(opp, "Forest")
 
-        // My land has the granted mana ability; the opponent's does not.
-        val myGrants = driver.state.grantedActivatedAbilities.filter { it.entityId == myLand }
+        // The grant is a static "Lands you control have …" ability, so it surfaces through the
+        // static-grant resolver (CastPermissionUtils), not the resolved-effect
+        // `grantedActivatedAbilities` list (which only one-shot grants populate). My land receives
+        // it from the Lute; the opponent's land does not.
+        val utils = makeCastPermissionUtils(driver)
+        val myGrants = utils.getStaticGrantedAbilitiesWithGranter(myLand, driver.state)
         myGrants.size shouldBe 1
-        driver.state.grantedActivatedAbilities.filter { it.entityId == oppLand }.size shouldBe 0
+        myGrants[0].granterId shouldBe lute
+        utils.getStaticGrantedAbilitiesWithGranter(oppLand, driver.state) shouldBe emptyList()
 
-        // Activating it adds two mana of one chosen color (mana ability — resolves immediately).
+        // Activating it adds two mana of one chosen color (mana ability — resolves immediately;
+        // the colour choice rides along on the activation).
         driver.submitSuccess(
-            ActivateAbility(playerId = p, sourceId = myLand, abilityId = myGrants[0].ability.id),
+            ActivateAbility(
+                playerId = p,
+                sourceId = myLand,
+                abilityId = myGrants[0].ability.id,
+                manaColorChoice = Color.RED,
+            ),
         )
+        // The mana is spendable only on instants/sorceries, so it lands in the restricted-mana
+        // pool (two RED entries) rather than the plain colour counts.
         val pool = driver.state.getEntity(p)?.get<ManaPoolComponent>()!!
-        val total = pool.white + pool.blue + pool.black + pool.red + pool.green + pool.colorless
-        total shouldBe 2
+        pool.total shouldBe 2
+        pool.restrictedMana.size shouldBe 2
+        pool.restrictedMana.all { it.color == Color.RED } shouldBe true
+        pool.restrictedMana.all { it.restriction == ManaRestriction.InstantOrSorceryOnly } shouldBe true
     }
 
     test("draw ability is legal with 7+ cards in hand") {

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -877,15 +877,20 @@ class GameTestDriver {
     }
 
     /**
-     * Move a permanent from the battlefield to its owner's graveyard (test helper). Strips its
-     * battlefield zone membership without running dies/leaves triggers — a blunt removal for
-     * setting up "the permanent is gone now" states. Returns silently if the entity has no owner.
+     * Move a card or permanent to its owner's graveyard (test helper). Strips its membership from
+     * whatever zone it currently occupies (battlefield, hand, …) without running dies/leaves
+     * triggers — a blunt removal for setting up "the card is in the graveyard now" states, and
+     * usable as a "discard from hand" helper. Returns silently if the entity has no owner.
      */
     fun moveToGraveyard(entityId: EntityId) {
         val ownerId = _state.getEntity(entityId)
             ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
             ?: return
-        _state = _state.removeFromZone(ZoneKey(ownerId, Zone.BATTLEFIELD), entityId)
+        // Remove from every zone the entity currently occupies rather than assuming battlefield;
+        // otherwise discarding a hand card here is a no-op and any "while in hand" setup loop spins
+        // forever (it never leaves the hand) while endlessly re-adding it to the graveyard.
+        val occupiedZones = _state.zones.keys.filter { entityId in _state.getZone(it) }
+        occupiedZones.forEach { _state = _state.removeFromZone(it, entityId) }
         _state = _state.addToZone(ZoneKey(ownerId, Zone.GRAVEYARD), entityId)
     }
 


### PR DESCRIPTION
## Problem

The `backend` CI job has been getting **SIGKILLed (exit 137)** after ~20 min on every PR branched from current `main` (e.g. #807). The thread dump showed one test worker burning **~615s of CPU** in an infinite loop:

```
ResonatingLuteScenarioTest.kt:86 → GameTestDriver.moveToGraveyard → GameState.addToZone (Arrays.copyOf)
```

This is a **pre-existing** issue in `main`, introduced with Resonating Lute in `6b5c91299` — unrelated to the card PRs that merely inherited it by branching from main.

## Two bugs fixed

1. **Infinite loop.** The test discarded from hand via `GameTestDriver.moveToGraveyard`, which was a **battlefield-only** helper. Removing a hand card from the *battlefield* zone is a no-op, so `while (getHandSize() > 6)` never terminated while endlessly re-adding the same entity to the graveyard zone (the hot `addToZone`/`copyOf` loop). Made `moveToGraveyard` **zone-agnostic**: it now strips the entity from whatever zone it currently occupies (so it doubles as a discard-from-hand helper) while remaining identical for battlefield permanents.

2. **Wrong-field assertion.** The test asserted the static *"Lands you control have …"* grant via `state.grantedActivatedAbilities`, which only **one-shot (resolved-effect)** grants populate — static grants surface through `CastPermissionUtils.getStaticGrantedAbilitiesWithGranter` (the same way Bootleggers' Stash is tested). Rewrote the assertion accordingly, supplied the mana-ability colour choice on activation, and asserted the result in the **restricted-mana pool** (instant/sorcery-only mana lives in `ManaPoolComponent.restrictedMana`, not the plain colour counts).

The Resonating Lute card itself is correct — only its scenario test was wrong.

## Verification

- `ResonatingLuteScenarioTest` — 3/3 pass, no hang.
- Full `:rules-engine:test` — **4353 tests across 1211 suites, 0 failures**, completes in ~35s (was a 20-min SIGKILL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)