### PR TITLE
Add 4 Secrets of Strixhaven cards (batch C)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RenderSpeechless.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RenderSpeechless.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Render Speechless — Secrets of Strixhaven #220
+ * {2}{W}{B} · Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ * that card.
+ * Put two +1/+1 counters on up to one target creature.
+ *
+ * Two independently-targeted clauses (CR 601.2c): the opponent (target 0) is the discarded-from
+ * player, and an optional creature (target 1) receives the counters. The targeted discard is the
+ * Duress pipeline (reveal → gather hand → controller chooses a nonland card → discard), filtered
+ * to nonland only. The counter clause uses an optional creature target so it can be cast with no
+ * legal/desired creature, in which case [Effects.AddCounters] no-ops on the empty target.
+ */
+val RenderSpeechless = card("Render Speechless") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it. That " +
+        "player discards that card.\nPut two +1/+1 counters on up to one target creature."
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        val creature = target("up to one target creature", TargetCreature(optional = true))
+        effect = Effects.Composite(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "opponentHand",
+                ),
+                SelectFromCollectionEffect(
+                    from = "opponentHand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "Choose a nonland card to discard",
+                    alwaysPrompt = true,
+                    showAllCards = true,
+                ),
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard,
+                ),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.ContextTarget(1)),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "David Astruga"
+        flavorText = "\"Seems like I took the words right out of your mouth.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/25bbb1c7-14e8-444f-ab98-e95f50927460.jpg?1775938531"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SocialSnub.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SocialSnub.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Social Snub — Secrets of Strixhaven #228
+ * {1}{W}{B} · Sorcery
+ *
+ * When you cast this spell while you control a creature, you may copy this spell.
+ * Each player sacrifices a creature of their choice. Each opponent loses 1 life and you gain
+ * 1 life.
+ *
+ * The intervening-if cast trigger (CR 603.4) fires from the stack via
+ * [Triggers.WhenYouCastThisSpell] with `triggerCondition = Conditions.ControlCreature`; its
+ * [MayEffect] optionally copies the spell with [Effects.CopyTargetSpell] of the triggering entity
+ * (a copy isn't cast, CR 707.10, so it doesn't re-trigger). Resolution is an edict —
+ * [Effects.Sacrifice] of a creature for each player (`Player.Each`, each chooses their own) — then
+ * each opponent loses 1 life and the controller gains 1.
+ */
+val SocialSnub = card("Social Snub") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Sorcery"
+    oracleText = "When you cast this spell while you control a creature, you may copy this spell.\n" +
+        "Each player sacrifices a creature of their choice. Each opponent loses 1 life and you " +
+        "gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        triggerCondition = Conditions.ControlCreature
+        effect = MayEffect(Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity))
+        description = "When you cast this spell while you control a creature, you may copy this spell."
+    }
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Sacrifice(
+                filter = GameObjectFilter.Creature,
+                target = EffectTarget.PlayerRef(Player.Each),
+            ),
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "228"
+        artist = "Raluca Marinescu"
+        flavorText = "\"Sorry. This seat's taken.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a04b6900-0436-4920-a0d4-c0186d605ae3.jpg?1775938590"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/VastlandsScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/VastlandsScavenger.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vastlands Scavenger // Bind to Life — Secrets of Strixhaven #166
+ * {1}{G}{G} · Creature — Bear Druid · 4/4
+ *
+ * Deathtouch
+ * This creature enters prepared. (While it's prepared, you may cast a copy of its spell.
+ * Doing so unprepares it.)
+ * //
+ * Bind to Life — {4}{G}, Instant: Mill seven cards. Then put a creature card from among them
+ * onto the battlefield.
+ *
+ * Prepare (Secrets of Strixhaven): the creature enters with [Keyword.PREPARED]; becoming prepared
+ * creates a copy of its prepare spell ("Bind to Life") in exile that its controller may cast for
+ * {4}{G}, and casting that copy unprepares the creature. Modeled via [CardLayout.PREPARE] +
+ * the `prepare(name) { }` DSL.
+ *
+ * Bind to Life mills seven (gather top 7 → graveyard), then puts a creature card from among the
+ * milled cards onto the battlefield: a [SelectFromCollectionEffect] of exactly one creature from
+ * the milled collection (auto-selects none if no creature was milled) followed by
+ * [MoveCollectionEffect] to the battlefield. The select reads the milled collection, which still
+ * tracks the cards' refs after they hit the graveyard.
+ */
+val VastlandsScavenger = card("Vastlands Scavenger") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear Druid"
+    power = 4
+    toughness = 4
+    oracleText = "Deathtouch\nThis creature enters prepared. (While it's prepared, you may cast a " +
+        "copy of its spell. Doing so unprepares it.)"
+
+    keywords(Keyword.DEATHTOUCH, Keyword.PREPARED)
+
+    // Bind to Life — the prepare spell. Mill seven; then put a milled creature card onto the battlefield.
+    prepare("Bind to Life") {
+        manaCost = "{4}{G}"
+        typeLine = "Instant"
+        oracleText = "Mill seven cards. Then put a creature card from among them onto the battlefield."
+        spell {
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7)),
+                        storeAs = "milled",
+                    ),
+                    MoveCollectionEffect(
+                        from = "milled",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "milled",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        filter = GameObjectFilter.Creature,
+                        storeSelected = "toBattlefield",
+                        showAllCards = true,
+                        prompt = "Put a creature card onto the battlefield",
+                    ),
+                    MoveCollectionEffect(
+                        from = "toBattlefield",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    ),
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/476b6a4d-cc05-4e98-8a45-a5c6582ec514.jpg?1778165152"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WiltInTheHeat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WiltInTheHeat.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Wilt in the Heat — Secrets of Strixhaven #243
+ * {2}{R}{W} · Instant
+ *
+ * This spell costs {2} less to cast if one or more cards left your graveyard this turn.
+ * Wilt in the Heat deals 5 damage to target creature. If that creature would die this turn,
+ * exile it instead.
+ *
+ * The cost reduction is a [ModifySpellCost] static on [SpellCostTarget.SelfCast], gated by
+ * [CostGating.OnlyIf] with [Conditions.CardsLeftGraveyardThisTurn] (≥1) — evaluated at cast time
+ * (the Essence Anchor / Primary Research graveyard-departure tracker). The spell deals 5 damage
+ * and then marks the creature with [MarkExileOnDeathEffect], a death-replacement (CR 614) that
+ * exiles it instead of letting it die this turn — so even lethal damage from another source
+ * sends it to exile rather than the graveyard.
+ */
+val WiltInTheHeat = card("Wilt in the Heat") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if one or more cards left your graveyard " +
+        "this turn.\nWilt in the Heat deals 5 damage to target creature. If that creature would " +
+        "die this turn, exile it instead."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.CardsLeftGraveyardThisTurn(1)),
+        )
+    }
+
+    spell {
+        val t = target("target creature", TargetCreature())
+        effect = DealDamageEffect(5, t) then MarkExileOnDeathEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "243"
+        artist = "Raluca Marinescu"
+        flavorText = "\"'It'll be fun,' they said. 'The Fields are full of dead things,' they said.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f63f7209-fc0f-400c-8076-125f3131cb32.jpg?1775938697"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -6947,6 +6947,102 @@
     ]
 }
 
+// Render Speechless
+{
+    "name": "Render Speechless",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nPut two +1/+1 counters on up to one target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RevealHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "opponentHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "opponentHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to one target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "David Astruga",
+        "flavorText": "\"Seems like I took the words right out of your mouth.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/25bbb1c7-14e8-444f-ab98-e95f50927460.jpg?1775938531"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Resonating Lute
 {
     "name": "Resonating Lute",
@@ -7568,6 +7664,79 @@
         "artist": "Alexandre Honoré",
         "flavorText": "Eavesdropping is not a misdeed in the Forum, but a fact of life.",
         "imageUri": "https://cards.scryfall.io/normal/front/7/3/73d06987-8686-461b-b260-9a4fee6a3b32.jpg?1775938584"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Social Snub
+{
+    "name": "Social Snub",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "When you cast this spell while you control a creature, you may copy this spell.\nEach player sacrifices a creature of their choice. Each opponent loses 1 life and you gain 1 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature"
+                },
+                "descriptionOverride": "When you cast this spell while you control a creature, you may copy this spell."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "UNCOMMON",
+        "artist": "Raluca Marinescu",
+        "flavorText": "\"Sorry. This seat's taken.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a04b6900-0436-4920-a0d4-c0186d605ae3.jpg?1775938590"
     },
     "colorIdentityOverride": [
         "WHITE",
@@ -9215,6 +9384,89 @@
     ]
 }
 
+// Vastlands Scavenger
+{
+    "name": "Vastlands Scavenger",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Bear Druid",
+    "oracleText": "Deathtouch\nThis creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "PREPARED"
+    ],
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "RARE",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/476b6a4d-cc05-4e98-8a45-a5c6582ec514.jpg?1778165152"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Bind to Life",
+            "manaCost": "{4}{G}",
+            "typeLine": "Instant",
+            "oracleText": "Mill seven cards. Then put a creature card from among them onto the battlefield.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 7
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "milled",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "toBattlefield",
+                            "prompt": "Put a creature card onto the battlefield",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Vibrant Outburst
 {
     "name": "Vibrant Outburst",
@@ -9400,6 +9652,84 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wilt in the Heat
+{
+    "name": "Wilt in the Heat",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if one or more cards left your graveyard this turn.\nWilt in the Heat deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "MarkExileOnDeath",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "CARDS_LEFT_GRAVEYARD"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "artist": "Raluca Marinescu",
+        "flavorText": "\"'It'll be fun,' they said. 'The Fields are full of dead things,' they said.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f63f7209-fc0f-400c-8076-125f3131cb32.jpg?1775938697"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCardsBatchCScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCardsBatchCScenarioTest.kt
@@ -1,0 +1,215 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the "Secrets of Strixhaven batch C" cards:
+ *  - Render Speechless     — targeted nonland discard + two +1/+1 counters on up to one creature.
+ *  - Social Snub           — cast-trigger may-copy; edict each player; opponents lose 1, you gain 1.
+ *  - Wilt in the Heat      — {2}-less if a card left your graveyard; 5 damage + exile-on-death.
+ *  - Vastlands Scavenger   — prepare creature; the "Bind to Life" copy mills 7 and reanimates a creature.
+ */
+class SosCardsBatchCScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.plusCounters(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun TestGame.findExileCopy(playerNumber: Int, name: String): EntityId? {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).firstOrNull { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    init {
+
+        context("Render Speechless") {
+            test("opponent discards a chosen nonland card and the targeted creature gets two +1/+1 counters") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Render Speechless")
+                    .withCardInHand(2, "Hill Giant")     // nonland — the discardable card
+                    .withCardInHand(2, "Forest")         // land — must NOT be choosable
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                val game = builder.build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Render Speechless").first()
+
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(
+                            ChosenTarget.Player(game.player2Id),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Controller chooses the nonland card (Hill Giant) to discard.
+                val hillGiant = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(hillGiant))
+                game.resolveStack()
+
+                withClue("opponent discarded the chosen nonland card") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("the land was not discardable and stays in hand") {
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+                withClue("targeted creature got two +1/+1 counters") {
+                    game.plusCounters(bears) shouldBe 2
+                }
+            }
+
+            test("can be cast with no creature target (up to one) and still forces the discard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Render Speechless")
+                    .withCardInHand(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.findCardsInHand(1, "Render Speechless").first()
+                game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Player(game.player2Id))),
+                ).error shouldBe null
+                game.resolveStack()
+
+                val hillGiant = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(hillGiant))
+                game.resolveStack()
+
+                withClue("opponent still discards even with no creature target") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+        }
+
+        context("Social Snub") {
+            test("each player sacrifices a creature; opponent loses 1 and you gain 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Social Snub")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // your creature (also enables the cast trigger)
+                    .withCardOnBattlefield(2, "Hill Giant")     // opponent's creature
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myLifeBefore = game.getLifeTotal(1)
+                val oppLifeBefore = game.getLifeTotal(2)
+
+                val cardId = game.findCardsInHand(1, "Social Snub").first()
+                game.execute(CastSpell(game.player1Id, cardId)).error shouldBe null
+                game.resolveStack()
+                // The cast trigger ("you may copy this spell") pauses for a yes/no — decline the copy.
+                if (game.state.pendingDecision != null) {
+                    game.answerYesNo(false)
+                    game.resolveStack()
+                }
+
+                withClue("each player sacrificed their only creature") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("each opponent lost 1 life") {
+                    game.getLifeTotal(2) shouldBe oppLifeBefore - 1
+                }
+                withClue("you gained 1 life") {
+                    game.getLifeTotal(1) shouldBe myLifeBefore + 1
+                }
+            }
+        }
+
+        context("Wilt in the Heat") {
+            test("deals 5 damage and exiles the creature instead of letting it die") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wilt in the Heat")
+                    .withCardOnBattlefield(2, "Grizzly Bears")  // 2/2 — 5 damage is lethal
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Wilt in the Heat", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the creature is exiled, not in the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.state.getExile(game.player2Id).any {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                }
+            }
+        }
+
+        context("Vastlands Scavenger // Bind to Life") {
+            test("enters prepared; the Bind to Life copy mills seven and reanimates a creature") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vastlands Scavenger")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Top of library: a creature among lands so the mill puts a creature onto the battlefield.
+                builder = builder.withCardInLibrary(1, "Hill Giant")
+                repeat(7) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpell(1, "Vastlands Scavenger")
+                game.resolveStack()
+
+                val scavenger = game.findPermanent("Vastlands Scavenger")!!
+                withClue("Vastlands Scavenger enters prepared") {
+                    game.state.getEntity(scavenger)?.get<PreparedComponent>() shouldNotBe null
+                }
+
+                val copyId = game.findExileCopy(1, "Vastlands Scavenger")!!
+                game.execute(CastSpell(game.player1Id, copyId, faceIndex = 0))
+                game.resolveStack()
+
+                // The mandatory "put a creature card from among them" selection — pick Hill Giant.
+                if (game.state.pendingDecision != null) {
+                    val milledGiant = game.findCardsInGraveyard(1, "Hill Giant").firstOrNull()
+                    if (milledGiant != null) game.selectCards(listOf(milledGiant))
+                    game.resolveStack()
+                }
+
+                withClue("the milled creature is reanimated onto the battlefield") {
+                    game.findPermanent("Hill Giant") shouldNotBe null
+                }
+                withClue("casting the copy unprepares Vastlands Scavenger") {
+                    game.state.getEntity(scavenger)?.get<PreparedComponent>() shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Secrets of Strixhaven (SOS) cards, all from existing SDK primitives — no new engine/SDK features required.

## Cards implemented

- **Render Speechless** ({2}{W}{B} Sorcery) — Target opponent reveals their hand, you choose a nonland card, they discard it; put two +1/+1 counters on up to one target creature. Two independently-targeted clauses; the discard is the Duress reveal→gather→controller-chooses→discard pipeline (nonland filter), the counters use an optional creature target.
- **Social Snub** ({1}{W}{B} Sorcery) — Intervening-if cast trigger (`WhenYouCastThisSpell` + `Conditions.ControlCreature`) with a `MayEffect(CopyTargetSpell)`; resolution edict (`Effects.Sacrifice`, `Player.Each`) + each opponent loses 1 / you gain 1.
- **Wilt in the Heat** ({2}{R}{W} Instant) — `ModifySpellCost(SelfCast, ReduceGeneric(2))` gated `OnlyIf(CardsLeftGraveyardThisTurn(1))`; deals 5 damage to target creature + `MarkExileOnDeathEffect` (exile-instead-of-die replacement).
- **Vastlands Scavenger // Bind to Life** ({1}{G}{G} Creature, Deathtouch + Prepared) — the "Bind to Life" prepare spell mills seven then puts a milled creature card onto the battlefield (gather→graveyard→select creature→put onto battlefield).

## Skipped

None — all four were implementable with existing primitives.

## Tests

- New `SosCardsBatchCScenarioTest` (5 cases) — all pass: targeted discard + counters, optional-no-creature cast, each-player edict + life swing (declining the copy), 5-damage-then-exile, and prepare → mill-7 → reanimate + unprepare.
- `CardDefinitionSnapshotTest` golden re-blessed — diff is **only** the four new cards (no other card moved).
- `CardLintTest` passes.

## mtgish-tooling

No emitter/bridge changes. All four cards correctly land in **NOT EMITTED** (declined to scaffold) under `coverage-verify --set SOS` — their shapes (two-target spell with a targeted-player discard, copy-this-spell from the stack, exile-on-death replacement, prepare + mill-then-reanimate) are not whole-renderable, so per the fidelity policy the emitter declines rather than emit a lossy render. The hermetic `EmitterGoldenTest` (SOS is not a committed fixture set) passes.

> ⚠️ **Pre-existing, unrelated:** `just coverage-verify POR` and `just coverage-verify SOS` both report a `GATE FAIL` from a `fromZone` emitter-vs-golden drift (POR "Breath of Life"; SOS "Primary Research" / "Prismari Charm" / "Silverquill Charm"). These are cards I did not touch and the drift exists on `main` — I left the emitter and its goldens alone rather than revert/re-bless someone else's in-flight work. Flagging for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)