### PR TITLE
SOS batch A: Borrowed Knowledge, Colorstorm Stallion, Molten Note, Encouraging Aviator

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BorrowedKnowledge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BorrowedKnowledge.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Borrowed Knowledge
+ * {2}{R}{W}
+ * Sorcery
+ * Choose one —
+ * • Discard your hand, then draw cards equal to the number of cards in target opponent's hand.
+ * • Discard your hand, then draw cards equal to the number of cards discarded this way.
+ *
+ * Both modes share the "discard your hand" prefix ([Patterns.Hand.discardHand], which gathers the
+ * hand into the `discardedHand` collection then discards it). The two modes differ only in how
+ * many cards are then drawn:
+ *  - Mode 1 draws `Count(TargetOpponent, HAND)` — read at resolution after the discard (the
+ *    discard never touches the opponent's hand, so ordering is harmless).
+ *  - Mode 2 draws `VariableReference("discardedHand_count")` — the size of the gathered collection
+ *    that `discardHand` discarded ("the number of cards discarded this way"). `GatherCardsEffect`
+ *    auto-publishes a `<storeAs>_count` variable (same convention as the wheel patterns).
+ */
+val BorrowedKnowledge = card("Borrowed Knowledge") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Discard your hand, then draw cards equal to the number of cards in target opponent's " +
+        "hand.\n" +
+        "• Discard your hand, then draw cards equal to the number of cards discarded this way."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Discard your hand, then draw cards equal to the number of cards in target opponent's hand") {
+                target = Targets.Opponent
+                effect = Patterns.Hand.discardHand()
+                    .then(Effects.DrawCards(DynamicAmount.Count(Player.TargetOpponent, Zone.HAND)))
+            }
+            mode("Discard your hand, then draw cards equal to the number of cards discarded this way") {
+                effect = Patterns.Hand.discardHand()
+                    .then(Effects.DrawCards(DynamicAmount.VariableReference("discardedHand_count")))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Inkognit"
+        flavorText = "\"Professor, we study history and my neighbor wrote his answer first. I " +
+            "was learning from the past.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3226e14-554d-47c9-b8b6-dfeb53cc41ba.jpg?1775938224"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ColorstormStallion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ColorstormStallion.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.opus
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Colorstorm Stallion
+ * {1}{U}{R}
+ * Creature — Elemental Horse
+ * 3/3
+ * Ward {1}, haste
+ * Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of
+ * turn. If five or more mana was spent to cast that spell, create a token that's a copy of this
+ * creature.
+ *
+ * "Opus" is an ability word (flavor only). The `opus { }` builder wires the spell-cast trigger and
+ * the 5+ mana tier (`ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL) >= 5`). The token copy is
+ * `alsoIfFiveOrMore`, so it runs in addition to the unconditional +1/+1 (see Expressive Firedancer).
+ */
+val ColorstormStallion = card("Colorstorm Stallion") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Elemental Horse"
+    power = 3
+    toughness = 3
+    oracleText = "Ward {1}, haste\nOpus — Whenever you cast an instant or sorcery spell, this " +
+        "creature gets +1/+1 until end of turn. If five or more mana was spent to cast that " +
+        "spell, create a token that's a copy of this creature."
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    opus {
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        alsoIfFiveOrMore = Effects.CreateTokenCopyOfSelf()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "180"
+        artist = "Lorenzo Lanfranconi"
+        flavorText = "Prismari students are never afraid to let their imaginations run wild."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5b54d46-2caf-4d1b-8be1-dbd9e9dce058.jpg?1775938240"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/EncouragingAviator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/EncouragingAviator.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Encouraging Aviator // Jump — Secrets of Strixhaven #46
+ * {2}{U} · Creature — Bird Wizard · 2/3
+ *
+ * Flying
+ * Whenever this creature attacks, it becomes prepared. (While it's prepared, you may cast a copy
+ * of its spell. Doing so unprepares it.)
+ * //
+ * Jump — {U}, Instant: Target creature gains flying until end of turn.
+ *
+ * Prepare (Secrets of Strixhaven): like Leech Collector, Encouraging Aviator does NOT enter
+ * prepared (it has no PREPARED keyword). It only becomes prepared via its attack trigger through
+ * [Effects.BecomePrepared]. Becoming prepared creates a copy of its prepare spell ("Jump") in
+ * exile that its controller may cast for {U}; casting that copy unprepares the creature. Modeled
+ * via [CardLayout.PREPARE] + the `prepare(name) { }` DSL.
+ */
+val EncouragingAviator = card("Encouraging Aviator") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\nWhenever this creature attacks, it becomes prepared. (While it's " +
+        "prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature attacks, it becomes prepared.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.BecomePrepared(EffectTarget.Self)
+    }
+
+    // Jump — the prepare spell. Target creature gains flying until end of turn.
+    prepare("Jump") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Target creature gains flying until end of turn."
+        spell {
+            target = Targets.Creature
+            effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.ContextTarget(0))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Oriana Menendez"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72654b84-9902-41db-92ab-a3499c31221c.jpg?1778165006"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoltenNote.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoltenNote.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Molten Note
+ * {X}{R}{W}
+ * Sorcery
+ *
+ * Molten Note deals damage to target creature equal to the amount of mana spent to cast this
+ * spell. Untap all creatures you control.
+ * Flashback {6}{R}{W}
+ *
+ * "The amount of mana spent to cast this spell" reads [DynamicAmount.TotalManaSpent] — the full
+ * mana paid for the resolving spell (the `{X}` portion is already included, e.g. 4 when cast for
+ * X=2, or 8 when cast via its {6}{R}{W} flashback). The untap is a `ForEachInGroup` over
+ * [Filters.Group.creaturesYouControl] (see Blinkmoth Infusion). Flashback is a keyword ability so
+ * the card can be re-cast from the graveyard for {6}{R}{W}.
+ */
+val MoltenNote = card("Molten Note") {
+    manaCost = "{X}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Molten Note deals damage to target creature equal to the amount of mana spent " +
+        "to cast this spell. Untap all creatures you control.\n" +
+        "Flashback {6}{R}{W} (You may cast this card from your graveyard for its flashback cost. " +
+        "Then exile it.)"
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.DealDamage(DynamicAmount.TotalManaSpent, EffectTarget.ContextTarget(0))
+            .then(
+                Effects.ForEachInGroup(
+                    Filters.Group.creaturesYouControl,
+                    Effects.Untap(EffectTarget.Self),
+                )
+            )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{6}{R}{W}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "David Álvarez"
+        flavorText = "It's characteristic of the Blood Age for instruments of music to also be " +
+            "tools of war."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/506f69aa-7dc4-4dd7-990a-7371fc1762c0.jpg?1775938416"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -502,6 +502,100 @@
     ]
 }
 
+// Borrowed Knowledge
+{
+    "name": "Borrowed Knowledge",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Discard your hand, then draw cards equal to the number of cards in target opponent's hand.\n• Discard your hand, then draw cards equal to the number of cards discarded this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "discardedHand"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discardedHand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Count",
+                                    "player": "TargetOpponent",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        "TargetOpponent"
+                    ],
+                    "description": "Discard your hand, then draw cards equal to the number of cards in target opponent's hand"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "discardedHand"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discardedHand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "VariableReference",
+                                    "variableName": "discardedHand_count"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Discard your hand, then draw cards equal to the number of cards discarded this way"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Inkognit",
+        "flavorText": "\"Professor, we study history and my neighbor wrote his answer first. I was learning from the past.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3226e14-554d-47c9-b8b6-dfeb53cc41ba.jpg?1775938224"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Brush Off
 {
     "name": "Brush Off",
@@ -841,6 +935,101 @@
                 ]
             }
         }
+    ]
+}
+
+// Colorstorm Stallion
+{
+    "name": "Colorstorm Stallion",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Creature — Elemental Horse",
+    "oracleText": "Ward {1}, haste\nOpus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn. If five or more mana was spent to cast that spell, create a token that's a copy of this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": "CreateTokenCopyOfSource"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn. If five or more mana was spent to cast that spell, create a token that's a copy of this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "RARE",
+        "artist": "Lorenzo Lanfranconi",
+        "flavorText": "Prismari students are never afraid to let their imaginations run wild.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5b54d46-2caf-4d1b-8be1-dbd9e9dce058.jpg?1775938240"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -1869,6 +2058,66 @@
     "colorIdentityOverride": [
         "BLUE",
         "GREEN"
+    ]
+}
+
+// Encouraging Aviator
+{
+    "name": "Encouraging Aviator",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Wizard",
+    "oracleText": "Flying\nWhenever this creature attacks, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": "BecomePrepared"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Oriana Menendez",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72654b84-9902-41db-92ab-a3499c31221c.jpg?1778165006"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Jump",
+            "manaCost": "{U}",
+            "typeLine": "Instant",
+            "oracleText": "Target creature gains flying until end of turn.",
+            "script": {
+                "spellEffect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -5021,6 +5270,71 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Molten Note
+{
+    "name": "Molten Note",
+    "manaCost": "{X}{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Molten Note deals damage to target creature equal to the amount of mana spent to cast this spell. Untap all creatures you control.\nFlashback {6}{R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{6}{R}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": "TotalManaSpent",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "David Álvarez",
+        "flavorText": "It's characteristic of the Blood Age for instruments of music to also be tools of war.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/506f69aa-7dc4-4dd7-990a-7371fc1762c0.jpg?1775938416"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorrowedKnowledgeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorrowedKnowledgeTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.BorrowedKnowledge
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Borrowed Knowledge (SOS #178).
+ *
+ * {2}{R}{W} Sorcery — Choose one —
+ * • Discard your hand, then draw cards equal to the number of cards in target opponent's hand.
+ * • Discard your hand, then draw cards equal to the number of cards discarded this way.
+ */
+class BorrowedKnowledgeTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BorrowedKnowledge))
+        return driver
+    }
+
+    fun castAndChooseMode(driver: GameTestDriver, caster: EntityId, modePrefix: String): EntityId {
+        driver.giveMana(caster, Color.RED, 1)
+        driver.giveMana(caster, Color.WHITE, 1)
+        driver.giveColorlessMana(caster, 2)
+        val card = driver.putCardInHand(caster, "Borrowed Knowledge")
+        driver.castSpell(caster, card)
+        val modeDecision = driver.pendingDecision
+        modeDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val idx = modeDecision.options.indexOfFirst { it.startsWith(modePrefix) }
+        require(idx >= 0) { "Mode '$modePrefix' not offered; options=${modeDecision.options}" }
+        driver.submitDecision(caster, OptionChosenResponse(modeDecision.id, idx))
+        return card
+    }
+
+    test("mode 1 - discard your hand, draw equal to target opponent's hand size") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Give me a few junk cards to discard, and give the opponent a known hand size.
+        repeat(2) { driver.putCardInHand(me, "Island") }
+        repeat(4) { driver.putCardInHand(opp, "Mountain") }
+
+        val oppHand = driver.getHandSize(opp)
+
+        castAndChooseMode(driver, me, "Discard your hand, then draw cards equal to the number of cards in target opponent")
+        // Mode 1 targets an opponent.
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitDecision(me, TargetsResponse(targetDecision.id, mapOf(0 to listOf(opp))))
+        driver.bothPass()
+
+        // Borrowed Knowledge is gone (it was cast), my whole prior hand was discarded, then I drew
+        // a number of cards equal to the opponent's hand size at resolution.
+        driver.getHandSize(me) shouldBe oppHand
+    }
+
+    test("mode 2 - discard your hand, draw equal to the number of cards discarded this way") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30, "Mountain" to 30), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed three extra junk cards on top of the opening hand.
+        repeat(3) { driver.putCardInHand(me, "Island") }
+
+        castAndChooseMode(driver, me, "Discard your hand, then draw cards equal to the number of cards discarded")
+        // Borrowed Knowledge is now on the stack; the remaining hand is exactly what will be
+        // discarded, and the same number is then redrawn — so discard-then-draw is net-neutral.
+        val handToDiscard = driver.getHandSize(me)
+        (handToDiscard > 0) shouldBe true // there is a non-empty hand to discard
+        driver.bothPass()
+
+        driver.getHandSize(me) shouldBe handToDiscard
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosBatchAScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosBatchAScenarioTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the first batch of Secrets of Strixhaven cards:
+ *  - Molten Note            ({X}{R}{W} sorcery: damage = total mana spent; untap your creatures; flashback)
+ *  - Colorstorm Stallion    (Opus: +1/+1 always; token copy if 5+ mana spent)
+ *  - Encouraging Aviator    (becomes prepared on attack; "Jump" grants flying)
+ */
+class SosBatchAScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun TestGame.findExileCopy(playerNumber: Int, name: String): EntityId? {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).firstOrNull { id ->
+            val e = state.getEntity(id)
+            e?.get<CardComponent>()?.name == name && e.get<PreparedSpellCopyComponent>() != null
+        }
+    }
+
+    init {
+        // -------------------------------------------------------------------
+        // Molten Note
+        // -------------------------------------------------------------------
+        test("Molten Note deals damage equal to total mana spent and untaps your creatures") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Molten Note")
+                .withCardOnBattlefield(1, "Grizzly Bears", tapped = true) // 2/2 tapped — should untap
+                .withCardOnBattlefield(2, "War Behemoth") // 3/6 target — survives 5 damage
+                .withLandsOnBattlefield(1, "Mountain", 4) // R + 3 generic
+                .withLandsOnBattlefield(1, "Plains", 1) // W
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val behemoth = game.findPermanent("War Behemoth")!!
+
+            withClue("Grizzly Bears starts tapped") {
+                game.state.getEntity(bears)?.get<TappedComponent>() shouldNotBe null
+            }
+
+            // X = 3 → {3}{R}{W} → 5 mana spent.
+            game.castXSpell(1, "Molten Note", xValue = 3, targetId = behemoth).error shouldBe null
+            game.resolveStack()
+
+            withClue("damage equals the 5 mana spent to cast Molten Note") {
+                game.state.getEntity(behemoth)?.get<DamageComponent>()?.amount shouldBe 5
+            }
+            withClue("all creatures you control untap") {
+                game.state.getEntity(bears)?.get<TappedComponent>() shouldBe null
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Colorstorm Stallion
+        // -------------------------------------------------------------------
+        test("Colorstorm Stallion gets +1/+1 on a cheap instant/sorcery and makes no token") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Colorstorm Stallion") // 3/3
+                .withCardInHand(1, "Lightning Bolt") // {R}
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val stallion = game.findPermanent("Colorstorm Stallion")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+            game.resolveStack()
+
+            withClue("1 mana spent → +1/+1 only → 4/4") {
+                projector.getProjectedPower(game.state, stallion) shouldBe 4
+                projector.getProjectedToughness(game.state, stallion) shouldBe 4
+            }
+            withClue("no token copy below the 5-mana threshold") {
+                game.findPermanents("Colorstorm Stallion").size shouldBe 1
+            }
+        }
+
+        test("Colorstorm Stallion gets +1/+1 AND a token copy when 5+ mana is spent") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Colorstorm Stallion") // 3/3
+                .withCardInHand(1, "Blaze") // {X}{R}
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 5)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val stallion = game.findPermanent("Colorstorm Stallion")!!
+            val giant = game.findPermanent("Hill Giant")!!
+
+            // Blaze X=4 → {4}{R} → 5 mana spent (boundary).
+            game.castXSpell(1, "Blaze", xValue = 4, targetId = giant).error shouldBe null
+            game.resolveStack()
+
+            withClue("5 mana spent → +1/+1 → 4/4 on the original") {
+                projector.getProjectedPower(game.state, stallion) shouldBe 4
+            }
+            withClue("a token copy of Colorstorm Stallion is created (2 now exist)") {
+                game.findPermanents("Colorstorm Stallion").size shouldBe 2
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Encouraging Aviator
+        // -------------------------------------------------------------------
+        test("Encouraging Aviator becomes prepared when it attacks and exposes the Jump copy") {
+            var builder = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Encouraging Aviator", summoningSickness = false) // 2/3 flyer
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+            repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+            repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+            val game = builder.build()
+
+            val aviator = game.findPermanent("Encouraging Aviator")!!
+            withClue("does not start prepared") {
+                game.state.getEntity(aviator)?.get<PreparedComponent>() shouldBe null
+            }
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Encouraging Aviator" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("attacking makes Encouraging Aviator prepared") {
+                game.state.getEntity(aviator)?.get<PreparedComponent>() shouldNotBe null
+            }
+            withClue("a Jump prepare-spell copy now exists in exile") {
+                game.findExileCopy(1, "Encouraging Aviator") shouldNotBe null
+            }
+        }
+
+        test("casting the Jump copy grants flying until end of turn, then unprepares the Aviator") {
+            var builder = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Encouraging Aviator", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 grounded creature to receive flying
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+            repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+            repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+            val game = builder.build()
+
+            val aviator = game.findPermanent("Encouraging Aviator")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Encouraging Aviator" to 2)).error shouldBe null
+            game.resolveStack()
+
+            val copyId = game.findExileCopy(1, "Encouraging Aviator")!!
+            withClue("Grizzly Bears has no flying before Jump") {
+                game.state.projectedState.hasKeyword(bears, com.wingedsheep.sdk.core.Keyword.FLYING) shouldBe false
+            }
+
+            game.execute(
+                CastSpell(
+                    game.player1Id,
+                    copyId,
+                    targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(bears)),
+                    faceIndex = 0
+                )
+            )
+            game.resolveStack()
+
+            withClue("Jump grants flying to the targeted creature") {
+                game.state.projectedState.hasKeyword(bears, com.wingedsheep.sdk.core.Keyword.FLYING) shouldBe true
+            }
+            withClue("the Aviator is no longer prepared after casting the copy") {
+                game.state.getEntity(aviator)?.get<PreparedComponent>() shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four **Secrets of Strixhaven** (SOS) cards, all with existing SDK primitives (no engine/SDK changes).

## Cards implemented

| Card | Cost / Type | How it's modeled |
|------|-------------|------------------|
| **Encouraging Aviator // Jump** | `{2}{U}` Creature — Bird Wizard 2/3, Flying | Becomes prepared on attack via `Effects.BecomePrepared` + `Triggers.Attacks` (no `PREPARED` keyword, like Leech Collector). The "Jump" prepare-spell grants flying to a target creature. |
| **Colorstorm Stallion** | `{1}{U}{R}` Creature — Elemental Horse 3/3, Ward {1}, haste | `opus { }` builder: unconditional +1/+1, plus `Effects.CreateTokenCopyOfSelf()` as `alsoIfFiveOrMore` (token copy when 5+ mana spent). |
| **Molten Note** | `{X}{R}{W}` Sorcery, Flashback `{6}{R}{W}` | `Effects.DealDamage(DynamicAmount.TotalManaSpent, …)` to target creature, then `ForEachInGroup(creaturesYouControl, Untap)`. `KeywordAbility.flashback`. |
| **Borrowed Knowledge** | `{2}{R}{W}` modal Sorcery (choose one) | Both modes use `Patterns.Hand.discardHand()`, then draw: mode 1 = `Count(TargetOpponent, HAND)`, mode 2 = `VariableReference("discardedHand_count")` (= cards discarded this way; `GatherCardsEffect` auto-publishes the `_count` variable). |

## Skipped cards

None — all four were implementable with existing primitives, so the fallback list was not needed.

## mtgish-tooling

**No emitter or bridge changes.** Re-emitting the four cards after implementation:

- **Encouraging Aviator** → `AUTO` (complete render).
- **Colorstorm Stallion / Molten Note / Borrowed Knowledge** → `SCAFFOLD`. Each touches a shape the emitter deliberately declines per the conservative fidelity policy (conditional token-creation inside an Opus trigger; spell damage equal to total mana spent; modal + discard-hand-then-draw-by-dynamic-count — the README's "inherited/dynamic value" sloppy zone). Per project policy I left these at SCAFFOLD rather than widen the emitter into a lossy approximation.

The hermetic `EmitterGoldenTest` stays green for all committed sets (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE).

## Tests

- `rules-engine` `SosBatchAScenarioTest` (5 tests) + `BorrowedKnowledgeTest` (2 tests) — all green.
- `mtg-sets` `CardLintTest` green; `CardDefinitionSnapshotTest` re-blessed — diff adds **only** the 4 new cards (zero removals, no other card moved).

## Note on the coverage gate (pre-existing, not from this PR)

`just coverage-verify SOS` / `POR` report `GATE FAIL`, but the mismatches are a pre-existing systemic emitter/golden drift on cards **not** authored here (return-from-graveyard `fromZone "Graveyard" vs <missing>` on Breath of Life, Lorehold Charm, Moment of Reckoning, Primary Research, Prismari Charm; a `counterType "+1/+1" vs "+1+1"` drift on Silverquill Charm). None of the four cards in this PR appear in any mismatch list, and this branch contains zero emitter/SDK changes. Per CLAUDE.md I left that pre-existing drift alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)