### PR TITLE
mtgish: track itemfive's token-creation derived-variable cleanup

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -120,6 +120,29 @@ internal val SELF_REFS = setOf(
     "ThisGraveyardCard",
 )
 
+/**
+ * The mtgish derived variables that name "the token(s) a CreateTokens action in this same effect just
+ * made". itemfive's mtgish token-creation cleanup (mtgish_grammar-create_tokens.json5) folded the old
+ * singular `_Permanent:TheCreatedToken` ref into these plural `_Permanents` derived variables, because a
+ * token-creation replacement effect (Doubling Season, "those tokens plus a Squirrel", …) means there is
+ * never exactly one created token — only "the tokens created this way". `TheCreatedToken` is kept as a
+ * legacy alias so a mixed/older IR snapshot still resolves. All name the same collection, which the token
+ * executor publishes under the [CREATED_TOKENS] pipeline slot.
+ */
+internal val CREATED_TOKEN_REFS = setOf("TheTokensCreatedThisWay", "TheCreatedTokens", "TheCreatedToken")
+
+/** The EffectTarget DSL addressing the just-created token collection. */
+internal const val CREATED_TOKENS_TARGET = "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"
+
+/** [CREATED_TOKENS_TARGET] if [node] is a created-token group/ref sentinel (under `_Permanents` or the
+ *  legacy `_Permanent` key), else null — so a "do X to the tokens created this way" action targets the
+ *  pipeline collection rather than being mistaken for a battlefield group. */
+internal fun createdTokensTarget(node: JsonElement?): String? {
+    val o = node as? JsonObject ?: return null
+    return if (o.strField("_Permanents") in CREATED_TOKEN_REFS || o.strField("_Permanent") in CREATED_TOKEN_REFS)
+        CREATED_TOKENS_TARGET else null
+}
+
 // ---------------------------------------------------------------------------
 // Dispatch + effect-list assembly.
 // ---------------------------------------------------------------------------
@@ -673,11 +696,13 @@ internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
         return targetRefVars[ref] ?: targetRefVarsByKind[ref]?.firstOrNull()
     }
     if (ref in SELF_REFS) return "EffectTarget.Self"
-    // "the created token" — the token a preceding CreateTokens action in this same action list just
-    // made (Fractal Tender: "create a 0/0 Fractal … and put three +1/+1 counters on it"). The token
-    // executor publishes its ids under the CREATED_TOKENS pipeline collection, so the follow-up effect
-    // addresses it via PipelineTarget(CREATED_TOKENS, 0).
-    if (ref == "TheCreatedToken") return "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"
+    // "the tokens created this way" / "the created tokens" — the tokens a preceding CreateTokens action
+    // in this same action list just made (Fractal Tender: "create a 0/0 Fractal … and put three +1/+1
+    // counters on it"). The token executor publishes their ids under the CREATED_TOKENS pipeline
+    // collection, so a follow-up effect addresses them via PipelineTarget(CREATED_TOKENS, 0). See
+    // [CREATED_TOKEN_REFS] for why these are plural — mtgish's token cleanup folded the old singular
+    // `TheCreatedToken` ref into the plural derived variables.
+    if (ref in CREATED_TOKEN_REFS) return CREATED_TOKENS_TARGET
     // "that player" in a trigger. In a spell-cast trigger the triggering entity is the spell, so "that
     // player" is its controller — the caster — modeled as ControllerOfTriggeringEntity (Magebane Lizard).
     // In every other trigger ("the player ~ dealt combat damage to") it's the triggering player itself.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -156,25 +156,42 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         )
     }
 
-    on("PutNumberCountersOfTypeOnEachPermanent") { _, args, tvar ->
+    on("PutNumberCountersOfTypeOnEachPermanent") { _, args, _ ->
         // "Put N <counter> counters on <permanents>." — the mass / dynamic-count form. IR args are
         // [<amount>, <counterType>, <permanents>]. The only recipient we render here is the just-created
-        // token (`TheTokensCreatedThisWay` -> the CREATED_TOKENS pipeline slot, Outlaw Stitcher: "put two
+        // token(s) (`TheTokensCreatedThisWay` -> the CREATED_TOKENS pipeline slot, Outlaw Stitcher: "put two
         // +1/+1 counters on that token for each spell …"); a real "each <group>" filter would need a
         // ForEach over the group, which this handler deliberately leaves to scaffold. The amount may be
         // dynamic, so render through AddDynamicCounters with the recovered DynamicAmount. Only the named
         // ±1/±1 / keyword counters render; an unrenderable amount or non-token recipient declines.
         val arr = args.asArr ?: return@on null
         val counter = counterTypeDsl(arr.getOrNull(1)) ?: return@on null
-        val recipient = arr.getOrNull(2) as? JsonObject ?: return@on null
-        if (recipient.strField("_Permanents") != "TheTokensCreatedThisWay") return@on null
+        val target = createdTokensTarget(arr.getOrNull(2)) ?: return@on null
+        // A fixed integer count renders through the static AddCountersEffect (matching the singular
+        // PutNumberCountersOfTypeOnPermanent handler — Fractal Tender's "put three +1/+1 counters on it");
+        // a derived count (Outlaw Stitcher's "two per spell cast this turn") through AddDynamicCounters.
+        (findInteger(arr.getOrNull(0)) as? Int)?.let { count ->
+            return@on call("AddCountersEffect", arg("counterType", counter), arg("count", "$count"), arg("target", target))
+        }
         val amount = dynamicAmount(arr.getOrNull(0)) ?: return@on null
         call(
             "Effects.AddDynamicCounters",
             arg("counterType", counter),
             arg("amount", Lit(amount)),
-            arg("target", "EffectTarget.PipelineTarget(CREATED_TOKENS, 0)"),
+            arg("target", target),
         )
+    }
+
+    on("PutCounters") { _, args, tvar ->
+        // mtgish's token-creation cleanup wraps the put-counter actions in a `PutCounters` envelope whose
+        // single arg carries the real action under `_PutCounterAction` (Fractal Tender: "create a 0/0
+        // Fractal, then put three +1/+1 counters on it" -> PutCounters(NumberCountersOfTypeOnEachPermanent
+        // (3, +1/+1, TheTokensCreatedThisWay))). Unwrap and re-dispatch to the matching top-level
+        // `Put<variant>` handler (the variant name is the action name minus the `Put` prefix) with the
+        // inner args; a variant with no handler declines -> SCAFFOLD.
+        val inner = args.asArr?.firstOrNull() as? JsonObject ?: return@on null
+        val variant = inner.strField("_PutCounterAction") ?: return@on null
+        ACTION_HANDLERS["Put$variant"]?.invoke(this, inner, inner["args"], tvar)
     }
 
     on("CreateReplaceWouldPutCountersUntil") { node, _, _ ->

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -43,16 +43,19 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         } else null
     }
 
-    on("AttachPermanentToPermanent") { _, args, tvar ->
+    on("AttachPermanentToPermanent", "AttachPermanentToAPermanent") { _, args, tvar ->
         // "attach it to target …" — an Equipment/Aura attaching ITSELF to a chosen permanent. The
         // engine idiom is `Effects.AttachEquipment(target)`, which always attaches the source. So this
         // renders ONLY the self-attach shape: args[0] (the permanent being attached) must be a self-ref
         // (`ThatEnteringPermanent` for an ETB "attach it to target creature you control", Thunder Lasso).
-        // Anything else (attaching a different permanent) declines -> SCAFFOLD.
+        // Anything else (attaching a different permanent) declines -> SCAFFOLD. The `…ToAPermanent` variant
+        // is the same self-attach onto the just-created token(s) (Ancestral Blade: "create a 1/1 Soldier,
+        // then attach Ancestral Blade to it") — its `_Permanents:TheTokensCreatedThisWay` recipient
+        // resolves to the CREATED_TOKENS pipeline slot via [createdTokensTarget].
         val arr = args.asArr ?: return@on null
         val subjectRef = findRef(arr.getOrNull(0)) ?: return@on null
         if (subjectRef !in SELF_REFS) return@on null
-        val tgt = refTargetFromRef(findRef(arr.getOrNull(1)), tvar) ?: return@on null
+        val tgt = createdTokensTarget(arr.getOrNull(1)) ?: refTargetFromRef(findRef(arr.getOrNull(1)), tvar) ?: return@on null
         call("Effects.AttachEquipment", arg(Lit(tgt)))
     }
 
@@ -82,6 +85,16 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("ExilePermanent") { _, args, tvar ->  // "Exile target permanent" -> the atomic Exile facade
         val tgt = refTarget(args, tvar) ?: return@on null
+        call("Effects.Exile", arg(Lit(tgt)))
+    }
+
+    on("ExileEachPermanent") { _, args, _ ->
+        // The mass form. The only group we render is the just-created token(s) ("exile that token at the
+        // beginning of the next end step", Daring Piracy; "exile those tokens", Rakdos Guildmage) — their
+        // `_Permanents:TheTokensCreatedThisWay` group is the CREATED_TOKENS pipeline collection, so one
+        // Exile addresses them all. A real "exile each <battlefield group>" would need a ForEach over the
+        // group, which this deliberately leaves to scaffold.
+        val tgt = createdTokensTarget(args) ?: return@on null
         call("Effects.Exile", arg(Lit(tgt)))
     }
 

--- a/mtgish-tooling/src/test/resources/fixtures/chk.fixture.json
+++ b/mtgish-tooling/src/test/resources/fixtures/chk.fixture.json
@@ -11538,9 +11538,9 @@
                             "_Actions": "ActionList",
                             "args": [
                               {
-                                "_Action": "SacrificePermanent",
+                                "_Action": "SacrificeEachPermanent",
                                 "args": {
-                                  "_Permanent": "TheCreatedToken"
+                                  "_Permanents": "TheTokensCreatedThisWay"
                                 }
                               }
                             ]
@@ -23789,9 +23789,9 @@
                     "_Action": "CreateFutureTrigger",
                     "args": [
                       {
-                        "_FutureTrigger": "WhenCreatureOrPlaneswalkerDies",
+                        "_FutureTrigger": "WhenACreatureOrPlaneswalkerDies",
                         "args": {
-                          "_Permanent": "TheCreatedToken"
+                          "_Permanents": "TheTokensCreatedThisWay"
                         }
                       },
                       {

--- a/mtgish-tooling/src/test/resources/fixtures/isd.fixture.json
+++ b/mtgish-tooling/src/test/resources/fixtures/isd.fixture.json
@@ -7662,9 +7662,9 @@
                         "_Actions": "ActionList",
                         "args": [
                           {
-                            "_Action": "ExilePermanent",
+                            "_Action": "ExileEachPermanent",
                             "args": {
-                              "_Permanent": "TheCreatedToken"
+                              "_Permanents": "TheTokensCreatedThisWay"
                             }
                           }
                         ]

--- a/mtgish-tooling/src/test/resources/fixtures/tmp.fixture.json
+++ b/mtgish-tooling/src/test/resources/fixtures/tmp.fixture.json
@@ -7147,10 +7147,10 @@
                         ]
                       },
                       {
-                        "_Action": "CreatePermanentLayerEffectUntil",
+                        "_Action": "CreateEachPermanentLayerEffectUntil",
                         "args": [
                           {
-                            "_Permanent": "TheCreatedToken"
+                            "_Permanents": "TheTokensCreatedThisWay"
                           },
                           [
                             {
@@ -7177,9 +7177,9 @@
                             "_Actions": "ActionList",
                             "args": [
                               {
-                                "_Action": "ExilePermanent",
+                                "_Action": "ExileEachPermanent",
                                 "args": {
-                                  "_Permanent": "TheCreatedToken"
+                                  "_Permanents": "TheTokensCreatedThisWay"
                                 }
                               }
                             ]


### PR DESCRIPTION
## Context

itemfive (mtgish author) [did a cleanup](https://github.com/i5jb/mtgish/blob/main/grammars/mtgish_grammar-create_tokens.json5) of the token-creation **derived variables**: because a token-creation replacement effect (Doubling Season, *"those tokens plus a Squirrel"*, …) means there is never exactly *one* created token, the singular forms were folded into plural ones. Upstream now exposes:

| removed / renamed | now |
|---|---|
| `TheTokenCreatedThisWay` (singular `_Permanent`) | `TheTokensCreatedThisWay` (`_Permanents`) |
| `TheTokenCreatedByPlayerThisWay(Player)` | `TheTokensCreatedByAPlayerThisWay(Players)` |
| `NumTokensCreatedByPlayerThisTurn(Permanents, Player)` | `TheTotalNumberOfTokensPlayersCreatedThisTurn(Permanents, Players)` |
| `NumPlayersWhoCreatedATokenThisWay` | removed |
| `_Permanent:TheCreatedToken` (the "the created token" ref) | `_Permanents:TheTokensCreatedThisWay` |

The singular host actions also moved to mass / wrapper forms: `PutNumberCountersOfTypeOnPermanent` → `PutCounters(NumberCountersOfTypeOnEachPermanent(…))`, `AttachPermanentToPermanent` → `AttachPermanentToAPermanent`, `ExilePermanent` → `ExileEachPermanent`.

## What broke

The emitter resolved the old singular `TheCreatedToken` ref (and its singular host actions) to `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)`. After refreshing the IR snapshot to the current upstream, those references arrive as the plural sentinel under the new actions, which the emitter didn't recognise — **15 cards dropped from complete render to scaffold** (Fractal Tender, Ancestral Blade, Daring Piracy, Headsplitter, Wooden Cane, Kyoshi Battle Fan, Manifestation Sage, Hiveheart Shaman, Leyline Invocation, Rakdos Guildmage, Fractal Anomaly/Harness/Summoning, Wild Hypothesis, Serpentine Curve).

## Fix

Map the new vocabulary to the same `CREATED_TOKENS` pipeline target:

- **`createdTokensTarget()` + `CREATED_TOKEN_REFS`** — one central helper; the plural sentinels (plus legacy `TheCreatedToken`) resolve to `PipelineTarget(CREATED_TOKENS, 0)`.
- **`PutCounters`** — unwrap the `_PutCounterAction` envelope and re-dispatch to the matching top-level `Put<variant>` handler.
- **`PutNumberCountersOfTypeOnEachPermanent`** — resolve the recipient via the helper; fixed count → static `AddCountersEffect` (matching the old singular handler), derived count → `AddDynamicCounters`.
- **`AttachPermanentToAPermanent`** — self-attach onto the created token(s).
- **`ExileEachPermanent`** — exile the created token(s).

Per the fidelity policy, everything else still declines → SCAFFOLD.

## Results (whole-corpus complete-render diff, old IR → new IR + this fix)

- **+146 net complete renders** — 139 from itemfive's other grammar improvements in the refreshed IR, plus this fix restoring the 15 regressed token cards and a few newly-coverable ones (Cori-Steel Cutter, Feral Lightning, Stunning Shot, …).
- **2 cards stay scaffolds by design:**
  - *Rolling Hamsphere* — new `EachPermanentDealsDamage` action; genuinely unsupported, so it declines rather than approximate "each token deals N" as "deal N once".
  - *Serpentine Curve* — an unrelated complex `NumCardsInExile` dynamic amount the recovery doesn't render.

## Tests

- `:mtgish-tooling:test` (incl. **EmitterGoldenTest**) — **green**. Re-blessed the full-set calibrated fixtures; only the chk/isd/tmp **input slices** changed (the 4 token cards' IR vocabulary) and their **golden output is unchanged** — those cards remain scaffolds for unrelated reasons, so the calibrated net shows no observable drift. EOE's curated 3-card slice left intact.
- `coverage-verify POR` / `ISD` each report **one pre-existing mismatch** (`Breath of Life` / `Unburial Rites`, `$.script.spellEffect.fromZone: generated="Graveyard" golden=<missing>`). These are an unrelated reanimation-emitter drift: they reproduce with the **old** IR + this branch's emitter, and none of the three edited files touch reanimation. **Not introduced by this change**; left out of scope.

## Note on Ezuri's Predation

itemfive flagged Ezuri's Predation (*"each token fights a different one of those creatures"*, with the Doubling-Season "extra tokens don't fight" ruling) as awkward to model. Our emitter declines the one-to-one fight mapping entirely (SCAFFOLD), so it needs no change here — defining "extra tokens" is a grammar-side concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note:** the two `coverage-verify` mismatches mentioned above (Breath of Life / Unburial Rites `fromZone`) are a separate pre-existing drift from commit `60d763beb`, now fixed in #817. They are unrelated to this PR and reproduce on `origin/main`.