### PR TITLE
Add 4 Secrets of Strixhaven cards (batch B) + mtgish growth-counter / counter-gated-lord rendering

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ComfortingCounsel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ComfortingCounsel.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Comforting Counsel
+ * {1}{G}
+ * Enchantment
+ *
+ * Whenever you gain life, put a growth counter on this enchantment.
+ * As long as there are five or more growth counters on this enchantment, creatures you control
+ * get +3/+3.
+ *
+ * Same shape as Beastmaster Ascension: a [Triggers.YouGainLife] trigger that drops a [Counters.GROWTH]
+ * counter on [EffectTarget.Self], plus a counter-gated anthem. The threshold gate is the generic
+ * [Conditions.SourceCounterCountAtLeast] (≥5 growth counters), which reads the enchantment's counters
+ * live, and the buff applies to all creatures you control via [GroupFilter.AllCreaturesYouControl].
+ */
+val ComfortingCounsel = card("Comforting Counsel") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you gain life, put a growth counter on this enchantment.\n" +
+        "As long as there are five or more growth counters on this enchantment, creatures you control get +3/+3."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.GROWTH, 1, EffectTarget.Self)
+    }
+
+    staticAbility {
+        condition = Conditions.SourceCounterCountAtLeast(Counters.GROWTH, 5)
+        ability = ModifyStats(
+            powerBonus = 3,
+            toughnessBonus = 3,
+            filter = GroupFilter.AllCreaturesYouControl
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "143"
+        artist = "Chris Rahn"
+        flavorText = "In the grief that followed the Invasion, Willowdusk's office turned into an unofficial hideaway for overwhelmed students."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5223a04f-6b47-4379-80ce-8489c4a91734.jpg?1775937970"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/GoblinGlasswright.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/GoblinGlasswright.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Glasswright // Craft with Pride — Secrets of Strixhaven #117
+ * {1}{R} · Creature — Goblin Sorcerer · 2/2
+ *
+ * This creature enters prepared. (While it's prepared, you may cast a copy of its spell.
+ * Doing so unprepares it.)
+ * //
+ * Craft with Pride — {R}, Sorcery: Create a Treasure token.
+ *
+ * Prepare (Secrets of Strixhaven): the creature enters with the PREPARED keyword. Becoming prepared
+ * synthesizes a free-to-cast copy of its prepare spell ("Craft with Pride") in exile for {R};
+ * casting that copy unprepares the creature. Modeled via [CardLayout.PREPARE] + the
+ * `prepare(name) { }` DSL, same as Cheerful Osteomancer. The prepare spell side just makes a Treasure
+ * via [Effects.CreateTreasure].
+ */
+val GoblinGlasswright = card("Goblin Glasswright") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Sorcerer"
+    power = 2
+    toughness = 2
+    oracleText = "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    keywords(Keyword.PREPARED)
+
+    // Craft with Pride — the prepare spell. Create a Treasure token.
+    prepare("Craft with Pride") {
+        manaCost = "{R}"
+        typeLine = "Sorcery"
+        oracleText = "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+        spell {
+            effect = Effects.CreateTreasure()
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "David Auden Nash"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c85c5f06-dd31-4e2c-97be-2f64d65069ea.jpg?1775937759"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MindRoots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MindRoots.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Mind Roots
+ * {1}{B}{G}
+ * Sorcery
+ *
+ * Target player discards two cards. Put up to one land card discarded this way onto the
+ * battlefield tapped under your control.
+ *
+ * One inline [Effects.Pipeline]: gather the target player's hand and have *them* choose exactly two
+ * to discard ([Chooser.TargetPlayer], [MoveType.Discard] → their graveyard). The selected slot keeps
+ * referencing those two cards after they land in the graveyard, so we [filter] it down to land cards,
+ * let *you* (the controller) pick up to one of those, and move it to the battlefield tapped under your
+ * control. If neither discarded card is a land, the land filter empties and the up-to-one selection is
+ * a no-op — matching "up to one".
+ */
+val MindRoots = card("Mind Roots") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Sorcery"
+    oracleText = "Target player discards two cards. Put up to one land card discarded this way " +
+        "onto the battlefield tapped under your control."
+
+    spell {
+        val player = target("player", TargetPlayer())
+        effect = Effects.Pipeline {
+            // Target player discards two cards (they choose).
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "hand")
+            val discarded = chooseExactly(
+                2, from = hand,
+                chooser = Chooser.TargetPlayer,
+                prompt = "Choose two cards to discard",
+                name = "discarded"
+            )
+            moveTracked(
+                discarded,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard,
+                name = "discardedToGrave"
+            )
+            // Of the cards discarded this way, you may put up to one land onto the battlefield
+            // tapped under your control.
+            val discardedLands = filter(discarded, GameObjectFilter.Land, name = "discardedLands")
+            val chosenLand = chooseUpTo(
+                1, from = discardedLands,
+                prompt = "Put up to one discarded land onto the battlefield tapped",
+                name = "chosenLand"
+            )
+            move(
+                chosenLand,
+                CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.Tapped)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Elliot Lang"
+        flavorText = "The best ideas stem from dreams."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d5fdbda-ebbe-45d6-a668-5ddee057a063.jpg?1775938410"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SnarlSong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SnarlSong.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snarl Song
+ * {5}{G}
+ * Sorcery
+ *
+ * Converge — Create two 0/0 green and blue Fractal creature tokens. Put X +1/+1 counters on each
+ * of them and you gain X life, where X is the number of colors of mana spent to cast this spell.
+ *
+ * Converge: X = [DynamicAmounts.colorsOfManaSpent] (`DynamicAmount.DistinctColorsManaSpent`),
+ * resolved while the spell is still on the stack so it reads the live per-colour payment buckets.
+ * Both Fractals are created with one `CreateToken(count = 2)` (publishing both entity IDs to the
+ * [CREATED_TOKENS] pipeline collection at indices 0 and 1); X +1/+1 counters then land on each via
+ * `PipelineTarget(CREATED_TOKENS, index)` — the same per-created-token addressing as Wild Hypothesis
+ * / Fractal Tender. Finally the controller gains X life.
+ */
+val SnarlSong = card("Snarl Song") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Converge — Create two 0/0 green and blue Fractal creature tokens. Put X +1/+1 " +
+        "counters on each of them and you gain X life, where X is the number of colors of mana " +
+        "spent to cast this spell."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN, Color.BLUE),
+            creatureTypes = setOf("Fractal"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+        )
+            .then(
+                Effects.AddDynamicCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmounts.colorsOfManaSpent(),
+                    EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+                )
+            )
+            .then(
+                Effects.AddDynamicCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmounts.colorsOfManaSpent(),
+                    EffectTarget.PipelineTarget(CREATED_TOKENS, 1)
+                )
+            )
+            .then(Effects.GainLife(DynamicAmounts.colorsOfManaSpent()))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Archaics and mana snarls have both existed since the beginning of time. Coincidence? Highly unlikely.\"\n—Zimone"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc4c7fa2-aebb-4636-9afd-f1010c923316.jpg?1775938101"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -844,6 +844,71 @@
     ]
 }
 
+// Comforting Counsel
+{
+    "name": "Comforting Counsel",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you gain life, put a growth counter on this enchantment.\nAs long as there are five or more growth counters on this enchantment, creatures you control get +3/+3.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "growth",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 3,
+                    "toughnessBonus": 3,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "growth"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "RARE",
+        "artist": "Chris Rahn",
+        "flavorText": "In the grief that followed the Invasion, Willowdusk's office turned into an unofficial hideaway for overwhelmed students.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5223a04f-6b47-4379-80ce-8489c4a91734.jpg?1775937970"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Conciliator's Duelist
 {
     "name": "Conciliator's Duelist",
@@ -3227,6 +3292,44 @@
     ]
 }
 
+// Goblin Glasswright
+{
+    "name": "Goblin Glasswright",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Sorcerer",
+    "oracleText": "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PREPARED"
+    ],
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "David Auden Nash",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c85c5f06-dd31-4e2c-97be-2f64d65069ea.jpg?1775937759"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Craft with Pride",
+            "manaCost": "{R}",
+            "typeLine": "Sorcery",
+            "oracleText": "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+            "script": {
+                "spellEffect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        }
+    ]
+}
+
 // Graduation Day
 {
     "name": "Graduation Day",
@@ -4954,6 +5057,109 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Mind Roots
+{
+    "name": "Mind Roots",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player discards two cards. Put up to one land card discarded this way onto the battlefield tapped under your control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "hand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "hand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "chooser": "TargetPlayer",
+                    "storeSelected": "discarded",
+                    "prompt": "Choose two cards to discard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "discarded",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard",
+                    "storeMovedAs": "discardedToGrave"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "discarded",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "land"
+                    },
+                    "storeMatching": "discardedLands"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "discardedLands",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "chosenLand",
+                    "prompt": "Put up to one discarded land onto the battlefield tapped"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosenLand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Elliot Lang",
+        "flavorText": "The best ideas stem from dreams.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d5fdbda-ebbe-45d6-a668-5ddee057a063.jpg?1775938410"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -7428,6 +7634,71 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Snarl Song
+{
+    "name": "Snarl Song",
+    "manaCost": "{5}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Converge — Create two 0/0 green and blue Fractal creature tokens. Put X +1/+1 counters on each of them and you gain X life, where X is the number of colors of mana spent to cast this spell.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [
+                        "GREEN",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Fractal"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                },
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": "DistinctColorsManaSpent",
+                    "target": {
+                        "type": "PipelineTarget",
+                        "collectionName": "createdTokens"
+                    }
+                },
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": "DistinctColorsManaSpent",
+                    "target": {
+                        "type": "PipelineTarget",
+                        "collectionName": "createdTokens",
+                        "index": 1
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": "DistinctColorsManaSpent"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Archaics and mana snarls have both existed since the beginning of time. Coincidence? Highly unlikely.\"\n—Zimone",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc4c7fa2-aebb-4636-9afd-f1010c923316.jpg?1775938101"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -579,8 +579,9 @@ private fun EmitCtx.youCommittedCrimeConditionDsl(condNode: JsonElement?): Strin
  * static gates (Vadmir's "menace and lifelink at 4+ counters"). The predicate reads the source's
  * counter map under projection, so the gated keywords appear/vanish as counters cross the threshold.
  *
- * Only the bare `PTCounter(1,1)` (+1/+1) renders here — a keyword/named counter threshold has different
- * `Counters.*` plumbing and would change meaning, so it declines (-> SCAFFOLD).
+ * Renders for any counter kind [counterTypeDsl] can name — the bare `PTCounter(1,1)` (+1/+1) and the
+ * named/keyword/storage counters (e.g. a GROWTH counter, Comforting Counsel's "five or more growth
+ * counters"). A counter type we can't name declines (-> SCAFFOLD) rather than guessing the plumbing.
  */
 private fun EmitCtx.sourceCounterCountAtLeastConditionDsl(condNode: JsonElement?): String? {
     val cond = condNode as? JsonObject ?: return null
@@ -594,10 +595,8 @@ private fun EmitCtx.sourceCounterCountAtLeastConditionDsl(condNode: JsonElement?
     if (comparison.strField("_Comparison") != "GreaterThanOrEqualTo") return null
     val n = (comparison["args"] as? JsonObject)?.takeIf { it.strField("_GameNumber") == "Integer" }
         ?.get("args").asInt() ?: return null
-    val counter = hArgs.getOrNull(1) as? JsonObject ?: return null
-    val pt = counter.takeIf { it.strField("_CounterType") == "PTCounter" }?.get("args").asArr
-    if (pt?.getOrNull(0).asInt() != 1 || pt?.getOrNull(1).asInt() != 1) return null
-    return "Conditions.SourceCounterCountAtLeast(Counters.PLUS_ONE_PLUS_ONE, $n)"
+    val counter = counterTypeDsl(hArgs.getOrNull(1)) ?: return null
+    return "Conditions.SourceCounterCountAtLeast($counter, $n)"
 }
 
 /**
@@ -755,12 +754,18 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
     //   If(PlayerPassesFilter(You, GainedLifeThisTurn))
     //     [ EachPermanentLayerEffect(creatures you control, [AdjustPT(1,0), AddAbility(Trample)]) ]
     // -> the same gated lord, one row per layer effect, gated on Conditions.YouGainedLifeThisTurn.
-    // Only the "during YOUR turn" or "you gained life this turn" gates render; any other condition
-    // declines (-> SCAFFOLD). The lord renderer itself still declines any group/ability it can't
-    // reproduce exactly.
+    // Comforting Counsel: "As long as there are five or more growth counters on this enchantment,
+    //   creatures you control get +3/+3."
+    //   If(PermanentPassesFilter(ThisPermanent, HasNumCountersOfType(>= 5, GrowthCounter)))
+    //     [ EachPermanentLayerEffect(creatures you control, [AdjustPT(3,3)]) ]
+    // -> the same gated lord, gated on Conditions.SourceCounterCountAtLeast(Counters.GROWTH, 5).
+    // Only the "during YOUR turn", "you gained life this turn", or "N+ counters on this permanent"
+    // gates render; any other condition declines (-> SCAFFOLD). The lord renderer itself still
+    // declines any group/ability it can't reproduce exactly.
     if (innerRule.strField("_Rule") == "EachPermanentLayerEffect") {
         val condDsl = isYourTurnConditionDsl(cond)
             ?: youGainedLifeConditionDsl(cond)
+            ?: sourceCounterCountAtLeastConditionDsl(cond)
             ?: run { reasons.add("If"); return null }
         return staticLordBlock(innerRule, condition = condDsl)
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -311,6 +311,10 @@ internal fun counterTypeDsl(counterNode: JsonElement?): String? {
         // Loot counter (OTJ — Bandit's Haul): a passive storage counter with no inherent rule; the
         // card's own abilities accumulate it and spend it. Adding one is a plain AddCounters.
         "LootCounter" -> "Counters.LOOT"
+        // Growth counter (SOS — Comforting Counsel): another passive storage counter with no inherent
+        // rule; the card's own static ability reads the count ("as long as there are five or more
+        // growth counters …"). Adding one is a plain AddCounters(Counters.GROWTH, …).
+        "GrowthCounter" -> "Counters.GROWTH"
         else -> null
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCardsBatchBScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCardsBatchBScenarioTest.kt
@@ -1,0 +1,195 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Secrets of Strixhaven "batch B" cards:
+ *  - Comforting Counsel ({1}{G} Enchantment) — growth counter on each life gain; +3/+3 anthem at 5+.
+ *  - Mind Roots ({1}{B}{G} Sorcery) — target player discards two; put up to one discarded land tapped under you.
+ *  - Snarl Song ({5}{G} Sorcery) — Converge; two 0/0 Fractals, X +1/+1 counters on each, gain X life.
+ *
+ * (Goblin Glasswright // Craft with Pride is covered by the shared prepare-mechanic tests; its
+ * prepare spell only makes a Treasure via existing effects.)
+ */
+class SosCardsBatchBScenarioTest : ScenarioTestBase() {
+
+    private fun growthCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.GROWTH) ?: 0
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Comforting Counsel — growth counters per life gain, +3/+3 anthem at 5+") {
+            test("each life gain adds a growth counter; the anthem turns on at five counters") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Comforting Counsel")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 30)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(6) { builder = builder.withCardInHand(1, "Venerable Monk") }
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val counsel = game.findPermanent("Comforting Counsel")!!
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                // Gain life four times (Venerable Monk ETB gains 2 each) → four growth counters.
+                repeat(4) {
+                    game.castSpell(1, "Venerable Monk")
+                    game.resolveStack()
+                }
+                withClue("Four life gains → four growth counters") {
+                    growthCounters(game, counsel) shouldBe 4
+                }
+                withClue("Below five counters: no anthem (Grizzly Bears stays 2/2)") {
+                    game.state.projectedState.getPower(bear) shouldBe 2
+                    game.state.projectedState.getToughness(bear) shouldBe 2
+                }
+
+                // Fifth life gain crosses the threshold.
+                game.castSpell(1, "Venerable Monk")
+                game.resolveStack()
+                withClue("Five growth counters now present") {
+                    growthCounters(game, counsel) shouldBe 5
+                }
+                withClue("At 5+ counters the anthem gives creatures you control +3/+3 (Grizzly Bears 5/5)") {
+                    game.state.projectedState.getPower(bear) shouldBe 5
+                    game.state.projectedState.getToughness(bear) shouldBe 5
+                }
+            }
+        }
+
+        context("Mind Roots — target player discards two, put a discarded land tapped under you") {
+            test("the target player discards two; you put one discarded land onto the battlefield tapped") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mind Roots")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Opponent's hand: a land (Mountain) plus two non-lands to choose among.
+                builder = builder.withCardInHand(2, "Mountain")
+                builder = builder.withCardInHand(2, "Grizzly Bears")
+                builder = builder.withCardInHand(2, "Grizzly Bears")
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val landsBefore = game.findPermanents("Mountain").size
+
+                game.castSpellTargetingPlayer(1, "Mind Roots", 2)
+                game.resolveStack()
+
+                // First decision: the opponent discards two cards — discard the Mountain + a Bears.
+                val mountain = game.findCardsInHand(2, "Mountain").first()
+                val aBears = game.findCardsInHand(2, "Grizzly Bears").first()
+                game.selectCards(listOf(mountain, aBears))
+                game.resolveStack()
+
+                withClue("Opponent discarded two — hand drops to one Grizzly Bears") {
+                    game.handSize(2) shouldBe 1
+                }
+
+                // Second decision: you may put up to one discarded land tapped under your control.
+                withClue("A put-the-land decision should be pending") {
+                    game.state.pendingDecision shouldNotBe null
+                }
+                game.selectCards(listOf(mountain))
+                game.resolveStack()
+
+                val mountainsAfter = game.findPermanents("Mountain")
+                withClue("The discarded Mountain enters the battlefield (one new Mountain permanent)") {
+                    mountainsAfter.size shouldBe landsBefore + 1
+                }
+                val newMountain = mountainsAfter.first()
+                withClue("It is controlled by you (player 1)") {
+                    game.state.getEntity(newMountain)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+                withClue("It enters tapped") {
+                    (game.state.getEntity(newMountain)?.get<TappedComponent>() != null) shouldBe true
+                }
+            }
+
+            test("if no land is discarded there is no land to put — the up-to-one is a no-op") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mind Roots")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Three non-lands in hand so the opponent actually chooses which two to discard.
+                builder = builder.withCardInHand(2, "Grizzly Bears")
+                builder = builder.withCardInHand(2, "Grizzly Bears")
+                builder = builder.withCardInHand(2, "Grizzly Bears")
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.castSpellTargetingPlayer(1, "Mind Roots", 2)
+                game.resolveStack()
+
+                // Opponent discards two non-lands; no land among them.
+                val bears = game.findCardsInHand(2, "Grizzly Bears").take(2)
+                game.selectCards(bears)
+                game.resolveStack()
+
+                withClue("Opponent discarded two — one Grizzly Bears remains in hand") {
+                    game.handSize(2) shouldBe 1
+                }
+                withClue("No land discarded → no permanent should appear under your control") {
+                    game.findPermanents("Grizzly Bears").isEmpty() shouldBe true
+                }
+                withClue("No pending land-put decision when nothing land was discarded") {
+                    game.state.pendingDecision shouldBe null
+                }
+            }
+        }
+
+        context("Snarl Song — Converge: two Fractals with X counters each, gain X life") {
+            test("three colors spent → two 0/0 Fractals with three +1/+1 counters each, gain 3 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Snarl Song")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // {5}{G} paid with W,W,U,U + G + ... three distinct colors (W, U, G).
+                game.castSpell(1, "Snarl Song")
+                game.resolveStack()
+
+                val fractals = game.findPermanents("Fractal Token")
+                withClue("Two Fractal tokens should have been created") {
+                    fractals.size shouldBe 2
+                }
+                withClue("Three colors spent → three +1/+1 counters on each Fractal") {
+                    fractals.forEach { plusOneCounters(game, it) shouldBe 3 }
+                }
+                withClue("You gain X = 3 life") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards implemented (all canonical in SOS, their earliest printing)

| Card | Cost / Type | Implementation |
|------|-------------|----------------|
| **Comforting Counsel** | `{1}{G}` Enchantment | `Triggers.YouGainLife` → `AddCounters(GROWTH)`; counter-gated `+3/+3` anthem via `staticAbility { condition = SourceCounterCountAtLeast(GROWTH, 5); ability = ModifyStats(3,3, AllCreaturesYouControl) }`. Same shape as Beastmaster Ascension. |
| **Goblin Glasswright // Craft with Pride** | `{1}{R}` 2/2 Goblin Sorcerer | `Keyword.PREPARED` + `prepare("Craft with Pride") { manaCost = "{R}"; spell { effect = Effects.CreateTreasure() } }`. |
| **Mind Roots** | `{1}{B}{G}` Sorcery | One inline `Effects.Pipeline`: the target player chooses & discards two; the controller then filters those discarded cards to lands and puts up to one onto the battlefield tapped under their own control. |
| **Snarl Song** | `{5}{G}` Sorcery (Converge) | `CreateToken(count = 2)` two 0/0 Fractals → `AddDynamicCounters(+1/+1, colorsOfManaSpent)` on each created token via `PipelineTarget(CREATED_TOKENS, i)` → `GainLife(colorsOfManaSpent)`. |

All four use existing SDK primitives — **no engine/SDK changes**, so the SDK reference needed no update.

### Skipped
None. All four cards were implementable with existing primitives.

## mtgish-tooling changes

The auto-draft probe initially put Comforting Counsel and Mind Roots at SCAFFOLD. Per the fidelity policy I fixed the **emitter** (render correctly) where it was safe, and left the genuinely-unrenderable shape at SCAFFOLD:

- `counterTypeDsl`: recognize the `GrowthCounter` storage counter → `Counters.GROWTH` (a passive storage counter with no inherent rule, exactly like `LootCounter`).
- `sourceCounterCountAtLeastConditionDsl`: render **any** counter kind `counterTypeDsl` can name (not just `+1/+1`), so "N+ growth counters on this permanent" gates emit `Conditions.SourceCounterCountAtLeast(Counters.GROWTH, N)`.
- `ifRuleBlock`: accept that counter-count gate on an `EachPermanentLayerEffect` lord, reusing the existing gated `staticLordBlock` renderer.

Net effect: **Comforting Counsel, Goblin Glasswright, and Snarl Song now render AUTO**. **Mind Roots stays SCAFFOLD** — its "put a land discarded this way onto the battlefield" is a linked/value-inheritance pipeline shape the emitter declines to approximate (per the creator's note).

`EmitterGoldenTest` stays **card-for-card green for every vendored set** (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE) — my emitter edits don't alter any committed emitter output.

## Tests
- `SosCardsBatchBScenarioTest` — 4 scenarios (growth-counter accrual + anthem threshold, Mind Roots discard→land-to-battlefield-tapped + no-land no-op, Snarl Song 3-color converge), all green.
- `CardDefinitionSnapshotTest` (SOS golden reblessed — diff is only the 4 new cards) + `CardLintTest` green.
- `:mtgish-tooling:test` (incl. `EmitterGoldenTest`) green.

## Pre-existing issue (NOT introduced here)
`just coverage-verify POR` / `--set SOS` report a **pre-existing** GATE FAIL unrelated to this branch: the reanimation emitter emits `Effects.Move(..., fromZone = Zone.GRAVEYARD)` while the implemented cards' `MoveToZone` golden omits `fromZone` (Breath of Life on POR; Forum Necroscribe, Lorehold Charm, etc. on SOS), plus a `+1/+1` vs `+1+1` counter-string diff on Silverquill Charm. The committed POR emitter golden already contains the `fromZone = Zone.GRAVEYARD` output, and `EmitterGoldenTest` confirms my changes leave it byte-identical, so these mismatches exist on `main` independent of this PR. None of the 7 SOS / 1 POR mismatches are my cards. Flagging rather than touching another agent's in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)