### PR TITLE
mtg-sets: fix fromZone drift on graveyard reanimators (coverage-verify gate)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BroodheartEngine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BroodheartEngine.kt
@@ -35,7 +35,7 @@ val BroodheartEngine = card("Broodheart Engine") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{2}{B}{G}"), Costs.Tap, Costs.SacrificeSelf)
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
         timing = TimingRule.SorcerySpeed
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EmergeFromTheCocoon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EmergeFromTheCocoon.kt
@@ -27,7 +27,7 @@ val EmergeFromTheCocoon = card("Emerge from the Cocoon") {
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
         effect = Effects.Composite(
-            Effects.Move(t, Zone.BATTLEFIELD),
+            Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
             GainLifeEffect(3)
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LiveOrDie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LiveOrDie.kt
@@ -30,7 +30,7 @@ val LiveOrDie = card("Live or Die") {
         modal(chooseCount = 1) {
             mode("Return target creature card from your graveyard to the battlefield") {
                 val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-                effect = Effects.Move(t, Zone.BATTLEFIELD)
+                effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
             }
             mode("Destroy target creature") {
                 val t = target("target", TargetCreature(filter = TargetFilter.Creature))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RiteOfTheMoth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RiteOfTheMoth.kt
@@ -30,7 +30,7 @@ val RiteOfTheMoth = card("Rite of the Moth") {
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
         effect = Effects.Composite(
-            Effects.Move(t, Zone.BATTLEFIELD),
+            Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
             AddCountersEffect(counterType = Counters.FINALITY, count = 1, target = t)
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothsFaithful.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothsFaithful.kt
@@ -31,7 +31,7 @@ val ValgavothsFaithful = card("Valgavoth's Faithful") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.SacrificeSelf)
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
         timing = TimingRule.SorcerySpeed
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ReyaDawnbringer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ReyaDawnbringer.kt
@@ -30,7 +30,7 @@ val ReyaDawnbringer = card("Reya Dawnbringer") {
     triggeredAbility {
         trigger = Triggers.YourUpkeep
         val t = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
-        effect = MayEffect(Effects.Move(t, Zone.BATTLEFIELD))
+        effect = MayEffect(Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/UnburialRites.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/UnburialRites.kt
@@ -27,7 +27,7 @@ val UnburialRites = card("Unburial Rites") {
     oracleText = "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
     keywordAbility(KeywordAbility.flashback("{3}{W}"))
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Resurrection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Resurrection.kt
@@ -25,7 +25,7 @@ val Resurrection = card("Resurrection") {
     oracleText = "Return target creature card from your graveyard to the battlefield."
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/DoomedNecromancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/DoomedNecromancer.kt
@@ -26,7 +26,7 @@ val DoomedNecromancer = card("Doomed Necromancer") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap, Costs.SacrificeSelf)
         val t = target("target", Targets.CreatureCardInYourGraveyard)
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BreathOfLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BreathOfLife.kt
@@ -25,7 +25,7 @@ val BreathOfLife = card("Breath of Life") {
     oracleText = "Return target creature card from your graveyard to the battlefield."
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ForumNecroscribe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ForumNecroscribe.kt
@@ -45,7 +45,7 @@ val ForumNecroscribe = card("Forum Necroscribe") {
             "target creature card from your graveyard",
             TargetObject(filter = TargetFilter.CreatureInYourGraveyard),
         )
-        effect = Effects.Move(returned, Zone.BATTLEFIELD)
+        effect = Effects.Move(returned, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ulg/cards/Unearth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ulg/cards/Unearth.kt
@@ -27,7 +27,7 @@ val Unearth = card("Unearth") {
     oracleText = "Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)"
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
-        effect = Effects.Move(t, Zone.BATTLEFIELD)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
     }
     keywordAbility(KeywordAbility.cycling("{2}"))
     metadata {

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -690,7 +690,8 @@
                         "type": "BoundVariable",
                         "name": "target"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 "targetRequirements": [
                     {

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -525,7 +525,8 @@
                         "type": "BoundVariable",
                         "name": "target"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 {
                     "type": "GainLife",
@@ -1450,7 +1451,8 @@
                             "type": "BoundVariable",
                             "name": "target"
                         },
-                        "destination": "Battlefield"
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
                     },
                     "targetRequirements": [
                         {
@@ -2306,7 +2308,8 @@
                         "type": "BoundVariable",
                         "name": "target"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 {
                     "type": "AddCounters",
@@ -3057,7 +3060,8 @@
                         "type": "BoundVariable",
                         "name": "target"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 "targetRequirements": [
                     {

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -11067,7 +11067,8 @@
                             "type": "BoundVariable",
                             "name": "target creature card from your graveyard"
                         },
-                        "destination": "Battlefield"
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
                     }
                 },
                 "targetRequirement": {

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -3519,7 +3519,8 @@
                 "type": "BoundVariable",
                 "name": "target"
             },
-            "destination": "Battlefield"
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
         },
         "targetRequirements": [
             {

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -3088,7 +3088,8 @@
                 "type": "BoundVariable",
                 "name": "target"
             },
-            "destination": "Battlefield"
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
         },
         "targetRequirements": [
             {

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -4954,7 +4954,8 @@
                         "type": "BoundVariable",
                         "name": "target"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 "targetRequirements": [
                     {

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -592,7 +592,8 @@
                 "type": "BoundVariable",
                 "name": "target"
             },
-            "destination": "Battlefield"
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
         },
         "targetRequirements": [
             {

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -2935,7 +2935,8 @@
                         "type": "BoundVariable",
                         "name": "target creature card from your graveyard"
                     },
-                    "destination": "Battlefield"
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
                 },
                 "targetRequirement": {
                     "type": "TargetObject",

--- a/mtg-sets/src/test/resources/snapshots/cards/ULG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ULG.json
@@ -2064,7 +2064,8 @@
                 "type": "BoundVariable",
                 "name": "target"
             },
-            "destination": "Battlefield"
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
         },
         "targetRequirements": [
             {


### PR DESCRIPTION
## Problem

Commit `60d763beb` ("Finish FIN autogen coverage") taught the mtgish emitter's `PutGraveyardCardOntoBattlefield` handler to emit

```kotlin
Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
```

for plain "return target creature card from your graveyard to the battlefield" reanimators, and re-blessed the emitter **fixture** goldens (`*.emitted.golden.txt`). But it did **not** re-align the already-promoted reanimator cards (still `Effects.Move(t, Zone.BATTLEFIELD)` without the guard) or their `CardDefinitionSnapshot` goldens.

Because `coverage-verify` is an **out-of-suite** gate (not part of `just test`), the drift landed silently:

```
coverage-verify POR → GAMEPLAY TREE MISMATCH: 1  (Breath of Life)
coverage-verify ISD → GAMEPLAY TREE MISMATCH: 1  (Unburial Rites)
  $.script.spellEffect.fromZone: generated="Graveyard" golden=<missing>
```

## Why `fromZone` is correct

`Effects.Move`'s `fromZone` is a guard — *"only moves if the card is currently in [fromZone]"*. `Zone.GRAVEYARD` faithfully encodes "from your graveyard" and correctly no-ops if the target left the graveyard before resolution. So the emitter's output is the right form; the promoted cards simply predate it.

## Change

Add `fromZone = Zone.GRAVEYARD` to the **12** promoted graveyard reanimators and re-bless their snapshot goldens (12 `fromZone: "Graveyard"` additions across DFT/DSK/INV/ISD/LEA/ONS/POR/SOS/ULG — nothing else):

> Breath of Life, Unburial Rites, Resurrection, Doomed Necromancer, Reya Dawnbringer, Unearth, Live or Die (reanimate mode), Emerge from the Cocoon, Rite of the Moth, Valgavoth's Faithful, Forum Necroscribe, Broodheart Engine

**Gravespawn Sovereign deliberately excluded** — its "onto the battlefield **under your control**" renders as `Effects.PutOntoBattlefieldUnderYourControl`, a separate pre-existing divergence (the hand-authored card omits the control grab), not the `fromZone` drift.

## Verification

- `coverage-verify POR` → **GATE PASS (158/158)**, `coverage-verify ISD` → **GATE PASS (84/84)** (was 1 mismatch each).
- `CardDefinitionSnapshotTest` green.
- Reanimator scenario tests pass — the guard is behavior-preserving (the target is in the graveyard in the normal case).

Found while refreshing the mtgish IR for #815 (token-creation cleanup); split out here since it's unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)