### PR TITLE
Visualize warped permanents on the battlefield (CR 702.185)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -258,6 +258,11 @@ data class ClientCard(
      * prepare spell sits castable in its controller's exile until cast. Battlefield only. */
     val isPrepared: Boolean = false,
 
+    /** Whether this permanent was cast for its warp cost (CR 702.185, Edge of Eternities): it will be
+     * exiled at the beginning of the next end step, after which it can be recast from exile. Drives the
+     * cosmic "warped" cue on the battlefield. Battlefield only. */
+    val isWarped: Boolean = false,
+
     /** Morph cost for face-down creatures (only visible to controller) */
     val morphCost: String? = null,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1065,6 +1065,11 @@ class ClientStateTransformer(
         val isPrepared = zoneKey.zoneType == Zone.BATTLEFIELD &&
             container.has<com.wingedsheep.engine.state.components.battlefield.PreparedComponent>()
 
+        // Warped permanents (CR 702.185, Edge of Eternities) carry a WarpedComponent until they're
+        // exiled at the next end step; surface a flag so the client can show the cosmic warp cue.
+        val isWarped = zoneKey.zoneType == Zone.BATTLEFIELD &&
+            container.has<com.wingedsheep.engine.state.components.battlefield.WarpedComponent>()
+
         // Threshold-style progress badge: detect static abilities gated on
         // "controller's graveyard has at least N cards".
         val thresholdInfo = cardDef?.let { def ->
@@ -1126,6 +1131,7 @@ class ClientStateTransformer(
             isSuspected = projectedValues?.isSuspected == true,
             isPlotted = isPlotted,
             isPrepared = isPrepared,
+            isWarped = isWarped,
             morphCost = if (isFaceDown && morphData != null) morphData.morphCost.description else null,
             targets = targets,
             imageUri = cardComponent.imageUri ?: cardDef?.metadata?.imageUri,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/WarpedCardVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/WarpedCardVisibilityTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * A permanent cast for its warp cost (CR 702.185, Edge of Eternities) carries a
+ * [com.wingedsheep.engine.state.components.battlefield.WarpedComponent] until it's exiled at the
+ * beginning of the next end step. [ClientStateTransformer] surfaces that as [ClientCard.isWarped] so
+ * the client can show the cosmic "warped" cue (a spinning ring + badge) — otherwise the permanent is
+ * visually indistinguishable from one cast for its regular cost. The flag is public (warp casting is
+ * visible to all players), so both the controller and the opponent see it.
+ */
+class WarpedCardVisibilityTest : FunSpec({
+
+    val warpCreature = card("Warp Test Creature") {
+        manaCost = "{3}{R}{R}"
+        typeLine = "Creature — Elemental"
+        power = 4
+        toughness = 3
+        warp = "{1}{R}"
+        keywords(Keyword.HASTE)
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + warpCreature)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("a creature cast for its regular cost is not flagged isWarped") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val cardId = d.putCardInHand(player, "Warp Test Creature")
+        d.giveMana(player, Color.RED, 5)
+
+        d.submit(CastSpell(playerId = player, cardId = cardId, paymentStrategy = PaymentStrategy.FromPool))
+        d.bothPass()
+
+        val permanent = d.findPermanent(player, "Warp Test Creature").shouldNotBeNull()
+        val view = transformer(d).transform(d.state, viewingPlayerId = player)
+        view.cards[permanent].shouldNotBeNull().isWarped shouldBe false
+    }
+
+    test("a creature cast for its warp cost is flagged isWarped for both players") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+        val cardId = d.putCardInHand(player, "Warp Test Creature")
+        d.giveMana(player, Color.RED, 2) // warp cost {1}{R}
+
+        d.submit(
+            CastSpell(
+                playerId = player,
+                cardId = cardId,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        d.bothPass()
+
+        val permanent = d.findPermanent(player, "Warp Test Creature").shouldNotBeNull()
+
+        val ownerView = transformer(d).transform(d.state, viewingPlayerId = player)
+        val opponentView = transformer(d).transform(d.state, viewingPlayerId = opponent)
+
+        ownerView.cards[permanent].shouldNotBeNull().isWarped shouldBe true
+        opponentView.cards[permanent].shouldNotBeNull().isWarped shouldBe true
+    }
+})

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1689,6 +1689,53 @@ export const styles: Record<string, React.CSSProperties> = {
     pointerEvents: 'none',
     zIndex: 6,
   } as React.CSSProperties,
+
+  // Warp (CR 702.185, Edge of Eternities) — a permanent cast for its warp cost that will be exiled at
+  // the next end step. The cue reads as the card being pulled out of phase with reality. The outward
+  // breathing halo is a box-shadow animation applied to the card div itself (`warpHaloPulse`), because
+  // a child overlay's box-shadow would be clipped by the card's `overflow: hidden`.
+  //
+  // warpRing: a slowly rotating violet/cyan conic gradient clipped to a thin ring just inside the card
+  // edge (the mask/composite trick hollows out the centre so the art stays clear). The spin sells the
+  // warp. Sits flush inside the card (inset 0) so `overflow: hidden` doesn't crop it.
+  warpRing: {
+    position: 'absolute',
+    inset: 0,
+    borderRadius: 'inherit',
+    padding: 2,
+    background:
+      'conic-gradient(from 0deg, rgba(126,92,232,0) 0deg, #9e74ff 70deg, #58dcff 150deg, rgba(126,92,232,0) 210deg, #9e74ff 300deg, rgba(126,92,232,0) 360deg)',
+    WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+    WebkitMaskComposite: 'xor',
+    maskComposite: 'exclude',
+    animation: 'warpRingSpin 5.5s linear infinite',
+    pointerEvents: 'none',
+    opacity: 0.9,
+    zIndex: 5,
+  } as React.CSSProperties,
+
+  // "Warped" badge — cosmic violet→cyan shimmer to match the ring.
+  warpedBadge: {
+    position: 'absolute',
+    top: 4,
+    left: 4,
+    borderRadius: 4,
+    padding: '1px 5px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 3,
+    fontWeight: 700,
+    fontSize: 10,
+    color: '#ecf6ff',
+    background: 'linear-gradient(90deg, #6a3fd0, #58dcff, #6a3fd0)',
+    backgroundSize: '200% 100%',
+    animation: 'warpBadgeShimmer 3.2s linear infinite',
+    border: '1px solid #bfe6ff',
+    boxShadow: '0 0 6px rgba(120, 160, 255, 0.85)',
+    textShadow: 'none',
+    pointerEvents: 'none',
+    zIndex: 6,
+  } as React.CSSProperties,
 }
 
 /**

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1180,6 +1180,12 @@ function GameCardImpl({
         userSelect: 'none',
         ...(voidEligible ? { outline: '1px solid rgba(140, 90, 220, 0.55)', outlineOffset: '2px' } : {}),
         ...(isBeheldPulsing ? { animation: 'beholdPulse 1.1s ease-in-out infinite alternate' } : {}),
+        // Warp (CR 702.185): a breathing cosmic halo around a permanent cast for its warp cost. The
+        // box-shadow lives on the card div (not a child) so it isn't clipped by `overflow: hidden`;
+        // a beheld pulse, when active, wins the single `animation` slot.
+        ...(battlefield && card.isWarped && !faceDown && !isBeheldPulsing
+          ? { animation: 'warpHaloPulse 2.6s ease-in-out infinite' }
+          : {}),
         // Banding: colored ring + glow on every member of a declared band (CR 702.22).
         ...(isBanded && bandColor ? {
           outline: `2px solid ${bandColor.border}`,
@@ -1446,6 +1452,18 @@ function GameCardImpl({
         <div style={styles.preparedBadge} title="Prepared (Secrets of Strixhaven) — cast a copy of its spell from exile; doing so unprepares it">
           Prepared
         </div>
+      )}
+
+      {/* Warp (CR 702.185, Edge of Eternities): a permanent cast for its warp cost — exiled at the next
+          end step, then recastable from exile. Cosmic spinning ring + shimmering badge sell the warp. */}
+      {battlefield && card.isWarped && !faceDown && (
+        <>
+          <div style={styles.warpRing} aria-hidden="true" />
+          <div style={styles.warpedBadge} title="Warped (Edge of Eternities) — exiled at the beginning of the next end step, then castable again from exile">
+            <span aria-hidden="true">✦</span>
+            Warped
+          </div>
+        </>
       )}
 
       {/* Counter badge for creatures with +1/+1 or -1/-1 counters */}

--- a/web-client/src/styles/responsive.css
+++ b/web-client/src/styles/responsive.css
@@ -94,6 +94,27 @@
 }
 
 /* =========================================================================
+ * Warp (CR 702.185, Edge of Eternities) — a permanent cast for its warp cost
+ * sits on the battlefield until it's exiled at the next end step. The cue reads
+ * as the card being pulled out of phase with reality: a slowly rotating
+ * violet/cyan cosmic ring around its edge plus a soft breathing halo.
+ * ========================================================================= */
+@keyframes warpRingSpin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes warpHaloPulse {
+  0%, 100% { box-shadow: 0 0 6px 1px rgba(126, 92, 232, 0.45), 0 0 15px 3px rgba(72, 200, 232, 0.22); }
+  50%      { box-shadow: 0 0 12px 3px rgba(158, 116, 255, 0.78), 0 0 28px 7px rgba(88, 220, 255, 0.42); }
+}
+
+@keyframes warpBadgeShimmer {
+  from { background-position: 0% 50%; }
+  to   { background-position: 200% 50%; }
+}
+
+/* =========================================================================
  * Utility classes for responsive visibility
  * ========================================================================= */
 .hide-mobile {

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -235,6 +235,10 @@ export interface ClientCard {
    * prepare spell sits castable in its controller's exile. Battlefield only. */
   readonly isPrepared?: boolean
 
+  /** Whether this permanent was cast for its warp cost (CR 702.185, Edge of Eternities): it will be
+   * exiled at the next end step, then can be recast from exile. Drives the cosmic warp cue. Battlefield only. */
+  readonly isWarped?: boolean
+
   /** Morph cost for face-down creatures (only visible to controller) */
   readonly morphCost?: string | null
 


### PR DESCRIPTION
## What

A permanent cast for its **warp** cost (Edge of Eternities, CR 702.185) sits on the battlefield carrying a `WarpedComponent` until it's exiled at the beginning of the next end step. Until now the client rendered it identically to a permanent cast for its regular cost, so there was no way to tell at a glance that it's about to phase out.

This surfaces the state and gives it a "pulled out of phase with reality" cue.

![Warped permanent cue](https://raw.githubusercontent.com/wingedsheep/argentum-engine/warped-card-visual-screenshots/warp-shot.png)

## How

Mirrors the existing `isPrepared` / `isPlotted` flag pattern end-to-end:

- **Engine** — `ClientStateTransformer` reads `WarpedComponent` on battlefield permanents and sets the new `ClientCard.isWarped` (public info — visible to both players, like warp casting itself).
- **Client** — `GameCard` renders the cue when `isWarped`:
  - a slowly rotating violet/cyan **cosmic ring** around the card edge (conic-gradient + mask, clipped just inside the edge so `overflow: hidden` doesn't crop it),
  - a soft **breathing halo** — a `box-shadow` animation on the card div itself (not a child overlay, which `overflow: hidden` would clip); it yields the single `animation` slot to an active behold pulse,
  - a shimmering **"Warped" badge**.
- New keyframes (`warpRingSpin`, `warpHaloPulse`, `warpBadgeShimmer`) live in `responsive.css`; the badge/ring styles live in the shared board `styles.ts`.

No SDK surface changes — the warp mechanic already exists; this is purely a view/DTO + presentation layer addition.

## Tests

- `WarpedCardVisibilityTest` (rules-engine) — the transformer flags a warp-cast permanent `isWarped` for both players, and leaves a regularly-cast one unflagged.
- `web-client` typecheck passes; `:rules-engine` compiles.

> The screenshot above is a faithful demo built from the exact implementation CSS (the animation can't be conveyed in a still). The screenshots branch is throwaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)