### PR TITLE
Fix reanimated Auras dying instead of attaching (Astelli Reclaimer)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -1,8 +1,14 @@
 package com.wingedsheep.engine.handlers.effects.zones
 
 import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.PutOntoBattlefieldAttachedToChosenContinuation
+import com.wingedsheep.engine.core.TargetRequirementInfo
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.handlers.effects.LibraryPlacement
@@ -17,9 +23,11 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -30,7 +38,8 @@ import kotlin.reflect.KClass
  * Delegates all zone movement to [ZoneTransitionService] for consistent cleanup.
  */
 class MoveToZoneEffectExecutor(
-    private val cardRegistry: CardRegistry
+    private val cardRegistry: CardRegistry,
+    private val targetFinder: TargetFinder = TargetFinder()
 ) : EffectExecutor<MoveToZoneEffect> {
 
     override val effectType: KClass<MoveToZoneEffect> = MoveToZoneEffect::class
@@ -72,6 +81,17 @@ class MoveToZoneEffectExecutor(
             context.resolveTarget(controllerOverride, state) ?: ownerId
         } else {
             ownerId
+        }
+
+        // CR 303.4g — an Aura entering the battlefield by any means other than resolving as an
+        // Aura spell (here: reanimation / return from graveyard, exile, etc.) has its controller
+        // choose what it enchants as it enters. Without that choice the Aura would enter
+        // unattached and immediately die to a state-based action (CR 704.5n). Cast Auras attach
+        // during stack resolution and never reach this executor, and the explicit
+        // "attached to ..." effect has its own executor, so a generic move-to-battlefield of an
+        // Aura is always the choose-as-it-enters case.
+        if (effect.destination == Zone.BATTLEFIELD && !effect.faceDown && cardComponent.typeLine.isAura) {
+            return attachAuraOnEnter(state, targetId, cardComponent, controllerId, context)
         }
 
         // Build ZoneEntryOptions based on placement and effect properties
@@ -127,6 +147,66 @@ class MoveToZoneEffectExecutor(
         )
 
         return EffectResult.success(resultState, transitionResult.events + extraEvents + revealEvents)
+    }
+
+    /**
+     * Handle an Aura that is being put onto the battlefield by something other than resolving as
+     * an Aura spell (CR 303.4g). The controller chooses what it enchants from among everything it
+     * can legally enchant (CR 303.4f — targeting restrictions like hexproof/shroud are ignored for
+     * this choice). The actual move-and-attach happens in
+     * [PutOntoBattlefieldAttachedToChosenContinuation], reused from the explicit "attached to"
+     * effect so both paths wire `AttachedToComponent`, the host's `AttachmentsComponent`, and the
+     * Aura's continuous/replacement effects identically.
+     */
+    private fun attachAuraOnEnter(
+        state: GameState,
+        cardId: EntityId,
+        cardComponent: CardComponent,
+        controllerId: EntityId,
+        context: EffectContext
+    ): EffectResult {
+        val auraTarget = cardRegistry.getCard(cardComponent.cardDefinitionId)?.script?.auraTarget
+        val legalHosts = if (auraTarget == null) emptyList() else targetFinder.findLegalTargets(
+            state = state,
+            requirement = auraTarget,
+            controllerId = controllerId,
+            sourceId = cardId,
+            ignoreTargetingRestrictions = true
+        )
+
+        // No legal host — the Aura can't enter and stays in its current zone (CR 303.4g).
+        if (legalHosts.isEmpty()) {
+            return EffectResult.success(state)
+        }
+
+        val cardName = cardComponent.name
+        val decisionId = UUID.randomUUID().toString()
+        val decision = ChooseTargetsDecision(
+            id = decisionId,
+            playerId = controllerId,
+            prompt = "Choose what $cardName attaches to",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                phase = DecisionPhase.RESOLUTION
+            ),
+            targetRequirements = listOf(
+                TargetRequirementInfo(
+                    index = 0,
+                    description = "what $cardName attaches to",
+                    minTargets = 1,
+                    maxTargets = 1
+                )
+            ),
+            legalTargets = mapOf(0 to legalHosts)
+        )
+        val continuation = PutOntoBattlefieldAttachedToChosenContinuation(
+            decisionId = decisionId,
+            cardId = cardId,
+            controllerId = controllerId
+        )
+        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        return EffectResult(state = newState, events = emptyList(), pendingDecision = decision)
     }
 
     private fun autoRevealForReturn(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
@@ -15,7 +15,7 @@ class ZonesExecutors(
     private val targetFinder: TargetFinder = TargetFinder()
 ) : ExecutorModule {
     override fun executors(): List<EffectExecutor<*>> = listOf(
-        MoveToZoneEffectExecutor(cardRegistry),
+        MoveToZoneEffectExecutor(cardRegistry, targetFinder),
         ExileAndGrantOwnerPlayPermissionExecutor(),
         WarpExileExecutor(),
         ForceExileMultiZoneExecutor(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AstelliReclaimerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AstelliReclaimerScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Astelli Reclaimer ({3}{W}{W}, Angel Warrior 5/4, Flying, Warp {2}{W}):
+ * "When this creature enters, return target noncreature, nonland permanent card with mana value X
+ * or less from your graveyard to the battlefield, where X is the amount of mana spent to cast this
+ * creature."
+ *
+ * Cast normally for {3}{W}{W}, X = 5.
+ */
+class AstelliReclaimerScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.graveyardCard(player: Int, name: String): EntityId {
+        val playerId = if (player == 1) player1Id else player2Id
+        return state.getGraveyard(playerId).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    init {
+        test("enters trigger returns a noncreature, nonland permanent and excludes creatures") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Astelli Reclaimer")
+                .withLandsOnBattlefield(1, "Plains", 5)
+                .withCardInGraveyard(1, "Sol Ring")       // Artifact, MV 1 — eligible
+                .withCardInGraveyard(1, "Grizzly Bears")   // Creature, MV 2 — NOT eligible
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Astelli Reclaimer")
+            game.resolveStack()
+
+            val decision = game.state.pendingDecision as? ChooseTargetsDecision
+            withClue("Enters trigger should pause to choose a target in the graveyard") {
+                decision shouldNotBe null
+            }
+            val legalTargets = decision!!.legalTargets[0] ?: emptyList()
+
+            withClue("Sol Ring (noncreature, nonland, MV 1 <= 5) is a legal target") {
+                legalTargets shouldContain game.graveyardCard(1, "Sol Ring")
+            }
+            withClue("Grizzly Bears (a creature) is not a legal target") {
+                legalTargets shouldNotContain game.graveyardCard(1, "Grizzly Bears")
+            }
+
+            game.selectTargets(listOf(game.graveyardCard(1, "Sol Ring")))
+            game.resolveStack()
+
+            withClue("Sol Ring returns to the battlefield") {
+                game.findPermanent("Sol Ring") shouldNotBe null
+            }
+        }
+
+        test("returning an Aura lets the controller choose what it enchants (CR 303.4g)") {
+            // Regression: an Aura returned by a generic put-onto-battlefield effect used to enter
+            // unattached and die instantly to a state-based action. It must instead let its
+            // controller pick a legal host as it enters.
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Astelli Reclaimer")
+                .withLandsOnBattlefield(1, "Plains", 5)
+                .withCardInGraveyard(1, "Pacifism")        // Aura — enchant creature, MV 2
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Astelli Reclaimer")
+            game.resolveStack()
+
+            // Choose Pacifism as the return target.
+            (game.state.pendingDecision as? ChooseTargetsDecision) shouldNotBe null
+            game.selectTargets(listOf(game.graveyardCard(1, "Pacifism")))
+            game.resolveStack()
+
+            // The Aura now pauses for the controller to choose a host. The only creature on the
+            // battlefield is Astelli Reclaimer itself.
+            val hostDecision = game.state.pendingDecision as? ChooseTargetsDecision
+            withClue("Returning the Aura should prompt for the host it enchants") {
+                hostDecision shouldNotBe null
+            }
+            val reclaimer = game.findPermanent("Astelli Reclaimer")!!
+            withClue("Astelli Reclaimer is a legal host for Pacifism") {
+                (hostDecision!!.legalTargets[0] ?: emptyList()) shouldContain reclaimer
+            }
+
+            game.selectTargets(listOf(reclaimer))
+            game.resolveStack()
+
+            val pacifism = game.findPermanent("Pacifism")
+            withClue("Pacifism enters the battlefield attached to a creature, not bounced by SBA") {
+                pacifism shouldNotBe null
+                game.state.getEntity(pacifism!!)?.get<AttachedToComponent>()?.targetId shouldBe reclaimer
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`AstelliReclaimer` (EOE) "doesn't allow me to return a permanent." Its enters trigger — *"return target noncreature, nonland permanent card with mana value X or less from your graveyard to the battlefield"* — worked for plain permanents (artifacts, enchantments) but **silently did nothing when the chosen card was an Aura** (Pacifism, etc.).

## Root cause

The trigger uses `Effects.PutOntoBattlefield`, i.e. a generic `MoveToZoneEffect` → battlefield. That executor just moved the card, so an Aura entered the battlefield **unattached**. An unattached Aura is immediately put back into its owner's graveyard by a state-based action (CR 704.5n) — so the card appeared to fizzle.

Targeting itself was correct (X = mana spent is recorded properly; creatures/lands are excluded; noncreature, nonland permanents with MV ≤ X are offered). The gap was purely the missing attach-on-enter step.

## Fix

Per **CR 303.4g**, an Aura entering the battlefield by any means *other than* resolving as an Aura spell (reanimation, return from graveyard/exile, …) has its controller choose what it enchants as it enters.

`MoveToZoneEffectExecutor` now detects an Aura entering the battlefield and:
- enumerates the hosts it can legally enchant (CR 303.4f, ignoring hexproof/shroud for this choice),
- pauses for the controller to pick one, reusing the existing `PutOntoBattlefieldAttachedToChosenContinuation` so attachment bookkeeping is identical to the explicit "attached to …" effect (One Last Job),
- leaves the Aura in its current zone if there's no legal host.

Cast Auras attach during stack resolution (they never reach this executor) and the explicit "attached to …" effect has its own executor, so a generic move-to-battlefield of an Aura is always the choose-on-enter case. The fix is general — it covers any reanimation/return effect that can hit an Aura, not just Astelli Reclaimer. The prompt reuses the existing `ChooseTargetsDecision` type, so client and AI handling are unchanged.

## Tests

New `AstelliReclaimerScenarioTest`:
- returns a noncreature, nonland permanent (Sol Ring) and excludes creatures (Grizzly Bears),
- returns an Aura (Pacifism), prompts for the host, and confirms it enters attached rather than being bounced by SBA.

Full `:rules-engine:test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)