### PR TITLE
Fix counter-filtered death triggers firing for counter-less creatures

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.engine.event
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.handlers.effects.permanent.counters.counterTypeToString
 
 import com.wingedsheep.engine.core.BecomesTargetEvent
 import com.wingedsheep.engine.core.AbilityActivatedEvent
@@ -1364,6 +1366,29 @@ class TriggerMatcher(
                 matchesStatePredicateForTrigger(predicate, state, event.entityId)
             }
         }
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasCounter -> {
+            // The dying / leaving entity is no longer on the battlefield, so its live counters are
+            // gone; gate against the counters captured on the event (LKI). For non-leave triggers
+            // (e.g. ETB, to=BATTLEFIELD) the entity is live, so read its current counters.
+            if (event.fromZone == Zone.BATTLEFIELD) {
+                event.lastKnownCounters.any { (type, count) ->
+                    count > 0 && counterTypesMatch(predicate.counterType, type)
+                }
+            } else {
+                val counters = state.getEntity(event.entityId)?.get<CountersComponent>()
+                counters?.counters?.entries?.any { (type, count) ->
+                    count > 0 && counterTypesMatch(predicate.counterType, counterTypeToString(type))
+                } ?: false
+            }
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasAnyCounter -> {
+            if (event.fromZone == Zone.BATTLEFIELD) {
+                event.lastKnownTotalCounterCount > 0
+            } else {
+                val counters = state.getEntity(event.entityId)?.get<CountersComponent>()
+                counters?.counters?.values?.any { it > 0 } ?: false
+            }
+        }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Or ->
             predicate.predicates.any { matchesStatePredicateForZoneChangeTrigger(it, state, event) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.And ->
@@ -1408,7 +1433,6 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttackedThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceUp,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasMorphAbility,
-        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasAnyCounter,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasGreatestPower,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPowerAmongAllCreatures,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped,
@@ -1417,8 +1441,13 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.CrewedOrSaddledSourceThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
-        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasCounter,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true
+        // Counter predicates require last-known-info to evaluate a creature that has already left
+        // the battlefield; the zone-change path ([matchesStatePredicateForZoneChangeTrigger])
+        // handles them against the event's captured counters. This entity-only fallback has no LKI,
+        // so it fails closed rather than fail-open (which would create tokens for counter-less deaths).
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasCounter,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasAnyCounter -> false
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaybladeTrooperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaybladeTrooperScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.RaybladeTrooper
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Rayblade Trooper — {2}{W} 2/2 Creature — Human Soldier
+ *
+ * "Whenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white
+ *  Human Soldier creature token."
+ *
+ * The death trigger gates on a `HasCounter(+1/+1)` state predicate. Because the creature has
+ * already left the battlefield when the trigger gates, the predicate must be evaluated against the
+ * dying creature's last-known counters — not the (now counter-less) live state. The bug being
+ * guarded here: the `HasCounter` predicate failed open in the zone-change gating path, so a token
+ * was created even when the creature had no +1/+1 counter.
+ */
+class RaybladeTrooperScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RaybladeTrooper)
+        return driver
+    }
+
+    test("does NOT create a token when a creature WITHOUT a +1/+1 counter dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Rayblade Trooper")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        // Kill the counter-less creature with Doom Blade (destroys regardless of P/T).
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.castSpell(player, doomBlade, targets = listOf(courser))
+        driver.bothPass() // resolve Doom Blade -> Centaur Courser dies
+
+        driver.findPermanent(player, "Centaur Courser") shouldBe null
+        // The death trigger must NOT fire — no token on the stack and none created.
+        driver.stackSize shouldBe 0
+        driver.getCreatures(player).count { driver.getCardName(it) == "Human Soldier Token" } shouldBe 0
+    }
+
+    test("DOES create a token when a creature WITH a +1/+1 counter dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Rayblade Trooper")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        driver.addComponent(courser, CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1))
+
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.castSpell(player, doomBlade, targets = listOf(courser))
+        driver.bothPass() // resolve Doom Blade -> Centaur Courser dies -> death trigger on stack
+        driver.bothPass() // resolve the death trigger -> token created
+
+        driver.findPermanent(player, "Centaur Courser") shouldBe null
+        driver.getCreatures(player).count { driver.getCardName(it) == "Human Soldier Token" } shouldBe 1
+    }
+})


### PR DESCRIPTION
## Problem

Rayblade Trooper creates its 1/1 Human Soldier token *whenever any nontoken creature you control dies* — even when that creature has **no** +1/+1 counter on it. The trigger is supposed to be gated on "...with a +1/+1 counter on it dies".

## Root cause

The death trigger's filter compiles to a `StatePredicate.HasCounter(+1/+1)`. In the zone-change trigger gating path, `matchesStatePredicateForZoneChangeTrigger` had no explicit case for `HasCounter`/`HasAnyCounter`, so it fell through to `matchesStatePredicateForTrigger`, which returned `true` unconditionally for these predicates — a fail-open.

By the time a death/leaves trigger gates, the creature has already left the battlefield, so its live counters are gone. The predicate must instead be evaluated against the **last-known counters** already captured on the `ZoneChangeEvent` (`lastKnownCounters` / `lastKnownTotalCounterCount`).

## Fix

- Handle `HasCounter` and `HasAnyCounter` explicitly in `matchesStatePredicateForZoneChangeTrigger`:
  - leaving the battlefield → evaluate against the event's last-known counters (LKI)
  - otherwise (e.g. ETB) → read the entity's current counters
- Make the entity-only fallback (`matchesStatePredicateForTrigger`) **fail closed** for these counter predicates instead of fail-open.

This also fixes **Meltstrider Eulogist** (EOE), which has the identical shape ("whenever a creature you control with a +1/+1 counter on it dies, draw a card").

## Tests

New `RaybladeTrooperScenarioTest`:
- ✅ does NOT create a token when a counter-less creature dies (reproduced the bug, now passing)
- ✅ DOES create a token when a creature with a +1/+1 counter dies (positive case preserved)

Full `:rules-engine:test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)