### PR TITLE
fix(auto-pass): stop opponent on split-card instant/sorcery faces

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.priority
 
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
@@ -42,7 +43,15 @@ import org.slf4j.LoggerFactory
  * - If OPPONENT's permanent spell is on top and you have no responses: AUTO-PASS (auto-resolve)
  * - If OPPONENT's non-permanent spell or ability is on top: STOP (so you can see what they're doing)
  */
-class AutoPassManager {
+class AutoPassManager(
+    /**
+     * Used to resolve the actually-cast face of a split-layout spell on the stack (CR 709/715).
+     * A null registry disables that resolution and falls back to the base card's type line — fine
+     * for unit tests that only exercise single-face spells, but production must supply it so an
+     * Omen/Adventure instant face isn't mistaken for the permanent (creature) face.
+     */
+    private val cardRegistry: CardRegistry? = null
+) {
 
     private val logger = LoggerFactory.getLogger(AutoPassManager::class.java)
 
@@ -175,7 +184,7 @@ class AutoPassManager {
                 val container = state.getEntity(topOfStack)
                 val cardComponent = container?.get<CardComponent>()
                 val isPermanentSpell = container?.get<SpellOnStackComponent>()?.let {
-                    cardComponent?.isPermanent ?: false
+                    isPermanentSpell(cardComponent, it)
                 } ?: false
                 val isAura = cardComponent?.isAura ?: false
 
@@ -554,6 +563,24 @@ class AutoPassManager {
             // Must be a spell cast or activatable ability (not land play or combat action)
             action.isInstantSpeedResponse()
         }
+    }
+
+    /**
+     * Whether a spell on the stack is a permanent spell, respecting the actually-cast face.
+     *
+     * Split-layout cards (Omen, Adventure, MDFC — CR 709 / 715) keep their *base* characteristics
+     * (a creature) in [CardComponent] even when cast as their instant/sorcery face. Casting the
+     * instant/sorcery face stamps [SpellOnStackComponent.faceIndex]; resolving the type from that
+     * face (like [com.wingedsheep.engine.mechanics.stack.StackResolver] does) is what keeps the
+     * spell off the "permanent spell → auto-resolve" path, so the opponent still stops and sees it
+     * on the stack. Falls back to the base type line when there's no cast face or no registry.
+     */
+    private fun isPermanentSpell(cardComponent: CardComponent?, spell: SpellOnStackComponent): Boolean {
+        if (cardComponent == null) return false
+        val faceTypeLine = spell.faceIndex?.let { idx ->
+            cardRegistry?.getCard(cardComponent.name)?.cardFaces?.getOrNull(idx)?.typeLine
+        }
+        return faceTypeLine?.isPermanent ?: cardComponent.isPermanent
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -163,7 +163,7 @@ class GameSession(
 
     private val actionProcessor = ActionProcessor(services)
     private val gameInitializer = GameInitializer(cardRegistry, services.printingRegistry)
-    private val autoPassManager = AutoPassManager()
+    private val autoPassManager = AutoPassManager(cardRegistry)
     private val spectatorStateBuilder = SpectatorStateBuilder(cardRegistry, stateTransformer)
     private val decisionEnricher = DecisionEnricher(cardRegistry)
     private val legalActionEnumerator = LegalActionEnumerator(

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
@@ -10,6 +10,10 @@ import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardFace
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
@@ -30,7 +34,19 @@ import io.mockk.mockk
 /**
  * Type of stack item for test mocking.
  */
-enum class StackItemType { ABILITY, PERMANENT_SPELL, AURA_SPELL, INSTANT_SORCERY }
+enum class StackItemType {
+    ABILITY,
+    PERMANENT_SPELL,
+    AURA_SPELL,
+    INSTANT_SORCERY,
+    /**
+     * A split-layout card (Omen / Adventure / MDFC) cast as its instant/sorcery face. The base
+     * [CardComponent] still describes the permanent (creature) face — `isPermanent = true` — but the
+     * spell carries `faceIndex`, and the registry resolves that face to an instant. The auto-pass
+     * logic must treat it as a non-permanent spell and stop, not auto-resolve it like a creature.
+     */
+    OMEN_INSTANT_FACE
+}
 
 /**
  * Tests for the Arena-style AutoPassManager.
@@ -42,7 +58,10 @@ enum class StackItemType { ABILITY, PERMANENT_SPELL, AURA_SPELL, INSTANT_SORCERY
  * - Rule 4: Stack Response (Absolute Rule)
  */
 class AutoPassManagerTest : FunSpec({
-    val autoPassManager = AutoPassManager()
+    // Registry that resolves split-card faces; configured per-test inside createMockState only for
+    // the OMEN_INSTANT_FACE case. Relaxed so the unused getCard calls of other cases return null.
+    val cardRegistry = mockk<CardRegistry>(relaxed = true)
+    val autoPassManager = AutoPassManager(cardRegistry)
     val player1 = EntityId.generate()
     val player2 = EntityId.generate()
 
@@ -149,6 +168,31 @@ class AutoPassManagerTest : FunSpec({
                     )
                     val cardComponent = mockk<com.wingedsheep.engine.state.components.identity.CardComponent>(relaxed = true)
                     every { cardComponent.isPermanent } returns false
+                    every { stackEntity.get<com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent>() } returns null
+                    every { stackEntity.get<com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent>() } returns null
+                    every { stackEntity.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>() } returns spellComponent
+                    every { stackEntity.get<com.wingedsheep.engine.state.components.identity.CardComponent>() } returns cardComponent
+                }
+                StackItemType.OMEN_INSTANT_FACE -> {
+                    // Split card cast as its instant face: faceIndex set, base card is a permanent,
+                    // but the registry-resolved cast face is an instant (isPermanent = false).
+                    val spellComponent = com.wingedsheep.engine.state.components.stack.SpellOnStackComponent(
+                        casterId = controllerId,
+                        faceIndex = 0
+                    )
+                    val cardComponent = mockk<com.wingedsheep.engine.state.components.identity.CardComponent>(relaxed = true)
+                    every { cardComponent.name } returns "Dirgur Island Dragon"
+                    every { cardComponent.isPermanent } returns true   // base creature face
+                    every { cardComponent.isAura } returns false
+                    // Registry resolves cast face[0] to an instant so it is NOT a permanent spell.
+                    val instantFace = mockk<CardFace>(relaxed = true)
+                    val instantTypeLine = mockk<TypeLine>(relaxed = true)
+                    every { instantTypeLine.isPermanent } returns false
+                    every { instantTypeLine.isAura } returns false
+                    every { instantFace.typeLine } returns instantTypeLine
+                    val cardDef = mockk<CardDefinition>(relaxed = true)
+                    every { cardDef.cardFaces } returns listOf(instantFace)
+                    every { cardRegistry.getCard("Dirgur Island Dragon") } returns cardDef
                     every { stackEntity.get<com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent>() } returns null
                     every { stackEntity.get<com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent>() } returns null
                     every { stackEntity.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>() } returns spellComponent
@@ -728,6 +772,24 @@ class AutoPassManagerTest : FunSpec({
             )
 
             // Auras are targeting spells - always stop so opponent can see what's being targeted
+            autoPassManager.shouldAutoPass(state, player1, actions) shouldBe false
+        }
+
+        test("STOP when opponent's Omen/Adventure spell (instant face of a creature) is on stack with no responses") {
+            // player2 cast the instant/sorcery face of a split card (e.g. Dirgur Island Dragon //
+            // Skimming Strike). The base card is a creature, but the cast face is an instant — the
+            // opponent should STOP and see it on the stack, not auto-resolve it like a creature.
+            val state = createMockState(
+                player1, player1, Step.PRECOMBAT_MAIN,
+                stackEmpty = false, stackControllerId = player2,
+                stackItemType = StackItemType.OMEN_INSTANT_FACE
+            )
+            val actions = listOf(
+                passPriorityAction(player1),
+                manaAbilityAction(player1) // Only mana ability, not a response
+            )
+
+            // Cast face is non-permanent → always stop for opponent's instant/sorcery face.
             autoPassManager.shouldAutoPass(state, player1, actions) shouldBe false
         }
     }


### PR DESCRIPTION
## Problem

When a player casts a card that can be played either as a permanent **or** as an instant/sorcery and chooses the instant/sorcery side (Omen, Adventure, MDFC — e.g. **Dirgur Island Dragon // Skimming Strike**), the opponent's auto-pass kicks in and auto-resolves the spell without stopping. The opponent never gets to see the instant on the stack before it resolves. A normal instant/sorcery would stop them.

## Root cause

`AutoPassManager` (Rule 4 — Stack Response) decided whether an opponent's spell is a "permanent spell that can auto-resolve" by reading `CardComponent.isPermanent`. For a split-layout card that's the **base** characteristics — the creature face — even when the spell on the stack is the instant/sorcery face. So the Omen instant looked like a creature spell and got auto-passed.

The cast face is recorded on the stack as `SpellOnStackComponent.faceIndex` (CR 709/715). `StackResolver` already resolves the real type from that face; the auto-pass logic did not.

## Fix

- `AutoPassManager.isPermanentSpell(...)` now resolves the type from the actually-cast face: `faceIndex` → `CardDefinition.cardFaces[idx].typeLine.isPermanent`, mirroring `StackResolver`. Falls back to the base type line for single-face cards (`faceIndex == null`) so all existing behavior is unchanged.
- Inject `CardRegistry` into `AutoPassManager` (nullable; null disables face resolution, used by single-face unit tests) and wire the real registry through `GameSession`.

## Test

Adds an `OMEN_INSTANT_FACE` stack-item case to `AutoPassManagerTest`: an opponent's split card cast as its instant face, with the base card a creature, now **stops** the opponent even with no responses. Full `AutoPassManagerTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)