### PR TITLE
Add 4 cards to The Big Score

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LegionExtruder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LegionExtruder.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Legion Extruder
+ * {1}{R}
+ * Artifact
+ *
+ * When this artifact enters, it deals 2 damage to any target.
+ * {2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.
+ */
+val LegionExtruder = card("Legion Extruder") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, it deals 2 damage to any target.\n" +
+        "{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token."
+
+    // ETB: deals 2 damage to any target (creature, player, or planeswalker).
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    // {2}, {T}, Sacrifice another artifact: create a 3/3 colorless Golem artifact creature token.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        // artifactToken flag isn't exposed on the Effects.CreateToken facade, so the raw
+        // CreateTokenEffect constructor is used (allowed by FacadeBoundaryTest).
+        effect = CreateTokenEffect(
+            power = 3,
+            toughness = 3,
+            colors = setOf(),
+            creatureTypes = setOf("Golem"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1712318018"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "12"
+        artist = "Anton Solovianchyk"
+        flavorText = "When the vault door opened, ancient war machines rumbled to life."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1739804188"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LotusRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LotusRing.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Lotus Ring
+ * {3}
+ * Artifact — Equipment
+ *
+ * Indestructible
+ * Equipped creature gets +3/+3 and has vigilance and "{T}, Sacrifice this creature:
+ * Add three mana of any one color."
+ * Equip {3}
+ *
+ * The granted "Add three mana of any one color" ability is a mana ability (CR 605.1a):
+ * it has no target, isn't a loyalty ability, and could add mana — the {T} + sacrifice
+ * cost doesn't disqualify it. [Effects.AddAnyColorMana] picks a single color and produces
+ * three of it (one chosen color, not three independently-colored mana).
+ */
+val LotusRing = card("Lotus Ring") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Indestructible\nEquipped creature gets +3/+3 and has vigilance and " +
+        "\"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}"
+
+    // Indestructible on the Equipment itself.
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // Equipped creature gets +3/+3.
+    staticAbility {
+        ability = ModifyStats(+3, +3, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has vigilance.
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has "{T}, Sacrifice this creature: Add three mana of any one color."
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf),
+                effect = Effects.AddAnyColorMana(3),
+                isManaAbility = true,
+                descriptionOverride = "{T}, Sacrifice this creature: Add three mana of any one color."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "24"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg?1739804230"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/PestControl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/PestControl.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Pest Control
+ * {W}{B}
+ * Sorcery
+ *
+ * Destroy all nonland permanents with mana value 1 or less.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * A filtered board wipe: every nonland permanent whose mana value is 1 or less is
+ * destroyed. [Effects.DestroyAll] runs the projected-state-aware destroy pipeline, so
+ * the mana-value filter is evaluated against the current battlefield projection.
+ */
+val PestControl = card("Pest Control") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all nonland permanents with mana value 1 or less.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.NonlandPermanent.manaValueAtMost(1),
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "22"
+        artist = "Jonas De Ro"
+        flavorText = "\"How dare these varmints befoul the shining streets of Prosperity?\"\n" +
+            "—Baron Bertram Graywater"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg?1739804223"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SandstormSalvager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SandstormSalvager.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sandstorm Salvager — The Big Score #19
+ * {2}{G} · Creature — Human Artificer · Mythic
+ * 1/1
+ *
+ * When this creature enters, create a 3/3 colorless Golem artifact creature token.
+ * {2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample
+ * until end of turn.
+ *
+ * The activated ability iterates the projected battlefield via [Effects.ForEachInGroup]
+ * over "creature tokens you control" ([GameObjectFilter.Creature.youControl().token]) and
+ * places a +1/+1 counter on each, then grants trample (default end-of-turn duration) to that
+ * same set — so only the creature tokens it counters gain trample, per the oracle text.
+ */
+val SandstormSalvager = card("Sandstorm Salvager") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Artificer"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, create a 3/3 colorless Golem artifact creature token.\n" +
+        "{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample " +
+        "until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 3,
+            toughness = 3,
+            colors = emptySet(),
+            creatureTypes = setOf("Golem"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1712318018"
+        )
+        description = "When this creature enters, create a 3/3 colorless Golem artifact creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        description = "{2}, {T}: Put a +1/+1 counter on each creature token you control. They " +
+            "gain trample until end of turn."
+        val creatureTokensYouControl = GroupFilter(GameObjectFilter.Creature.youControl().token())
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                filter = creatureTokensYouControl,
+                effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            ),
+            Effects.ForEachInGroup(
+                filter = creatureTokensYouControl,
+                effect = GrantKeywordEffect(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "19"
+        artist = "Francis Tneh"
+        flavorText = "Mora didn't want friends, but she didn't mind having someone to watch her back."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg?1739804214"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -1,3 +1,315 @@
+// Legion Extruder
+{
+    "name": "Legion Extruder",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Golem"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1712318018",
+                    "artifactToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "MYTHIC",
+        "artist": "Anton Solovianchyk",
+        "flavorText": "When the vault door opened, ancient war machines rumbled to life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1739804188"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lotus Ring
+{
+    "name": "Lotus Ring",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            "CostTap",
+                            "CostSacrificeSelf"
+                        ]
+                    },
+                    "effect": {
+                        "type": "AddManaOfChoice",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "isManaAbility": true,
+                    "descriptionOverride": "{T}, Sacrifice this creature: Add three mana of any one color."
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "MYTHIC",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg?1739804230"
+    },
+    "colorIdentityOverride": []
+}
+
+// Pest Control
+{
+    "name": "Pest Control",
+    "manaCost": "{W}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "nonland permanent mv<=1"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "MYTHIC",
+        "artist": "Jonas De Ro",
+        "flavorText": "\"How dare these varmints befoul the shining streets of Prosperity?\"\n—Baron Bertram Graywater",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg?1739804223"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Sandstorm Salvager
+{
+    "name": "Sandstorm Salvager",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "When this creature enters, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Golem"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1712318018",
+                    "artifactToken": true
+                },
+                "descriptionOverride": "When this creature enters, create a 3/3 colorless Golem artifact creature token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature token ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature token ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "MYTHIC",
+        "artist": "Francis Tneh",
+        "flavorText": "Mora didn't want friends, but she didn't mind having someone to watch her back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg?1739804214"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Vaultborn Tyrant
 {
     "name": "Vaultborn Tyrant",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegionExtruderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegionExtruderScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.LegionExtruder
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Legion Extruder (BIG #12) — {1}{R} Artifact.
+ *
+ * "When this artifact enters, it deals 2 damage to any target.
+ *  {2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token."
+ *
+ * Covers the activated ability: paying {2}, tapping, and sacrificing *another* artifact yields a
+ * 3/3 colorless Golem artifact creature token. A single fodder artifact on the battlefield makes
+ * the sacrifice deterministic.
+ */
+class LegionExtruderScenarioTest : FunSpec({
+
+    val activateAbilityId = LegionExtruder.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    test("{2}, {T}, Sacrifice another artifact: create a 3/3 colorless Golem artifact creature token") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val extruder = driver.putPermanentOnBattlefield(player, "Legion Extruder")
+        driver.removeSummoningSickness(extruder)
+        // One other artifact to feed the "Sacrifice another artifact" cost.
+        val fodder = driver.putPermanentOnBattlefield(player, "Legion Extruder")
+        driver.removeSummoningSickness(fodder)
+        driver.giveMana(player, Color.RED, 2)
+
+        val before = artifactCreatureTokens(driver.state, player).toSet()
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = extruder, abilityId = activateAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val newTokens = artifactCreatureTokens(driver.state, player) - before
+        newTokens.size shouldBe 1
+
+        val token = newTokens.first()
+        val card = driver.state.getEntity(token)!!.get<CardComponent>()!!
+        card.typeLine.isArtifact shouldBe true
+        card.typeLine.isCreature shouldBe true
+        card.typeLine.subtypes.map { it.value } shouldBe listOf("Golem")
+        card.colors shouldBe emptySet()
+        projector.getProjectedPower(driver.state, token) shouldBe 3
+        projector.getProjectedToughness(driver.state, token) shouldBe 3
+
+        // The fodder artifact was sacrificed; the source remains, now tapped.
+        driver.state.getBattlefield().contains(fodder) shouldBe false
+    }
+})
+
+private fun artifactCreatureTokens(state: GameState, player: EntityId): List<EntityId> =
+    state.getBattlefield().filter {
+        val e = state.getEntity(it) ?: return@filter false
+        e.has<TokenComponent>() &&
+            e.get<ControllerComponent>()?.playerId == player &&
+            e.get<CardComponent>()?.typeLine?.isCreature == true
+    }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LotusRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LotusRingScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.LotusRing
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Lotus Ring — {3} Artifact — Equipment
+ *
+ * "Indestructible
+ *  Equipped creature gets +3/+3 and has vigilance and "{T}, Sacrifice this creature:
+ *  Add three mana of any one color."
+ *  Equip {3}"
+ *
+ * Pins the equipment wiring: the {3} equip attaches it, the static layer grants +3/+3 and
+ * vigilance to the equipped creature, the Equipment carries Indestructible itself, and the
+ * equipped creature gains the granted "{T}, Sacrifice this creature: Add three mana of any
+ * one color." activated mana ability.
+ */
+class LotusRingScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // The granted "{T}, Sacrifice this creature: Add three mana of any one color." ability.
+    val grantedAbilityId = LotusRing.staticAbilities
+        .filterIsInstance<GrantActivatedAbility>()
+        .first().ability.id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + LotusRing)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("equip {3} attaches, granting +3/+3, vigilance, and the sacrifice-for-mana ability") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        driver.removeSummoningSickness(courser)
+        val ring = driver.putPermanentOnBattlefield(you, "Lotus Ring")
+        val equipId = LotusRing.activatedAbilities.first().id
+
+        // Unequipped baseline: 3/3, no vigilance.
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+        projector.project(driver.state).hasKeyword(courser, Keyword.VIGILANCE) shouldBe false
+
+        // The Equipment itself has Indestructible.
+        projector.project(driver.state).hasKeyword(ring, Keyword.INDESTRUCTIBLE) shouldBe true
+
+        driver.giveColorlessMana(you, 3)
+        driver.submit(
+            ActivateAbility(you, ring, equipId, targets = listOf(ChosenTarget.Permanent(courser)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Attached to the chosen creature.
+        driver.state.getEntity(ring)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+        // +3/+3 and vigilance on the equipped creature.
+        projector.getProjectedPower(driver.state, courser) shouldBe 6
+        projector.getProjectedToughness(driver.state, courser) shouldBe 6
+        projector.project(driver.state).hasKeyword(courser, Keyword.VIGILANCE) shouldBe true
+
+        // The equipped creature gains the granted "{T}, Sacrifice this creature: Add three
+        // mana of any one color." mana ability. Activating it taps + sacrifices the creature
+        // and lets the controller pick one color, producing three of it.
+        val result = driver.submit(ActivateAbility(playerId = you, sourceId = courser, abilityId = grantedAbilityId))
+        result.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<ChooseColorDecision>()
+        val decision = driver.pendingDecision as ChooseColorDecision
+        driver.submitDecision(you, ColorChosenResponse(decision.id, Color.GREEN))
+
+        // Three green mana, and the creature was sacrificed to pay the cost.
+        driver.state.getEntity(you)?.get<ManaPoolComponent>()?.green shouldBe 3
+        driver.findPermanent(you, "Centaur Courser") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PestControlScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PestControlScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.PestControl
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Pest Control.
+ *
+ * Pest Control: {W}{B}
+ * Sorcery
+ * Destroy all nonland permanents with mana value 1 or less.
+ * Cycling {2}
+ *
+ * Verifies the filtered board wipe: only nonland permanents whose mana value is 1 or
+ * less are destroyed. Higher-mana-value permanents and lands survive.
+ */
+class PestControlScenarioTest : FunSpec({
+
+    // MV 1 — should be destroyed
+    val TinyBird = CardDefinition.creature(
+        name = "Tiny Bird",
+        manaCost = ManaCost.parse("{W}"),
+        subtypes = setOf(Subtype("Bird")),
+        power = 1,
+        toughness = 1
+    )
+
+    // MV 0 — should be destroyed
+    val FreeBlob = CardDefinition.creature(
+        name = "Free Blob",
+        manaCost = ManaCost.parse("{0}"),
+        subtypes = setOf(Subtype("Ooze")),
+        power = 0,
+        toughness = 1
+    )
+
+    // MV 3 — should survive
+    val BigBeast = CardDefinition.creature(
+        name = "Big Beast",
+        manaCost = ManaCost.parse("{2}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 3,
+        toughness = 3
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(PestControl, TinyBird, FreeBlob, BigBeast)
+        )
+        return driver
+    }
+
+    test("Pest Control destroys nonland permanents with mana value 1 or less and spares the rest") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // MV 1 and MV 0 nonland permanents — destroyed.
+        driver.putCreatureOnBattlefield(activePlayer, "Tiny Bird")
+        driver.putCreatureOnBattlefield(opponent, "Free Blob")
+        // MV 3 nonland permanent — survives.
+        driver.putCreatureOnBattlefield(opponent, "Big Beast")
+        // Land — never matches "nonland", survives.
+        val survivingLand = driver.putLandOnBattlefield(opponent, "Plains")
+
+        val pestControl = driver.putCardInHand(activePlayer, "Pest Control")
+        driver.giveMana(activePlayer, Color.WHITE, 1)
+        driver.giveMana(activePlayer, Color.BLACK, 1)
+
+        val result = driver.castSpell(activePlayer, pestControl)
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // MV <= 1 nonland permanents destroyed.
+        driver.findPermanent(activePlayer, "Tiny Bird") shouldBe null
+        driver.findPermanent(opponent, "Free Blob") shouldBe null
+
+        // MV 3 creature survives.
+        driver.findPermanent(opponent, "Big Beast") shouldNotBe null
+
+        // Land survives (it's a land, regardless of mana value).
+        driver.findPermanent(opponent, "Plains") shouldNotBe null
+        survivingLand shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandstormSalvagerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandstormSalvagerScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sandstorm Salvager (BIG #19) — {2}{G} Creature — Human Artificer (1/1).
+ *
+ * "When this creature enters, create a 3/3 colorless Golem artifact creature token.
+ *  {2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample
+ *  until end of turn."
+ *
+ * Verifies the activated ability: the +1/+1 counter and the (end-of-turn) trample grant land
+ * on every creature *token* you control and on nothing else — a non-token creature you control
+ * is untouched, even though it's a creature.
+ */
+class SandstormSalvagerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private val salvagerAbilityId =
+        cardRegistry.getCard("Sandstorm Salvager")!!.activatedAbilities.first().id
+
+    private fun plusOneCounters(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        // Two stand-in creatures we can drop onto the battlefield as tokens / non-tokens.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Golem",
+                manaCost = ManaCost.parse("{3}"),
+                subtypes = setOf(Subtype("Golem")),
+                power = 3,
+                toughness = 3
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Sandstorm Salvager activated ability") {
+
+            test("counters and trample land only on creature tokens you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sandstorm Salvager", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Golem", summoningSickness = false, isToken = true)
+                    .withCardOnBattlefield(1, "Test Bear", summoningSickness = false) // non-token creature
+                    .withLandsOnBattlefield(1, "Forest", 2) // pay {2}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tokenGolem = game.findPermanent("Test Golem")!!
+                val nonTokenBear = game.findPermanent("Test Bear")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Sandstorm Salvager")!!,
+                        abilityId = salvagerAbilityId,
+                    )
+                )
+                withClue("Activating Sandstorm Salvager should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+
+                withClue("The creature token gets a +1/+1 counter") {
+                    plusOneCounters(game, tokenGolem) shouldBe 1
+                }
+                withClue("The non-token creature gets no counter") {
+                    plusOneCounters(game, nonTokenBear) shouldBe 0
+                }
+                withClue("The creature token gains trample") {
+                    projected.hasKeyword(tokenGolem, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("The non-token creature does not gain trample") {
+                    projected.hasKeyword(nonTokenBear, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four new-to-**The Big Score** (BIG) mythics. Each card is original to BIG, so its canonical `CardDefinition` lives in the BIG set (no reprint/earlier-set handling). Everything composes from existing SDK primitives — **no new effects, keywords, triggers, conditions, or static abilities**, so no `card-sdk-language-reference.md` change is needed.

## Cards

| Card | Cost | Type | Implementation |
|------|------|------|----------------|
| **Pest Control** | `{W}{B}` | Sorcery | `Effects.DestroyAll` over `NonlandPermanent.manaValueAtMost(1)` + `KeywordAbility.cycling("{2}")` |
| **Legion Extruder** | `{1}{R}` | Artifact | ETB `DealDamage(2)` to any target; activated `{2},{T}, Sacrifice another artifact` → 3/3 colorless Golem artifact token |
| **Sandstorm Salvager** | `{2}{G}` | 1/1 Creature | ETB 3/3 Golem token; `{2},{T}` puts a +1/+1 counter on each creature token you control and grants them trample EOT (projection-aware `ForEachInGroup` over `Creature.youControl().token()`) |
| **Lotus Ring** | `{3}` | Equipment | Indestructible; equipped creature gets +3/+3, vigilance, and a granted mana ability `{T}, Sacrifice this creature: Add three mana of any one color`; Equip {3} |

## Testing

- Added scenario tests for all four cards (`rules-engine` Kotest) — all pass.
- `:mtg-sets:test` green, including `CardLintTest` and `CardDefinitionSnapshotTest`.
- Re-blessed the BIG card snapshot golden — diff is **purely additive** (312 insertions, 0 deletions; only the four new cards).
- BIG set status: 1/30 → 5/30 implemented.

All card metadata (mana cost, type, P/T, oracle text, collector number, artist, image URI) verified against Scryfall (`&set=big`); image URIs confirmed HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)