### PR TITLE
feat(sdk): CreateAdditionalToken token-creation replacement (Worldwalker Helm)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3762,6 +3762,12 @@ replacementEffect {
   attachment-type validation already happens at cast/attach time via `equipmentTarget` /
   `auraTarget`. Token copies are summoning-sick only when the copy is a creature (CR 302.6).
   Mirrormind Crown: `attachmentVerb = "equipped"`; Moonlit Meditation: `attachmentVerb = "enchanted"`.
+- `CreateAdditionalToken(additionalTokenType, additionalTokenCount = 1, inheritTapped = false, appliesTo)` —
+  token-creation replacement that keeps the original tokens and appends one or more predefined tokens of
+  another type. `appliesTo = EventPattern.TokenCreationEvent(controller, tokenFilter)` gates the original
+  creation event, and the extra tokens are added once per qualifying event, not once per token. The added
+  tokens bypass the same replacement pass so a Map added for an artifact-token event does not recursively
+  trigger itself. Used by Worldwalker Helm (`TokenCreationEvent(You, Artifact)`, add `Map`, `inheritTapped = true`).
 - `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
   "enter as a copy of …". As the permanent resolves, the controller picks an object matching
   `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -110,6 +110,47 @@ data class ModifyTokenCount(
     }
 }
 
+/**
+ * When a player would create one or more tokens matching [appliesTo], also create
+ * [additionalTokenCount] predefined token(s) of a *different* type ([additionalTokenType]).
+ *
+ * Models "If you would create one or more artifact tokens, instead create those tokens
+ * plus an additional Map token" (Worldwalker Helm). Unlike [ModifyTokenCount] (which adds
+ * more copies of the *same* token), this appends tokens of a named predefined type. The
+ * extra tokens are created once per qualifying creation event, regardless of how many
+ * tokens the original effect made.
+ *
+ * The [appliesTo] event's `controller` / `tokenFilter` gate which creations qualify
+ * (e.g. `TokenCreationEvent(controller = You, tokenFilter = GameObjectFilter.Artifact)`).
+ * Per the Worldwalker Helm ruling, the added token inherits the original effect's
+ * "tapped" rider when [inheritTapped] is set, but never the original tokens' abilities.
+ *
+ * @property additionalTokenType The predefined token to additionally create (e.g. "Map").
+ * @property additionalTokenCount How many of that token to add per qualifying event.
+ * @property inheritTapped When true, the added token enters tapped if the original
+ *           creation made tapped tokens.
+ */
+@SerialName("CreateAdditionalToken")
+@Serializable
+data class CreateAdditionalToken(
+    val additionalTokenType: String,
+    val additionalTokenCount: Int = 1,
+    val inheritTapped: Boolean = false,
+    override val appliesTo: EventPattern = EventPattern.TokenCreationEvent()
+) : ReplacementEffect {
+    override val description: String = buildString {
+        append("If ${appliesTo.description}, create those tokens plus ")
+        append(if (additionalTokenCount == 1) "an additional " else "$additionalTokenCount additional ")
+        append(additionalTokenType)
+        append(if (additionalTokenCount == 1) " token instead" else " tokens instead")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+    }
+}
+
 // =============================================================================
 // Counter Replacement Effects
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/GenerousPlunderer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/GenerousPlunderer.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Generous Plunderer
+ * {1}{R}
+ * Creature — Human Rogue
+ * 2/2
+ *
+ * Menace
+ * At the beginning of your upkeep, you may create a Treasure token. When you do,
+ * target opponent creates a tapped Treasure token.
+ * Whenever this creature attacks, it deals damage to defending player equal to
+ * the number of artifacts they control.
+ */
+val GenerousPlunderer = card("Generous Plunderer") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\n" +
+        "At the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\n" +
+        "Whenever this creature attacks, it deals damage to defending player equal to the number of artifacts they control."
+
+    keywords(Keyword.MENACE)
+
+    // "you may create a Treasure token. When you do, target opponent creates a tapped Treasure token."
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = ReflexiveTriggerEffect(
+            action = Effects.CreateTreasure(1),
+            optional = true,
+            reflexiveEffect = CreatePredefinedTokenEffect(
+                "Treasure",
+                controller = EffectTarget.ContextTarget(0),
+                tapped = true,
+            ),
+            reflexiveTargetRequirements = listOf(Targets.Opponent),
+        )
+    }
+
+    // "Whenever this creature attacks, it deals damage to defending player equal
+    // to the number of artifacts they control."
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.AggregateBattlefield(
+                Player.DefendingPlayer,
+                GameObjectFilter.Artifact,
+            ),
+            target = EffectTarget.PlayerRef(Player.DefendingPlayer),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "11"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg?1739804185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/HostileInvestigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/HostileInvestigator.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Hostile Investigator
+ * {3}{B}
+ * Creature — Ogre Rogue Detective
+ * 4/3
+ *
+ * When this creature enters, target opponent discards a card.
+ * Whenever one or more players discard one or more cards, investigate. This
+ * ability triggers only once each turn. (Create a Clue token. It's an artifact
+ * with "{2}, Sacrifice this token: Draw a card.")
+ */
+val HostileInvestigator = card("Hostile Investigator") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ogre Rogue Detective"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, target opponent discards a card.\n" +
+        "Whenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    // ETB: target opponent discards a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Patterns.Hand.discardCards(1, opponent)
+    }
+
+    // "Whenever one or more players discard one or more cards, investigate." The
+    // batch ("one or more") collapses to a single fire because oncePerTurn caps
+    // the ability at one Clue per turn regardless of how many discards happen.
+    triggeredAbility {
+        trigger = Triggers.discards(player = Player.Each)
+        effect = Effects.Investigate()
+        oncePerTurn = true
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "10"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg?1739804181"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/WorldwalkerHelm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/WorldwalkerHelm.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CreateAdditionalToken
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.events.ControllerFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Worldwalker Helm
+ * {2}{U}
+ * Artifact
+ *
+ * If you would create one or more artifact tokens, instead create those tokens
+ * plus an additional Map token. (It's an artifact with "{1}, {T}, Sacrifice this
+ * token: Target creature you control explores. Activate only as a sorcery.")
+ * {1}{U}, {T}: Create a token that's a copy of target artifact token you control.
+ */
+val WorldwalkerHelm = card("Worldwalker Helm") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. " +
+        "(It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")\n" +
+        "{1}{U}, {T}: Create a token that's a copy of target artifact token you control."
+
+    // "If you would create one or more artifact tokens, instead create those tokens
+    // plus an additional Map token." Per the ruling this applies to ALL artifact
+    // tokens you create (not just Map tokens) and adds one Map per creation event.
+    replacementEffect(
+        CreateAdditionalToken(
+            additionalTokenType = "Map",
+            additionalTokenCount = 1,
+            // Per the ruling, creation-effect properties (e.g. "tapped") apply to both the
+            // original tokens and the added Map.
+            inheritTapped = true,
+            appliesTo = EventPattern.TokenCreationEvent(
+                controller = ControllerFilter.You,
+                tokenFilter = GameObjectFilter.Artifact,
+            ),
+        )
+    )
+
+    // "{1}{U}, {T}: Create a token that's a copy of target artifact token you control."
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        val artifactToken = target(
+            "target artifact token you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.token().youControl())),
+        )
+        effect = Effects.CreateTokenCopyOfTarget(artifactToken)
+        timing = TimingRule.InstantSpeed
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "7"
+        artist = "Camille Alquier"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg?1739804167"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -1,3 +1,167 @@
+// Generous Plunderer
+{
+    "name": "Generous Plunderer",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever this creature attacks, it deals damage to defending player equal to the number of artifacts they control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Treasure"
+                    },
+                    "reflexiveEffect": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Treasure",
+                        "controller": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "tapped": true
+                    },
+                    "reflexiveTargetRequirements": [
+                        "TargetOpponent"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "DefendingPlayer",
+                        "filter": "artifact"
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "DefendingPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "MYTHIC",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg?1739804185"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Hostile Investigator
+{
+    "name": "Hostile Investigator",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Ogre Rogue Detective",
+    "oracleText": "When this creature enters, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "oncePerTurn": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "MYTHIC",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg?1739804181"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Legion Extruder
 {
     "name": "Legion Extruder",
@@ -382,5 +546,69 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Worldwalker Helm
+{
+    "name": "Worldwalker Helm",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact token you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact token ctrl:you"
+                        },
+                        "id": "target artifact token you control"
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "CreateAdditionalToken",
+                "additionalTokenType": "Map",
+                "inheritTapped": true,
+                "appliesTo": {
+                    "type": "TokenCreationEvent",
+                    "tokenFilter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "MYTHIC",
+        "artist": "Camille Alquier",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg?1739804167"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -329,16 +329,44 @@ class TriggerDetector(
         // decayed counter is declared as an attacker, it must be sacrificed at end of combat.
         detectDecayedCounterAttackTriggers(state, events, triggers)
 
-        // Filter out once-per-turn triggers that have already fired this turn
-        val filteredTriggers = triggers.filter { trigger ->
-            if (!trigger.ability.oncePerTurn) return@filter true
-            val entity = state.getEntity(trigger.sourceId)
-            val tracker = entity?.get<TriggeredAbilityFiredThisTurnComponent>()
-            tracker == null || !tracker.hasFired(trigger.ability.id)
-        }
+        // Filter out once-per-turn triggers that have already fired this turn, and dedupe
+        // simultaneous fires (see [capOncePerTurnTriggers]).
+        val filteredTriggers = capOncePerTurnTriggers(state, triggers)
 
         // Rule 603.4: Filter out triggers with unmet intervening-if conditions
         return matcher.sortByApnapOrder(state, matcher.filterByTriggerCondition(state, filteredTriggers))
+    }
+
+    /**
+     * Filter [triggers] for "this ability triggers only once each turn" (`oncePerTurn`) abilities.
+     *
+     * Two cuts, in order:
+     *  1. Drop any oncePerTurn trigger whose source has already fired that ability id this turn
+     *     (tracked by [TriggeredAbilityFiredThisTurnComponent], stamped on resolution).
+     *  2. Within this single detection pass, keep only the *first* trigger per
+     *     `(sourceId, abilityId)` for oncePerTurn abilities. The fired-this-turn tracker is only
+     *     written when a trigger resolves, so a single multi-subject event (e.g. a player
+     *     discarding two cards, which fires a per-card "whenever a player discards" trigger twice)
+     *     would otherwise queue two instances before either resolves and stamps the tracker. This
+     *     dedupe enforces the "only once each turn" cap for batch-style triggers — e.g. Hostile
+     *     Investigator investigating once even when several cards are discarded at once.
+     *
+     * Non-oncePerTurn triggers are never deduped (two lord bonuses, two prowess fires, etc. must
+     * all survive).
+     */
+    private fun capOncePerTurnTriggers(
+        state: GameState,
+        triggers: List<PendingTrigger>
+    ): List<PendingTrigger> {
+        val seenOncePerTurn = HashSet<Pair<EntityId, com.wingedsheep.sdk.scripting.AbilityId>>()
+        return triggers.filter { trigger ->
+            if (!trigger.ability.oncePerTurn) return@filter true
+            val entity = state.getEntity(trigger.sourceId)
+            val tracker = entity?.get<TriggeredAbilityFiredThisTurnComponent>()
+            if (tracker != null && tracker.hasFired(trigger.ability.id)) return@filter false
+            // Collapse simultaneous fires of the same ability from the same source.
+            seenOncePerTurn.add(trigger.sourceId to trigger.ability.id)
+        }
     }
 
     /**
@@ -511,13 +539,9 @@ class TriggerDetector(
         // abilities (e.g., Twinflame Travelers) — also applies to phase/step triggers.
         duplicateSourceTriggers(state, triggers)
 
-        // Filter out once-per-turn triggers that have already fired this turn
-        val filteredTriggers = triggers.filter { trigger ->
-            if (!trigger.ability.oncePerTurn) return@filter true
-            val entity = state.getEntity(trigger.sourceId)
-            val tracker = entity?.get<TriggeredAbilityFiredThisTurnComponent>()
-            tracker == null || !tracker.hasFired(trigger.ability.id)
-        }
+        // Filter out once-per-turn triggers that have already fired this turn, and dedupe
+        // simultaneous fires (see [capOncePerTurnTriggers]).
+        val filteredTriggers = capOncePerTurnTriggers(state, triggers)
 
         // Rule 603.4: Filter out triggers with unmet intervening-if conditions
         return matcher.sortByApnapOrder(state, matcher.filterByTriggerCondition(state, filteredTriggers))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -136,7 +136,18 @@ class CreatePredefinedTokenExecutor(
                 toZone = Zone.BATTLEFIELD,
                 ownerId = tokenControllerId
             )
-        }
+        }.toMutableList<com.wingedsheep.engine.core.GameEvent>()
+
+        // Apply "create those tokens plus an additional X token" replacements (Worldwalker
+        // Helm) once for this batch. Only the original tokens are matched against the filter,
+        // so the added token can't recursively re-trigger.
+        val (afterAdditional, additionalEvents) = TokenCreationReplacementHelper
+            .applyAdditionalTokenReplacements(
+                newState, tokenControllerId, createdTokenIds, effect.tapped,
+                cardRegistry, staticAbilityHandler
+            )
+        newState = afterAdditional
+        events.addAll(additionalEvents)
 
         // Publish the freshly-created token entity IDs to the pipeline so
         // sibling effects in a CompositeEffect can address them via

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -345,6 +345,16 @@ class CreateTokenExecutor(
             )
         }
 
+        // Apply "create those tokens plus an additional X token" replacements (Worldwalker
+        // Helm) once for this batch. Only the just-created tokens are matched against the
+        // filter, so an added artifact token can't recursively re-trigger.
+        val (afterAdditional, additionalEvents) = TokenCreationReplacementHelper
+            .applyAdditionalTokenReplacements(
+                newState, tokenControllerId, createdTokens, effect.tapped,
+                cardRegistry, staticAbilityHandler
+            )
+        newState = afterAdditional
+
         // Publish the freshly-created token entity IDs to the pipeline so sibling effects in a
         // CompositeEffect can address them via EffectTarget.PipelineTarget(CREATED_TOKENS, index).
         // Mirrors CreatePredefinedTokenExecutor — lets a composite grant keywords/counters to the
@@ -352,7 +362,7 @@ class CreateTokenExecutor(
         // haste until end of turn").
         return EffectResult(
             state = newState,
-            events = events + counterEvents,
+            events = events + counterEvents + additionalEvents,
             updatedCollections = mapOf(CREATED_TOKENS to createdTokens)
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -18,12 +18,17 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.battlefield.TokenReplacementOfferedThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CreateAdditionalToken
 import com.wingedsheep.sdk.scripting.DoubleTokenCreation
 import com.wingedsheep.sdk.scripting.EventPattern as SdkGameEvent
 import com.wingedsheep.sdk.scripting.ModifyTokenCount
@@ -103,6 +108,127 @@ object TokenCreationReplacementHelper {
         if (count <= 0) return 0
         repeat(doublings) { count = com.wingedsheep.engine.core.GameLimits.mulClamped(count, 2) }
         return count
+    }
+
+    /**
+     * Apply [CreateAdditionalToken] replacement effects after a batch of tokens has been
+     * created. Models Worldwalker Helm: "If you would create one or more artifact tokens,
+     * instead create those tokens plus an additional Map token."
+     *
+     * Called by the token-creation executors *after* they place their batch, passing the
+     * IDs of the tokens just created and the player who created them. For each battlefield
+     * permanent with a matching [CreateAdditionalToken] whose `appliesTo` controller filter
+     * matches and whose `tokenFilter` (if any) matches at least one of [createdTokenIds],
+     * the additional predefined tokens are created once.
+     *
+     * The additional tokens are placed directly (no further replacement check) so the added
+     * artifact Map token cannot recursively re-trigger the same effect — only the original
+     * [createdTokenIds] are considered for the filter match.
+     *
+     * @return the updated state plus the created additional-token events (empty if none applied).
+     */
+    fun applyAdditionalTokenReplacements(
+        state: GameState,
+        tokenControllerId: EntityId,
+        createdTokenIds: List<EntityId>,
+        originalTapped: Boolean,
+        cardRegistry: CardRegistry?,
+        staticAbilityHandler: StaticAbilityHandler?,
+        predicateEvaluator: PredicateEvaluator = PredicateEvaluator()
+    ): Pair<GameState, List<com.wingedsheep.engine.core.GameEvent>> {
+        if (createdTokenIds.isEmpty() || cardRegistry == null) return state to emptyList()
+
+        var newState = state
+        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val sourceController = state.projectedState.getController(entityId)
+                ?: container.get<ControllerComponent>()?.playerId
+                ?: continue
+            val repl = container.get<ReplacementEffectSourceComponent>() ?: continue
+            for (effect in repl.replacementEffects) {
+                if (effect !is CreateAdditionalToken) continue
+                val event = effect.appliesTo
+                if (event !is SdkGameEvent.TokenCreationEvent) continue
+
+                val controllerMatches = when (event.controller) {
+                    is ControllerFilter.You -> sourceController == tokenControllerId
+                    is ControllerFilter.Opponent -> sourceController != tokenControllerId
+                    is ControllerFilter.Any -> true
+                }
+                if (!controllerMatches) continue
+
+                // The replacement applies only if at least one of the just-created tokens
+                // matches the event's token filter (e.g. "artifact tokens"). A null filter
+                // means "any token". Match against base+projected state of the created tokens.
+                val filter = event.tokenFilter
+                val anyMatch = if (filter == null) {
+                    true
+                } else {
+                    createdTokenIds.any { tokenId ->
+                        predicateEvaluator.matches(
+                            state, state.projectedState, tokenId, filter,
+                            PredicateContext(controllerId = tokenControllerId)
+                        )
+                    }
+                }
+                if (!anyMatch) continue
+
+                val cardDef = cardRegistry.getCard(effect.additionalTokenType) ?: continue
+                val tapped = effect.inheritTapped && originalTapped
+
+                repeat(
+                    com.wingedsheep.engine.core.GameLimits.cappedTokenCount(
+                        effect.additionalTokenCount, "additional tokens"
+                    )
+                ) {
+                    val (tokenId, stateWithId) = newState.newEntity()
+                    newState = stateWithId
+
+                    val tokenComponent = CardComponent(
+                        cardDefinitionId = effect.additionalTokenType,
+                        name = effect.additionalTokenType,
+                        manaCost = ManaCost.ZERO,
+                        typeLine = cardDef.typeLine,
+                        baseStats = cardDef.creatureStats,
+                        baseKeywords = cardDef.keywords,
+                        colors = cardDef.colors,
+                        ownerId = tokenControllerId,
+                        imageUri = cardDef.metadata.imageUri
+                    )
+
+                    var tokenContainer = ComponentContainer.of(
+                        tokenComponent,
+                        TokenComponent,
+                        ControllerComponent(tokenControllerId),
+                        SummoningSicknessComponent,
+                        EnteredThisTurnComponent
+                    )
+                    if (tapped) tokenContainer = tokenContainer.with(TappedComponent)
+                    if (staticAbilityHandler != null) {
+                        tokenContainer = staticAbilityHandler.addContinuousEffectComponent(tokenContainer, cardDef)
+                        tokenContainer = staticAbilityHandler.addReplacementEffectComponent(tokenContainer, cardDef)
+                    }
+
+                    newState = newState.withEntity(tokenId, tokenContainer)
+                    newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
+                        .place(newState, tokenControllerId, tokenId)
+
+                    events.add(
+                        ZoneChangeEvent(
+                            entityId = tokenId,
+                            entityName = effect.additionalTokenType,
+                            fromZone = null,
+                            toZone = Zone.BATTLEFIELD,
+                            ownerId = tokenControllerId
+                        )
+                    )
+                }
+            }
+        }
+
+        return newState to events
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -842,7 +842,8 @@ class StaticAbilityHandler(
             // Token creation:
             is com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy,
             is com.wingedsheep.sdk.scripting.DoubleTokenCreation,
-            is com.wingedsheep.sdk.scripting.ModifyTokenCount -> true
+            is com.wingedsheep.sdk.scripting.ModifyTokenCount,
+            is com.wingedsheep.sdk.scripting.CreateAdditionalToken -> true
 
             // Entry-time replacements, consumed once as the permanent enters
             // (StackResolver / PlayLandHandler / ModalAndCloneContinuations):

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GenerousPlundererScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GenerousPlundererScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Generous Plunderer (BIG #11, {1}{R}, Creature — Human Rogue, 2/2).
+ *
+ *   Menace
+ *   At the beginning of your upkeep, you may create a Treasure token. When you do, target
+ *   opponent creates a tapped Treasure token.
+ *   Whenever this creature attacks, it deals damage to defending player equal to the number
+ *   of artifacts they control.
+ */
+class GenerousPlundererScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Generous Plunderer") {
+
+            test("upkeep: creating a Treasure gives a target opponent a tapped Treasure") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Generous Plunderer", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                // The "you may create a Treasure" upkeep trigger should be on the stack.
+                game.resolveStack()
+                // Accept the optional Treasure, then choose the opponent for the reflexive trigger.
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Player1 makes one Treasure, the opponent makes one") {
+                    treasures(game, 1) shouldBe 1
+                    treasures(game, 2) shouldBe 1
+                }
+            }
+
+            test("attack: deals damage equal to defending player's artifact count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Generous Plunderer", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Ornithopter")
+                    .withCardOnBattlefield(2, "Bottle Gnomes")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Generous Plunderer" to 2))
+                attack.error shouldBe null
+                game.resolveStack()
+
+                withClue("Defending player controls 2 artifacts → 2 damage from the attack trigger") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+        }
+    }
+
+    private fun treasures(game: TestGame, playerNumber: Int): Int {
+        val owner = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getBattlefield().count { id ->
+            val e = game.state.getEntity(id) ?: return@count false
+            e.get<CardComponent>()?.name == "Treasure" &&
+                e.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId == owner
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HostileInvestigatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HostileInvestigatorScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Hostile Investigator (BIG #10, {3}{B}, Creature — Ogre Rogue Detective, 4/3).
+ *
+ *   When this creature enters, target opponent discards a card.
+ *   Whenever one or more players discard one or more cards, investigate. This ability
+ *   triggers only once each turn. (Create a Clue token...)
+ *
+ * Casting the creature exercises both abilities at once: the ETB discard fires a discard
+ * event that the second ability sees, producing one Clue.
+ */
+class HostileInvestigatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hostile Investigator") {
+
+            test("ETB makes the opponent discard, which investigates once") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hostile Investigator")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Hostile Investigator")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // ETB targets the opponent; discard the opponent's only card.
+                if (game.hasPendingDecision()) {
+                    val bears = game.findCardsInHand(2, "Grizzly Bears")
+                    if (bears.isNotEmpty()) game.selectCards(bears) else game.resolveStack()
+                }
+                game.resolveStack()
+
+                withClue("Opponent discarded their only card") {
+                    game.handSize(2) shouldBe 0
+                }
+                withClue("The discard triggers investigate → exactly one Clue token") {
+                    clueTokens(game) shouldBe 1
+                }
+            }
+
+            test("investigate only fires once per turn even on multiple discards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hostile Investigator", summoningSickness = false)
+                    .withCardInHand(1, "Mind Rot")
+                    .withCardsInHand(2, "Grizzly Bears", 3)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Mind Rot: target player discards two cards (one discard event of >1 card).
+                val cast = game.castSpellTargetingPlayer(1, "Mind Rot", 2)
+                withClue("Mind Rot cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val bears = game.findCardsInHand(2, "Grizzly Bears").take(2)
+                    if (bears.isNotEmpty()) game.selectCards(bears)
+                }
+                game.resolveStack()
+
+                withClue("Two cards discarded in one batch → still only one Clue (once each turn)") {
+                    clueTokens(game) shouldBe 1
+                }
+            }
+        }
+    }
+
+    private fun clueTokens(game: TestGame): Int =
+        game.state.getBattlefield().count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Clue"
+        }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldwalkerHelmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldwalkerHelmScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+
+/**
+ * Scenario tests for Worldwalker Helm (BIG #7, {2}{U}, Artifact).
+ *
+ *   If you would create one or more artifact tokens, instead create those tokens plus an
+ *   additional Map token.
+ *   {1}{U}, {T}: Create a token that's a copy of target artifact token you control.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.CreateAdditionalToken] replacement
+ * effect: any artifact-token creation you control gets one extra Map token, and the Map
+ * itself (also an artifact token) must NOT recursively re-trigger the effect.
+ */
+class WorldwalkerHelmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Worldwalker Helm") {
+
+            test("creating a Treasure also makes one Map (no recursive re-trigger)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Worldwalker Helm")
+                    .withCardInHand(1, "Brazen Freebooter")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Brazen Freebooter's ETB creates one Treasure (an artifact token).
+                val cast = game.castSpell(1, "Brazen Freebooter")
+                withClue("Casting Brazen Freebooter should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.resolveStack()
+
+                withClue("Brazen Freebooter makes one Treasure token") {
+                    tokensNamed(game, "Treasure") shouldBe 1
+                }
+                withClue("The artifact-token creation triggers exactly ONE additional Map (Map doesn't recurse)") {
+                    tokensNamed(game, "Map") shouldBe 1
+                }
+            }
+
+            test("no Helm: a Treasure creation makes no Map") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Brazen Freebooter")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Brazen Freebooter")
+                cast.error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.resolveStack()
+
+                withClue("Without the Helm there is no Map token") {
+                    tokensNamed(game, "Treasure") shouldBe 1
+                    tokensNamed(game, "Map") shouldBe 0
+                }
+            }
+
+            test("copy ability duplicates a target artifact token you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Worldwalker Helm", summoningSickness = false)
+                    .withCardInHand(1, "Brazen Freebooter")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Make a Treasure (and Map, via the Helm) to have artifact tokens to copy.
+                game.castSpell(1, "Brazen Freebooter").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.resolveStack()
+
+                val artifactToken = game.state.getBattlefield().first { id ->
+                    val e = game.state.getEntity(id) ?: return@first false
+                    e.get<TokenComponent>() != null &&
+                        e.get<CardComponent>()?.name == "Treasure"
+                }
+                val before = tokensNamed(game, "Treasure") + tokensNamed(game, "Map")
+
+                val helm = game.findPermanent("Worldwalker Helm")!!
+                val copyAbility = cardRegistry.getCard("Worldwalker Helm")!!.script.activatedAbilities.first()
+                val act = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = helm,
+                        abilityId = copyAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(artifactToken)),
+                    )
+                )
+                withClue("Activating the copy ability should succeed: ${act.error}") { act.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.resolveStack()
+
+                withClue("Copying an artifact token adds at least one more artifact token") {
+                    (tokensNamed(game, "Treasure") + tokensNamed(game, "Map")) shouldBeGreaterThanOrEqual (before + 1)
+                }
+            }
+        }
+    }
+
+    private fun tokensNamed(game: TestGame, name: String): Int =
+        game.state.getBattlefield().count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+}


### PR DESCRIPTION
## Summary
Adds a new token-creation **replacement effect**, `CreateAdditionalToken`, plus three The Big Score (BIG) cards. Rescued from an abandoned agent worktree, rebased onto current `main`, and verified.

`CreateAdditionalToken(additionalTokenType, additionalTokenCount = 1, inheritTapped = false, appliesTo)` — when a player would create one or more tokens matching `appliesTo`, keep the original tokens and additionally create predefined token(s) of another type. Unlike `ModifyTokenCount` (more copies of the *same* token), this appends a *different* token. Extra tokens are added once per qualifying creation event (not once per token), and bypass the same replacement pass so e.g. a Map added for an artifact-token event does not recursively re-trigger itself.

## Cards
- **Worldwalker Helm** ({2}{U} Artifact) — *"If you would create one or more artifact tokens, instead create those tokens plus an additional Map token."* The feature's demonstrator (`TokenCreationEvent(You, Artifact)` → add `Map`, `inheritTapped = true`), plus its copy-a-token activated ability.
- **Generous Plunderer**, **Hostile Investigator** — two further BIG cards built on existing primitives (Treasure / Investigate), completed alongside.

## Layers touched
SDK type (`ReplacementEffect.kt`) → engine (`TriggerDetector`, `CreateTokenExecutor`, `CreatePredefinedTokenExecutor`, `TokenCreationReplacementHelper`, `StaticAbilityHandler`) → doc (`card-sdk-language-reference.md`) → BIG snapshot.

## Testing
- 7 scenario tests pass (Worldwalker Helm incl. no-recursive-retrigger + copy ability; Generous Plunderer; Hostile Investigator once-per-turn).
- `CardDefinitionSnapshotTest` (BIG re-blessed: only the 3 new cards added) and `CardLintTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)