### PR TITLE
feat(sdk): SuppressEntersTriggers static ability (Torpor Orb)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2384,6 +2384,14 @@ staticAbility {
 - `PreventActivatedAbilities(filter)` — activated abilities (mana + non-mana) of matching
   permanents can't be activated; loyalty abilities and animation costs that haven't yet
   produced a creature are unaffected. (Cursed Totem → `GameObjectFilter.Creature`)
+- `SuppressEntersTriggers(filter = GameObjectFilter.Creature)` — permanents matching `filter`
+  entering the battlefield don't cause abilities to trigger (CR 603.6 enters-the-battlefield
+  triggers). Suppresses both the entering permanent's *own* ETB triggers and any other permanent's
+  "whenever a [...] enters" trigger whose triggering object is that permanent — the gate is whether
+  the *entering object* matches `filter` in projected state (continuous effects apply), not what the
+  watching trigger names. Replacement effects (enters with counters/tapped) and `EntersWithChoice`
+  "as it enters" choices are unaffected (they aren't triggered abilities). Torpor Orb / Hushwing Gryff
+  → `SuppressEntersTriggers()`; Tocatli Honor Guard → `SuppressEntersTriggers(GameObjectFilter.Creature.youControl())`.
 - `PreventManaPoolEmptying` — mana pools don't empty between steps/phases. (Upwelling)
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -437,6 +437,49 @@ data class PreventActivatedAbilities(
 }
 
 /**
+ * Permanents matching [filter] entering the battlefield don't cause abilities to trigger
+ * (CR 603.6 enters-the-battlefield triggers are suppressed).
+ *
+ * Models the Torpor Orb family — Torpor Orb / Hushwing Gryff ("Creatures entering don't cause
+ * abilities to trigger.") with `filter = GameObjectFilter.Creature`, and Tocatli Honor Guard
+ * ("Creatures entering the battlefield under your control don't cause abilities to trigger") with
+ * `filter = GameObjectFilter.Creature.youControl()`.
+ *
+ * This suppresses **every** triggered ability that the matching permanent's entry would cause —
+ * the entering permanent's own enters-the-battlefield triggers *and* any other permanent's
+ * "whenever a [...] enters" trigger whose triggering object is that permanent (per Torpor Orb's
+ * Gatherer rulings). The gate is whether the *entering object* matches [filter] in projected state
+ * (continuous effects apply — e.g. with March of the Machines an artifact enters as a creature and
+ * is suppressed), not what the watching trigger's text names.
+ *
+ * Deliberately **not** affected, matching the rulings:
+ *  - Replacement effects (enters with counters, enters tapped) — those are not triggered abilities
+ *    and run through the replacement layer, which this never touches.
+ *  - "As [this] enters the battlefield" choices (`EntersWithChoice`) — not triggered abilities.
+ *  - Triggers caused by anything other than a matching permanent entering (leaves-the-battlefield
+ *    triggers, attack triggers, etc.).
+ *
+ * The engine evaluates this as a final filtering pass over the batch's pending triggers, so it
+ * covers the per-permanent ETB path, the "one or more permanents entered" batch path, and any
+ * duplicated (Panharmonicon-style) copies uniformly. Multiple copies are redundant.
+ *
+ * @property filter Which entering permanents have their entry suppressed (matched via projected
+ *   state). Defaults to [GameObjectFilter.Creature].
+ */
+@SerialName("SuppressEntersTriggers")
+@Serializable
+data class SuppressEntersTriggers(
+    val filter: GameObjectFilter = GameObjectFilter.Creature
+) : StaticAbility {
+    override val description: String =
+        "${filter.description} entering the battlefield don't cause abilities to trigger"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Prevents mana pools from emptying as steps and phases end.
  * Used for Upwelling: "Players don't lose unspent mana as steps and phases end."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TorporOrbReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TorporOrbReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Torpor Orb reprint in The Big Score (BIG).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in NPH's `cards/` package
+ * (the card's earliest real printing). This file contributes only the BIG presentation row.
+ */
+val TorporOrbReprint = Printing(
+    oracleId = "97326cad-b13c-4e52-82ce-850a39e5ff08",
+    name = "Torpor Orb",
+    setCode = "BIG",
+    collectorNumber = "27",
+    scryfallId = "dbf02a38-d10d-463e-ab99-e7fd848a1bd3",
+    artist = "Robin Olausson",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/dbf02a38-d10d-463e-ab99-e7fd848a1bd3.jpg?1770090426",
+    releaseDate = "2024-04-19",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/NewPhyrexiaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/NewPhyrexiaSet.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.nph
+
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * New Phyrexia Set (2011)
+ *
+ * Third and final set in the Scars of Mirrodin block. Phyrexia's victory over Mirrodin;
+ * introduces Phyrexian mana and the Living Weapon mechanic's continuation.
+ *
+ * Set Code: NPH
+ * Release Date: May 13, 2011
+ * Card Count: 175
+ */
+object NewPhyrexiaSet : MtgSet {
+
+    override val code = "NPH"
+    override val displayName = "New Phyrexia"
+    override val releaseDate = "2011-05-13"
+    override val block = "Scars of Mirrodin"
+    override val basicLandsFallback = PortalSet
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.nph.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/TorporOrb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/TorporOrb.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
+
+/**
+ * Torpor Orb
+ * {2}
+ * Artifact
+ * Creatures entering don't cause abilities to trigger.
+ *
+ * The [SuppressEntersTriggers] static (default `filter = Creature`): when a creature enters the
+ * battlefield, no triggered ability fires from that entry — neither the creature's own
+ * enters-the-battlefield triggers nor any other permanent's "whenever a [...] enters" trigger that
+ * the creature would cause. Replacement effects (enters with counters / tapped) and "as it enters"
+ * choices are unaffected, matching the printed rulings.
+ */
+val TorporOrb = card("Torpor Orb") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "Creatures entering don't cause abilities to trigger."
+
+    staticAbility {
+        ability = SuppressEntersTriggers()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "162"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Phyrexia is certainly dangerous, but I have to admire some of its innovations.\"\n—Tezzeret"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg?1722108794"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/NPH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NPH.json
@@ -1,0 +1,19 @@
+// Torpor Orb
+{
+    "name": "Torpor Orb",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Creatures entering don't cause abilities to trigger.",
+    "script": {
+        "staticAbilities": [
+            "SuppressEntersTriggers"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Phyrexia is certainly dangerous, but I have to admire some of its innovations.\"\n—Tezzeret",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg?1722108794"
+    }
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -182,4 +182,9 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // of any type that artifact token produced." A triggered mana ability; renders to the
     // AdditionalManaOnSourceTap mirror static (color = null), the same shape as Lavaleaper's land mirror.
     supported("WhenAPlayerTapsAPermanentForMana", "trigger: tap a permanent for mana → AdditionalManaOnSourceTap mirror static")
+
+    // Torpor Orb / Hushwing Gryff / Tocatli Honor Guard — "Creatures entering don't cause abilities to
+    // trigger." A continuous static that suppresses CR 603.6 enters-the-battlefield triggers caused by a
+    // matching permanent entering. Renders to the SuppressEntersTriggers static ability.
+    supported("PermanentsEnteringTheBattlefieldDontCauseAbilitiesToTrigger", "rule: matching permanents entering don't cause abilities to trigger (SuppressEntersTriggers)")
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -28,6 +28,8 @@ import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFired
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.RoomFaceId
 import com.wingedsheep.engine.state.components.identity.TokenComponent
@@ -328,6 +330,12 @@ class TriggerDetector(
         // Detect the Decayed counter's attack trigger (CR 702.147a): when a creature with a
         // decayed counter is declared as an attacker, it must be sacrificed at end of combat.
         detectDecayedCounterAttackTriggers(state, events, triggers)
+
+        // Torpor Orb family (SuppressEntersTriggers): remove every pending trigger that a
+        // matching permanent entering the battlefield caused (CR 603.6 enters-the-battlefield
+        // triggers). Runs after all ETB detection paths so it covers the per-permanent, "one or
+        // more permanents entered" batch, and duplicated (Panharmonicon) copies uniformly.
+        suppressEntersTriggers(state, events, triggers)
 
         // Filter out once-per-turn triggers that have already fired this turn, and dedupe
         // simultaneous fires (see [capOncePerTurnTriggers]).
@@ -638,6 +646,101 @@ class TriggerDetector(
                     triggerContext = TriggerContext(triggeringEntityId = attackerId)
                 )
             )
+        }
+    }
+
+    /**
+     * Torpor Orb family ([com.wingedsheep.sdk.scripting.SuppressEntersTriggers]): strip every
+     * pending trigger that a *matching permanent entering the battlefield* caused.
+     *
+     * Per Torpor Orb's Gatherer rulings this suppresses both the entering permanent's own
+     * enters-the-battlefield triggers and any other permanent's "whenever a [...] enters" trigger
+     * whose triggering object is that permanent — the gate is whether the entering object matches a
+     * [SuppressEntersTriggers.filter] in projected state (continuous effects apply), not what the
+     * watching trigger's text names. Replacement effects (enters with counters/tapped) and
+     * "as it enters" choices are untouched because they never become [PendingTrigger]s.
+     *
+     * Operates as a final filter over the already-detected batch, so it covers the per-permanent
+     * ETB path ([detectTriggersForEvent]), the "one or more permanents entered" batch path
+     * ([detectPermanentsEnteredBatchTriggers]), and the Panharmonicon-style duplicates uniformly.
+     */
+    private fun suppressEntersTriggers(
+        state: GameState,
+        events: List<EngineGameEvent>,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        if (triggers.isEmpty()) return
+
+        // Which permanents entered the battlefield in this batch.
+        val enteredIds = events.asSequence()
+            .filterIsInstance<ZoneChangeEvent>()
+            .filter { it.toZone == Zone.BATTLEFIELD }
+            .map { it.entityId }
+            .toSet()
+        if (enteredIds.isEmpty()) return
+
+        // Active suppressors (filter + the granting permanent's projected controller, which is the
+        // reference player for the filter's controller predicate so `youControl()` scopes correctly).
+        val projected = state.projectedState
+        data class Suppressor(val filter: GameObjectFilter, val controllerId: EntityId)
+        val suppressors = mutableListOf<Suppressor>()
+        for (permanentId in state.getBattlefield()) {
+            val container = state.getEntity(permanentId) ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val cardDef = container.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is SuppressEntersTriggers) {
+                    val controller = projected.getController(permanentId)
+                        ?: container.get<ControllerComponent>()?.playerId ?: continue
+                    suppressors.add(Suppressor(ability.filter, controller))
+                }
+            }
+        }
+        if (suppressors.isEmpty()) return
+
+        // An entered permanent whose entry is suppressed by at least one active suppressor.
+        val suppressionCache = HashMap<EntityId, Boolean>()
+        fun isSuppressed(entityId: EntityId): Boolean {
+            if (entityId !in enteredIds) return false
+            return suppressionCache.getOrPut(entityId) {
+                suppressors.any { s ->
+                    predicateEvaluator.matches(
+                        state, projected, entityId, s.filter,
+                        PredicateContext(controllerId = s.controllerId)
+                    )
+                }
+            }
+        }
+
+        // Whether an ability's trigger is an enters-the-battlefield shape (the only triggers an
+        // entry causes); leaves/attack/etc. triggers are never suppressed even if their context
+        // entity happens to have entered this batch.
+        fun isEntersTrigger(trigger: com.wingedsheep.sdk.scripting.EventPattern): Boolean = when (trigger) {
+            is com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent -> trigger.to == Zone.BATTLEFIELD
+            is com.wingedsheep.sdk.scripting.EventPattern.PermanentsEnteredEvent -> true
+            else -> false
+        }
+
+        val iterator = triggers.listIterator()
+        while (iterator.hasNext()) {
+            val trigger = iterator.next()
+            if (!isEntersTrigger(trigger.ability.trigger)) continue
+            val ctx = trigger.triggerContext
+            val captured = ctx.capturedEntityIds
+            if (captured != null) {
+                // Batch trigger: strip the suppressed entries; drop the whole trigger if none
+                // of the permanents that caused it survive.
+                val survivors = captured.filterNot { isSuppressed(it) }
+                when {
+                    survivors.isEmpty() -> iterator.remove()
+                    survivors.size != captured.size ->
+                        iterator.set(trigger.copy(triggerContext = ctx.copy(capturedEntityIds = survivors)))
+                }
+            } else {
+                val triggeringId = ctx.triggeringEntityId ?: trigger.sourceId
+                if (isSuppressed(triggeringId)) iterator.remove()
+            }
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -118,6 +118,7 @@ import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
 import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
 import com.wingedsheep.sdk.scripting.PreventCycling
+import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
 import com.wingedsheep.sdk.scripting.PreventManaPoolEmptying
 import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
 import com.wingedsheep.sdk.scripting.RestrictSpellsCastPerTurn
@@ -726,6 +727,10 @@ class StaticAbilityHandler(
             is GrantActivatedAbility,
             is PreventActivatedAbilities,
             is PreventCycling,
+
+            // Trigger detection (TriggerDetector.suppressEntersTriggers) — not a continuous
+            // projection effect; consulted as a final filter over the batch's pending triggers:
+            is SuppressEntersTriggers,
 
             // Turn-based actions (BeginningPhaseManager / CleanupPhaseManager):
             is NoMaximumHandSize,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TorporOrbScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TorporOrbScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Torpor Orb (New Phyrexia):
+ * "Creatures entering don't cause abilities to trigger."
+ *
+ * Pins the documented rulings:
+ *  - A creature's own enters-the-battlefield triggered ability is suppressed (Venerable Monk's
+ *    "gain 2 life" does not fire).
+ *  - Without Torpor Orb the same ETB trigger fires normally (control).
+ *  - Replacement effects are unaffected — a creature that enters with a +1/+1 counter
+ *    (District Mascot) still gets the counter.
+ */
+class TorporOrbScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Torpor Orb suppresses enters-the-battlefield triggers of creatures") {
+            test("Venerable Monk's ETB life gain does not fire while Torpor Orb is in play") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Torpor Orb")
+                    .withCardInHand(1, "Venerable Monk")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Venerable Monk")
+                withClue("Venerable Monk should be castable") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Venerable Monk should be on the battlefield") {
+                    (game.findPermanent("Venerable Monk") != null) shouldBe true
+                }
+                withClue("ETB life-gain must be suppressed by Torpor Orb") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("Without Torpor Orb, Venerable Monk's ETB life gain fires normally") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Venerable Monk")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Venerable Monk")
+                withClue("Venerable Monk should be castable") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("ETB life-gain should fire when no Torpor Orb is present") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+
+        context("Torpor Orb leaves replacement effects untouched") {
+            test("District Mascot still enters with its +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Torpor Orb")
+                    .withCardInHand(1, "District Mascot")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "District Mascot")
+                withClue("District Mascot should be castable") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val mascot = game.findPermanent("District Mascot")!!
+                val counters = game.state.getEntity(mascot)?.get<CountersComponent>()
+                withClue("Enters-with-counter is a replacement effect, unaffected by Torpor Orb") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds `SuppressEntersTriggers` — the Torpor Orb family static ability — plus Torpor Orb itself. Rescued from an abandoned agent worktree that had bundled it with `PreventActivatedAbilities` (which has since landed on `main` independently); this PR extracts **only** the unlanded `SuppressEntersTriggers` half, rebased onto current `main`.

`SuppressEntersTriggers(filter = GameObjectFilter.Creature)` — permanents matching `filter` entering the battlefield don't cause abilities to trigger (CR 603.6). It suppresses both the entering permanent's *own* ETB triggers and any other permanent's "whenever a [...] enters" trigger whose triggering object is that permanent. The gate is whether the *entering object* matches `filter` in projected state (continuous effects apply), not what the watching trigger names.

Deliberately **not** affected (matching the printed rulings): replacement effects (enters with counters/tapped), `EntersWithChoice` "as it enters" choices, and triggers caused by anything other than a matching entry.

## How it works
`TriggerDetector` runs `suppressEntersTriggers` as a final filter over the already-detected batch of pending triggers — after every ETB detection path — so it covers the per-permanent ETB path, the "one or more permanents entered" batch path, and Panharmonicon-style duplicate copies uniformly. Batch triggers have suppressed entries stripped (dropped entirely if none survive).

## Cards / sets
- **Torpor Orb** ({2} Artifact, *"Creatures entering don't cause abilities to trigger."*) — New Phyrexia canonical (seeds the new **NPH** set) + The Big Score (BIG) reprint `Printing` row.
- mtgish bridge: `PermanentsEnteringTheBattlefieldDontCauseAbilitiesToTrigger` → `SuppressEntersTriggers`.

## Layers touched
SDK type (`MiscStaticAbilities.kt`) → engine (`TriggerDetector` filter pass, `StaticAbilityHandler` classification) → mtgish bridge → doc (`card-sdk-language-reference.md`) → NPH snapshot.

## Testing
- 3 Torpor Orb scenario tests pass: ETB life-gain suppressed (Venerable Monk), control case without the Orb fires normally, and a replacement effect (District Mascot's +1/+1 counter) is left untouched.
- `:rules-engine` compiles (sealed-`when` classification handled), `CardDefinitionSnapshotTest` (new NPH golden) and `CardLintTest` pass, `:mtgish-tooling` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)