### PR TITLE
Add Simulacrum Synthesizer, Molten Duplication, Ancient Cornucopia (BIG)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -587,10 +587,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `CreateChosenTokenEffect`; under the hood it sets `CreateTokenEffect.colorsFromChoice` /
   `creatureTypesFromChoice`.)
 - `CreateTokenCopyOfSelf(count?, tapped?)` — token copies of source.
-- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?)` —
+- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?)` —
   token copy of another permanent (or a card in any zone — the executor copies the target's `CardComponent`,
   so a graveyard/exile card works). `overrideColors`/`overrideSubtypes` replace the copy's colors/subtypes
   outright for "a token that's a copy … except it's a 5/5 black Demon" wording (Ardyn, the Usurper).
+  `addCardTypes` (e.g. `setOf("ARTIFACT")`) *unions* extra card types onto the copy's type line for the
+  "except it's a [type] in addition to its other types" clause (the targeted sibling of
+  `CreateTokenCopyOfSource`'s `addCardTypes`; Molten Duplication).
   `attacking` only applies to copies whose printed type line is a creature (a copy of a non-creature card
   still enters tapped but never attacking). `sacrificeAtStep` schedules one delayed `SacrificeTargetEffect`
   per created copy at that step (the sacrifice sibling of `CreateTokenEffect.sacrificeAtStep`);

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1492,7 +1492,8 @@ object Effects {
         overrideColors: Set<com.wingedsheep.sdk.core.Color>? = null,
         overrideSubtypes: Set<com.wingedsheep.sdk.core.Subtype>? = null,
         sacrificeAtStep: com.wingedsheep.sdk.core.Step? = null,
-        sacrificeOnlyOnControllersTurn: Boolean = false
+        sacrificeOnlyOnControllersTurn: Boolean = false,
+        addCardTypes: Set<String> = emptySet()
     ): Effect = CreateTokenCopyOfTargetEffect(
         target = target,
         count = DynamicAmount.Fixed(count),
@@ -1507,7 +1508,8 @@ object Effects {
         overrideColors = overrideColors,
         overrideSubtypes = overrideSubtypes,
         sacrificeAtStep = sacrificeAtStep,
-        sacrificeOnlyOnControllersTurn = sacrificeOnlyOnControllersTurn
+        sacrificeOnlyOnControllersTurn = sacrificeOnlyOnControllersTurn,
+        addCardTypes = addCardTypes
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -368,7 +368,18 @@ data class CreateTokenCopyOfTargetEffect(
      * controller's turn — i.e. "at the beginning of *your* next end step" rather than the
      * very next end step of any player.
      */
-    val sacrificeOnlyOnControllersTurn: Boolean = false
+    val sacrificeOnlyOnControllersTurn: Boolean = false,
+    /**
+     * Extra card types to union onto the token's type line on top of the copied permanent's
+     * types. Use the [com.wingedsheep.sdk.core.CardType] `name` (e.g. `"ARTIFACT"`).
+     *
+     * Models the "except it's a [type] in addition to its other types" copy clause — the token
+     * has every type the copied permanent had, plus the listed types. The targeted sibling of
+     * [CreateTokenCopyOfSourceEffect.addCardTypes]. First used for Molten Duplication ("a copy of
+     * target artifact or creature you control, except it's an artifact in addition to its other
+     * types"); any future targeted copy-token effect with the same shape can reuse the field.
+     */
+    val addCardTypes: Set<String> = emptySet()
 ) : Effect {
     override val description: String = buildString {
         append("Create ${count.description} token copies of target permanent")
@@ -397,6 +408,14 @@ data class CreateTokenCopyOfTargetEffect(
             append(", except ${if (count == DynamicAmount.Fixed(1)) "it's" else "they're"} ${
                 addedSupertypes.joinToString(" ") { it.displayName.lowercase() }
             }")
+        }
+        if (addCardTypes.isNotEmpty()) {
+            val pronoun = if (count == DynamicAmount.Fixed(1)) "it's" else "they're"
+            val typeWords = addCardTypes.joinToString(" ") { it.lowercase() }
+            val article = if (count == DynamicAmount.Fixed(1)) {
+                if (typeWords.first() in "aeiou") "an " else "a "
+            } else ""
+            append(", except $pronoun $article$typeWords in addition to its other types")
         }
         if (addedKeywords.isNotEmpty()) {
             append(" with ${addedKeywords.joinToString(", ") { it.displayName.lowercase() }}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/AncientCornucopia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/AncientCornucopia.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Ancient Cornucopia
+ * {2}{G}
+ * Artifact
+ * Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that
+ * spell's colors. Do this only once each turn.
+ * {T}: Add one mana of any color.
+ */
+val AncientCornucopia = card("Ancient Cornucopia") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color."
+
+    // Whenever you cast a colored spell, you may gain 1 life per color. Once each turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsColored))
+        )
+        // "Do this only once each turn." — the ability triggers at most once per turn.
+        oncePerTurn = true
+        // "you may gain 1 life for each of that spell's colors" — resolution-time yes/no.
+        effect = MayEffect(Effects.GainLife(DynamicAmounts.colorCountOf(EntityReference.Triggering)))
+    }
+
+    // {T}: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "16"
+        artist = "Bartek Fedyczak"
+        flavorText = "\"I reckon that thing's trying to put me out of a job!\"\n—Bristly Bill, cactusfolk gardener"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1739804204"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/MoltenDuplication.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/MoltenDuplication.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Molten Duplication
+ * {1}{R}
+ * Sorcery
+ * Create a token that's a copy of target artifact or creature you control, except it's an
+ * artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at
+ * the beginning of the next end step.
+ */
+val MoltenDuplication = card("Molten Duplication") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step."
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.youControl()))
+        )
+        // Haste is granted as a permanent keyword on the copy; because the token is sacrificed
+        // at the next end step it never outlives "until end of turn" — same modeling Esika's
+        // Chariot / Mardu Siegebreaker use for haste copies.
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = t,
+            addCardTypes = setOf("ARTIFACT"),
+            addedKeywords = setOf(Keyword.HASTE),
+            sacrificeAtStep = Step.END
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "14"
+        artist = "Justyna Dura"
+        flavorText = "No one had seen this side of Angeline before, not even her."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1739804204"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SimulacrumSynthesizer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SimulacrumSynthesizer.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Simulacrum Synthesizer
+ * {2}{U}
+ * Artifact
+ * When this artifact enters, scry 2.
+ * Whenever another artifact you control with mana value 3 or greater enters, create a 0/0
+ * colorless Construct artifact creature token with "This token gets +1/+1 for each artifact
+ * you control."
+ */
+val SimulacrumSynthesizer = card("Simulacrum Synthesizer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, scry 2.\nWhenever another artifact you control with mana value 3 or greater enters, create a 0/0 colorless Construct artifact creature token with \"This token gets +1/+1 for each artifact you control.\""
+
+    // When this artifact enters, scry 2.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    // Whenever another artifact you control with mana value 3 or greater enters,
+    // create a 0/0 Construct token with "+1/+1 for each artifact you control".
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl().manaValueAtLeast(3),
+            binding = TriggerBinding.OTHER
+        )
+        effect = CreateTokenEffect(
+            power = 0,
+            toughness = 0,
+            colors = emptySet(),
+            creatureTypes = setOf("Construct"),
+            artifactToken = true,
+            staticAbilities = listOf(
+                GrantDynamicStatsEffect(
+                    filter = GroupFilter.source(),
+                    powerBonus = DynamicAmount.AggregateBattlefield(
+                        Player.You,
+                        GameObjectFilter.Artifact
+                    ),
+                    toughnessBonus = DynamicAmount.AggregateBattlefield(
+                        Player.You,
+                        GameObjectFilter.Artifact
+                    )
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg?1712317494"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "6"
+        artist = "Anton Solovianchyk"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1739804163"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -1,3 +1,58 @@
+// Ancient Cornucopia
+{
+    "name": "Ancient Cornucopia",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsColored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Triggering",
+                            "numericProperty": "ColorCount"
+                        }
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "MYTHIC",
+        "artist": "Bartek Fedyczak",
+        "flavorText": "\"I reckon that thing's trying to put me out of a job!\"\n—Bristly Bill, cactusfolk gardener",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1739804204"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Generous Plunderer
 {
     "name": "Generous Plunderer",
@@ -327,6 +382,49 @@
     "colorIdentityOverride": []
 }
 
+// Molten Duplication
+{
+    "name": "Molten Duplication",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "addedKeywords": [
+                "HASTE"
+            ],
+            "sacrificeAtStep": "END",
+            "addCardTypes": [
+                "ARTIFACT"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|artifact ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "MYTHIC",
+        "artist": "Justyna Dura",
+        "flavorText": "No one had seen this side of Angeline before, not even her.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1739804204"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pest Control
 {
     "name": "Pest Control",
@@ -471,6 +569,124 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Simulacrum Synthesizer
+{
+    "name": "Simulacrum Synthesizer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, scry 2.\nWhenever another artifact you control with mana value 3 or greater enters, create a 0/0 colorless Construct artifact creature token with \"This token gets +1/+1 for each artifact you control.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact mv>=3 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Construct"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg?1712317494",
+                    "artifactToken": true,
+                    "staticAbilities": [
+                        {
+                            "type": "GrantDynamicStats",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            },
+                            "powerBonus": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "artifact"
+                            },
+                            "toughnessBonus": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "MYTHIC",
+        "artist": "Anton Solovianchyk",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1739804163"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -1,3 +1,219 @@
+// Ancient Cornucopia
+{
+    "name": "Ancient Cornucopia",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsColored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Triggering",
+                            "numericProperty": "ColorCount"
+                        }
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "MYTHIC",
+        "artist": "Bartek Fedyczak",
+        "flavorText": "\"I reckon that thing's trying to put me out of a job!\"\n—Bristly Bill, cactusfolk gardener",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1739804204"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Molten Duplication
+{
+    "name": "Molten Duplication",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "addedKeywords": [
+                "HASTE"
+            ],
+            "sacrificeAtStep": "END",
+            "addCardTypes": [
+                "ARTIFACT"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|artifact ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "MYTHIC",
+        "artist": "Justyna Dura",
+        "flavorText": "No one had seen this side of Angeline before, not even her.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1739804204"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Simulacrum Synthesizer
+{
+    "name": "Simulacrum Synthesizer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, scry 2.\nWhenever another artifact you control with mana value 3 or greater enters, create a 0/0 colorless Construct artifact creature token with \"This token gets +1/+1 for each artifact you control.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact mv>=3 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Construct"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg?1712317494",
+                    "artifactToken": true,
+                    "staticAbilities": [
+                        {
+                            "type": "GrantDynamicStats",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            },
+                            "powerBonus": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "artifact"
+                            },
+                            "toughnessBonus": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "MYTHIC",
+        "artist": "Anton Solovianchyk",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1739804163"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vaultborn Tyrant
 {
     "name": "Vaultborn Tyrant",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.EntityId
@@ -83,7 +84,11 @@ class CreateTokenCopyOfTargetExecutor(
             val overrideStats = if (op != null && ot != null) {
                 CreatureStats(op, ot)
             } else null
+            val extraCardTypes = effect.addCardTypes
+                .mapNotNull { name -> runCatching { CardType.valueOf(name.uppercase()) }.getOrNull() }
+                .toSet()
             val tokenTypeLine = targetCard.typeLine.copy(
+                cardTypes = targetCard.typeLine.cardTypes + extraCardTypes,
                 supertypes = targetCard.typeLine.supertypes + effect.addedSupertypes - effect.removedSupertypes,
                 subtypes = effect.overrideSubtypes ?: targetCard.typeLine.subtypes
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientCornucopiaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientCornucopiaScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Ancient Cornucopia (BIG #16).
+ *
+ * Ancient Cornucopia — {2}{G} Artifact.
+ *   "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that
+ *    spell's colors. Do this only once each turn.
+ *    {T}: Add one mana of any color."
+ */
+class AncientCornucopiaScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A mono-green sorcery (1 color).
+        val monoSpell = card("Test Green Spell") {
+            manaCost = "{G}"; typeLine = "Sorcery"
+            spell { effect = Effects.DrawCards(0) }
+        }
+        // A two-color (Selesnya) sorcery (2 colors).
+        val goldSpell = card("Test Gold Spell") {
+            manaCost = "{G}{W}"; typeLine = "Sorcery"
+            spell { effect = Effects.DrawCards(0) }
+        }
+        // A colorless artifact spell (0 colors → never triggers).
+        val colorlessSpell = card("Test Colorless Spell") {
+            manaCost = "{1}"; typeLine = "Artifact"
+        }
+        cardRegistry.register(listOf(monoSpell, goldSpell, colorlessSpell))
+
+        test("casting a 1-color spell offers to gain 1 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ancient Cornucopia")
+                .withCardInHand(1, "Test Green Spell")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            val start = game.getLifeTotal(1)
+            game.castSpell(1, "Test Green Spell").error shouldBe null
+            game.resolveStack() // cast trigger goes on the stack; resolving it pauses at the "may"
+
+            val decision = game.getPendingDecision()
+            withClue("a 'you may gain life' yes/no is offered") {
+                (decision is YesNoDecision) shouldBe true
+            }
+            game.answerYesNo(true)
+            game.resolveStack()
+
+            withClue("gained 1 life for 1 color") {
+                game.getLifeTotal(1) shouldBe start + 1
+            }
+        }
+
+        test("a 2-color spell gains 2 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ancient Cornucopia")
+                .withCardInHand(1, "Test Gold Spell")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            val start = game.getLifeTotal(1)
+            game.castSpell(1, "Test Gold Spell").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(true)
+            game.resolveStack()
+
+            withClue("gained 2 life for 2 colors") {
+                game.getLifeTotal(1) shouldBe start + 2
+            }
+        }
+
+        test("declining the 'may' gains no life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ancient Cornucopia")
+                .withCardInHand(1, "Test Green Spell")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            val start = game.getLifeTotal(1)
+            game.castSpell(1, "Test Green Spell").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(false)
+            game.resolveStack()
+
+            withClue("declined → no life gained") {
+                game.getLifeTotal(1) shouldBe start
+            }
+        }
+
+        test("a colorless spell does not trigger") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ancient Cornucopia")
+                .withCardInHand(1, "Test Colorless Spell")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            val start = game.getLifeTotal(1)
+            game.castSpell(1, "Test Colorless Spell").error shouldBe null
+
+            withClue("no 'one or more colors' → no trigger, no decision") {
+                game.hasPendingDecision() shouldBe false
+            }
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe start
+        }
+
+        test("only triggers once each turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ancient Cornucopia")
+                .withCardInHand(1, "Test Green Spell")
+                .withCardInHand(1, "Test Gold Spell")
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withCardInLibrary(1, "Forest")
+                .build()
+
+            val start = game.getLifeTotal(1)
+            game.castSpell(1, "Test Green Spell").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(true)
+            game.resolveStack()
+            withClue("first cast this turn gained 1 life") {
+                game.getLifeTotal(1) shouldBe start + 1
+            }
+
+            // Second colored spell the same turn: the ability already triggered this turn.
+            game.castSpell(1, "Test Gold Spell").error shouldBe null
+            withClue("second colored spell the same turn does not trigger again") {
+                game.hasPendingDecision() shouldBe false
+            }
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe start + 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenDuplicationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenDuplicationScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContain
+
+/**
+ * Scenario tests for Molten Duplication (BIG #14).
+ *
+ * Molten Duplication — {1}{R} Sorcery.
+ *   "Create a token that's a copy of target artifact or creature you control, except it's an
+ *    artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at
+ *    the beginning of the next end step."
+ */
+class MoltenDuplicationScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        test("copies a creature you control as an artifact token with haste") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Molten Duplication")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardInLibrary(1, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bear = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Molten Duplication", bear).error shouldBe null
+            game.resolveStack()
+
+            val copies = game.findPermanents("Grizzly Bears")
+            withClue("original + token copy = 2 Grizzly Bears") {
+                copies.size shouldBe 2
+            }
+            val token = copies.first { it != bear }
+
+            val tokenCard = game.state.getEntity(token)!!.get<CardComponent>()!!
+            withClue("token is an artifact in addition to being a creature") {
+                tokenCard.typeLine.cardTypes shouldContain CardType.ARTIFACT
+                tokenCard.typeLine.cardTypes shouldContain CardType.CREATURE
+            }
+
+            withClue("token has haste") {
+                projector.hasProjectedKeyword(game.state, token, Keyword.HASTE) shouldBe true
+            }
+            val projected = projector.project(game.state)
+            withClue("token copies the 2/2 base stats") {
+                projected.getPower(token) shouldBe 2
+                projected.getToughness(token) shouldBe 2
+            }
+        }
+
+        test("the copy is sacrificed at the next end step") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Molten Duplication")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bear = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Molten Duplication", bear).error shouldBe null
+            game.resolveStack()
+            game.findPermanents("Grizzly Bears").size shouldBe 2
+
+            // Advance to the end step through real game flow; the delayed sacrifice fires there.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            withClue("the token copy is sacrificed at the beginning of the next end step") {
+                game.findPermanents("Grizzly Bears").size shouldBe 1
+            }
+            withClue("the original Grizzly Bears survives") {
+                game.findPermanent("Grizzly Bears") shouldBe bear
+            }
+        }
+
+        test("can copy an artifact you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Molten Duplication")
+                .withCardOnBattlefield(1, "Mind Stone")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardInLibrary(1, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findPermanent("Mind Stone")!!
+            game.castSpell(1, "Molten Duplication", ring).error shouldBe null
+            game.resolveStack()
+
+            withClue("a token copy of the artifact is created") {
+                game.findPermanents("Mind Stone").size shouldBe 2
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SimulacrumSynthesizerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SimulacrumSynthesizerScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Simulacrum Synthesizer (BIG #6).
+ *
+ * Simulacrum Synthesizer — {2}{U} Artifact.
+ *   "When this artifact enters, scry 2.
+ *    Whenever another artifact you control with mana value 3 or greater enters, create a 0/0
+ *    colorless Construct artifact creature token with 'This token gets +1/+1 for each artifact
+ *    you control.'"
+ */
+class SimulacrumSynthesizerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        // MV 3 colorless artifact — should trigger the Construct token.
+        val bigArtifact = card("Test MV3 Artifact") {
+            manaCost = "{3}"
+            typeLine = "Artifact"
+        }
+        // MV 2 colorless artifact — below threshold, should NOT trigger.
+        val smallArtifact = card("Test MV2 Artifact") {
+            manaCost = "{2}"
+            typeLine = "Artifact"
+        }
+        cardRegistry.register(listOf(bigArtifact, smallArtifact))
+
+        test("ETB scrys 2") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Simulacrum Synthesizer")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            game.castSpell(1, "Simulacrum Synthesizer").error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("scry 2 presents a selection over the top two cards") {
+                (decision is SelectCardsDecision) shouldBe true
+                (decision as SelectCardsDecision).options.size shouldBe 2
+            }
+            game.skipSelection() // keep both on top
+            game.resolveStack()
+
+            game.isOnBattlefield("Simulacrum Synthesizer") shouldBe true
+        }
+
+        test("an MV3+ artifact entering creates a 0/0 Construct token") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Simulacrum Synthesizer")
+                .withCardInHand(1, "Test MV3 Artifact")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            game.castSpell(1, "Test MV3 Artifact").error shouldBe null
+            game.resolveStack()
+
+            val tokens = game.findPermanents("Construct Token")
+            withClue("exactly one Construct token created") {
+                tokens.size shouldBe 1
+            }
+
+            // Artifacts controlled now: Synthesizer, Test MV3 Artifact, the Construct token
+            // itself = 3 → token gets +3/+3 on its 0/0 base.
+            val projected = projector.project(game.state)
+            withClue("token gets +1/+1 for each artifact you control (3 artifacts)") {
+                projected.getPower(tokens.single()) shouldBe 3
+                projected.getToughness(tokens.single()) shouldBe 3
+            }
+        }
+
+        test("an MV2 artifact entering does NOT create a token") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Simulacrum Synthesizer")
+                .withCardInHand(1, "Test MV2 Artifact")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            game.castSpell(1, "Test MV2 Artifact").error shouldBe null
+            game.resolveStack()
+
+            withClue("MV2 is below the 'mana value 3 or greater' threshold") {
+                game.findPermanents("Construct Token").size shouldBe 0
+            }
+        }
+
+        test("the Synthesizer entering does not trigger its own token clause (another artifact)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Simulacrum Synthesizer")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            game.castSpell(1, "Simulacrum Synthesizer").error shouldBe null
+            game.resolveStack()
+            if (game.hasPendingDecision()) game.skipSelection()
+            game.resolveStack()
+
+            withClue("'another artifact' excludes the Synthesizer itself") {
+                game.findPermanents("Construct Token").size shouldBe 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three artifact / token-maker cards from **The Big Score** (BIG), all canonical in BIG.

## Cards

- **Simulacrum Synthesizer** — `{2}{U}` Artifact. When it enters, scry 2. Whenever another artifact you control with mana value 3 or greater enters, create a 0/0 colorless Construct artifact creature token with "This token gets +1/+1 for each artifact you control." Composes `Triggers.entersBattlefield` (OTHER binding + `manaValueAtLeast(3)` filter) and `CreateTokenEffect` carrying a `GrantDynamicStatsEffect` static (same shape as Karn, Scion of Urza's token).
- **Molten Duplication** — `{1}{R}` Sorcery. Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types; it gains haste; sacrifice it at the beginning of the next end step. Reuses `CreateTokenCopyOfTargetEffect` (`sacrificeAtStep = Step.END`, `addedKeywords = HASTE`).
- **Ancient Cornucopia** — `{2}{G}` Artifact. Once each turn, you may gain 1 life for each color of a colored spell you cast; `{T}`: add one mana of any color. Uses `MayEffect` (the faithful no-target "you may" form) + `oncePerTurn` + `DynamicAmounts.colorCountOf(Triggering)` + `Effects.AddAnyColorMana` mana ability.

## SDK change

Added `addCardTypes` to `CreateTokenCopyOfTargetEffect` — the targeted sibling of `CreateTokenCopyOfSourceEffect.addCardTypes` — so a targeted token copy can gain extra card types ("except it's an artifact in addition to its other types"). Wired in the executor (unioned onto the copy's type line), the `Effects.CreateTokenCopyOfTarget` facade, and `docs/card-sdk-language-reference.md`.

## Tests

New scenario tests for all three cards (token creation, MV threshold, "another" exclusion, copy-as-artifact + haste + end-step sacrifice, color-count life gain, may-decline, once-each-turn, colorless-no-trigger). Full `rules-engine` suite, `mtg-sets` snapshot/lint, and `mtg-sdk` tests green. BIG card snapshot re-blessed (only the three new cards added).

## mtgish tooling

All three cards remain **SCAFFOLD** (emitter left unchanged — not widened). Their shapes are not faithfully renderable by the current emitter:
- Simulacrum's token is `[Artifact, Creature]` with an embedded continuous "+1/+1 for each artifact" P/T static (the `TokenWithPT` handler only renders plain creature tokens with bare/keyword abilities).
- Molten Duplication is a `TokenCopyOfPermanent` + `AddCardtypes` + an until-EOT haste layer effect + a delayed end-step sacrifice — the copy-token-with-riders shape is not handled.
- Ancient Cornucopia is a `TriggerMayOnceEachTurn` no-target "you may … once each turn" cast trigger; the engine drops `optional` on a no-target trigger (the faithful form is `MayEffect`), so an emitted `optional = true` card would silently always gain life.

Per the fidelity policy ("render correctly or decline to SCAFFOLD — never emit a lossy approximation"), these are left declined rather than mis-rendered. No emitter/bridge change. `EmitterGoldenTest` (all sets, incl. POR) and the deep `coverage-verify POR` gate (158/158) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)