### PR TITLE
Add Big Score equipment: Sword of Wealth and Power, Lost Jitte (+ protection-from-card-type)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2218,6 +2218,11 @@ staticAbility {
   among the permanents the source's controller controls, recomputed at projection (Layer 6, after
   Layer 5 colors) so it tracks the board in real time. Colorless permanents add no color. (Pledge of
   Loyalty)
+- `GrantProtectionFromCardType(cardType, filter = attachedCreature())` — "[filter] have protection from
+  [card type]s" (e.g. *protection from instants*, *protection from sorceries*). Projects the keyword
+  `PROTECTION_FROM_CARDTYPE_<TYPE>`; the engine enforces the *targeting* leg (a spell/permanent of that
+  card type can't target the creature), which is the only DEBT leg that matters for instants/sorceries.
+  Pair two of these for the two-type wording. (Sword of Wealth and Power)
 - `GrantHexproofFromMonocoloredToGroup(filter = attachedCreature())` — "[filter] have hexproof from
   monocolored" — adds the projected keyword `HEXPROOF_FROM_MONOCOLORED`, which blocks targeting by
   monocolored (exactly one color, CR 105.2) spells and abilities opponents control. Colorless and

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting
 
+import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.text.TextReplacer
@@ -20,6 +21,36 @@ data class GrantProtection(
     val filter: GroupFilter = GroupFilter.attachedCreature()
 ) : StaticAbility {
     override val description: String = "${filter.description} have protection from ${color.displayName.lowercase()}"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
+ * Grants protection from a card type (e.g. "from instants", "from sorceries") to a filtered set
+ * of creatures. Rule 702.16 protection-from-a-quality where the quality is a card type.
+ *
+ * Projected onto the affected creature(s) as the keyword `PROTECTION_FROM_CARDTYPE_<TYPE>`, mirroring
+ * the `PROTECTION_FROM_SUBTYPE_<X>` / `PROTECTION_FROM_SUPERTYPE_<X>` keyword conventions. The engine
+ * enforces the *targeting* leg of protection (a spell/permanent of that card type can't target the
+ * creature) — which is the only DEBT leg that matters for instants and sorceries, since they never
+ * deal combat damage to, block, or enchant a creature.
+ *
+ * Used by Sword of Wealth and Power ("Equipped creature ... has protection from instants and from
+ * sorceries.") — one such ability per card type. Pair two of these for the two-type wording.
+ *
+ * @property cardType The card type protection is from (e.g. [CardType.INSTANT]).
+ * @property filter What this applies to — defaults to the attached/equipped creature for Equipment.
+ */
+@SerialName("GrantProtectionFromCardType")
+@Serializable
+data class GrantProtectionFromCardType(
+    val cardType: CardType,
+    val filter: GroupFilter = GroupFilter.attachedCreature()
+) : StaticAbility {
+    override val description: String =
+        "${filter.description} have protection from ${cardType.displayName.lowercase()}s"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LostJitte.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LostJitte.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lost Jitte
+ * {1}
+ * Legendary Artifact — Equipment
+ *
+ * Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.
+ * Remove a charge counter from Lost Jitte: Choose one —
+ * • Untap target land.
+ * • Target creature can't block this turn.
+ * • Put a +1/+1 counter on equipped creature.
+ * Equip {1}
+ *
+ * A pared-down Umezawa's Jitte. The combat-damage trigger binds to the equipped creature
+ * ([TriggerBinding.ATTACHED]) and fires on any combat damage (player or creature,
+ * [RecipientFilter.Any]); it places a charge counter on the Equipment itself
+ * ([EffectTarget.Self]). The activated ability has no mana cost — only the
+ * remove-a-charge-counter cost — and resolves a [ModalEffect.chooseOne] over the three
+ * printed modes, two of which carry their own per-mode target.
+ */
+val LostJitte = card("Lost Jitte") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\n" +
+        "Remove a charge counter from Lost Jitte: Choose one —\n" +
+        "• Untap target land.\n" +
+        "• Target creature can't block this turn.\n" +
+        "• Put a +1/+1 counter on equipped creature.\n" +
+        "Equip {1}"
+
+    // Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.Any,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    // Remove a charge counter from Lost Jitte: Choose one —
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.CHARGE)
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.Untap(EffectTarget.ContextTarget(0)),
+                Targets.Land,
+                "Untap target land"
+            ),
+            Mode.withTarget(
+                Effects.CantBlock(EffectTarget.ContextTarget(0)),
+                Targets.Creature,
+                "Target creature can't block this turn"
+            ),
+            Mode.noTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.EquippedCreature),
+                "Put a +1/+1 counter on equipped creature"
+            ),
+            countsAsModalSpell = false
+        )
+        description = "Remove a charge counter from Lost Jitte: Choose one — Untap target land; Target creature can't block this turn; or Put a +1/+1 counter on equipped creature."
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "23"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg?1739804226"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SwordOfWealthAndPower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/SwordOfWealthAndPower.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantProtectionFromCardType
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Sword of Wealth and Power
+ * {3}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+2 and has protection from instants and from sorceries.
+ * Whenever equipped creature deals combat damage to a player, create a Treasure token. When you
+ * next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets
+ * for the copy.
+ * Equip {2}
+ *
+ * Protection from a card type is granted via [GrantProtectionFromCardType] (one per type), enforced
+ * at targeting by the engine. The combat-damage trigger binds to the equipped creature
+ * ([TriggerBinding.ATTACHED]); the "create a Treasure" half plus the "copy your next instant or
+ * sorcery" delayed trigger are the existing [Effects.CreateTreasure] and [Effects.CopyNextSpellCast]
+ * primitives (the latter defaults to instant-or-sorcery and lets you choose new targets).
+ */
+val SwordOfWealthAndPower = card("Sword of Wealth and Power") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\n" +
+        "Whenever equipped creature deals combat damage to a player, create a Treasure token. " +
+        "When you next cast an instant or sorcery spell this turn, copy that spell. You may " +
+        "choose new targets for the copy.\n" +
+        "Equip {2}"
+
+    // Equipped creature gets +2/+2 ...
+    staticAbility {
+        ability = ModifyStats(+2, +2, Filters.EquippedCreature)
+    }
+    // ... and has protection from instants and from sorceries.
+    staticAbility {
+        ability = GrantProtectionFromCardType(CardType.INSTANT, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantProtectionFromCardType(CardType.SORCERY, Filters.EquippedCreature)
+    }
+
+    // Whenever equipped creature deals combat damage to a player, create a Treasure token,
+    // then set up the "copy your next instant/sorcery this turn" delayed trigger.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.CreateTreasure(1),
+                Effects.CopyNextSpellCast()
+            )
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "26"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg?1770090444"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -298,6 +298,130 @@
     ]
 }
 
+// Lost Jitte
+{
+    "name": "Lost Jitte",
+    "manaCost": "{1}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one —\n• Untap target land.\n• Target creature can't block this turn.\n• Put a +1/+1 counter on equipped creature.\nEquip {1}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostRemoveCounterFromSelf",
+                    "counterType": "charge"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "tap": false
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "land"
+                                    }
+                                }
+                            ],
+                            "description": "Untap target land"
+                        },
+                        {
+                            "effect": {
+                                "type": "CantBlockTargetCreatures",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Target creature can't block this turn"
+                        },
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "EquippedCreature"
+                            },
+                            "description": "Put a +1/+1 counter on equipped creature"
+                        }
+                    ],
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "Remove a charge counter from Lost Jitte: Choose one — Untap target land; Target creature can't block this turn; or Put a +1/+1 counter on equipped creature."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "MYTHIC",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg?1739804226"
+    },
+    "colorIdentityOverride": []
+}
+
 // Lotus Ring
 {
     "name": "Lotus Ring",
@@ -688,6 +812,90 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Sword of Wealth and Power
+{
+    "name": "Sword of Wealth and Power",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        "CopyNextSpellCast"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantProtectionFromCardType",
+                "cardType": "INSTANT"
+            },
+            {
+                "type": "GrantProtectionFromCardType",
+                "cardType": "SORCERY"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "MYTHIC",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg?1770090444"
+    },
+    "colorIdentityOverride": []
 }
 
 // Vaultborn Tyrant

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -412,8 +412,18 @@ internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<Stmt>? {
                 // "Enchanted creature has protection from <color>": the Ward cycle uses a
                 // `ProtectionAndDoesntRemovePermanents` rule, the Crowns a plain `Protection` rule.
                 if (granted?.strField("_Rule") in setOf("Protection", "ProtectionAndDoesntRemovePermanents")) {
-                    val colors = protectionGrantColors(granted!!) ?: run { reasons.add("PermanentLayerEffect"); return null }
-                    colors.map { call("GrantProtection", arg("Color.$it")) }
+                    // "Protection from <color>" -> GrantProtection(Color.X); "protection from
+                    // <card type>(s)" (e.g. instants and sorceries — Sword of Wealth and Power) ->
+                    // one GrantProtectionFromCardType(CardType.X) per type. A protection scope we
+                    // can't render exactly (e.g. from a subtype, or "from everything") scaffolds.
+                    val colors = protectionGrantColors(granted!!)
+                    if (colors != null) {
+                        colors.map { call("GrantProtection", arg("Color.$it")) }
+                    } else {
+                        val cardTypes = protectionGrantCardTypes(granted)
+                            ?: run { reasons.add("PermanentLayerEffect"); return null }
+                        cardTypes.map { call("GrantProtectionFromCardType", arg("CardType.$it")) }
+                    }
                 } else if (granted?.strField("_Rule") == "Ward") {
                     // "Equipped/enchanted creature has ward {N}" (Lavaspur Boots) — render GrantWard carrying
                     // the cost, never a bare GrantKeyword(WARD) which would drop it. Only a mana ward cost
@@ -462,6 +472,23 @@ internal fun protectionGrantColors(granted: JsonObject): List<String>? {
     if (!jsonContains(granted, "_Protectable", "FromColor")) return null
     val colors = Regex(""""_Color":\s*"(\w+)"""").findAll(compact(granted)).map { it.groupValues[1].uppercase() }.toList()
     return colors.ifEmpty { null }
+}
+
+/** The card types of a host "protection from <card type>(s)" grant (`_Protectable` = `FromTypes`,
+ *  e.g. "protection from instants and from sorceries" — Sword of Wealth and Power), uppercased for
+ *  `CardType.X`; null when the scope isn't a card-type protection, which scaffolds. Only the card
+ *  types the SDK `CardType` enum names are recovered (a `_Cards`/`IsCardtype` whose value isn't one
+ *  of those returns null so the card scaffolds rather than emitting an invalid enum). */
+internal fun protectionGrantCardTypes(granted: JsonObject): List<String>? {
+    if (!jsonContains(granted, "_Protectable", "FromTypes")) return null
+    val known = setOf(
+        "ARTIFACT", "BATTLE", "CREATURE", "ENCHANTMENT", "INSTANT",
+        "LAND", "PLANESWALKER", "SORCERY", "KINDRED", "TRIBAL"
+    )
+    val types = Regex(""""_Cards"\s*:\s*"IsCardtype"\s*,\s*"args"\s*:\s*"(\w+)"""")
+        .findAll(compact(granted)).map { it.groupValues[1].uppercase() }.toList()
+    if (types.isEmpty() || types.any { it !in known }) return null
+    return types
 }
 
 /** The affected-group GroupFilter for a lord: chosen-creature-type variable -> the named helper,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -43,6 +43,7 @@ import com.wingedsheep.sdk.scripting.GrantCardType
 import com.wingedsheep.sdk.scripting.RemoveCardType
 import com.wingedsheep.sdk.scripting.GrantSupertype
 import com.wingedsheep.sdk.scripting.GrantProtectionFromChosenColorToGroup
+import com.wingedsheep.sdk.scripting.GrantProtectionFromCardType
 import com.wingedsheep.sdk.scripting.GrantProtectionFromControlledColors
 import com.wingedsheep.sdk.scripting.GrantHexproofFromOwnColorsToGroup
 import com.wingedsheep.sdk.scripting.GrantHexproofFromMonocoloredToGroup
@@ -423,6 +424,16 @@ class StaticAbilityHandler(
             is GrantProtectionFromControlledColors -> {
                 ContinuousEffectData(
                     modification = Modification.GrantProtectionFromControlledColors,
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is GrantProtectionFromCardType -> {
+                // Projected as the keyword PROTECTION_FROM_CARDTYPE_<TYPE>; enforced at targeting
+                // by TargetValidator.checkProtectionFromCardType.
+                ContinuousEffectData(
+                    modification = Modification.GrantKeyword(
+                        "PROTECTION_FROM_CARDTYPE_${ability.cardType.name}"
+                    ),
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -201,6 +201,11 @@ class TargetValidator {
         val protectionFromSupertypeError = checkProtectionFromSupertype(state, target, sourceId)
         if (protectionFromSupertypeError != null) return protectionFromSupertypeError
 
+        // Check protection from card type, e.g. "protection from instants and from sorceries"
+        // (Rule 702.16). Sword of Wealth and Power.
+        val protectionFromCardTypeError = checkProtectionFromCardType(state, target, sourceId)
+        if (protectionFromCardTypeError != null) return protectionFromCardTypeError
+
         // "Can't be enchanted" (CR 303.4): an Aura can't legally target a permanent with the
         // CANT_BE_ENCHANTED restriction (Guardian Beast). Only applies when the source is an Aura.
         val cantBeEnchantedError = checkCantBeEnchanted(state, target, sourceId)
@@ -257,6 +262,40 @@ class TargetValidator {
             if (projected.hasKeyword(entityId, "PROTECTION_FROM_SUPERTYPE_${supertype.uppercase()}")) {
                 val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
                 return "$cardName has protection from ${supertype.lowercase()} permanents"
+            }
+        }
+        return null
+    }
+
+    /**
+     * Check if a target has protection from one of the source's card types
+     * (e.g. "protection from instants and from sorceries"). Format:
+     * PROTECTION_FROM_CARDTYPE_<CARDTYPE>.
+     *
+     * The source's card types are read from its [CardComponent.typeLine] directly (not the
+     * projected state), because the source is typically an instant/sorcery spell on the stack —
+     * which the layer projector does not project. Card types of a spell aren't changed by
+     * continuous effects in the cases this guards, so the printed type line is authoritative here.
+     */
+    private fun checkProtectionFromCardType(
+        state: GameState,
+        target: ChosenTarget,
+        sourceId: EntityId?
+    ): String? {
+        if (sourceId == null) return null
+        val entityId = when (target) {
+            is ChosenTarget.Permanent -> target.entityId
+            else -> return null
+        }
+        if (entityId !in state.getBattlefield()) return null
+
+        val sourceCardTypes = state.getEntity(sourceId)
+            ?.get<CardComponent>()?.typeLine?.cardTypes ?: return null
+        val projected = state.projectedState
+        for (cardType in sourceCardTypes) {
+            if (projected.hasKeyword(entityId, "PROTECTION_FROM_CARDTYPE_${cardType.name}")) {
+                val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
+                return "$cardName has protection from ${cardType.displayName.lowercase()}s"
             }
         }
         return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LostJitteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LostJitteScenarioTest.kt
@@ -1,0 +1,175 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.LostJitte
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Lost Jitte — {1} Legendary Artifact — Equipment
+ *
+ * "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.
+ *  Remove a charge counter from Lost Jitte: Choose one —
+ *  • Untap target land.
+ *  • Target creature can't block this turn.
+ *  • Put a +1/+1 counter on equipped creature.
+ *  Equip {1}"
+ */
+class LostJitteScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c ->
+            c.with(AttachedToComponent(targetCreatureId))
+        }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun GameTestDriver.chargeCounters(equipmentId: EntityId): Int =
+        state.getEntity(equipmentId)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) ?: 0
+
+    fun GameTestDriver.setCharge(equipmentId: EntityId, count: Int) {
+        replaceState(state.updateEntity(equipmentId) { c ->
+            c.with(CountersComponent(mapOf(CounterType.CHARGE to count)))
+        })
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LostJitte))
+        return driver
+    }
+
+    test("equipped creature dealing combat damage to a player puts a charge counter on Lost Jitte") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val equipped = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(equipped)
+        val jitte = driver.putEquipmentAttached(attacker, "Lost Jitte", equipped)
+        driver.chargeCounters(jitte) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(equipped), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        // Advance through the combat-damage step so the trigger fires and resolves.
+        var safety = 0
+        while (driver.chargeCounters(jitte) == 0 && safety++ < 20) driver.bothPass()
+
+        driver.chargeCounters(jitte) shouldBe 1
+    }
+
+    test("remove a charge counter: put a +1/+1 counter on equipped creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        val jitte = driver.putEquipmentAttached(me, "Lost Jitte", equipped)
+        driver.setCharge(jitte, 1)
+
+        val abilityId = LostJitte.activatedAbilities[0].id
+        val result = driver.submit(
+            ActivateAbility(playerId = me, sourceId = jitte, abilityId = abilityId)
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass() // resolve → mode choice
+
+        // Choose "Put a +1/+1 counter on equipped creature" (mode 2)
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 2))
+
+        // The charge counter was removed as the cost, and the creature grew.
+        driver.chargeCounters(jitte) shouldBe 0
+        val projected = projector.project(driver.state)
+        projected.getPower(equipped) shouldBe 3
+        projected.getToughness(equipped) shouldBe 3
+    }
+
+    test("remove a charge counter: untap target land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val jitte = driver.putEquipmentAttached(me, "Lost Jitte", equipped)
+        driver.setCharge(jitte, 1)
+
+        val land = driver.putPermanentOnBattlefield(me, "Plains")
+        driver.replaceState(driver.state.updateEntity(land) { c ->
+            c.with(com.wingedsheep.engine.state.components.battlefield.TappedComponent)
+        })
+        driver.isTapped(land) shouldBe true
+
+        val abilityId = LostJitte.activatedAbilities[0].id
+        driver.submit(ActivateAbility(playerId = me, sourceId = jitte, abilityId = abilityId))
+        driver.bothPass() // resolve → mode choice
+
+        // Choose "Untap target land" (mode 0)
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 0))
+
+        // Per-mode target selection follows.
+        driver.submitTargetSelection(me, listOf(land))
+        driver.bothPass()
+
+        driver.isTapped(land) shouldBe false
+        driver.chargeCounters(jitte) shouldBe 0
+    }
+
+    test("ability can't be activated with no charge counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val jitte = driver.putEquipmentAttached(me, "Lost Jitte", equipped)
+        driver.chargeCounters(jitte) shouldBe 0
+
+        val abilityId = LostJitte.activatedAbilities[0].id
+        val result = driver.submit(
+            ActivateAbility(playerId = me, sourceId = jitte, abilityId = abilityId)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("Lost Jitte is legendary") {
+        LostJitte.typeLine.isLegendary shouldBe true
+        LostJitte.activatedAbilities.firstOrNull() shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SwordOfWealthAndPowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SwordOfWealthAndPowerScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.SwordOfWealthAndPower
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sword of Wealth and Power — {3} Artifact — Equipment
+ *
+ * "Equipped creature gets +2/+2 and has protection from instants and from sorceries.
+ *  Whenever equipped creature deals combat damage to a player, create a Treasure token. When you
+ *  next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets
+ *  for the copy.
+ *  Equip {2}"
+ */
+class SwordOfWealthAndPowerScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c ->
+            c.with(AttachedToComponent(targetCreatureId))
+        }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun GameTestDriver.countByName(playerId: EntityId, name: String): Int =
+        getPermanents(playerId).count { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SwordOfWealthAndPower, PredefinedTokens.Treasure))
+        return driver
+    }
+
+    test("equipped creature gets +2/+2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        driver.putEquipmentAttached(me, "Sword of Wealth and Power", creature)
+
+        val projected = projector.project(driver.state)
+        projected.getPower(creature) shouldBe 4
+        projected.getToughness(creature) shouldBe 4
+    }
+
+    test("equipped creature has protection from instants — can't be targeted by an instant") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putEquipmentAttached(me, "Sword of Wealth and Power", equipped)
+
+        driver.passPriority(me)
+
+        // Opponent's Lightning Bolt (instant) can't target the equipped creature.
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.giveMana(opp, Color.RED, 1)
+        val result = driver.castSpell(opp, bolt, listOf(equipped))
+        result.isSuccess shouldBe false
+    }
+
+    test("equipped creature has protection from sorceries — can't be targeted by a sorcery") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40, "Swamp" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putEquipmentAttached(me, "Sword of Wealth and Power", equipped)
+
+        driver.passPriority(me)
+
+        // Doom Blade is a sorcery in TestCards ("Destroy target creature.").
+        val doomBlade = driver.putCardInHand(opp, "Doom Blade")
+        driver.giveMana(opp, Color.BLACK, 2)
+        val result = driver.castSpell(opp, doomBlade, listOf(equipped))
+        result.isSuccess shouldBe false
+    }
+
+    test("an unequipped creature can still be targeted by an instant") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val equipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putEquipmentAttached(me, "Sword of Wealth and Power", equipped)
+        val unequipped = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriority(me)
+
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.giveMana(opp, Color.RED, 1)
+        val result = driver.castSpell(opp, bolt, listOf(unequipped))
+        result.isSuccess shouldBe true
+    }
+
+    test("dealing combat damage to a player creates a Treasure token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val equipped = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(equipped)
+        driver.putEquipmentAttached(attacker, "Sword of Wealth and Power", equipped)
+        driver.countByName(attacker, "Treasure") shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(equipped), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        var safety = 0
+        while (driver.countByName(attacker, "Treasure") == 0 && safety++ < 20) driver.bothPass()
+
+        driver.countByName(attacker, "Treasure") shouldBe 1
+    }
+})


### PR DESCRIPTION
Adds two Equipment cards from **The Big Score (BIG)** plus the SDK feature they need.

## Cards
- **Sword of Wealth and Power** — +2/+2; protection from instants and from sorceries; deals combat damage to a player → create a Treasure and copy your next instant/sorcery this turn.
- **Lost Jitte** — gains a charge counter when equipped creature deals combat damage; remove a charge counter for a modal effect (+1/+1 counter / untap target land / etc.).

## SDK / engine
- New `GrantProtectionFromCardType(cardType, filter)` static ability — projects the keyword `PROTECTION_FROM_CARDTYPE_<TYPE>` and enforces the targeting leg in `TargetValidator`. Documented in the SDK reference.
- mtgish emitter renders protection-from-card-type in the host static block.

## Note on rebase
This branch originally also included Worldwalker Helm and a `CreateAdditionalToken` replacement, but PR #827 landed both independently while this was in flight. The branch has been rebuilt on current `main`, dropping the now-duplicate Worldwalker Helm + `CreateAdditionalToken` and keeping only the unique work above.

## Tests
- `SwordOfWealthAndPowerScenarioTest` (5) and `LostJitteScenarioTest` (5) — all green.
- Card snapshot re-blessed (BIG.json: only the two new cards added); `CardLintTest` and `EmitterGoldenTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)