### PR TITLE
Add Ambitious Augmenter, Chelonian Tackle, Skycoach Conductor (SOS)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AmbitiousAugmenter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AmbitiousAugmenter.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.increment
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ambitious Augmenter
+ * {G}
+ * Creature — Turtle Wizard
+ * 1/1
+ *
+ * Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this
+ * creature's power or toughness, put a +1/+1 counter on this creature.)
+ * When this creature dies, if it had one or more counters on it, create a 0/0 green and blue
+ * Fractal creature token, then put this creature's counters on that token.
+ *
+ * `increment()` is the SOS ability-word keyword (no real keyword added). The dies trigger uses
+ * the intervening-if `Conditions.TriggeringEntityHadCounters` (CR 603.4 — reads the dying
+ * creature's last-known total counter count). The effect composes two atomic facades: create the
+ * 0/0 Fractal (published to the `CREATED_TOKENS` pipeline collection), then move *every* last-known
+ * counter kind from the dying creature onto that just-created token via
+ * `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)`. Because the creature only ever bears +1/+1
+ * counters from Increment, moving all last-known counters faithfully reproduces the printed wording.
+ */
+val AmbitiousAugmenter = card("Ambitious Augmenter") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Turtle Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Increment (Whenever you cast a spell, if the amount of mana you spent is greater " +
+        "than this creature's power or toughness, put a +1/+1 counter on this creature.)\n" +
+        "When this creature dies, if it had one or more counters on it, create a 0/0 green and blue " +
+        "Fractal creature token, then put this creature's counters on that token."
+
+    increment()
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerCondition = Conditions.TriggeringEntityHadCounters
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN, Color.BLUE),
+            creatureTypes = setOf("Fractal"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+        ).then(
+            Effects.MoveAllLastKnownCounters(EffectTarget.PipelineTarget(CREATED_TOKENS, 0))
+        )
+        description = "When this creature dies, if it had one or more counters on it, create a 0/0 " +
+            "green and blue Fractal creature token, then put this creature's counters on that token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "140"
+        artist = "Mariah Tekulve"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85629088-2007-4db5-9397-bac12a3d7498.jpg?1775937950"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ChelonianTackle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ChelonianTackle.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Chelonian Tackle
+ * {2}{G}
+ * Sorcery
+ *
+ * Target creature you control gets +0/+10 until end of turn. Then it fights up to one
+ * target creature an opponent controls. (Each deals damage equal to its power to the other.)
+ *
+ * Two targets, the second "up to one" (optional). The pump (`Effects.ModifyStats(0, 10,
+ * EndOfTurn)`) applies to the creature you control regardless of whether a fight target was
+ * chosen; the fight then reuses `Effects.Fight`, whose opponent target is optional — so if the
+ * second target is declined or becomes illegal, the creature is still pumped but no fight
+ * occurs. Mirrors Dragonclaw Strike's "pump then fights up to one" shape.
+ */
+val ChelonianTackle = card("Chelonian Tackle") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Target creature you control gets +0/+10 until end of turn. Then it fights up to " +
+        "one target creature an opponent controls. (Each deals damage equal to its power to the other.)"
+
+    spell {
+        val yourCreature = target(
+            "creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        val opponentCreature = target(
+            "creature an opponent controls",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = Effects.ModifyStats(0, 10, yourCreature)
+            .then(Effects.Fight(yourCreature, opponentCreature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "\"Scurrids to climb the tower, cervins to cross the stadium, and turtles to " +
+            "win the game.\"\n—Quandrix Mage Tower tactics"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a82a4d8c-4105-4923-85a2-ef58241f725c.jpg?1775937964"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SkycoachConductor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SkycoachConductor.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Skycoach Conductor // All Aboard — Secrets of Strixhaven #67
+ * {2}{U} · Creature — Bird Pilot · 2/3
+ *
+ * Flash
+ * Flying, vigilance
+ * This creature enters prepared. (While it's prepared, you may cast a copy of its spell.
+ * Doing so unprepares it.)
+ * //
+ * All Aboard — {U}, Instant: Exile target non-Pilot creature you control, then return that card to
+ * the battlefield under its owner's control.
+ *
+ * Prepare (Secrets of Strixhaven): the creature enters with the PREPARED keyword. Becoming prepared
+ * creates a copy of its prepare spell ("All Aboard") in exile that its controller may cast for {U};
+ * casting that copy unprepares the creature. Modeled via [com.wingedsheep.sdk.model.CardLayout.PREPARE]
+ * + the `prepare(name) { }` DSL.
+ *
+ * "All Aboard" is a self-blink: exile the chosen non-Pilot creature you control, then move that card
+ * back to the battlefield. Routing it through exile makes it a new object (CR 400.7), and a
+ * battlefield re-entry with no controllerOverride defaults to the owner — matching "return that card
+ * to the battlefield under its owner's control."
+ */
+val SkycoachConductor = card("Skycoach Conductor") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Pilot"
+    power = 2
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Flying, vigilance\n" +
+        "This creature enters prepared. (While it's prepared, you may cast a copy of its spell. " +
+        "Doing so unprepares it.)"
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.VIGILANCE)
+    keywords(Keyword.PREPARED)
+
+    // All Aboard — the prepare spell. Blink a non-Pilot creature you control.
+    prepare("All Aboard") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Exile target non-Pilot creature you control, then return that card to the " +
+            "battlefield under its owner's control."
+        spell {
+            val creature = target(
+                "non-Pilot creature you control",
+                TargetCreature(
+                    filter = TargetFilter(
+                        GameObjectFilter.Creature.notSubtype(Subtype("Pilot")).youControl()
+                    )
+                )
+            )
+            effect = Effects.Exile(creature)
+                .then(Effects.Move(creature, Zone.BATTLEFIELD))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "67"
+        artist = "Christina Kraus"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ecbca71-9a1d-44c5-b709-d6f565941d5e.jpg?1778165128"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -171,6 +171,117 @@
     ]
 }
 
+// Ambitious Augmenter
+{
+    "name": "Ambitious Augmenter",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Turtle Wizard",
+    "oracleText": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)\nWhen this creature dies, if it had one or more counters on it, create a 0/0 green and blue Fractal creature token, then put this creature's counters on that token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "INCREMENT"
+    ],
+    "keywordAbilities": [
+        "Increment"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "GREEN",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Fractal"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                        },
+                        {
+                            "type": "MoveAllLastKnownCounters",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": "TriggeringEntityHadCounters",
+                "descriptionOverride": "When this creature dies, if it had one or more counters on it, create a 0/0 green and blue Fractal creature token, then put this creature's counters on that token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "RARE",
+        "artist": "Mariah Tekulve",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85629088-2007-4db5-9397-bac12a3d7498.jpg?1775937950"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Arcane Omens
 {
     "name": "Arcane Omens",
@@ -988,6 +1099,74 @@
                 ]
             }
         }
+    ]
+}
+
+// Chelonian Tackle
+{
+    "name": "Chelonian Tackle",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature you control gets +0/+10 until end of turn. Then it fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 10
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                {
+                    "type": "Fight",
+                    "target1": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    },
+                    "target2": {
+                        "type": "BoundVariable",
+                        "name": "creature an opponent controls"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "\"Scurrids to climb the tower, cervins to cross the stadium, and turtles to win the game.\"\n—Quandrix Mage Tower tactics",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a82a4d8c-4105-4923-85a2-ef58241f725c.jpg?1775937964"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -8773,6 +8952,83 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Skycoach Conductor
+{
+    "name": "Skycoach Conductor",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Pilot",
+    "oracleText": "Flash\nFlying, vigilance\nThis creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "VIGILANCE",
+        "PREPARED"
+    ],
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "RARE",
+        "artist": "Christina Kraus",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ecbca71-9a1d-44c5-b709-d6f565941d5e.jpg?1778165128"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "All Aboard",
+            "manaCost": "{U}",
+            "typeLine": "Instant",
+            "oracleText": "Exile target non-Pilot creature you control, then return that card to the battlefield under its owner's control.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "non-Pilot creature you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "non-Pilot creature you control"
+                            },
+                            "destination": "Battlefield"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Pilot"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "non-Pilot creature you control"
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -14,6 +14,8 @@ internal fun BridgeBuilder.damageLifeAndCards() {
         tag = "DealDamage",
     )
     effect("SpellDealsDistributedDamage", "DividedDamage")
+    // "<creature> fights <creature>" (Savage Punch, Dragonclaw Strike, Chelonian Tackle) -> FightEffect.
+    effect("Fight", "Fight")
 
     // "where X is …" — mtgish binds the value with a CreateValueX action, then a later action spends
     // `ValueX`. Argentum has no separate "set X" step for a one-shot spell: the computed DynamicAmount

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -95,6 +95,19 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         call("DividedDamageEffect", arg("totalDamage", "$total"))
     }
 
+    on("Fight") { _, args, tvar ->
+        // "<creature> fights <creature>" (Savage Punch, Dragonclaw Strike, Chelonian Tackle's
+        // "Then it fights up to one target creature an opponent controls"). The IR carries two
+        // `_Permanent` refs — typically the two chosen targets of a multi-target spell. Resolve both
+        // to their bound-target locals and render `Effects.Fight(t1, t2)`. Decline (-> SCAFFOLD) if
+        // either ref can't be resolved exactly, so we never emit a fight against the wrong creature.
+        val refs = args.objects().mapNotNull { it.strField("_Permanent") }.toList()
+        if (refs.size != 2) return@on null
+        val t1 = refTargetFromRef(refs[0], tvar) ?: return@on null
+        val t2 = refTargetFromRef(refs[1], tvar) ?: return@on null
+        call("Effects.Fight", arg(Lit(t1)), arg(Lit(t2)))
+    }
+
     on("GainLifeForEach") { _, args, _ ->
         val dyn = dynamicAmountExpr(gainForEachAmount(args)) ?: return@on null
         call("GainLifeEffect", arg(dyn))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmbitiousAugmenterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmbitiousAugmenterScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Ambitious Augmenter (Secrets of Strixhaven #140).
+ *
+ * Ambitious Augmenter ({G}, 1/1, Turtle Wizard):
+ *   Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this
+ *     creature's power or toughness, put a +1/+1 counter on this creature.)
+ *   When this creature dies, if it had one or more counters on it, create a 0/0 green and blue
+ *     Fractal creature token, then put this creature's counters on that token.
+ *
+ * Exercises the composed dies trigger: create the 0/0 Fractal token, then move all of the dying
+ * creature's last-known counters onto that just-created token via PipelineTarget(CREATED_TOKENS, 0),
+ * gated by the `TriggeringEntityHadCounters` intervening-if.
+ */
+class AmbitiousAugmenterScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Ambitious Augmenter — Increment + dies-makes-Fractal-with-counters") {
+
+            test("dying with counters creates a Fractal token and moves the counters onto it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ambitious Augmenter")
+                    .withCardInHand(1, "Grizzly Bears") // {1}{G} = 2 mana spent > 1 P/T -> increment
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val augmenter = game.findPermanent("Ambitious Augmenter")!!
+
+                // Cast a 2-mana spell: 2 mana spent > power/toughness 1 -> Increment puts a +1/+1 counter.
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack() // Increment trigger
+                game.resolveStack() // Grizzly Bears
+
+                withClue("Increment placed one +1/+1 counter (2 mana > 1 P/T)") {
+                    plusOneCounters(game, augmenter) shouldBe 1
+                }
+
+                // Augmenter is now a 2/2 (1/1 + one +1/+1). A 3-damage bolt kills it.
+                // Casting the bolt itself fires an Increment trigger (no-op: 1 mana is not > 2),
+                // which must resolve before the bolt, which then kills the augmenter and queues the
+                // dies trigger. Resolve the whole chain.
+                game.castSpell(1, "Lightning Bolt", augmenter).error shouldBe null
+                game.resolveStack() // Increment trigger from casting the bolt (no counter)
+                game.resolveStack() // bolt resolves, augmenter dies, dies-trigger goes on stack
+                game.resolveStack() // dies trigger: create Fractal, then move counters onto it
+
+                withClue("Augmenter is in the graveyard") {
+                    game.findPermanent("Ambitious Augmenter") shouldBe null
+                }
+
+                val fractal = game.findPermanent("Fractal Token")
+                withClue("A Fractal token should have been created on death") {
+                    (fractal != null) shouldBe true
+                }
+                withClue("The dying creature's single +1/+1 counter moved onto the Fractal token") {
+                    plusOneCounters(game, fractal!!) shouldBe 1
+                }
+            }
+
+            test("dying with no counters does not create a Fractal token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ambitious Augmenter")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val augmenter = game.findPermanent("Ambitious Augmenter")!!
+
+                // The 1/1 has no counters; one bolt kills it. Intervening "if it had counters" is false.
+                game.castSpell(1, "Lightning Bolt", augmenter)
+                game.resolveStack()
+
+                withClue("Augmenter is dead") { game.findPermanent("Ambitious Augmenter") shouldBe null }
+                withClue("No counters -> no Fractal token created on death") {
+                    (game.findPermanent("Fractal Token") == null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChelonianTackleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChelonianTackleScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Chelonian Tackle (Secrets of Strixhaven #142).
+ *
+ * "{2}{G} Sorcery.
+ *  Target creature you control gets +0/+10 until end of turn. Then it fights up to one
+ *  target creature an opponent controls."
+ *
+ * Exercises the "pump (+0/+10) then fight up to one" composition: the toughness boost lets the
+ * creature survive a fight it would otherwise lose, and the opponent's creature is optional.
+ */
+class ChelonianTackleScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        // A 6/6 vanilla so the fight kills the opponent's creature and would kill the
+        // unbuffed 6/4 Craw Wurm too — proving the +0/+10 toughness boost is what saves it.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Brute",
+                manaCost = ManaCost.parse("{5}{G}"),
+                subtypes = setOf(Subtype("Beast")),
+                power = 6,
+                toughness = 6
+            )
+        )
+
+        context("Chelonian Tackle") {
+
+            test("+0/+10 lets your creature survive the fight while killing the opponent's") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Chelonian Tackle")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")     // 6/4 -> +0/+10 -> 6/14
+                    .withCardOnBattlefield(2, "Test Brute")    // 6/6 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Craw Wurm")!!
+                val victim = game.findPermanent("Test Brute")!!
+                val cardId = game.findCardsInHand(1, "Chelonian Tackle").first()
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(victim))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Your Craw Wurm is buffed to 6/14") {
+                    stateProjector.getProjectedToughness(game.state, mine) shouldBe 14
+                }
+                withClue("Opponent's 6/6 Test Brute takes 6 damage and dies") {
+                    game.isOnBattlefield("Test Brute") shouldBe false
+                }
+                withClue("Your Craw Wurm (now 6/14) takes 6 damage and survives") {
+                    game.isOnBattlefield("Craw Wurm") shouldBe true
+                }
+            }
+
+            test("with no opponent creature targeted, the spell only pumps (fight has no second target)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Chelonian Tackle")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm") // 6/4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Craw Wurm")!!
+                val cardId = game.findCardsInHand(1, "Chelonian Tackle").first()
+
+                val cast = game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(mine)))
+                )
+                withClue("Cast with no opponent creature should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Your Craw Wurm is buffed to 6/14 and survives (no fight)") {
+                    stateProjector.getProjectedToughness(game.state, mine) shouldBe 14
+                    game.isOnBattlefield("Craw Wurm") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkycoachConductorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkycoachConductorScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Skycoach Conductor // All Aboard (Secrets of Strixhaven #67).
+ *
+ * "{2}{U} Creature — Bird Pilot 2/3. Flash. Flying, vigilance. This creature enters prepared.
+ *  // All Aboard — {U} Instant: Exile target non-Pilot creature you control, then return that card
+ *  to the battlefield under its owner's control."
+ *
+ * Exercises the PREPARED enters-prepared keyword + the prepare spell's self-blink. The blink routes
+ * the target through exile (a new object, CR 400.7) and returns it under its owner's control;
+ * casting the copy unprepares the Conductor.
+ */
+class SkycoachConductorScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.findExileCopy(playerNumber: Int, name: String): com.wingedsheep.sdk.model.EntityId? {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).firstOrNull { id ->
+            val e = state.getEntity(id)
+            e?.get<CardComponent>()?.name == name && e.get<PreparedSpellCopyComponent>() != null
+        }
+    }
+
+    init {
+        context("Skycoach Conductor // All Aboard") {
+
+            test("enters prepared with a prepare-spell copy in exile") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skycoach Conductor")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skycoach Conductor")
+                game.resolveStack()
+
+                val conductor = game.findPermanent("Skycoach Conductor")!!
+                withClue("Skycoach Conductor enters prepared") {
+                    game.state.getEntity(conductor)?.get<PreparedComponent>() shouldNotBe null
+                }
+                withClue("A prepare-spell copy ('All Aboard') exists in exile") {
+                    game.findExileCopy(1, "Skycoach Conductor") shouldNotBe null
+                }
+            }
+
+            test("casting All Aboard blinks a non-Pilot creature and unprepares the Conductor") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skycoach Conductor")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skycoach Conductor")
+                game.resolveStack()
+
+                val conductor = game.findPermanent("Skycoach Conductor")!!
+                val bearsBefore = game.findPermanent("Grizzly Bears")!!
+                val copyId = game.findExileCopy(1, "Skycoach Conductor")!!
+
+                // Cast the prepare spell (face 0) targeting Grizzly Bears (non-Pilot, you control).
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        copyId,
+                        targets = listOf(ChosenTarget.Permanent(bearsBefore)),
+                        faceIndex = 0
+                    )
+                )
+                withClue("Casting All Aboard should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val inExile = game.state.getExile(game.player1Id).any {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                withClue("Grizzly Bears was blinked and is back on the battlefield, not stranded in exile (inExile=$inExile)") {
+                    inExile shouldBe false
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Skycoach Conductor is no longer prepared after casting the copy") {
+                    game.state.getEntity(conductor)?.get<PreparedComponent>() shouldBe null
+                }
+                withClue("The prepare-spell copy is gone from exile") {
+                    game.findExileCopy(1, "Skycoach Conductor") shouldBe null
+                }
+            }
+
+            test("cannot blink a Pilot creature (the Conductor itself is an illegal target)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skycoach Conductor")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skycoach Conductor")
+                game.resolveStack()
+
+                val conductor = game.findPermanent("Skycoach Conductor")!!
+                val copyId = game.findExileCopy(1, "Skycoach Conductor")!!
+
+                // Skycoach Conductor is a Bird Pilot, so the "non-Pilot" filter must reject it.
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        copyId,
+                        targets = listOf(ChosenTarget.Permanent(conductor)),
+                        faceIndex = 0
+                    )
+                )
+                withClue("Targeting the Pilot Conductor should be illegal") {
+                    cast.error shouldNotBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards (Secrets of Strixhaven)

Three SOS cards, all composed from existing SDK facades — no new SDK surface:

- Ambitious Augmenter ({G}, 1/1 Turtle Wizard) — increment() + a dies trigger gated by the intervening-if Conditions.TriggeringEntityHadCounters that creates a 0/0 green-and-blue Fractal token, then moves the dying creature's last-known counters onto that just-created token via MoveAllLastKnownCounters(PipelineTarget(CREATED_TOKENS, 0)).
- Chelonian Tackle ({2}{G} Sorcery) — ModifyStats(0, 10) on target creature you control, then Effects.Fight against an optional ("up to one") opponent creature. Mirrors Dragonclaw Strike's pump-then-fight-up-to-one shape.
- Skycoach Conductor // All Aboard ({2}{U}, 2/3 Bird Pilot) — Flash, Flying, Vigilance, enters Prepared; the prepare spell "All Aboard" blinks a non-Pilot creature you control (Exile then Move to battlefield, returning under its owner's control).

Each card has a passing rules-engine scenario test (AmbitiousAugmenterScenarioTest, ChelonianTackleScenarioTest, SkycoachConductorScenarioTest), covering the happy path and edge cases (no-counter dies = no token; optional fight with no second target; can't blink a Pilot).

## mtgish auto-generator

Taught the generator the Fight effect, which previously had no emitter handler at all:
- Emitter (DamageDrawLifeHandlers.kt): new on("Fight") handler rendering Effects.Fight(t1, t2), resolving both multi-target permanent refs (declines if either can't resolve exactly).
- Bridge (DamageLifeAndCards.kt): effect("Fight", "Fight") so the probe scores fight cards as coverable.

Result: Chelonian Tackle now renders AUTO and matches its golden tree; the handler also unlocks other "pump then fight" cards (Dragonclaw Strike, Savage Punch). Skycoach Conductor was already AUTO and matches. Ambitious Augmenter's create-token-then-move-counters shape remains correctly declined to SCAFFOLD rather than emitting a lossy approximation. coverage-verify POR stays GATE PASS, 0 mismatches; the pre-existing SOS-gate mismatches are unrelated cards not touched here.

## Tests
- :mtg-sets:test (card snapshot + lint nets) — green; SOS snapshot re-blessed (only the 3 new cards added).
- :rules-engine:test for the 3 scenario tests — green.
- :mtgish-tooling:test — green; emitter fixtures re-blessed (no diff — no fight card in the committed fixture slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
