### PR TITLE
feat: implement The Big Score cards (group B)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -587,13 +587,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `CreateChosenTokenEffect`; under the hood it sets `CreateTokenEffect.colorsFromChoice` /
   `creatureTypesFromChoice`.)
 - `CreateTokenCopyOfSelf(count?, tapped?)` — token copies of source.
-- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?)` —
+- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, addedSubtypes?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?)` —
   token copy of another permanent (or a card in any zone — the executor copies the target's `CardComponent`,
-  so a graveyard/exile card works). `overrideColors`/`overrideSubtypes` replace the copy's colors/subtypes
+  so a graveyard/exile card works; pass `EffectTarget.PipelineTarget("name")` to copy a card a prior pipeline
+  step exiled/stored, as Nexus of Becoming and Mardu Siegebreaker do).
+  `overrideColors`/`overrideSubtypes` replace the copy's colors/subtypes
   outright for "a token that's a copy … except it's a 5/5 black Demon" wording (Ardyn, the Usurper).
+  `addedSubtypes` *unions* extra subtypes onto the copy (vs `overrideSubtypes` which replaces) — e.g.
+  Nexus of Becoming's "a 3/3 Golem … in addition to its other types".
   `addCardTypes` (e.g. `setOf("ARTIFACT")`) *unions* extra card types onto the copy's type line for the
   "except it's a [type] in addition to its other types" clause (the targeted sibling of
-  `CreateTokenCopyOfSource`'s `addCardTypes`; Molten Duplication).
+  `CreateTokenCopyOfSource`'s `addCardTypes`; Molten Duplication, Nexus of Becoming).
   `attacking` only applies to copies whose printed type line is a creature (a copy of a non-creature card
   still enters tapped but never attacking). `sacrificeAtStep` schedules one delayed `SacrificeTargetEffect`
   per created copy at that step (the sacrifice sibling of `CreateTokenEffect.sacrificeAtStep`);
@@ -3302,6 +3306,12 @@ Numbers computed at resolution time.
   "the number of different powers among creatures you control" via
   `aggregation = DISTINCT_VALUES, property = POWER`; two permanents sharing a value count once).
   Builder shortcut: `DynamicAmounts.battlefield(player, filter).distinctValues(CardNumericProperty.POWER)`.
+  `excludeSelf = true` drops the aggregate's own source/affected entity ("among *other* …"), e.g.
+  Loot, the Key to Everything's "the number of card types among other nonland permanents you control"
+  (`filter = GameObjectFilter.NonlandPermanent, aggregation = DISTINCT_TYPES, excludeSelf = true`).
+  `DISTINCT_TYPES` counts only true **card types** (CR 205.2a: Artifact/Creature/Enchantment/…), never
+  supertypes or subtypes, while still honoring projection-changed types (an animated land that became a
+  Creature counts as a Creature).
 - `AggregateZone(player, zone, filter?, aggregation?)` — count cards in a zone.
 - `CountPermanentsOfType(player, subtype)` — count by creature type.
 - `CountCreaturesYouControl` — shorthand for "your creatures".

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1491,6 +1491,7 @@ object Effects {
         removedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet(),
         overrideColors: Set<com.wingedsheep.sdk.core.Color>? = null,
         overrideSubtypes: Set<com.wingedsheep.sdk.core.Subtype>? = null,
+        addedSubtypes: Set<com.wingedsheep.sdk.core.Subtype> = emptySet(),
         sacrificeAtStep: com.wingedsheep.sdk.core.Step? = null,
         sacrificeOnlyOnControllersTurn: Boolean = false,
         addCardTypes: Set<String> = emptySet()
@@ -1507,6 +1508,7 @@ object Effects {
         removedSupertypes = removedSupertypes,
         overrideColors = overrideColors,
         overrideSubtypes = overrideSubtypes,
+        addedSubtypes = addedSubtypes,
         sacrificeAtStep = sacrificeAtStep,
         sacrificeOnlyOnControllersTurn = sacrificeOnlyOnControllersTurn,
         addCardTypes = addCardTypes

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -357,6 +357,13 @@ data class CreateTokenCopyOfTargetEffect(
      */
     val overrideSubtypes: Set<Subtype>? = null,
     /**
+     * Subtypes unioned onto the token copy's subtypes *in addition* to those copied
+     * (e.g., Golem for Nexus of Becoming's "a 3/3 Golem artifact creature in addition to
+     * its other types"). Distinct from [overrideSubtypes] (which replaces). Ignored when
+     * [overrideSubtypes] is set.
+     */
+    val addedSubtypes: Set<Subtype> = emptySet(),
+    /**
      * If set, create delayed triggers to sacrifice each created token copy at this step
      * (the sacrifice sibling of [CreateTokenEffect.sacrificeAtStep]). Used for "create a
      * tapped token copy ... at the beginning of your next end step, sacrifice those tokens"
@@ -409,11 +416,12 @@ data class CreateTokenCopyOfTargetEffect(
                 addedSupertypes.joinToString(" ") { it.displayName.lowercase() }
             }")
         }
-        if (addCardTypes.isNotEmpty()) {
+        if (addCardTypes.isNotEmpty() || addedSubtypes.isNotEmpty()) {
             val pronoun = if (count == DynamicAmount.Fixed(1)) "it's" else "they're"
-            val typeWords = addCardTypes.joinToString(" ") { it.lowercase() }
+            val typeWords = (addedSubtypes.map { it.value } + addCardTypes.map { it.lowercase() })
+                .joinToString(" ")
             val article = if (count == DynamicAmount.Fixed(1)) {
-                if (typeWords.first() in "aeiou") "an " else "a "
+                if (typeWords.first().lowercaseChar() in "aeiou") "an " else "a "
             } else ""
             append(", except $pronoun $article$typeWords in addition to its other types")
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/HarvesterOfMisery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/HarvesterOfMisery.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Harvester of Misery
+ * {3}{B}{B}
+ * Creature — Spirit
+ * 5/4
+ *
+ * Menace
+ * When this creature enters, other creatures get -2/-2 until end of turn.
+ * {1}{B}, Discard this card: Target creature gets -2/-2 until end of turn.
+ */
+val HarvesterOfMisery = card("Harvester of Misery") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 5
+    toughness = 4
+    oracleText = "Menace\n" +
+        "When this creature enters, other creatures get -2/-2 until end of turn.\n" +
+        "{1}{B}, Discard this card: Target creature gets -2/-2 until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    // When this enters, all OTHER creatures get -2/-2 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature, excludeSelf = true),
+            Effects.ModifyStats(-2, -2, EffectTarget.Self)
+        )
+    }
+
+    // {1}{B}, Discard this card (from hand): Target creature gets -2/-2 until end of turn.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.DiscardSelf)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-2, -2, t)
+        activateFromZone = Zone.HAND
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "9"
+        artist = "Jorge Jacinto"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg?1739804174"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LootTheKeyToEverything.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/LootTheKeyToEverything.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Loot, the Key to Everything
+ * {G}{U}{R}
+ * Legendary Creature — Beast Noble
+ * 1/2
+ *
+ * Ward {1}
+ * At the beginning of your upkeep, exile the top X cards of your library, where X is the
+ * number of card types among other nonland permanents you control. You may play those
+ * cards this turn.
+ *
+ * Modeling: X is [DynamicAmount.AggregateBattlefield] with [Aggregation.DISTINCT_TYPES] over
+ * your nonland permanents, `excludeSelf = true` ("among *other* nonland permanents"). The
+ * impulse exile reuses the Outpost Siege / Light Up the Stage shape — Gather top X →
+ * Move-to-exile → [GrantMayPlayFromExileEffect] with [MayPlayExpiry.EndOfTurn].
+ */
+val LootTheKeyToEverything = card("Loot, the Key to Everything") {
+    manaCost = "{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Legendary Creature — Beast Noble"
+    power = 1
+    toughness = 2
+    oracleText = "Ward {1}\n" +
+        "At the beginning of your upkeep, exile the top X cards of your library, where X is " +
+        "the number of card types among other nonland permanents you control. You may play " +
+        "those cards this turn."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(
+                    DynamicAmount.AggregateBattlefield(
+                        player = Player.You,
+                        filter = GameObjectFilter.NonlandPermanent,
+                        aggregation = Aggregation.DISTINCT_TYPES,
+                        excludeSelf = true
+                    )
+                ),
+                storeAs = "exiledCards"
+            ),
+            MoveCollectionEffect(
+                from = "exiledCards",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            GrantMayPlayFromExileEffect("exiledCards", MayPlayExpiry.EndOfTurn)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "21"
+        artist = "Rudy Siswanto"
+        flavorText = "The vault's ultimate prize wasn't exactly what Kellan had imagined."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg?1739804220"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/NexusOfBecoming.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/NexusOfBecoming.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nexus of Becoming
+ * {6}
+ * Artifact
+ *
+ * At the beginning of combat on your turn, draw a card. Then you may exile an artifact
+ * or creature card from your hand. If you do, create a token that's a copy of the exiled
+ * card, except it's a 3/3 Golem artifact creature in addition to its other types.
+ *
+ * Modeling: the optional exile is a Gather → Select(ChooseUpTo 1) → Move-to-exile pipeline
+ * over hand artifact/creature cards. The token copies the *exiled* card (CR 707: copiable
+ * values are the card's printed characteristics), referenced via [EffectTarget.PipelineTarget]
+ * — the same shape Mardu Siegebreaker uses to copy a card it exiled. "3/3" overrides the
+ * copy's P/T; "Golem artifact creature in addition to its other types" unions the Golem
+ * subtype plus the ARTIFACT and CREATURE card types onto the copied type line.
+ */
+val NexusOfBecoming = card("Nexus of Becoming") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of combat on your turn, draw a card. Then you may exile an " +
+        "artifact or creature card from your hand. If you do, create a token that's a copy of " +
+        "the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Effects.Composite(listOf(
+            Effects.DrawCards(1),
+            // You may exile an artifact or creature card from your hand.
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.HAND,
+                    player = Player.You,
+                    filter = GameObjectFilter.CreatureOrArtifact
+                ),
+                storeAs = "candidates"
+            ),
+            SelectFromCollectionEffect(
+                from = "candidates",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "exiledCard",
+                prompt = "You may exile an artifact or creature card from your hand"
+            ),
+            MoveCollectionEffect(
+                from = "exiledCard",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            // If you did, create a 3/3 Golem artifact creature token copy of the exiled card.
+            Effects.CreateTokenCopyOfTarget(
+                target = EffectTarget.PipelineTarget("exiledCard"),
+                overridePower = 3,
+                overrideToughness = 3,
+                addedSubtypes = setOf(Subtype("Golem")),
+                addCardTypes = setOf("ARTIFACT", "CREATURE")
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "25"
+        artist = "Adam Volker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg?1739804233"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/OltecMatterweaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/OltecMatterweaver.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Oltec Matterweaver
+ * {2}{W}
+ * Creature — Human Artificer
+ * 2/4
+ *
+ * Whenever you cast a creature spell, choose one —
+ * • Create a 1/1 colorless Gnome artifact creature token.
+ * • Create a token that's a copy of target artifact token you control.
+ */
+val OltecMatterweaver = card("Oltec Matterweaver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever you cast a creature spell, choose one —\n" +
+        "• Create a 1/1 colorless Gnome artifact creature token.\n" +
+        "• Create a token that's a copy of target artifact token you control."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                // 1/1 colorless (emptySet colors) Gnome artifact creature token.
+                CreateTokenEffect(
+                    power = 1,
+                    toughness = 1,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Gnome"),
+                    artifactToken = true,
+                    imageUri = "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg?1712317852"
+                ),
+                "Create a 1/1 colorless Gnome artifact creature token"
+            ),
+            Mode.withTarget(
+                Effects.CreateTokenCopyOfTarget(target = EffectTarget.ContextTarget(0)),
+                TargetPermanent(
+                    filter = TargetFilter(GameObjectFilter.Artifact.token().youControl())
+                ),
+                "Create a token that's a copy of target artifact token you control"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "3"
+        artist = "Villarrte"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg?1739804152"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -124,6 +124,106 @@
     ]
 }
 
+// Harvester of Misery
+{
+    "name": "Harvester of Misery",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Menace\nWhen this creature enters, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard this card: Target creature gets -2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature",
+                            "excludeSelf": true
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "activateFromZone": "Hand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "MYTHIC",
+        "artist": "Jorge Jacinto",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg?1739804174"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hostile Investigator
 {
     "name": "Hostile Investigator",
@@ -294,6 +394,85 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1739804188"
     },
     "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Loot, the Key to Everything
+{
+    "name": "Loot, the Key to Everything",
+    "manaCost": "{G}{U}{R}",
+    "typeLine": "Legendary Creature — Beast Noble",
+    "oracleText": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": "nonland permanent",
+                                    "aggregation": "DISTINCT_TYPES",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "storeAs": "exiledCards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCards",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiledCards"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "MYTHIC",
+        "artist": "Rudy Siswanto",
+        "flavorText": "The vault's ultimate prize wasn't exactly what Kellan had imagined.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg?1739804220"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
         "RED"
     ]
 }
@@ -546,6 +725,165 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Nexus of Becoming
+{
+    "name": "Nexus of Becoming",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "creature|artifact"
+                            },
+                            "storeAs": "candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "exiledCard",
+                            "prompt": "You may exile an artifact or creature card from your hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "exiledCard"
+                            },
+                            "overridePower": 3,
+                            "overrideToughness": 3,
+                            "addedSubtypes": [
+                                "Golem"
+                            ],
+                            "addCardTypes": [
+                                "ARTIFACT",
+                                "CREATURE"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "MYTHIC",
+        "artist": "Adam Volker",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg?1739804233"
+    },
+    "colorIdentityOverride": []
+}
+
+// Oltec Matterweaver
+{
+    "name": "Oltec Matterweaver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever you cast a creature spell, choose one —\n• Create a 1/1 colorless Gnome artifact creature token.\n• Create a token that's a copy of target artifact token you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [],
+                                "creatureTypes": [
+                                    "Gnome"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg?1712317852",
+                                "artifactToken": true
+                            },
+                            "description": "Create a 1/1 colorless Gnome artifact creature token"
+                        },
+                        {
+                            "effect": {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact token ctrl:you"
+                                    }
+                                }
+                            ],
+                            "description": "Create a token that's a copy of target artifact token you control"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "MYTHIC",
+        "artist": "Villarrte",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg?1739804152"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -39,6 +39,14 @@ import kotlin.math.min
 private val BASIC_LAND_SUBTYPES: Set<String> = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
 
 /**
+ * The names of every true card type (CR 205.2a). Used to count "card types" via
+ * [Aggregation.DISTINCT_TYPES] without including supertypes/subtypes, which
+ * [ProjectedState.getTypes] folds into the same set.
+ */
+private val CARD_TYPE_NAMES: Set<String> =
+    com.wingedsheep.sdk.core.CardType.entries.mapTo(mutableSetOf()) { it.name }
+
+/**
  * Evaluates DynamicAmount values against the current game state.
  *
  * DynamicAmount represents values that depend on game state, like
@@ -629,8 +637,13 @@ class DynamicAmountEvaluator(
                 val prop = amount.property ?: return 0
                 matchingEntities.sumOf { resolveCardNumericProperty(state, projection, it, prop) }
             }
+            // "Number of card types" (CR 205.2a) — count only true card types
+            // (Artifact, Creature, Enchantment, …), never supertypes or subtypes.
+            // [ProjectedState.getTypes] folds supertypes + subtypes into one set, so intersect
+            // with the known [CardType] names; this still respects projection-changed types
+            // (e.g. an animated land that became a Creature).
             Aggregation.DISTINCT_TYPES -> matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
-                projection.getTypes(entityId).ifEmpty {
+                projection.getTypes(entityId).filterTo(mutableSetOf()) { it in CARD_TYPE_NAMES }.ifEmpty {
                     state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes?.map { it.name }?.toSet()
                         ?: emptySet()
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -90,7 +90,7 @@ class CreateTokenCopyOfTargetExecutor(
             val tokenTypeLine = targetCard.typeLine.copy(
                 cardTypes = targetCard.typeLine.cardTypes + extraCardTypes,
                 supertypes = targetCard.typeLine.supertypes + effect.addedSupertypes - effect.removedSupertypes,
-                subtypes = effect.overrideSubtypes ?: targetCard.typeLine.subtypes
+                subtypes = effect.overrideSubtypes ?: (targetCard.typeLine.subtypes + effect.addedSubtypes)
             )
             val tokenCard = targetCard.copy(
                 ownerId = controllerId,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarvesterOfMiseryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarvesterOfMiseryScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Harvester of Misery (BIG #9).
+ *
+ * {3}{B}{B} Creature — Spirit 5/4. Menace.
+ *   When this creature enters, other creatures get -2/-2 until end of turn.
+ *   {1}{B}, Discard this card: Target creature gets -2/-2 until end of turn.
+ */
+class HarvesterOfMiseryScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        test("has menace") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Harvester of Misery")
+                .build()
+
+            val harvester = game.findPermanent("Harvester of Misery")!!
+            projector.project(game.state).hasKeyword(harvester, Keyword.MENACE) shouldBe true
+        }
+
+        test("ETB gives other creatures -2/-2 until end of turn, killing small ones but not itself") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Harvester of Misery")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 → dies
+                .withCardOnBattlefield(2, "Hill Giant")    // 3/3 → becomes 1/1
+                .withCardInLibrary(1, "Swamp")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Harvester of Misery").error shouldBe null
+            game.resolveStack()
+
+            withClue("the 2/2 Grizzly Bears is destroyed by -2/-2") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+            }
+            val harvester = game.findPermanent("Harvester of Misery")!!
+            val projected = projector.project(game.state)
+            withClue("Harvester itself is unaffected (other creatures only) — stays 5/4") {
+                projected.getPower(harvester) shouldBe 5
+                projected.getToughness(harvester) shouldBe 4
+            }
+            val giant = game.findPermanent("Hill Giant")
+            withClue("Hill Giant survives at 1/1") {
+                giant shouldBe game.findPermanent("Hill Giant")
+                projected.getPower(giant!!) shouldBe 1
+                projected.getToughness(giant) shouldBe 1
+            }
+        }
+
+        test("discard-from-hand ability gives target creature -2/-2") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Harvester of Misery")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val harvesterCard = game.findCardsInHand(1, "Harvester of Misery").first()
+            val abilityId = cardRegistry.getCard("Harvester of Misery")!!.activatedAbilities.first().id
+
+            // {1}{B}, Discard this card: Target creature gets -2/-2.
+            val result = game.execute(
+                com.wingedsheep.engine.core.ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = harvesterCard,
+                    abilityId = abilityId,
+                    targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(bears))
+                )
+            )
+            result.error shouldBe null
+            game.resolveStack()
+
+            withClue("the discard ability resolves: Harvester is in the graveyard") {
+                game.isInGraveyard(1, "Harvester of Misery") shouldBe true
+            }
+            withClue("the targeted 2/2 is destroyed by -2/-2") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LootTheKeyToEverythingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LootTheKeyToEverythingScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Loot, the Key to Everything (BIG #21).
+ *
+ * {G}{U}{R} Legendary Creature — Beast Noble 1/2. Ward {1}.
+ *   At the beginning of your upkeep, exile the top X cards of your library, where X is the
+ *   number of card types among other nonland permanents you control. You may play those cards
+ *   this turn.
+ */
+class LootTheKeyToEverythingScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.exileCount(playerNumber: Int): Int {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).size
+    }
+
+    init {
+        test("upkeep exiles X cards where X = distinct card types among other nonland permanents") {
+            // Other nonland permanents: an artifact (Mind Stone), a plain enchantment
+            // (Angelic Shield), and another creature (Grizzly Bears) → 3 distinct card types.
+            // Loot itself is a creature but excluded (excludeSelf). Lands don't count.
+            // Start on player 2's end step so a single advance lands on player 1's upkeep.
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Loot, the Key to Everything")
+                .withCardOnBattlefield(1, "Mind Stone")        // Artifact
+                .withCardOnBattlefield(1, "Grizzly Bears")     // Creature
+                .withCardOnBattlefield(1, "Angelic Shield")    // Enchantment
+                .withLandsOnBattlefield(1, "Forest", 2)        // lands don't add a card type
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(2)
+                .inPhase(Phase.ENDING, Step.END)
+                .build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 1's upkeep
+            game.state.activePlayerId shouldBe game.player1Id
+            game.resolveStack()
+
+            withClue("X = 3 distinct card types (Artifact, Creature, Enchantment) → exile top 3") {
+                game.exileCount(1) shouldBe 3
+            }
+        }
+
+        test("with only lands and Loot, X = 0 and nothing is exiled") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Loot, the Key to Everything")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(2)
+                .inPhase(Phase.ENDING, Step.END)
+                .build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 1's upkeep
+            game.state.activePlayerId shouldBe game.player1Id
+            game.resolveStack()
+
+            withClue("only Loot (excluded as self) and lands → X = 0, no cards exiled") {
+                game.exileCount(1) shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NexusOfBecomingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NexusOfBecomingScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Nexus of Becoming (BIG #25).
+ *
+ * {6} Artifact.
+ *   At the beginning of combat on your turn, draw a card. Then you may exile an artifact or
+ *   creature card from your hand. If you do, create a token that's a copy of the exiled card,
+ *   except it's a 3/3 Golem artifact creature in addition to its other types.
+ */
+class NexusOfBecomingScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    /** Advance from precombat main to the begin-of-combat trigger pausing for the exile choice. */
+    private fun TestGame.advanceToNexusChoice(): SelectCardsDecision {
+        var safety = 0
+        while (getPendingDecision() == null && state.step != Step.BEGIN_COMBAT && safety++ < 30) {
+            passPriority()
+        }
+        // The begin-combat trigger is on the stack; resolve it (draw, then pause for the exile choice).
+        var safety2 = 0
+        while (getPendingDecision() == null && safety2++ < 10) {
+            passPriority()
+        }
+        return getPendingDecision() as SelectCardsDecision
+    }
+
+    init {
+        test("exiling a creature card creates a 3/3 Golem artifact creature copy of it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Nexus of Becoming")
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val decision = game.advanceToNexusChoice()
+
+            withClue("the card was drawn before the exile choice (Hill Giant now in hand)") {
+                game.isInHand(1, "Hill Giant") shouldBe true
+            }
+
+            val bearsInHand = game.findCardsInHand(1, "Grizzly Bears").first()
+            withClue("Grizzly Bears (a creature card in hand) is an option to exile") {
+                decision.options shouldContain bearsInHand
+            }
+            game.selectCards(listOf(bearsInHand))
+            game.resolveStack()
+
+            withClue("a token copy of the exiled Grizzly Bears is created") {
+                game.findPermanents("Grizzly Bears").size shouldBe 1
+            }
+            val token = game.findPermanents("Grizzly Bears").first()
+            val tokenCard = game.state.getEntity(token)!!.get<CardComponent>()!!
+            withClue("token is an artifact creature with the Golem subtype, in addition to its own types") {
+                tokenCard.typeLine.cardTypes shouldContain CardType.ARTIFACT
+                tokenCard.typeLine.cardTypes shouldContain CardType.CREATURE
+                tokenCard.typeLine.subtypes shouldContain Subtype("Golem")
+                tokenCard.typeLine.subtypes shouldContain Subtype("Bear")
+            }
+            val projected = projector.project(game.state)
+            withClue("token's P/T is overridden to 3/3") {
+                projected.getPower(token) shouldBe 3
+                projected.getToughness(token) shouldBe 3
+            }
+        }
+
+        test("declining the exile draws but creates no token") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Nexus of Becoming")
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val decision = game.advanceToNexusChoice()
+            withClue("the optional exile can be skipped (minimum 0 selections)") {
+                decision.minSelections shouldBe 0
+            }
+            game.skipSelection()
+            game.resolveStack()
+
+            withClue("no token copy is created when the exile is declined") {
+                game.findPermanents("Grizzly Bears").size shouldBe 0
+            }
+            withClue("the draw still happened (Hill Giant in hand, Grizzly Bears still in hand)") {
+                game.isInHand(1, "Hill Giant") shouldBe true
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OltecMatterweaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OltecMatterweaverScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Oltec Matterweaver (BIG #3).
+ *
+ * {2}{W} Creature — Human Artificer 2/4.
+ *   Whenever you cast a creature spell, choose one —
+ *   • Create a 1/1 colorless Gnome artifact creature token.
+ *   • Create a token that's a copy of target artifact token you control.
+ */
+class OltecMatterweaverScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("choosing mode 1 creates a 1/1 Gnome artifact creature token on a creature cast") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Oltec Matterweaver")
+                .withCardInHand(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+
+            // The "whenever you cast a creature spell" trigger goes on the stack above the spell.
+            // Resolve it first → mode choice.
+            game.resolveStack()
+            val modeDecision = game.getPendingDecision() as ChooseOptionDecision
+            withClue("two modes are offered") {
+                modeDecision.options.size shouldBe 2
+            }
+            game.submitDecision(OptionChosenResponse(modeDecision.id, 0))
+            game.resolveStack()
+
+            val gnome = game.findPermanent("Gnome Token")
+            withClue("a Gnome token is created") {
+                (gnome != null) shouldBe true
+            }
+            val gnomeCard = game.state.getEntity(gnome!!)!!.get<CardComponent>()!!
+            withClue("Gnome token is a 1/1 artifact creature") {
+                gnomeCard.typeLine.cardTypes shouldContainType CardType.ARTIFACT
+                gnomeCard.typeLine.cardTypes shouldContainType CardType.CREATURE
+                gnomeCard.typeLine.subtypes shouldContainSubtype Subtype("Gnome")
+            }
+        }
+
+        test("choosing mode 2 copies a target artifact token you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Oltec Matterweaver")
+                .withCardOnBattlefield(1, "Treasure", isToken = true)
+                .withCardInHand(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.resolveStack()
+
+            val modeDecision = game.getPendingDecision() as ChooseOptionDecision
+            game.submitDecision(OptionChosenResponse(modeDecision.id, 1))
+
+            // Mode 2 targets an artifact token; supply the Treasure as the target.
+            val targetDecision = game.getPendingDecision() as ChooseTargetsDecision
+            val treasure = game.findPermanent("Treasure")!!
+            game.selectTargets(listOf(treasure))
+            game.resolveStack()
+
+            withClue("a second Treasure token (the copy) now exists") {
+                game.findPermanents("Treasure").size shouldBe 2
+            }
+        }
+    }
+
+    private infix fun Set<CardType>.shouldContainType(type: CardType) {
+        (type in this) shouldBe true
+    }
+
+    private infix fun Set<Subtype>.shouldContainSubtype(subtype: Subtype) {
+        (subtype in this) shouldBe true
+    }
+}


### PR DESCRIPTION
Implements 4 of 5 assigned cards from **The Big Score** (BIG). One card (Memory Vessel) is intentionally skipped — see below.

## Cards implemented

| Card | # | Notes |
|------|---|-------|
| **Harvester of Misery** | 9 | Menace; ETB other creatures −2/−2 EOT; `{1}{B}`, Discard this card: target creature −2/−2 EOT (activated from hand). Pure composition. |
| **Loot, the Key to Everything** | 21 | Ward {1}; upkeep impulse-exile of the top X cards, X = card types among other nonland permanents you control, playable this turn. |
| **Nexus of Becoming** | 25 | Begin-combat: draw, then *may* exile an artifact/creature card from hand and create a 3/3 Golem artifact-creature token copy of it. |
| **Oltec Matterweaver** | 3 | On casting a creature spell, choose one — make a 1/1 Gnome artifact-creature token, or copy a target artifact token you control. |

## SDK / engine changes (reusable)

- **`CreateTokenCopyOfTargetEffect.addedSubtypes`** — *unions* extra subtypes onto a token copy ("a 3/3 Golem … in addition to its other types"), distinct from the replacing `overrideSubtypes`. Executor + `Effects.CreateTokenCopyOfTarget` facade + SDK reference updated. Nexus is the first user; reusable for any "copy … except it's also a [subtype]" card.
- **`AggregateBattlefield(DISTINCT_TYPES)` card-types fix** — now counts only true **card types** (CR 205.2a), not the supertypes/subtypes that `ProjectedState.getTypes` folds into one set. This was a latent over-count on the battlefield path (the graveyard `AggregateZone` path was already correct). Loot is the first battlefield user. Verified against the official Comprehensive Rules (205.2a).

## Skipped: Memory Vessel (#13)

`{T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand.`

Requires a brand-new player-wide **"can't play cards from hand until your next turn"** restriction (enforced across the cast / play-land legal-action enumerators + end-of-turn-tied cleanup + DTO surface) plus per-player exile-and-may-play grants. That is a full cross-layer add-feature that would balloon this PR; rather than ship a lossy/incorrect approximation I left it unimplemented. It currently declines to SCAFFOLD in the tooling, and the build stays green.

## mtgish tooling

- **Harvester of Misery** renders **AUTO** — the emitter's output matches the hand-authored card.
- **Loot / Nexus / Oltec** stay **SCAFFOLD**: the emitter correctly *declines* the computed-X impulse, pipeline copy-of-exiled-with-type-overrides, and modal-trigger-token-copy shapes rather than emit a lossy approximation, per the project rule "render correctly or decline→SCAFFOLD, don't widen." The capability bridge already scores `MayCost`/`CreateTokens`, so coverage triage recognizes the mechanics.
- `just coverage-verify BIG` and `just coverage-verify POR` both **PASS with 0 mismatches**.

## Tests

- 9 new scenario tests in `rules-engine` (Harvester ×3, Loot ×2, Nexus ×2, Oltec ×2) — all pass.
- `CardDefinitionSnapshotTest` re-blessed: diff is **only** `BIG.json`, +4 cards, nothing else moved.
- `CardLintTest`, the full `rules-engine` suite, `mtg-sdk`, and `mtgish-tooling` suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)