### PR TITLE
LTR: add 13 Lord of the Rings cards (The One Ring, Sméagol, Glorfindel, …)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AOneRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AOneRing.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * A-The One Ring (Alchemy rebalance of [TheOneRing])
+ * {4}
+ * Legendary Artifact
+ *
+ * Indestructible
+ * When The One Ring enters, if you cast it, you gain protection from everything until your next turn.
+ * At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.
+ * {1}, {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring.
+ *
+ * Identical to the printed [TheOneRing] except the draw ability gains a {1} mana cost
+ * (the Alchemy nerf). Reuses Gap 8 player-level protection — see [TheOneRing] for the full
+ * engine notes.
+ */
+val AOneRing = card("A-The One Ring") {
+    manaCost = "{4}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Indestructible\n" +
+        "When The One Ring enters, if you cast it, you gain protection from everything until your next turn.\n" +
+        "At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.\n" +
+        "{1}, {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // When The One Ring enters, if you cast it, you gain protection from everything until your next turn.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.GrantPlayerProtection()
+    }
+
+    // At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.LoseLife(
+            DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.BURDEN)),
+            EffectTarget.Controller
+        )
+    }
+
+    // {1}, {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on it.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                Effects.AddCounters(Counters.BURDEN, 1, EffectTarget.Self),
+                Effects.DrawCards(DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.BURDEN)))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "A-246"
+        artist = "Veli Nyström"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23b91af8-eff9-402a-8ba8-ab470c5c1a44.jpg?1730837118"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BarrowBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BarrowBlade.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barrow-Blade
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1.
+ * Whenever equipped creature blocks or becomes blocked by a creature, that creature loses
+ * all abilities until end of turn.
+ * Equip {1}
+ *
+ * The blocks-or-blocked trigger uses the existing `BlocksOrBecomesBlockedBy` event with the
+ * new `ATTACHED` binding (so it fires off the equipped creature's combat), and the partner
+ * (TriggeringEntity) loses all abilities via the existing `RemoveAllAbilities` effect.
+ */
+val BarrowBlade = card("Barrow-Blade") {
+    manaCost = "{1}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "Whenever equipped creature blocks or becomes blocked by a creature, that creature " +
+        "loses all abilities until end of turn.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BlocksOrBecomesBlockedBy(
+            filter = GameObjectFilter.Creature,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.RemoveAllAbilities(EffectTarget.TriggeringEntity, Duration.EndOfTurn)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg?1686970135"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BoromirWardenOfTheTower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BoromirWardenOfTheTower.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Boromir, Warden of the Tower
+ * {2}{W}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ *
+ * Vigilance
+ * Whenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.
+ * Sacrifice Boromir: Creatures you control gain indestructible until end of turn. The Ring tempts you.
+ *
+ * The counter clause uses the new `Conditions.TriggeringSpellCastWithoutPayingMana` intervening-if
+ * (reads the triggering spell's cast-mana record) + `Effects.CounterTriggeringSpell()`.
+ */
+val BoromirWardenOfTheTower = card("Boromir, Warden of the Tower") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "Whenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.\n" +
+        "Sacrifice Boromir: Creatures you control gain indestructible until end of turn. The Ring tempts you."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.OpponentCastsSpell
+        triggerCondition = Conditions.TriggeringSpellCastWithoutPayingMana
+        effect = Effects.CounterTriggeringSpell()
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = GrantKeywordEffect(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        flavorText = "\"Farewell, Aragorn! Go to Minas Tirith and save my people!\""
+        artist = "Yigit Koroglu"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg?1686967669"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BreakingOfTheFellowship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BreakingOfTheFellowship.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Breaking of the Fellowship
+ * {1}{R}
+ * Sorcery
+ *
+ * Target creature an opponent controls deals damage equal to its power to another target
+ * creature that player controls. The Ring tempts you.
+ *
+ * Modeled as a single two-target requirement constrained to creatures the same opponent
+ * controls (`sameController = true`, count = 2 — which also enforces "another", since the
+ * two targets must be distinct). The first chosen creature deals damage equal to its power
+ * to the second (`DealDamage(targetPower(0), ContextTarget(1), damageSource = ContextTarget(0))`).
+ */
+val BreakingOfTheFellowship = card("Breaking of the Fellowship") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target creature an opponent controls deals damage equal to its power to " +
+        "another target creature that player controls. The Ring tempts you."
+
+    spell {
+        target(
+            "creatures an opponent controls",
+            TargetCreature(
+                count = 2,
+                filter = TargetFilter.CreatureOpponentControls,
+                sameController = true
+            )
+        )
+        effect = DealDamageEffect(
+            amount = DynamicAmounts.targetPower(0),
+            target = EffectTarget.ContextTarget(1),
+            damageSource = EffectTarget.ContextTarget(0)
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        flavorText = "\"It might have been mine. It should be mine. Give it to me!\""
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg?1686968821"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/CallOfTheRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/CallOfTheRing.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Call of the Ring
+ * {1}{B}
+ * Enchantment
+ *
+ * At the beginning of your upkeep, the Ring tempts you.
+ * Whenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card.
+ *
+ * The second ability uses the new `Triggers.WheneverYouChooseRingBearer` (a `RingTemptedEvent`
+ * pattern with `requireBearerChosen = true`), so it only fires when a temptation actually
+ * designates a creature — not when you control none to choose.
+ */
+val CallOfTheRing = card("Call of the Ring") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, the Ring tempts you.\n" +
+        "Whenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouChooseRingBearer
+        effect = MayEffect(
+            effect = Effects.Composite(
+                listOf(
+                    Effects.LoseLife(2, EffectTarget.Controller),
+                    Effects.DrawCards(1),
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "79"
+        artist = "Anato Finnstark"
+        flavorText = "\"The Ring is mine!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg?1686968397"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DisplayOfPower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DisplayOfPower.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Display of Power
+ * {1}{R}{R}
+ * Instant
+ *
+ * This spell can't be copied.
+ * Copy any number of target instant and/or sorcery spells. You may choose new targets
+ * for the copies.
+ *
+ * Uses [com.wingedsheep.sdk.scripting.effects.CopyEachTargetSpellEffect] (CR 707.10): one
+ * copy is made per targeted spell, with optional retargeting per copy. The "can't be
+ * copied" clause maps to the card-level `cantBeCopied` flag (CR 707.10 — no copy results
+ * if a copy effect names this spell).
+ */
+val DisplayOfPower = card("Display of Power") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell can't be copied.\n" +
+        "Copy any number of target instant and/or sorcery spells. You may choose new " +
+        "targets for the copies."
+
+    cantBeCopied = true
+
+    spell {
+        target("any number of target instant and/or sorcery spells", Targets.AnyNumberOfInstantOrSorcerySpells)
+        effect = Effects.CopyEachTargetSpell()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "119"
+        flavorText = "\"The Nazgûl closed round at night, and I was besieged. Such light and flame cannot have been seen on Weathertop since the war-beacons of old.\"\n—Gandalf"
+        artist = "Shahab Alizadeh"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg?1686968845"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainRangers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainRangers.kt
@@ -11,7 +11,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  * Dúnedain Rangers
  * {3}{G}
  * Creature — Human Ranger
- * 4/3
+ * 4/4
  *
  * Landfall — Whenever a land you control enters, if you don't control a Ring-bearer, the Ring tempts you.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainRangers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunedainRangers.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Dúnedain Rangers
+ * {3}{G}
+ * Creature — Human Ranger
+ * 4/3
+ *
+ * Landfall — Whenever a land you control enters, if you don't control a Ring-bearer, the Ring tempts you.
+ *
+ * Gap 18 (player-level Ring-bearer condition): adds `StatePredicate.IsRingBearer` +
+ * `GameObjectFilter.Creature.ringBearer()`, consumed via the existing
+ * `Conditions.YouControl(filter, negate = true)` as the landfall trigger's intervening-if.
+ */
+val DunedainRangers = card("Dúnedain Rangers") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Ranger"
+    power = 4
+    toughness = 4
+    oracleText = "Landfall — Whenever a land you control enters, if you don't control a Ring-bearer, " +
+        "the Ring tempts you."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.ringBearer(), negate = true)
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Eric Wilkerson"
+        flavorText = "\"Aragorn has need of his kindred. Let the Dúnedain go to him in Rohan!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg?1687694686"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElrondLordOfRivendell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElrondLordOfRivendell.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.IncrementAbilityResolutionCountEffect
+
+/**
+ * Elrond, Lord of Rivendell
+ * {2}{U}
+ * Legendary Creature — Elf Noble
+ * 3/2
+ *
+ * Whenever Elrond or another creature you control enters, scry 1. If this is the second time this
+ * ability has resolved this turn, the Ring tempts you.
+ *
+ * Composable: scry + `IncrementAbilityResolutionCountEffect` +
+ * `ConditionalEffect(Conditions.SourceAbilityResolvedNTimes(2), TheRingTemptsYou())`. The increment
+ * must run before the conditional reads the per-ability resolution count, or `count == 2` is never
+ * met and the Ring never tempts (cf. Tannuk Memorial Ensign, Harvestrite Host).
+ */
+val ElrondLordOfRivendell = card("Elrond, Lord of Rivendell") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever Elrond or another creature you control enters, scry 1. If this is the second " +
+        "time this ability has resolved this turn, the Ring tempts you."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Patterns.Library.scry(1)
+            .then(IncrementAbilityResolutionCountEffect)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(2),
+                    effect = Effects.TheRingTemptsYou()
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "49"
+        flavorText = "\"This is the hour of the Shire-folk, when they arise from their quiet fields to shake the towers and counsels of the Great. Who of all the Wise could have foreseen it?\""
+        artist = "Ryan Yee"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg?1686968084"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoBaggins.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoBaggins.kt
@@ -14,7 +14,7 @@ import com.wingedsheep.sdk.scripting.TriggerBinding
  * Frodo Baggins
  * {G}{W}
  * Legendary Creature — Halfling Scout
- * 1/1
+ * 1/3
  *
  * Whenever Frodo Baggins or another legendary creature you control enters, the Ring tempts you.
  * As long as Frodo Baggins is your Ring-bearer, it must be blocked if able.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoBaggins.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoBaggins.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MustBeBlocked
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Frodo Baggins
+ * {G}{W}
+ * Legendary Creature — Halfling Scout
+ * 1/1
+ *
+ * Whenever Frodo Baggins or another legendary creature you control enters, the Ring tempts you.
+ * As long as Frodo Baggins is your Ring-bearer, it must be blocked if able.
+ *
+ * The "must be blocked if able" half uses the new `MustBeBlocked` static ability (the static
+ * counterpart of `MustBeBlockedEffect`), wrapped in `ConditionalStaticAbility` gated on
+ * `SourceIsRingBearer`; `BlockPhaseManager` now honors that static alongside the floating
+ * must-be-blocked modifications.
+ */
+val FrodoBaggins = card("Frodo Baggins") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Halfling Scout"
+    power = 1
+    toughness = 3
+    oracleText = "Whenever Frodo Baggins or another legendary creature you control enters, the Ring " +
+        "tempts you.\n" +
+        "As long as Frodo Baggins is your Ring-bearer, it must be blocked if able."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.legendary().youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = MustBeBlocked(allCreatures = false),
+            condition = Conditions.SourceIsRingBearer
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Ekaterina Burmak"
+        flavorText = "\"Few have ever come hither through greater peril or on an errand more urgent.\"\n—Elrond"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg?1686969787"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GaladrielOfLothlorien.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GaladrielOfLothlorien.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Galadriel of Lothlórien
+ * {1}{G}{U}
+ * Legendary Creature — Elf Noble
+ * 3/3
+ *
+ * Whenever the Ring tempts you, if you chose a creature other than Galadriel as your
+ * Ring-bearer, scry 3.
+ * Whenever you scry, you may reveal the top card of your library. If a land card is
+ * revealed this way, put it onto the battlefield tapped.
+ *
+ * The reveal/place half composes the gather→reveal→move pipeline with the new
+ * `MoveCollectionEffect.filter` (move only the revealed land) into the battlefield tapped
+ * (`ZonePlacement.Tapped`); a non-land simply stays on top.
+ */
+val GaladrielOfLothlorien = card("Galadriel of Lothlórien") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever the Ring tempts you, if you chose a creature other than Galadriel " +
+        "as your Ring-bearer, scry 3.\n" +
+        "Whenever you scry, you may reveal the top card of your library. If a land card is " +
+        "revealed this way, put it onto the battlefield tapped."
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        triggerCondition = Conditions.YouChoseOtherCreatureAsRingBearer
+        effect = Patterns.Library.scry(3)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        effect = MayEffect(
+            Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.You),
+                        storeAs = "revealedTop"
+                    ),
+                    RevealCollectionEffect(from = "revealedTop"),
+                    MoveCollectionEffect(
+                        from = "revealedTop",
+                        filter = GameObjectFilter.Land,
+                        destination = CardDestination.ToZone(
+                            Zone.BATTLEFIELD,
+                            player = Player.You,
+                            placement = ZonePlacement.Tapped
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        flavorText = "\"I pass the test. I will diminish, and go into the West, and remain Galadriel.\""
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg?1686969798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfsSanction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfsSanction.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Gandalf's Sanction
+ * {1}{U}{R}
+ * Sorcery
+ *
+ * Gandalf's Sanction deals X damage to target creature, where X is the number of instant and
+ * sorcery cards in your graveyard. Excess damage is dealt to that creature's controller instead.
+ *
+ * Uses the new `DealDamageExcessToController` (DealDamageEffect.excessToController) — the creature
+ * takes only the lethal portion and the excess (CR 120.4a) is dealt to its controller.
+ */
+val GandalfsSanction = card("Gandalf's Sanction") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Sorcery"
+    oracleText = "Gandalf's Sanction deals X damage to target creature, where X is the number of " +
+        "instant and sorcery cards in your graveyard. Excess damage is dealt to that creature's " +
+        "controller instead."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.DealDamageExcessToController(
+            amount = DynamicAmounts.zone(Player.You, Zone.GRAVEYARD, GameObjectFilter.InstantOrSorcery).count(),
+            target = t,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Tatiana Veryayskaya"
+        flavorText = "There was a crack, and the staff split asunder in Saruman's hand, and the head of it fell down at Gandalf's feet."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg?1688134626"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GlorfindelDauntlessRescuer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GlorfindelDauntlessRescuer.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glorfindel, Dauntless Rescuer
+ * {2}{G}
+ * Legendary Creature — Elf Noble
+ * 3/2
+ *
+ * Whenever you scry, choose one and Glorfindel gets +1/+1 until end of turn.
+ * • Glorfindel must be blocked this turn if able.
+ * • Glorfindel can't be blocked by more than one creature each combat this turn.
+ *
+ * Engine notes (Gap 39 — granted "can't be blocked by more than one creature"):
+ * - The +1/+1 always happens (it's outside the bullet list), so the trigger effect is a
+ *   `Composite` of `ModifyStats(1, 1, Self)` then the `ModalEffect.chooseOne(...)`.
+ * - Mode 1 = `MustBeBlockedEffect(Self, allCreatures = false)` ("must be blocked if able").
+ * - Mode 2 grants `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE` for the turn. This required wiring
+ *   that flag into `BlockPhaseManager.validateMaxBlockersRequirements` (Gap 39): a projected grant of
+ *   the flag now caps blockers at one, alongside the printed `CantBeBlockedByMoreThan` static.
+ */
+val GlorfindelDauntlessRescuer = card("Glorfindel, Dauntless Rescuer") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever you scry, choose one and Glorfindel gets +1/+1 until end of turn.\n" +
+        "• Glorfindel must be blocked this turn if able.\n" +
+        "• Glorfindel can't be blocked by more than one creature each combat this turn."
+
+    // The +1/+1 always happens (it sits before the bullet list), so it is folded into each mode:
+    // exactly one mode is chosen, so Glorfindel always gets +1/+1 once. Modeling it as the top-level
+    // modal effect (rather than Composite(pump, modal)) matches the engine's modal-decision path.
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.Composite(
+                    listOf(
+                        Effects.ModifyStats(1, 1, EffectTarget.Self),
+                        MustBeBlockedEffect(EffectTarget.Self, allCreatures = false)
+                    )
+                ),
+                "Glorfindel gets +1/+1 until end of turn and must be blocked this turn if able"
+            ),
+            Mode.noTarget(
+                Effects.Composite(
+                    listOf(
+                        Effects.ModifyStats(1, 1, EffectTarget.Self),
+                        Effects.GrantKeyword(
+                            AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE,
+                            EffectTarget.Self,
+                            Duration.EndOfTurn
+                        )
+                    )
+                ),
+                "Glorfindel gets +1/+1 until end of turn and can't be blocked by more than one creature each combat this turn"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        flavorText = "On the Elf-lord's brow sat wisdom, and in his hand was strength."
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg?1686969418"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GlorfindelDauntlessRescuer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GlorfindelDauntlessRescuer.kt
@@ -21,13 +21,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * • Glorfindel must be blocked this turn if able.
  * • Glorfindel can't be blocked by more than one creature each combat this turn.
  *
- * Engine notes (Gap 39 — granted "can't be blocked by more than one creature"):
- * - The +1/+1 always happens (it's outside the bullet list), so the trigger effect is a
- *   `Composite` of `ModifyStats(1, 1, Self)` then the `ModalEffect.chooseOne(...)`.
- * - Mode 1 = `MustBeBlockedEffect(Self, allCreatures = false)` ("must be blocked if able").
- * - Mode 2 grants `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE` for the turn. This required wiring
- *   that flag into `BlockPhaseManager.validateMaxBlockersRequirements` (Gap 39): a projected grant of
- *   the flag now caps blockers at one, alongside the printed `CantBeBlockedByMoreThan` static.
+ * The +1/+1 always happens (it sits before the bullet list), so it is folded into each mode
+ * (exactly one mode is chosen → +1/+1 once). Mode 1 = `MustBeBlockedEffect(Self, allCreatures =
+ * false)` ("must be blocked if able"); mode 2 grants `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE`
+ * for the turn.
  */
 val GlorfindelDauntlessRescuer = card("Glorfindel, Dauntless Rescuer") {
     manaCost = "{2}{G}"
@@ -39,9 +36,8 @@ val GlorfindelDauntlessRescuer = card("Glorfindel, Dauntless Rescuer") {
         "• Glorfindel must be blocked this turn if able.\n" +
         "• Glorfindel can't be blocked by more than one creature each combat this turn."
 
-    // The +1/+1 always happens (it sits before the bullet list), so it is folded into each mode:
-    // exactly one mode is chosen, so Glorfindel always gets +1/+1 once. Modeling it as the top-level
-    // modal effect (rather than Composite(pump, modal)) matches the engine's modal-decision path.
+    // Folding the +1/+1 into each mode (rather than Composite(pump, modal)) keeps it on the
+    // engine's modal-decision path.
     triggeredAbility {
         trigger = Triggers.WheneverYouScry
         effect = ModalEffect.chooseOne(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GloriousGale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GloriousGale.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Glorious Gale
+ * {1}{U}
+ * Instant
+ *
+ * Counter target creature spell. If it was a legendary spell, the Ring tempts you.
+ *
+ * Composable: the legendary check is evaluated while the spell is still on the stack (legendary-ness
+ * is intrinsic, so ordering the conditional before the counter is functionally identical to the
+ * printed order), then the spell is countered.
+ */
+val GloriousGale = card("Glorious Gale") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell. If it was a legendary spell, the Ring tempts you."
+
+    spell {
+        target("creature spell", Targets.CreatureSpell)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Any.legendary(), 0),
+            effect = Effects.TheRingTemptsYou()
+        ).then(Effects.CounterSpell())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        flavorText = "The Elves of Lórien took Dol Guldur. Galadriel threw down its walls and laid bare its pits, and the forest was cleansed."
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg?1686968102"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GwaihirTheWindlord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GwaihirTheWindlord.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gwaihir the Windlord
+ * {4}{W}{U}
+ * Legendary Creature — Bird Noble
+ * 4/4
+ *
+ * This spell costs {2} less to cast as long as you've drawn two or more cards this turn.
+ * Flying, vigilance
+ * Other Birds you control have vigilance.
+ *
+ * The conditional cost reduction uses `ModifySpellCost(SelfCast, ReduceGeneric(2),
+ * gating = OnlyIf(Conditions.YouDrewCardsThisTurn(2)))` — the new "drew N+ cards this turn"
+ * condition backed by the per-player `CardsDrawnThisTurnComponent`.
+ */
+val GwaihirTheWindlord = card("Gwaihir the Windlord") {
+    manaCost = "{4}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Bird Noble"
+    power = 4
+    toughness = 4
+    oracleText = "This spell costs {2} less to cast as long as you've drawn two or more cards this turn.\n" +
+        "Flying, vigilance\n" +
+        "Other Birds you control have vigilance."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.YouDrewCardsThisTurn(2)),
+        )
+    }
+
+    // Other Birds you control have vigilance.
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.VIGILANCE,
+            filter = GroupFilter(
+                baseFilter = GameObjectFilter.Creature.youControl().withSubtype("Bird"),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Axel Sauerwald"
+        flavorText = "There came Gwaihir the Windlord, greatest of all the Eagles of the North, mightiest of the descendants of old Thorondor."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg?1686969841"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasMasterArcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasMasterArcher.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Legolas, Master Archer
+ * {1}{G}{G}
+ * Legendary Creature — Elf Archer
+ * 1/4
+ *
+ * Reach
+ * Whenever you cast a spell that targets Legolas, put a +1/+1 counter on Legolas.
+ * Whenever you cast a spell that targets a creature you don't control, Legolas deals
+ * damage equal to its power to up to one target creature.
+ *
+ * Both abilities use the new `SpellCastPredicate.TargetsSource` / `TargetsMatching`
+ * cast-time predicates (Triggers.youCastSpellTargetingSource / youCastSpellTargeting).
+ * The damage clause composes `DealDamage(sourcePower(), target)` — the damage source
+ * defaults to Legolas (the trigger source).
+ */
+val LegolasMasterArcher = card("Legolas, Master Archer") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elf Archer"
+    power = 1
+    toughness = 4
+    oracleText = "Reach\n" +
+        "Whenever you cast a spell that targets Legolas, put a +1/+1 counter on Legolas.\n" +
+        "Whenever you cast a spell that targets a creature you don't control, Legolas deals " +
+        "damage equal to its power to up to one target creature."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpellTargetingSource()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpellTargeting(GameObjectFilter.Creature.opponentControls())
+        val t = target("up to one target creature", TargetCreature(optional = true))
+        effect = Effects.DealDamage(DynamicAmounts.sourcePower(), t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "173"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg?1686969439"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasMasterArcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasMasterArcher.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 
@@ -22,10 +23,11 @@ import com.wingedsheep.sdk.scripting.targets.TargetCreature
  * Whenever you cast a spell that targets a creature you don't control, Legolas deals
  * damage equal to its power to up to one target creature.
  *
- * Both abilities use the new `SpellCastPredicate.TargetsSource` / `TargetsMatching`
- * cast-time predicates (Triggers.youCastSpellTargetingSource / youCastSpellTargeting).
- * The damage clause composes `DealDamage(sourcePower(), target)` — the damage source
- * defaults to Legolas (the trigger source).
+ * Both abilities use the `SpellCastPredicate.TargetsSource` / `TargetsMatching` cast-time
+ * predicates (Triggers.youCastSpellTargetingSource / youCastSpellTargeting). "A creature you
+ * don't control" is `Not(ControlledByYou)` (not `opponentControls()`, which would miss a
+ * teammate's creatures in multiplayer). The damage clause composes `DealDamage(sourcePower(),
+ * target)` — the damage source defaults to Legolas (the trigger source).
  */
 val LegolasMasterArcher = card("Legolas, Master Archer") {
     manaCost = "{1}{G}{G}"
@@ -46,7 +48,11 @@ val LegolasMasterArcher = card("Legolas, Master Archer") {
     }
 
     triggeredAbility {
-        trigger = Triggers.youCastSpellTargeting(GameObjectFilter.Creature.opponentControls())
+        trigger = Triggers.youCastSpellTargeting(
+            GameObjectFilter.Creature.withControllerPredicate(
+                ControllerPredicate.Not(ControllerPredicate.ControlledByYou)
+            )
+        )
         val t = target("up to one target creature", TargetCreature(optional = true))
         effect = Effects.DealDamage(DynamicAmounts.sourcePower(), t)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MountDoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MountDoom.kt
@@ -35,6 +35,7 @@ import com.wingedsheep.sdk.scripting.values.ManaColorSet
  */
 val MountDoom = card("Mount Doom") {
     typeLine = "Legendary Land"
+    colorIdentity = "BR"
     oracleText = "{T}, Pay 1 life: Add {B} or {R}.\n" +
         "{1}{B}{R}, {T}: Mount Doom deals 1 damage to each opponent.\n" +
         "{5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: Choose up to two creatures, " +

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MountDoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MountDoom.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Mount Doom
+ * Legendary Land
+ *
+ * {T}, Pay 1 life: Add {B} or {R}.
+ * {1}{B}{R}, {T}: Mount Doom deals 1 damage to each opponent.
+ * {5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: Choose up to two creatures, then
+ * destroy the rest. Activate only as a sorcery.
+ *
+ * Composable: the "choose up to two, destroy the rest" wrath uses the Duneblast pipeline
+ * (Gather → Select ChooseUpTo(2) with storeRemainder → Move Destroy).
+ */
+val MountDoom = card("Mount Doom") {
+    typeLine = "Legendary Land"
+    oracleText = "{T}, Pay 1 life: Add {B} or {R}.\n" +
+        "{1}{B}{R}, {T}: Mount Doom deals 1 damage to each opponent.\n" +
+        "{5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: Choose up to two creatures, " +
+        "then destroy the rest. Activate only as a sorcery."
+
+    // {T}, Pay 1 life: Add {B} or {R}.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = AddManaOfChoiceEffect(ManaColorSet.Specific(setOf(Color.BLACK, Color.RED)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {1}{B}{R}, {T}: deal 1 damage to each opponent.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}{R}"), Costs.Tap)
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    // {5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: choose up to two creatures,
+    // destroy the rest.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{5}{B}{R}"),
+            Costs.Tap,
+            Costs.SacrificeSelf,
+            Costs.Sacrifice(GameObjectFilter.Artifact.legendary())
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(filter = GameObjectFilter.Creature),
+                    storeAs = "all_creatures"
+                ),
+                SelectFromCollectionEffect(
+                    from = "all_creatures",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "saved",
+                    storeRemainder = "to_destroy",
+                    prompt = "Choose up to two creatures to save",
+                    selectedLabel = "Save",
+                    remainderLabel = "Destroy",
+                    useTargetingUI = true
+                ),
+                MoveCollectionEffect(
+                    from = "to_destroy",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Destroy
+                )
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "258"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg?1686970382"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PhialOfGaladriel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PhialOfGaladriel.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyDrawAmount
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Phial of Galadriel
+ * {3}
+ * Legendary Artifact
+ *
+ * If you would draw a card while you have no cards in hand, draw two cards instead.
+ * If you would gain life while you have 5 or less life, you gain twice that much life instead.
+ * {T}: Add one mana of any color.
+ *
+ * The two replacements compose from existing primitives: `ModifyDrawAmount(+1)` gated on an empty
+ * hand, and `ModifyLifeGain(×2)` gated on the new `restrictions` field (life ≤ 5).
+ */
+val PhialOfGaladriel = card("Phial of Galadriel") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "If you would draw a card while you have no cards in hand, draw two cards instead.\n" +
+        "If you would gain life while you have 5 or less life, you gain twice that much life instead.\n" +
+        "{T}: Add one mana of any color."
+
+    replacementEffect(
+        ModifyDrawAmount(
+            modifier = 1,
+            restrictions = listOf(Conditions.CardsInHandAtMost(0)),
+            appliesTo = EventPattern.DrawEvent(player = Player.You),
+        )
+    )
+
+    replacementEffect(
+        ModifyLifeGain(
+            multiplier = 2,
+            appliesTo = EventPattern.LifeGainEvent(player = Player.You),
+            restrictions = listOf(Conditions.LifeAtMost(5)),
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaOfChoiceEffect(
+            colorSet = ManaColorSet.AnyColor,
+            amount = DynamicAmount.Fixed(1),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "248"
+        artist = "Andrea Piparo"
+        flavorText = "\"May it be a light to you in dark places, when all other lights go out.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg?1686970260"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RangersOfIthilien.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RangersOfIthilien.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Rangers of Ithilien
+ * {2}{U}{U}
+ * Creature — Human Ranger
+ * 3/3
+ *
+ * Vigilance
+ * When this creature enters, gain control of up to one target creature with lesser power for as long
+ * as you control this creature. Then the Ring tempts you.
+ *
+ * "Lesser power" uses the new strict `CardPredicate.PowerLessThanEntity` / `powerLessThanEntity()`
+ * (compared to the source's power); the control change uses `Duration.WhileYouControlSource`.
+ */
+val RangersOfIthilien = card("Rangers of Ithilien") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "When this creature enters, gain control of up to one target creature with lesser power for " +
+        "as long as you control this creature. Then the Ring tempts you."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one target creature with lesser power",
+            TargetCreature(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Creature.powerLessThanEntity(EntityReference.Source))
+            )
+        )
+        effect = Effects.GainControl(creature, Duration.WhileYouControlSource("Rangers of Ithilien"))
+            .then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        flavorText = "\"We have a new errand on this journey: to ambush the Men of Harad.\""
+        artist = "Torgeir Fjereide"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg?1686968256"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RidersOfTheMark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RidersOfTheMark.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Riders of the Mark
+ * {6}{R}
+ * Creature — Human Knight
+ * 7/4
+ *
+ * Affinity for Humans (This spell costs {1} less to cast for each Human you control.)
+ * Trample, haste
+ * At the beginning of your end step, if this creature attacked this turn, return it to its owner's
+ * hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to its toughness.
+ *
+ * Composable: the token count reads `DynamicAmounts.sourceToughness()` (last-known toughness, like
+ * Heartfire Hero's source-power-on-death), evaluated after the bounce.
+ */
+val RidersOfTheMark = card("Riders of the Mark") {
+    manaCost = "{6}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Knight"
+    power = 7
+    toughness = 4
+    oracleText = "Affinity for Humans (This spell costs {1} less to cast for each Human you control.)\n" +
+        "Trample, haste\n" +
+        "At the beginning of your end step, if this creature attacked this turn, return it to its " +
+        "owner's hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to " +
+        "its toughness."
+
+    keywordAbility(KeywordAbility.AffinityForSubtype(Subtype.HUMAN))
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.SourceAttackedThisTurn
+        effect = Effects.ReturnToHand(EffectTarget.Self).then(
+            Effects.CreateToken(
+                count = DynamicAmounts.sourceToughness(),
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Human", "Soldier")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "827"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de77686e-c4c1-4d38-a05c-03eb7363fc0b.jpg?1719684208"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Ringsight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Ringsight.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ringsight
+ * {1}{U}{B}
+ * Sorcery
+ *
+ * The Ring tempts you. Search your library for a card that shares a color with a legendary
+ * creature you control, reveal it, put it into your hand, then shuffle.
+ *
+ * The tutor filter uses the new `sharingColorWithPermanentYouControl(Creature.legendary())`
+ * (CardPredicate.SharesColorWithPermanentYouControl). If you control no legendary creature,
+ * the filter matches nothing and the search finds nothing.
+ */
+val Ringsight = card("Ringsight") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "The Ring tempts you. Search your library for a card that shares a color with a legendary " +
+        "creature you control, reveal it, put it into your hand, then shuffle."
+
+    spell {
+        effect = Effects.TheRingTemptsYou() then Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Any.sharingColorWithPermanentYouControl(
+                GameObjectFilter.Creature.legendary()
+            ),
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Campbell White"
+        flavorText = "Frodo was able to see beneath their black wrappings. In their white faces burned keen and merciless eyes."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg?1686969951"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SmeagolHelpfulGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SmeagolHelpfulGuide.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Sméagol, Helpful Guide
+ * {1}{B}{G}
+ * Legendary Creature — Halfling Horror
+ * 4/2
+ *
+ * At the beginning of your end step, if a creature died under your control this turn, the
+ * Ring tempts you.
+ * Whenever the Ring tempts you, target opponent reveals cards from the top of their library
+ * until they reveal a land card. Put that card onto the battlefield tapped under your control
+ * and the rest into their graveyard.
+ *
+ * The reveal half composes GatherUntilMatch (until a land, from the target opponent's library)
+ * + RevealCollection + two filtered MoveCollections: the land → your battlefield tapped, the
+ * rest → the opponent's graveyard.
+ */
+val SmeagolHelpfulGuide = card("Sméagol, Helpful Guide") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Halfling Horror"
+    power = 4
+    toughness = 2
+    oracleText = "At the beginning of your end step, if a creature died under your control this " +
+        "turn, the Ring tempts you.\n" +
+        "Whenever the Ring tempts you, target opponent reveals cards from the top of their " +
+        "library until they reveal a land card. Put that card onto the battlefield tapped under " +
+        "your control and the rest into their graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.ControlledCreatureDiedThisTurn
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            listOf(
+                GatherUntilMatchEffect(
+                    player = Player.TargetOpponent,
+                    filter = GameObjectFilter.Land,
+                    storeMatch = "revealedLand",
+                    storeRevealed = "allRevealed"
+                ),
+                RevealCollectionEffect(from = "allRevealed"),
+                // The land enters under your control, tapped.
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter.Land,
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        player = Player.You,
+                        placement = ZonePlacement.Tapped
+                    )
+                ),
+                // The rest go into the opponent's graveyard (they own them).
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter.Nonland,
+                    destination = CardDestination.ToZone(
+                        Zone.GRAVEYARD,
+                        player = Player.TargetOpponent
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg?1686970071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheGreyHavens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheGreyHavens.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * The Grey Havens
+ * Legendary Land
+ *
+ * When The Grey Havens enters, scry 1.
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color among legendary creature cards in your graveyard.
+ *
+ * The third ability uses the new `Effects.AddManaOfColorAmongGraveyard(filter)` (backed by
+ * `ManaColorSet.AmongCardsInGraveyard`), which reads the colors among matching cards in your
+ * graveyard.
+ */
+val TheGreyHavens = card("The Grey Havens") {
+    typeLine = "Legendary Land"
+    oracleText = "When The Grey Havens enters, scry 1.\n" +
+        "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any color among legendary creature cards in your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfColorAmongGraveyard(GameObjectFilter.Creature.legendary())
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "255"
+        artist = "Alayna Danner"
+        flavorText = "There dwelt Círdan the Shipwright, and some say he dwells there still, until the Last Ship sets sail into the West."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg?1687694648"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheOneRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheOneRing.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The One Ring
+ * {4}
+ * Legendary Artifact
+ *
+ * Indestructible
+ * When The One Ring enters, if you cast it, you gain protection from everything until your next turn.
+ * At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.
+ * {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring.
+ *
+ * Engine notes (Gap 8 — player-level protection):
+ * - "You gain protection from everything until your next turn" is the player counterpart of the
+ *   creature protection statics. Modeled via `Effects.GrantPlayerProtection()` (defaults to
+ *   ProtectionScope.Everything / Duration.UntilYourNextTurn / the controller), which adds a
+ *   `PlayerProtectionComponent`. The targeting validator + target enumerator + damage executor
+ *   all consult `PlayerProtectionRules`, so while protected the controller can't be targeted by,
+ *   or dealt damage from, any source (CR 702.16). Cleared after the untap step of their next turn.
+ * - The ETB is gated on `Conditions.WasCast` ("if you cast it") — putting The One Ring onto the
+ *   battlefield by another effect grants no protection (CR 603.4 intervening-if).
+ * - The {T} ability adds the burden counter first, then draws reading the *new* count (sequential
+ *   resolution, CR 608.2c): `AddCounters` then `DrawCards(countersOnSelf(burden))`.
+ * - The burden counter has no rules meaning of its own; it only feeds the upkeep life-loss and the
+ *   draw count, and grows the upkeep tax each activation.
+ */
+val TheOneRing = card("The One Ring") {
+    manaCost = "{4}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Indestructible\n" +
+        "When The One Ring enters, if you cast it, you gain protection from everything until your next turn.\n" +
+        "At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.\n" +
+        "{T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // When The One Ring enters, if you cast it, you gain protection from everything until your next turn.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.GrantPlayerProtection()
+    }
+
+    // At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.LoseLife(
+            DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.BURDEN)),
+            EffectTarget.Controller
+        )
+    }
+
+    // {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on it.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            listOf(
+                Effects.AddCounters(Counters.BURDEN, 1, EffectTarget.Self),
+                Effects.DrawCards(DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.BURDEN)))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "246"
+        artist = "Veli Nyström"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg?1763472900"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheOneRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheOneRing.kt
@@ -25,10 +25,9 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Engine notes (Gap 8 — player-level protection):
  * - "You gain protection from everything until your next turn" is the player counterpart of the
  *   creature protection statics. Modeled via `Effects.GrantPlayerProtection()` (defaults to
- *   ProtectionScope.Everything / Duration.UntilYourNextTurn / the controller), which adds a
- *   `PlayerProtectionComponent`. The targeting validator + target enumerator + damage executor
- *   all consult `PlayerProtectionRules`, so while protected the controller can't be targeted by,
- *   or dealt damage from, any source (CR 702.16). Cleared after the untap step of their next turn.
+ *   ProtectionScope.Everything / Duration.UntilYourNextTurn / the controller). While protected the
+ *   controller can't be targeted by, or dealt damage from, any source (CR 702.16), until cleared
+ *   after the untap step of their next turn.
  * - The ETB is gated on `Conditions.WasCast` ("if you cast it") — putting The One Ring onto the
  *   battlefield by another effect grants no protection (CR 603.4 intervening-if).
  * - The {T} ability adds the burden counter first, then draws reading the *new* count (sequential

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheRingGoesSouth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheRingGoesSouth.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The Ring Goes South
+ * {3}{G}
+ * Sorcery
+ *
+ * The Ring tempts you. Then reveal cards from the top of your library until you reveal X land
+ * cards, where X is the number of legendary creatures you control. Put those land cards onto
+ * the battlefield tapped and the rest on the bottom of your library in a random order.
+ *
+ * Composes the Ring tempt with GatherUntilMatch (X = legendary creatures you control) +
+ * two filtered MoveCollections: lands → battlefield tapped, the rest → bottom of library at
+ * random.
+ */
+val TheRingGoesSouth = card("The Ring Goes South") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "The Ring tempts you. Then reveal cards from the top of your library until you " +
+        "reveal X land cards, where X is the number of legendary creatures you control. Put those " +
+        "land cards onto the battlefield tapped and the rest on the bottom of your library in a " +
+        "random order."
+
+    spell {
+        effect = Effects.TheRingTemptsYou()
+            .then(
+                GatherUntilMatchEffect(
+                    player = Player.You,
+                    filter = GameObjectFilter.Land,
+                    count = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count(),
+                    storeMatch = "lands",
+                    storeRevealed = "allRevealed"
+                )
+            )
+            .then(RevealCollectionEffect(from = "allRevealed"))
+            .then(
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter.Land,
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        player = Player.You,
+                        placement = ZonePlacement.Tapped
+                    )
+                )
+            )
+            .then(
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter.Nonland,
+                    destination = CardDestination.ToZone(
+                        Zone.LIBRARY,
+                        player = Player.You,
+                        placement = ZonePlacement.Bottom
+                    ),
+                    order = CardOrder.Random
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "186"
+        artist = "Wangjie Li"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg?1686969579"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TrollOfKhazadDum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TrollOfKhazadDum.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByFewerThan
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Troll of Khazad-dûm
+ * {5}{B}
+ * Creature — Troll
+ * 6/5
+ *
+ * This creature can't be blocked except by three or more creatures.
+ * Swampcycling {1}
+ *
+ * The block restriction uses the new `CantBeBlockedByFewerThan(3)` static (a generalization of
+ * menace's minimum-2). Swampcycling composes via `KeywordAbility.typecycling("Swamp", "{1}")`.
+ */
+val TrollOfKhazadDum = card("Troll of Khazad-dûm") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Troll"
+    power = 6
+    toughness = 5
+    oracleText = "This creature can't be blocked except by three or more creatures.\n" +
+        "Swampcycling {1} ({1}, Discard this card: Search your library for a Swamp card, reveal it, " +
+        "put it into your hand, then shuffle.)"
+
+    staticAbility {
+        ability = CantBeBlockedByFewerThan(3)
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Swamp", "{1}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Simon Dominic"
+        flavorText = "\"A great cave-troll, I think. There is no hope of escape that way.\"\n—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg?1743419034"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/YouCannotPass.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/YouCannotPass.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * You Cannot Pass!
+ * {W}
+ * Instant
+ *
+ * Destroy target creature that blocked or was blocked by a legendary creature this turn.
+ *
+ * The target filter uses the new `StatePredicate.BlockedOrWasBlockedByLegendaryThisTurn`
+ * (`blockedOrWasBlockedByLegendaryThisTurn()`), backed by a per-creature marker stamped at
+ * block declaration. The marker captures the legendary partner's status at pairing time, so
+ * the spell can still target the creature even after that legendary creature has left the
+ * battlefield (per the card's ruling).
+ */
+val YouCannotPass = card("You Cannot Pass!") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature that blocked or was blocked by a legendary creature this turn."
+
+    spell {
+        val t = target(
+            "target creature that blocked or was blocked by a legendary creature this turn",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.blockedOrWasBlockedByLegendaryThisTurn())
+            )
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Leonardo Borazio"
+        flavorText = "It raised the whip, and the thongs whined and cracked. Fire came from its nostrils. But Gandalf stood firm."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg?1686967987"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -1672,6 +1672,74 @@
     ]
 }
 
+// Boromir, Warden of the Tower
+{
+    "name": "Boromir, Warden of the Tower",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Vigilance\nWhenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.\nSacrifice Boromir: Creatures you control gain indestructible until end of turn. The Ring tempts you.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Counter",
+                    "targetSource": "CounterTargetSource.TriggeringEntity"
+                },
+                "triggerCondition": "TriggeringSpellCastWithoutPayingMana"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": "Self"
+                            }
+                        },
+                        "TheRingTemptsYou"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Yigit Koroglu",
+        "flavorText": "\"Farewell, Aragorn! Go to Minas Tirith and save my people!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg?1686967669"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Brandywine Farmer
 {
     "name": "Brandywine Farmer",
@@ -1764,6 +1832,69 @@
     "colorIdentityOverride": [
         "GREEN",
         "WHITE"
+    ]
+}
+
+// Call of the Ring
+{
+    "name": "Call of the Ring",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, the Ring tempts you.\nWhenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": "TheRingTemptsYou"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "RingTemptedEvent",
+                    "requireBearerChosen": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "RARE",
+        "artist": "Anato Finnstark",
+        "flavorText": "\"The Ring is mine!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg?1686968397"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2901,6 +3032,56 @@
     ]
 }
 
+// Dúnedain Rangers
+{
+    "name": "Dúnedain Rangers",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Human Ranger",
+    "oracleText": "Landfall — Whenever a land you control enters, if you don't control a Ring-bearer, the Ring tempts you.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": "TheRingTemptsYou",
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsRingBearer"
+                        ]
+                    },
+                    "negate": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Wilkerson",
+        "flavorText": "\"Aragorn has need of his kindred. Let the Dúnedain go to him in Rohan!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg?1687694686"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Eagle of Deliverance
 {
     "name": "Eagle of Deliverance",
@@ -3313,6 +3494,104 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Elrond, Lord of Rivendell
+{
+    "name": "Elrond, Lord of Rivendell",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Whenever Elrond or another creature you control enters, scry 1. If this is the second time this ability has resolved this turn, the Ring tempts you.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent",
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 2
+                                }
+                            },
+                            "then": "TheRingTemptsYou"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Yee",
+        "flavorText": "\"This is the hour of the Shire-folk, when they arise from their quiet fields to shake the towers and counsels of the Great. Who of all the Wise could have foreseen it?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg?1686968084"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5039,6 +5318,56 @@
     ]
 }
 
+// Frodo Baggins
+{
+    "name": "Frodo Baggins",
+    "manaCost": "{G}{W}",
+    "typeLine": "Legendary Creature — Halfling Scout",
+    "oracleText": "Whenever Frodo Baggins or another legendary creature you control enters, the Ring tempts you.\nAs long as Frodo Baggins is your Ring-bearer, it must be blocked if able.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": "TheRingTemptsYou"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "MustBeBlockedStatic",
+                "condition": "SourceIsRingBearer"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "\"Few have ever come hither through greater peril or on an errand more urgent.\"\n—Elrond",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg?1686969787"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Frodo, Determined Hero
 {
     "name": "Frodo, Determined Hero",
@@ -6097,6 +6426,60 @@
     ]
 }
 
+// Glorious Gale
+{
+    "name": "Glorious Gale",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature spell. If it was a legendary spell, the Ring tempts you.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsLegendary"
+                                ]
+                            }
+                        }
+                    },
+                    "then": "TheRingTemptsYou"
+                },
+                "Counter"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature",
+                    "zone": "Stack"
+                },
+                "id": "creature spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "The Elves of Lórien took Dol Guldur. Galadriel threw down its walls and laid bare its pits, and the forest was cleansed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg?1686968102"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Glóin, Dwarf Emissary
 {
     "name": "Glóin, Dwarf Emissary",
@@ -6783,6 +7166,60 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Gwaihir the Windlord
+{
+    "name": "Gwaihir the Windlord",
+    "manaCost": "{4}{W}{U}",
+    "typeLine": "Legendary Creature — Bird Noble",
+    "oracleText": "This spell costs {2} less to cast as long as you've drawn two or more cards this turn.\nFlying, vigilance\nOther Birds you control have vigilance.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "PlayerDrewCardsThisTurn",
+                        "atLeast": 2
+                    }
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature Bird ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Axel Sauerwald",
+        "flavorText": "There came Gwaihir the Windlord, greatest of all the Eagles of the North, mightiest of the descendants of old Thorondor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg?1686969841"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 
@@ -9899,6 +10336,148 @@
     ]
 }
 
+// Mount Doom
+{
+    "name": "Mount Doom",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}, Pay 1 life: Add {B} or {R}.\n{1}{B}{R}, {T}: Mount Doom deals 1 damage to each opponent.\n{5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: Choose up to two creatures, then destroy the rest. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": {
+                        "type": "ManaColorSet.Specific",
+                        "colors": [
+                            "BLACK",
+                            "RED"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{B}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsArtifact",
+                                        "IsLegendary"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature"
+                            },
+                            "storeAs": "all_creatures"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "all_creatures",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "saved",
+                            "storeRemainder": "to_destroy",
+                            "prompt": "Choose up to two creatures to save",
+                            "selectedLabel": "Save",
+                            "remainderLabel": "Destroy",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "to_destroy",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "MYTHIC",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg?1686970382"
+    }
+}
+
 // Mushroom Watchdogs
 {
     "name": "Mushroom Watchdogs",
@@ -11159,6 +11738,75 @@
     ]
 }
 
+// Rangers of Ithilien
+{
+    "name": "Rangers of Ithilien",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Human Ranger",
+    "oracleText": "Vigilance\nWhen this creature enters, gain control of up to one target creature with lesser power for as long as you control this creature. Then the Ring tempts you.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainControl",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature with lesser power"
+                            },
+                            "duration": {
+                                "type": "WhileYouControlSource",
+                                "sourceDescription": "Rangers of Ithilien"
+                            }
+                        },
+                        "TheRingTemptsYou"
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "PowerLessThanEntity",
+                                    "reference": "Source"
+                                }
+                            ]
+                        }
+                    },
+                    "id": "up to one target creature with lesser power"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "Torgeir Fjereide",
+        "flavorText": "\"We have a new errand on this journey: to ambush the Men of Harad.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg?1686968256"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Relentless Rohirrim
 {
     "name": "Relentless Rohirrim",
@@ -11278,6 +11926,161 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Riders of the Mark
+{
+    "name": "Riders of the Mark",
+    "manaCost": "{6}{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Affinity for Humans (This spell costs {1} less to cast for each Human you control.)\nTrample, haste\nAt the beginning of your end step, if this creature attacked this turn, return it to its owner's hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to its toughness.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "AffinityForSubtype",
+            "forSubtype": "Human"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "WHITE"
+                            ],
+                            "creatureTypes": [
+                                "Human",
+                                "Soldier"
+                            ]
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "AttackedThisTurn"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "827",
+        "rarity": "RARE",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de77686e-c4c1-4d38-a05c-03eb7363fc0b.jpg?1719684208"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ringsight
+{
+    "name": "Ringsight",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "The Ring tempts you. Search your library for a card that shares a color with a legendary creature you control, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "TheRingTemptsYou",
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "SharesColorWithPermanentYouControl",
+                                            "filter": {
+                                                "cardPredicates": [
+                                                    "IsCreature",
+                                                    "IsLegendary"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Campbell White",
+        "flavorText": "Frodo was able to see beneath their black wrappings. In their white faces burned keen and merciless eyes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg?1686969951"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -14271,6 +15074,116 @@
     ]
 }
 
+// The Grey Havens
+{
+    "name": "The Grey Havens",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "When The Grey Havens enters, scry 1.\n{T}: Add {C}.\n{T}: Add one mana of any color among legendary creature cards in your graveyard.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": {
+                        "type": "ManaColorSet.AmongCardsInGraveyard",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ]
+                        }
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "rarity": "UNCOMMON",
+        "artist": "Alayna Danner",
+        "flavorText": "There dwelt Círdan the Shipwright, and some say he dwells there still, until the Last Ship sets sail into the West.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg?1687694648"
+    }
+}
+
 // The Mouth of Sauron
 {
     "name": "The Mouth of Sauron",
@@ -15654,6 +16567,51 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// You Cannot Pass!
+{
+    "name": "You Cannot Pass!",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature that blocked or was blocked by a legendary creature this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature that blocked or was blocked by a legendary creature this turn"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "BlockedOrWasBlockedByLegendaryThisTurn"
+                        ]
+                    }
+                },
+                "id": "target creature that blocked or was blocked by a legendary creature this turn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Borazio",
+        "flavorText": "It raised the whip, and the thongs whined and cracked. Fire came from its nostrils. But Gandalf stood firm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg?1686967987"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -10475,7 +10475,11 @@
         "rarity": "MYTHIC",
         "artist": "Jonas De Ro",
         "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg?1686970382"
-    }
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
 }
 
 // Mushroom Watchdogs

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -60,6 +60,102 @@
     ]
 }
 
+// A-The One Ring
+{
+    "name": "A-The One Ring",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Indestructible\nWhen The One Ring enters, if you cast it, you gain protection from everything until your next turn.\nAt the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.\n{1}, {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "GrantPlayerProtection",
+                "triggerCondition": "WasCast"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "burden"
+                            }
+                        }
+                    },
+                    "target": "Controller"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "burden",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": {
+                                    "type": "CounterCount",
+                                    "counterType": {
+                                        "type": "Named",
+                                        "name": "burden"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "A-246",
+        "rarity": "MYTHIC",
+        "artist": "Veli Nyström",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23b91af8-eff9-402a-8ba8-ab470c5c1a44.jpg?1730837118"
+    }
+}
+
 // Andúril, Flame of the West
 {
     "name": "Andúril, Flame of the West",
@@ -1019,6 +1115,78 @@
     ]
 }
 
+// Barrow-Blade
+{
+    "name": "Barrow-Blade",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nWhenever equipped creature blocks or becomes blocked by a creature, that creature loses all abilities until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BlocksOrBecomesBlockedByEvent",
+                    "partnerFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "RemoveAllAbilities",
+                    "target": "TriggeringEntity"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg?1686970135"
+    }
+}
+
 // Battle-Scarred Goblin
 {
     "name": "Battle-Scarred Goblin",
@@ -1784,6 +1952,58 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Breaking of the Fellowship
+{
+    "name": "Breaking of the Fellowship",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature an opponent controls deals damage equal to its power to another target creature that player controls. The Ring tempts you.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 1
+                    },
+                    "damageSource": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "TheRingTemptsYou"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creatures an opponent controls",
+                "sameController": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"It might have been mine. It should be mine. Give it to me!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg?1686968821"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2694,6 +2914,39 @@
     "colorIdentityOverride": [
         "BLACK",
         "WHITE"
+    ]
+}
+
+// Display of Power
+{
+    "name": "Display of Power",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be copied.\nCopy any number of target instant and/or sorcery spells. You may choose new targets for the copies.",
+    "script": {
+        "spellEffect": "CopyEachTargetSpell",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "unlimited": true,
+                "filter": {
+                    "baseFilter": "instant|sorcery",
+                    "zone": "Stack"
+                },
+                "id": "any number of target instant and/or sorcery spells"
+            }
+        ],
+        "cantBeCopied": true
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "RARE",
+        "artist": "Shahab Alizadeh",
+        "flavorText": "\"The Nazgûl closed round at night, and I was besieged. Such light and flame cannot have been seen on Weathertop since the war-beacons of old.\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg?1686968845"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5630,6 +5883,129 @@
     ]
 }
 
+// Galadriel of Lothlórien
+{
+    "name": "Galadriel of Lothlórien",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Whenever the Ring tempts you, if you chose a creature other than Galadriel as your Ring-bearer, scry 3.\nWhenever you scry, you may reveal the top card of your library. If a land card is revealed this way, put it onto the battlefield tapped.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "RingTemptedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "scried"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "scried",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeSelected": "toBottom",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put on bottom",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        "EmitScriedEvent"
+                    ]
+                },
+                "triggerCondition": "YouChoseOtherCreatureAsRingBearer"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "ScriedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeAs": "revealedTop"
+                            },
+                            {
+                                "type": "RevealCollection",
+                                "from": "revealedTop"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "revealedTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                },
+                                "filter": "land"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"I pass the test. I will diminish, and go into the West, and remain Galadriel.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg?1686969798"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Galadriel, Gift-Giver
 {
     "name": "Galadriel, Gift-Giver",
@@ -5802,6 +6178,50 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Gandalf's Sanction
+{
+    "name": "Gandalf's Sanction",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gandalf's Sanction deals X damage to target creature, where X is the number of instant and sorcery cards in your graveyard. Excess damage is dealt to that creature's controller instead.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "AggregateZone",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "instant|sorcery"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            },
+            "excessToController": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Tatiana Veryayskaya",
+        "flavorText": "There was a crack, and the staff split asunder in Saruman's hand, and the head of it fell down at Gandalf's feet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg?1688134626"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -6423,6 +6843,92 @@
     "colorIdentityOverride": [
         "GREEN",
         "RED"
+    ]
+}
+
+// Glorfindel, Dauntless Rescuer
+{
+    "name": "Glorfindel, Dauntless Rescuer",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Whenever you scry, choose one and Glorfindel gets +1/+1 until end of turn.\n• Glorfindel must be blocked this turn if able.\n• Glorfindel can't be blocked by more than one creature each combat this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "ScriedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "MustBeBlocked",
+                                        "target": "Self",
+                                        "allCreatures": false
+                                    }
+                                ]
+                            },
+                            "description": "Glorfindel gets +1/+1 until end of turn and must be blocked this turn if able"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "CANT_BE_BLOCKED_BY_MORE_THAN_ONE",
+                                        "target": "Self"
+                                    }
+                                ]
+                            },
+                            "description": "Glorfindel gets +1/+1 until end of turn and can't be blocked by more than one creature each combat this turn"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Viko Menezes",
+        "flavorText": "On the Elf-lord's brow sat wisdom, and in his hand was strength.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg?1686969418"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -8470,6 +8976,83 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Legolas, Master Archer
+{
+    "name": "Legolas, Master Archer",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Legendary Creature — Elf Archer",
+    "oracleText": "Reach\nWhenever you cast a spell that targets Legolas, put a +1/+1 counter on Legolas.\nWhenever you cast a spell that targets a creature you don't control, Legolas deals damage equal to its power to up to one target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellTargetsSource"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellTargetsMatching",
+                            "filter": "creature ctrl:opponent"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "RARE",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg?1686969439"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -11358,6 +11941,70 @@
     ]
 }
 
+// Phial of Galadriel
+{
+    "name": "Phial of Galadriel",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "If you would draw a card while you have no cards in hand, draw two cards instead.\nIf you would gain life while you have 5 or less life, you gain twice that much life instead.\n{T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyDrawAmount",
+                "modifier": 1,
+                "restrictions": [
+                    {
+                        "type": "Compare",
+                        "left": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Hand"
+                        },
+                        "operator": "LTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 0
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "ModifyLifeGain",
+                "restrictions": [
+                    {
+                        "type": "Compare",
+                        "left": {
+                            "type": "LifeTotal",
+                            "player": "You"
+                        },
+                        "operator": "LTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "RARE",
+        "artist": "Andrea Piparo",
+        "flavorText": "\"May it be a light to you in dark places, when all other lights go out.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg?1686970260"
+    }
+}
+
 // Pippin's Bravery
 {
     "name": "Pippin's Bravery",
@@ -13986,6 +14633,87 @@
     ]
 }
 
+// Sméagol, Helpful Guide
+{
+    "name": "Sméagol, Helpful Guide",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Halfling Horror",
+    "oracleText": "At the beginning of your end step, if a creature died under your control this turn, the Ring tempts you.\nWhenever the Ring tempts you, target opponent reveals cards from the top of their library until they reveal a land card. Put that card onto the battlefield tapped under your control and the rest into their graveyard.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": "TheRingTemptsYou",
+                "triggerCondition": "ControlledCreatureDiedThisTurn"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RingTemptedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "player": "TargetOpponent",
+                            "filter": "land",
+                            "storeMatch": "revealedLand",
+                            "storeRevealed": "allRevealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "allRevealed"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "allRevealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            },
+                            "filter": "land"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "allRevealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "TargetOpponent"
+                            },
+                            "filter": "nonland"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "RARE",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg?1686970071"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Snarling Warg
 {
     "name": "Snarling Warg",
@@ -15275,6 +16003,156 @@
     ]
 }
 
+// The One Ring
+{
+    "name": "The One Ring",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Indestructible\nWhen The One Ring enters, if you cast it, you gain protection from everything until your next turn.\nAt the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.\n{T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "GrantPlayerProtection",
+                "triggerCondition": "WasCast"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "burden"
+                            }
+                        }
+                    },
+                    "target": "Controller"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "burden",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": {
+                                    "type": "CounterCount",
+                                    "counterType": {
+                                        "type": "Named",
+                                        "name": "burden"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "MYTHIC",
+        "artist": "Veli Nyström",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg?1763472900"
+    }
+}
+
+// The Ring Goes South
+{
+    "name": "The Ring Goes South",
+    "manaCost": "{3}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "The Ring tempts you. Then reveal cards from the top of your library until you reveal X land cards, where X is the number of legendary creatures you control. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "TheRingTemptsYou",
+                {
+                    "type": "GatherUntilMatch",
+                    "filter": "land",
+                    "storeMatch": "lands",
+                    "storeRevealed": "allRevealed",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "allRevealed"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "allRevealed",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    },
+                    "filter": "land"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "allRevealed",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random",
+                    "filter": "nonland"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "RARE",
+        "artist": "Wangjie Li",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg?1686969579"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // The Shire
 {
     "name": "The Shire",
@@ -15848,6 +16726,50 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Troll of Khazad-dûm
+{
+    "name": "Troll of Khazad-dûm",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Troll",
+    "oracleText": "This creature can't be blocked except by three or more creatures.\nSwampcycling {1} ({1}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Swamp"
+                    }
+                ]
+            },
+            "displayPrefix": "Swampcycling"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByFewerThan",
+                "minBlockers": 3
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Simon Dominic",
+        "flavorText": "\"A great cave-troll, I think. There is no hope of escape that way.\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg?1743419034"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -9017,7 +9017,15 @@
                     "requires": [
                         {
                             "type": "SpellTargetsMatching",
-                            "filter": "creature ctrl:opponent"
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControllerNot",
+                                    "predicate": "ControlledByYou"
+                                }
+                            }
                         }
                     ]
                 },

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AOneRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AOneRingScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * A-The One Ring — the Alchemy rebalance of The One Ring. Identical except the draw ability
+ * costs {1}, {T} instead of just {T}. This test pins the extra mana cost: with an untapped
+ * land the ability resolves (burden + draw); the Gap 8 protection path is covered by
+ * [TheOneRingScenarioTest].
+ */
+class AOneRingScenarioTest : ScenarioTestBase() {
+
+    private val tapAbilityId by lazy {
+        cardRegistry.requireCard("A-The One Ring").activatedAbilities[0].id
+    }
+
+    init {
+        test("{1},{T} adds a burden counter and draws that many") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "A-The One Ring")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findPermanent("A-The One Ring")!!
+            val handBefore = game.handSize(1)
+
+            // The {1} is auto-paid from the untapped Island.
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = ring, abilityId = tapAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.handSize(1) shouldBe handBefore + 1
+        }
+
+        test("{1},{T} can't be activated without the mana available") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "A-The One Ring")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findPermanent("A-The One Ring")!!
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = ring, abilityId = tapAbilityId)
+            ).error shouldNotBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarrowBladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarrowBladeScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Barrow-Blade — "Equipped creature gets +1/+1. Whenever equipped creature blocks or becomes
+ * blocked by a creature, that creature loses all abilities until end of turn. Equip {1}."
+ *
+ * Exercises the ATTACHED binding for BlocksOrBecomesBlockedBy: when the equipped creature is
+ * blocked, the blocker loses its abilities (here, flying).
+ */
+class BarrowBladeScenarioTest : ScenarioTestBase() {
+
+    private val equipAbilityId by lazy {
+        cardRegistry.requireCard("Barrow-Blade").activatedAbilities[0].id
+    }
+
+    init {
+        test("equipped creature becoming blocked strips the blocker's abilities") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hill Giant")     // 3/3 attacker (4/4 equipped)
+                .withCardOnBattlefield(1, "Barrow-Blade")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(2, "Wind Drake")      // 2/2 flyer blocker
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val giant = game.findPermanent("Hill Giant")!!
+            val blade = game.findPermanent("Barrow-Blade")!!
+            val drake = game.findPermanent("Wind Drake")!!
+
+            game.state.projectedState.hasKeyword(drake, Keyword.FLYING) shouldBe true
+
+            // Equip Barrow-Blade onto the Hill Giant.
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = blade,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(giant))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Equipped: +1/+1.
+            game.state.projectedState.getPower(giant) shouldBe 4
+            game.state.projectedState.getToughness(giant) shouldBe 4
+
+            // Attack with the Giant; opponent blocks with the Drake.
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hill Giant" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Wind Drake" to listOf("Hill Giant"))).error shouldBe null
+
+            // Pass priority so the pending Barrow-Blade trigger is put on the stack, then resolve
+            // it — staying in the declare-blockers step (before combat damage would kill the Drake).
+            game.passPriority()
+            game.resolveStack()
+
+            // The Drake lost all abilities — including flying — until end of turn.
+            game.findPermanent("Wind Drake") shouldBe drake
+            game.state.projectedState.hasKeyword(drake, Keyword.FLYING) shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoromirWardenOfTheTowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoromirWardenOfTheTowerScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Boromir, Warden of the Tower — "Whenever an opponent casts a spell, if no mana was spent to cast
+ * it, counter that spell." Exercises the new `Conditions.TriggeringSpellCastWithoutPayingMana`
+ * intervening-if (reads the triggering spell's cast-mana record).
+ */
+class BoromirWardenOfTheTowerScenarioTest : FunSpec({
+
+    fun advanceToOpponentMain(driver: GameTestDriver, opponent: EntityId) {
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+        driver.activePlayer shouldBe opponent
+    }
+
+    test("counters an opponent's spell cast for free (no mana spent)") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        driver.putCreatureOnBattlefield(p1, "Boromir, Warden of the Tower")
+        advanceToOpponentMain(driver, p2)
+
+        val mox = driver.putCardInHand(p2, "Mox Ruby") // {0} artifact → no mana spent
+        driver.castSpell(p2, mox)
+        driver.bothPass() // Boromir's trigger resolves and counters the free spell
+
+        driver.state.getGraveyard(p2).contains(mox) shouldBe true
+        driver.findPermanent(p2, "Mox Ruby") shouldBe null
+    }
+
+    test("does not counter an opponent's spell that mana was spent on") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        driver.putCreatureOnBattlefield(p1, "Boromir, Warden of the Tower")
+        advanceToOpponentMain(driver, p2)
+
+        val bears = driver.putCardInHand(p2, "Grizzly Bears") // {1}{G}, paid with mana
+        driver.giveMana(p2, Color.GREEN, 2)
+        driver.castSpell(p2, bears)
+        driver.bothPass()
+
+        // Boromir's intervening-if is false (mana was spent), so the spell resolves.
+        driver.findPermanent(p2, "Grizzly Bears").shouldNotBeNull()
+        driver.state.getGraveyard(p2).contains(bears) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakingOfTheFellowshipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakingOfTheFellowshipScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Breaking of the Fellowship — "Target creature an opponent controls deals damage equal to
+ * its power to another target creature that player controls. The Ring tempts you."
+ *
+ * The first target (a 3/3) deals 3 damage to the second (a 2/2), killing it.
+ */
+class BreakingOfTheFellowshipScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("first targeted creature deals its power to the second") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Breaking of the Fellowship")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardOnBattlefield(2, "Hill Giant")    // 3/3 — the damage dealer
+                .withCardOnBattlefield(2, "Grizzly Bears")  // 2/2 — the recipient
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val giant = game.findPermanent("Hill Giant")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            // Target order matters: [0] is the dealer, [1] the recipient.
+            val card = game.findCardsInHand(1, "Breaking of the Fellowship").first()
+            game.execute(
+                CastSpell(game.player1Id, card, listOf(ChosenTarget.Permanent(giant), ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The 3/3 dealt 3 to the 2/2, which died; the dealer survives.
+            game.findPermanent("Grizzly Bears") shouldBe null
+            game.findPermanent("Hill Giant") shouldBe giant
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakingOfTheFellowshipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakingOfTheFellowshipScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.player.TheRingComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
@@ -39,6 +40,10 @@ class BreakingOfTheFellowshipScenarioTest : ScenarioTestBase() {
             // The 3/3 dealt 3 to the 2/2, which died; the dealer survives.
             game.findPermanent("Grizzly Bears") shouldBe null
             game.findPermanent("Hill Giant") shouldBe giant
+
+            // The trailing "The Ring tempts you" resolved (caster controls no creatures, so no
+            // Ring-bearer is chosen, but the temptation still happened).
+            (game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount ?: 0) shouldBe 1
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallOfTheRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallOfTheRingScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Call of the Ring — upkeep "the Ring tempts you" + "Whenever you choose a creature as your
+ * Ring-bearer, you may pay 2 life. If you do, draw a card." Exercises the new
+ * `Triggers.WheneverYouChooseRingBearer` (RingTemptedEvent with requireBearerChosen): it fires
+ * only when a creature is actually chosen.
+ */
+class CallOfTheRingScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("choosing a Ring-bearer lets you pay 2 life to draw") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Call of the Ring")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // P1's upkeep → "the Ring tempts you"
+            game.resolveStack()
+
+            // The temptation pauses to choose a Ring-bearer; the only creature is Grizzly Bears.
+            val ringDec = game.getPendingDecision()
+            ringDec.shouldBeInstanceOf<SelectCardsDecision>()
+            game.selectCards(listOf(ringDec.options.first()))
+            game.resolveStack()
+
+            // The chosen-bearer trigger asks whether to pay 2 life and draw.
+            game.answerYesNo(true)
+            game.resolveStack()
+
+            game.getLifeTotal(1) shouldBe 18
+            game.state.getHand(game.player1Id).size shouldBe 1
+            game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount shouldBe 1
+        }
+
+        test("upkeep temptation with no creatures does not trigger the draw") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Call of the Ring")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.resolveStack()
+
+            // No creatures → no Ring-bearer chosen → the second ability never triggers.
+            game.getPendingDecision() shouldBe null
+            game.getLifeTotal(1) shouldBe 20
+            game.state.getHand(game.player1Id).size shouldBe 0
+            game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisplayOfPowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisplayOfPowerScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CantBeCopiedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Display of Power — "This spell can't be copied. Copy any number of target instant and/or
+ * sorcery spells. You may choose new targets for the copies." (CR 707.10).
+ *
+ * Exercises the CopyEachTargetSpellEffect + the cantBeCopied flag.
+ */
+class DisplayOfPowerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("copies a targeted instant on the stack and retargets the copy") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Display of Power")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardOnBattlefield(2, "Grizzly Bears") // bolt target A (2/2)
+                .withCardOnBattlefield(2, "Hill Giant")    // copy target B (3/3)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bearsA = game.findPermanent("Grizzly Bears")!!
+            val giantB = game.findPermanent("Hill Giant")!!
+
+            // Cast Lightning Bolt at the Grizzly Bears — it sits on the stack.
+            game.castSpell(1, "Lightning Bolt", bearsA).error shouldBe null
+
+            // Cast Display of Power targeting the Bolt spell on the stack.
+            game.castSpellTargetingStackSpell(1, "Display of Power", "Lightning Bolt").error shouldBe null
+
+            // Resolve Display of Power — it pauses to retarget the copy of the Bolt.
+            game.resolveStack()
+            game.hasPendingDecision().shouldBeTrue()
+
+            // Retarget the copy at the Hill Giant; then resolve the copy and the original.
+            game.selectTargets(listOf(giantB)).error shouldBe null
+            game.resolveStack()
+
+            // Original Bolt killed the Bears; the copy killed the Giant.
+            game.findPermanent("Grizzly Bears") shouldBe null
+            game.findPermanent("Hill Giant") shouldBe null
+        }
+
+        test("Display of Power itself can't be copied") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Display of Power")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bearsA = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Lightning Bolt", bearsA).error shouldBe null
+            game.castSpellTargetingStackSpell(1, "Display of Power", "Lightning Bolt").error shouldBe null
+
+            // The Display of Power spell entity carries the uncopiable marker.
+            val displayId = game.state.stack.first { entityId ->
+                game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Display of Power"
+            }
+            game.state.getEntity(displayId)?.has<CantBeCopiedComponent>().shouldNotBeNull()
+            game.state.getEntity(displayId)!!.has<CantBeCopiedComponent>().shouldBeTrue()
+        }
+
+        test("copies two targeted spells, each independently") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Display of Power")
+                .withCardsInHand(1, "Lightning Bolt", 2)
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val player1Id = game.player1Id
+            val player2Id = game.player2Id
+
+            // Two Bolts on the stack, both aimed at the opponent's face.
+            val bolts = game.findCardsInHand(1, "Lightning Bolt")
+            game.execute(CastSpell(player1Id, bolts[0], listOf(ChosenTarget.Player(player2Id)))).error shouldBe null
+            game.execute(CastSpell(player1Id, bolts[1], listOf(ChosenTarget.Player(player2Id)))).error shouldBe null
+
+            // Display of Power targeting BOTH Bolt spells on the stack.
+            val display = game.findCardsInHand(1, "Display of Power").first()
+            val boltSpellIds = game.state.stack.filter {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+            }.map { ChosenTarget.Spell(it) }
+            game.execute(CastSpell(player1Id, display, boltSpellIds)).error shouldBe null
+
+            // Resolve: each copy keeps the opponent as target (decline retargeting by
+            // re-selecting the same legal target) — the copies have a player target so the
+            // engine inherits verbatim only if no retarget is offered; player targets are
+            // offered, so answer each.
+            var guard = 0
+            while (game.state.stack.isNotEmpty() && guard++ < 20) {
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(player2Id))
+                }
+            }
+
+            // 4 Bolts total resolved (2 originals + 2 copies) = 12 damage.
+            game.getLifeTotal(2) shouldBe 8
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DunedainRangersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DunedainRangersScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Dúnedain Rangers — "Landfall — Whenever a land you control enters, if you don't control a
+ * Ring-bearer, the Ring tempts you." Exercises the new `StatePredicate.IsRingBearer` via the
+ * `Conditions.YouControl(ringBearer, negate = true)` intervening-if.
+ */
+class DunedainRangersScenarioTest : FunSpec({
+
+    test("landfall tempts you when you don't control a Ring-bearer") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(p1, "Dúnedain Rangers")
+        val land = driver.putCardInHand(p1, "Forest")
+        driver.playLand(p1, land) // landfall → no Ring-bearer → the Ring tempts you
+        driver.bothPass()
+
+        // The temptation pauses to choose a Ring-bearer.
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.state.getEntity(p1)?.get<TheRingComponent>()?.temptCount shouldBe 1
+    }
+
+    test("landfall does not tempt you when you already control a Ring-bearer") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(p1, "Dúnedain Rangers")
+        val bear = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+
+        // Make p1 control a Ring-bearer first (tempt via Birthday Escape).
+        val spell = driver.putCardInHand(p1, "Birthday Escape")
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.castSpell(p1, spell)
+        driver.bothPass()
+        val dec = driver.pendingDecision as SelectCardsDecision
+        driver.submitDecision(p1, CardsSelectedResponse(dec.id, listOf(bear)))
+        driver.state.getEntity(p1)?.get<TheRingComponent>()?.temptCount shouldBe 1
+
+        // Now a landfall: the intervening-if (no Ring-bearer) is false → no new temptation.
+        val land = driver.putCardInHand(p1, "Forest")
+        driver.playLand(p1, land)
+        driver.bothPass()
+
+        driver.pendingDecision shouldBe null
+        driver.state.getEntity(p1)?.get<TheRingComponent>()?.temptCount shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondLordOfRivendellScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondLordOfRivendellScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+
+/**
+ * Elrond, Lord of Rivendell (LTR #49, {2}{U}) — "Whenever Elrond or another creature you control
+ * enters, scry 1. If this is the second time this ability has resolved this turn, the Ring tempts
+ * you."
+ *
+ * Regression: the ability must increment its per-ability resolution count so the `count == 2`
+ * conditional fires on the second resolution. Without the IncrementAbilityResolutionCountEffect the
+ * count stayed 0 and the Ring never tempted (cf. Tannuk, Memorial Ensign / Harvestrite Host).
+ *
+ * Libraries are left empty so scry 1 is a silent no-op (nothing to look at, no decision), isolating
+ * the temptation as the only player decision.
+ */
+class ElrondLordOfRivendellScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the Ring tempts you on the second creature to enter in a turn, not the first") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Elrond, Lord of Rivendell", summoningSickness = false)
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInHand(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun temptCount(player: EntityId): Int =
+                game.state.getEntity(player)?.get<TheRingComponent>()?.temptCount ?: 0
+
+            // First creature enters: Elrond's ability resolves once → scry only, no temptation.
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.resolveStack()
+            game.hasPendingDecision() shouldBe false
+            temptCount(game.player1Id) shouldBe 0
+
+            // A second creature enters this same turn: the ability resolves a second time, so the
+            // Ring tempts you — pick a Ring-bearer to complete the temptation.
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.resolveStack()
+            game.hasPendingDecision() shouldBe true
+            val bearer = game.findPermanent("Grizzly Bears")!!
+            game.selectCards(listOf(bearer))
+            game.resolveStack()
+
+            temptCount(game.player1Id) shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrodoBagginsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrodoBagginsScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.RingBearerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Frodo Baggins — "As long as Frodo Baggins is your Ring-bearer, it must be blocked if able."
+ * Exercises the new `MustBeBlocked` static ability (gated on `SourceIsRingBearer`) honored by
+ * BlockPhaseManager. Frodo is designated Ring-bearer by being tempted (Birthday Escape).
+ */
+class FrodoBagginsScenarioTest : FunSpec({
+
+    fun driverWithRingBearerFrodo(): Triple<GameTestDriver, com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val frodo = driver.putCreatureOnBattlefield(p1, "Frodo Baggins")
+        driver.removeSummoningSickness(frodo)
+        // The Ring's level-1 temptation makes the bearer "can't be blocked by creatures with greater
+        // power", so the blocker must have power <= Frodo's (1). Savannah Lions is 1/1.
+        driver.putCreatureOnBattlefield(p2, "Savannah Lions")
+
+        // Designate Frodo as the Ring-bearer by tempting p1 (Birthday Escape).
+        val spell = driver.putCardInHand(p1, "Birthday Escape")
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.castSpell(p1, spell)
+        driver.bothPass() // resolve: draw, then pause to choose a Ring-bearer
+        val dec = driver.pendingDecision as SelectCardsDecision
+        driver.submitDecision(p1, CardsSelectedResponse(dec.id, listOf(frodo)))
+        driver.state.getEntity(frodo)?.get<RingBearerComponent>()?.ownerId shouldBe p1
+
+        return Triple(driver, frodo, p2)
+    }
+
+    test("Ring-bearer Frodo must be blocked if able") {
+        val (driver, frodo, p2) = driverWithRingBearerFrodo()
+        val p1 = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(frodo), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // p2 controls a Savannah Lions that can block, so declaring no blockers is illegal.
+        driver.declareBlockers(p2, emptyMap()).isSuccess shouldBe false
+
+        // Blocking Frodo with the Lions is legal.
+        val lions = driver.findPermanent(p2, "Savannah Lions")!!
+        driver.declareBlockers(p2, mapOf(lions to listOf(frodo))).isSuccess shouldBe true
+    }
+
+    test("non-Ring-bearer Frodo has no must-be-blocked requirement") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val frodo = driver.putCreatureOnBattlefield(p1, "Frodo Baggins")
+        driver.removeSummoningSickness(frodo)
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(frodo), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Frodo isn't the Ring-bearer → the defender may decline to block.
+        driver.declareBlockers(p2, emptyMap()).isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GaladrielOfLothlorienScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GaladrielOfLothlorienScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blc.cards.TempleOfMystery
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GaladrielOfLothlorien
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Galadriel of Lothlórien — "Whenever you scry, you may reveal the top card of your library.
+ * If a land card is revealed this way, put it onto the battlefield tapped."
+ *
+ * Triggered by an unrelated scry (Temple of Mystery's ETB scry 1). Exercises the
+ * gather→reveal→MoveCollection(filter) pipeline placing the revealed land tapped.
+ */
+class GaladrielOfLothlorienScenarioTest : FunSpec({
+
+    test("a scry lets Galadriel reveal the top land and put it onto the battlefield tapped") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GaladrielOfLothlorien, TempleOfMystery))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Galadriel of Lothlórien")
+        // Put a land on top so the scry (kept) then Galadriel's reveal find a land.
+        driver.putCardOnTopOfLibrary(active, "Forest")
+
+        val temple = driver.putCardInHand(active, "Temple of Mystery")
+        driver.playLand(active, temple)
+
+        // Drain: Temple ETB scry 1 (keep top → bottom none, reorder trivially), then Galadriel's
+        // "may reveal" — say yes.
+        var guard = 0
+        while (guard++ < 12) {
+            when (val pd = driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(active, emptyList()) // scry: bottom none
+                is ReorderLibraryDecision -> driver.submitOrderedResponse(active, pd.cards)
+                is YesNoDecision -> driver.submitYesNo(active, true) // Galadriel: yes, reveal
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // The revealed Forest entered the battlefield tapped.
+        val forestOnBf = driver.state.getBattlefield().firstOrNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+        }
+        (forestOnBf != null) shouldBe true
+        driver.state.getEntity(forestOnBf!!)?.has<TappedComponent>() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GaladrielOfLothlorienScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GaladrielOfLothlorienScenarioTest.kt
@@ -9,7 +9,9 @@ import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.blc.cards.TempleOfMystery
 import com.wingedsheep.mtg.sets.definitions.ltr.cards.GaladrielOfLothlorien
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -55,5 +57,40 @@ class GaladrielOfLothlorienScenarioTest : FunSpec({
         }
         (forestOnBf != null) shouldBe true
         driver.state.getEntity(forestOnBf!!)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("a scry that reveals a non-land leaves it on top of the library") {
+        val driver = GameTestDriver()
+        val testOgre = CardDefinition.creature("Test Ogre", ManaCost.parse("{3}"), emptySet(), 3, 3)
+        driver.registerCards(TestCards.all + listOf(GaladrielOfLothlorien, TempleOfMystery, testOgre))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Galadriel of Lothlórien")
+        // A non-land on top: Galadriel reveals it, finds no land, so nothing enters.
+        driver.putCardOnTopOfLibrary(active, "Test Ogre")
+
+        val temple = driver.putCardInHand(active, "Temple of Mystery")
+        driver.playLand(active, temple)
+
+        var guard = 0
+        while (guard++ < 12) {
+            when (val pd = driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(active, emptyList())
+                is ReorderLibraryDecision -> driver.submitOrderedResponse(active, pd.cards)
+                is YesNoDecision -> driver.submitYesNo(active, true) // Galadriel: yes, reveal
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // The Ogre did not enter the battlefield...
+        driver.state.getBattlefield().none {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+        } shouldBe true
+        // ...and it's still in the library — not lost in a gather/reveal limbo.
+        driver.state.getLibrary(active).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+        } shouldBe true
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfsSanctionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfsSanctionScenarioTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf's Sanction — "deals X damage to target creature, where X is the number of instant and
+ * sorcery cards in your graveyard. Excess damage is dealt to that creature's controller instead."
+ * Exercises the new `DealDamageExcessToController` (excess beyond lethal goes to the controller).
+ */
+class GandalfsSanctionScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("X = instants/sorceries in graveyard; excess goes to the creature's controller") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Gandalf's Sanction")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardInGraveyard(1, "Glorious Gale")   // instant
+                .withCardInGraveyard(1, "Claim the Precious") // sorcery
+                .withCardInGraveyard(1, "Many Partings")   // sorcery
+                .withCardInGraveyard(1, "Ringsight")       // sorcery  → X = 4
+                .withCardOnBattlefield(2, "Grizzly Bears") // 2/2
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Gandalf's Sanction", bears).error shouldBe null
+            game.resolveStack()
+
+            // 4 damage to a 2/2: lethal 2 kills it; the 2 excess hits its controller (20 → 18).
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+            game.getLifeTotal(2) shouldBe 18
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlorfindelDauntlessRescuerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlorfindelDauntlessRescuerScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blc.cards.TempleOfMystery
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GlorfindelDauntlessRescuer
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Glorfindel, Dauntless Rescuer — "Whenever you scry, choose one and Glorfindel gets +1/+1 until
+ * end of turn. • must be blocked if able • can't be blocked by more than one creature each combat."
+ *
+ * Exercises Gap 39: choosing mode 2 grants the floating CANT_BE_BLOCKED_BY_MORE_THAN_ONE flag,
+ * which BlockPhaseManager now honors (caps blockers at one).
+ */
+class GlorfindelDauntlessRescuerScenarioTest : FunSpec({
+
+    test("scry mode 2 grants +1/+1 and caps Glorfindel's blockers at one") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GlorfindelDauntlessRescuer, TempleOfMystery))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != active }
+
+        val glorfindel = driver.putCreatureOnBattlefield(active, "Glorfindel, Dauntless Rescuer")
+        // Two would-be blockers for the opponent.
+        val blockerA = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val blockerB = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        // Trigger "you scry" via Temple of Mystery's ETB scry 1.
+        val temple = driver.putCardInHand(active, "Temple of Mystery")
+        driver.playLand(active, temple)
+
+        // Drain the scry decisions, then choose Glorfindel's mode 2 (option index 1 = can't be
+        // blocked by more than one creature).
+        var guard = 0
+        while (guard++ < 16) {
+            when (val pd = driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(active, emptyList())
+                is ReorderLibraryDecision -> driver.submitOrderedResponse(active, pd.cards)
+                is YesNoDecision -> driver.submitYesNo(active, true)
+                is ChooseOptionDecision -> driver.submitDecision(active, OptionChosenResponse(pd.id, 1))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // +1/+1 applied (base 3/2 -> 4/3) and the can't-be-blocked-by-more-than-one flag granted.
+        driver.state.projectedState.getPower(glorfindel) shouldBe 4
+        driver.state.projectedState.getToughness(glorfindel) shouldBe 3
+        driver.state.projectedState
+            .hasKeyword(glorfindel, AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE) shouldBe true
+
+        // Attack with Glorfindel this turn; the opponent may not assign two blockers to it.
+        driver.removeSummoningSickness(glorfindel)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(glorfindel), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            opponent,
+            mapOf(blockerA to listOf(glorfindel), blockerB to listOf(glorfindel))
+        ).error shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloriousGaleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloriousGaleScenarioTest.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Glorious Gale — "Counter target creature spell. If it was a legendary spell, the Ring tempts you."
+ * Verifies the legendary check on the targeted spell-on-stack (the only non-obvious composition).
+ * Player 1 controls no creatures, so the temptation increments the count without pausing to choose a
+ * Ring-bearer.
+ */
+class GloriousGaleScenarioTest : ScenarioTestBase() {
+
+    private fun gale(opponentSpell: String) = scenario()
+        .withPlayers()
+        .withCardInHand(1, "Glorious Gale")
+        .withLandsOnBattlefield(1, "Island", 2)
+        .withCardInHand(2, opponentSpell)
+        .withCardOnBattlefield(2, "Island")
+        .withCardOnBattlefield(2, "Forest")
+        .withCardInLibrary(1, "Island")
+        .withCardInLibrary(2, "Island")
+        .withActivePlayer(2)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("counters a legendary creature spell and the Ring tempts you") {
+            val game = gale("Naban, Dean of Iteration") // {1}{U} legendary creature
+            game.castSpell(2, "Naban, Dean of Iteration").error shouldBe null
+            game.passPriority()
+            game.castSpellTargetingStackSpell(1, "Glorious Gale", "Naban, Dean of Iteration").error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Naban, Dean of Iteration") shouldBe false
+            game.isInGraveyard(2, "Naban, Dean of Iteration") shouldBe true
+            (game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount ?: 0) shouldBe 1
+        }
+
+        test("counters a nonlegendary creature spell without tempting you") {
+            val game = gale("Grizzly Bears") // {1}{G} nonlegendary creature
+            game.castSpell(2, "Grizzly Bears").error shouldBe null
+            game.passPriority()
+            game.castSpellTargetingStackSpell(1, "Glorious Gale", "Grizzly Bears").error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            (game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount ?: 0) shouldBe 0
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwaihirTheWindlordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwaihirTheWindlordScenarioTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Gwaihir the Windlord — "This spell costs {2} less to cast as long as you've drawn two or more
+ * cards this turn." Exercises the new `PlayerDrewCardsThisTurn` condition gating a `ModifySpellCost`
+ * reduction. Full cost {4}{W}{U} = 6 mana; reduced = {2}{W}{U} = 4 mana.
+ */
+class GwaihirTheWindlordScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("costs {2} less with two cards drawn this turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Gwaihir the Windlord")
+                .withLandsOnBattlefield(1, "Plains", 2) // W + 1 generic
+                .withLandsOnBattlefield(1, "Island", 2) // U + 1 generic  → 4 mana total
+                .withCardsDrawnThisTurn(1, 2)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Gwaihir the Windlord").error shouldBe null
+            game.resolveStack()
+            game.isOnBattlefield("Gwaihir the Windlord") shouldBe true
+        }
+
+        test("costs full price with fewer than two cards drawn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Gwaihir the Windlord")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withLandsOnBattlefield(1, "Island", 2) // only 4 mana — not enough for {4}{W}{U}
+                .withCardsDrawnThisTurn(1, 1)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Without the reduction the spell needs 6 mana; only 4 are available.
+            game.castSpell(1, "Gwaihir the Windlord").error shouldNotBe null
+            game.isOnBattlefield("Gwaihir the Windlord") shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegolasMasterArcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegolasMasterArcherScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Legolas, Master Archer —
+ *  - "Whenever you cast a spell that targets Legolas, put a +1/+1 counter on Legolas."
+ *  - "Whenever you cast a spell that targets a creature you don't control, Legolas deals
+ *     damage equal to its power to up to one target creature."
+ *
+ * Exercises the new SpellCastPredicate.TargetsSource / TargetsMatching cast-time predicates.
+ */
+class LegolasMasterArcherScenarioTest : ScenarioTestBase() {
+
+    private fun plusCounters(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        test("a spell targeting Legolas puts a +1/+1 counter on it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Giant Growth")
+                .withCardOnBattlefield(1, "Legolas, Master Archer")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val legolas = game.findPermanent("Legolas, Master Archer")!!
+            plusCounters(game, legolas) shouldBe 0
+
+            game.castSpell(1, "Giant Growth", legolas).error shouldBe null
+            game.resolveStack()
+
+            plusCounters(game, legolas) shouldBe 1
+        }
+
+        test("a spell targeting an opponent's creature makes Legolas deal its power in damage") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Giant Growth")
+                .withCardOnBattlefield(1, "Legolas, Master Archer") // 1/4
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardOnBattlefield(2, "Grizzly Bears")  // the spell's target
+                .withCardOnBattlefield(2, "Raging Goblin")  // 1/1 — Legolas's damage target
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val goblin = game.findPermanent("Raging Goblin")!!
+
+            // Cast Giant Growth on the opponent's Grizzly Bears.
+            game.castSpell(1, "Giant Growth", bears).error shouldBe null
+
+            // Legolas's trigger asks for up to one target creature — aim it at the 1/1 Goblin.
+            if (game.hasPendingDecision()) {
+                game.selectTargets(listOf(goblin))
+            }
+            game.resolveStack()
+
+            // Legolas (power 1) dealt 1 damage to the 1/1 Goblin — it died.
+            game.findPermanent("Raging Goblin") shouldBe null
+            // The Bears survived (Giant Growth only pumped it).
+            game.findPermanent("Grizzly Bears") shouldBe bears
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MountDoomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MountDoomScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Mount Doom — "{5}{B}{R}, {T}, Sacrifice Mount Doom and a legendary artifact: Choose up to two
+ * creatures, then destroy the rest. Activate only as a sorcery."
+ *
+ * Exercises the Duneblast-style wrath composition (Gather all creatures → SelectFromCollection
+ * ChooseUpTo(2) with storeRemainder → MoveCollection Destroy) and the dual sacrifice cost
+ * (SacrificeSelf auto-paid + an explicit legendary-artifact sacrifice passed in the cost payment).
+ */
+class MountDoomScenarioTest : FunSpec({
+
+    // Index 2: [0] = mana ability, [1] = ping each opponent, [2] = the wrath.
+    val wrathAbilityId = TestCards.all.first { it.name == "Mount Doom" }.activatedAbilities[2].id
+
+    test("sacrifices Mount Doom + a legendary artifact, saves chosen creatures, destroys the rest") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mountDoom = driver.putPermanentOnBattlefield(p1, "Mount Doom")
+        val stone = driver.putPermanentOnBattlefield(p1, "Stone of Erech") // {1} legendary artifact
+        val survivor = driver.putCreatureOnBattlefield(p1, "Grizzly Bears") // the one we'll save
+        driver.putCreatureOnBattlefield(p2, "Savannah Lions")
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        // {5}{B}{R} = 7 mana; generic paid from black.
+        driver.giveMana(p1, Color.BLACK, 6)
+        driver.giveMana(p1, Color.RED, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = mountDoom,
+                abilityId = wrathAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(stone)),
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // Both halves of the cost were paid up front.
+        driver.findPermanent(p1, "Mount Doom") shouldBe null
+        driver.getGraveyard(p1).contains(mountDoom) shouldBe true
+        driver.getGraveyard(p1).contains(stone) shouldBe true
+
+        // Resolve: choose up to two creatures to save — keep only our Grizzly Bears.
+        driver.bothPass()
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(p1, CardsSelectedResponse(decision.id, listOf(survivor)))
+
+        // The saved creature lives; the two unchosen creatures are destroyed.
+        driver.getCreatures(p1).contains(survivor) shouldBe true
+        driver.getCreatures(p1).size shouldBe 1
+        driver.getCreatures(p2).size shouldBe 0
+    }
+
+    test("cannot activate the wrath without a legendary artifact to sacrifice") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mountDoom = driver.putPermanentOnBattlefield(p1, "Mount Doom")
+        driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLACK, 6)
+        driver.giveMana(p1, Color.RED, 1)
+
+        // No legendary artifact is on the battlefield, so the sacrifice cost can't be paid.
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = mountDoom,
+                abilityId = wrathAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = emptyList()),
+            )
+        )
+        result.isSuccess shouldBe false
+        driver.findPermanent(p1, "Mount Doom").let { it shouldBe mountDoom }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhialOfGaladrielScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhialOfGaladrielScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Phial of Galadriel — conditional draw and life-gain replacements:
+ *  - "If you would draw a card while you have no cards in hand, draw two cards instead."
+ *  - "If you would gain life while you have 5 or less life, you gain twice that much life instead."
+ * Exercises the new `restrictions` gate on `ModifyLifeGain` (and the existing `ModifyDrawAmount`).
+ */
+class PhialOfGaladrielScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("draws two when drawing with an empty hand") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Phial of Galadriel")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Swamp")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.DRAW) // P1's turn-based draw, hand empty
+            game.resolveStack()
+            game.handSize(1) shouldBe 2
+        }
+
+        test("draws only one when hand is not empty") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Phial of Galadriel")
+                .withCardInHand(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Swamp")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+            game.resolveStack()
+            game.handSize(1) shouldBe 2 // 1 held + 1 drawn (no doubling), not 3
+        }
+
+        test("doubles life gain while at 5 or less life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Phial of Galadriel")
+                .withCardInHand(1, "Reviving Dose")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withLifeTotal(1, 5)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Swamp")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Reviving Dose").error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 11 // 5 + (3 * 2)
+        }
+
+        test("does not double life gain above 5 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Phial of Galadriel")
+                .withCardInHand(1, "Reviving Dose")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withLifeTotal(1, 10)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Swamp")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Reviving Dose").error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 13 // 10 + 3 (no doubling)
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RangersOfIthilienScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RangersOfIthilienScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rangers of Ithilien — "When this creature enters, gain control of up to one target creature with
+ * lesser power for as long as you control this creature." Exercises the new strict
+ * `powerLessThanEntity(Source)` target filter (3/3 Rangers can take a 2/2 but not a 3/3+).
+ */
+class RangersOfIthilienScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("gains control of an opponent's creature with lesser power") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Rangers of Ithilien")
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withCardOnBattlefield(2, "Grizzly Bears") // 2/2, power 2 < 3
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Rangers of Ithilien").error shouldBe null
+            game.resolveStack() // enters → ETB trigger asks for a (lesser-power) target
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            // Control of the 2/2 transferred to player 1 (the tempt may then pause for a Ring-bearer
+            // choice, but the control change has already happened).
+            game.state.projectedState.getController(bears) shouldBe game.player1Id
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RidersOfTheMarkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RidersOfTheMarkScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Riders of the Mark — "At the beginning of your end step, if this creature attacked this turn,
+ * return it to its owner's hand. If you do, create a number of 1/1 white Human Soldier creature
+ * tokens equal to its toughness." Verifies the last-known-toughness token count after the bounce.
+ */
+class RidersOfTheMarkScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("after attacking, returns itself and makes tokens equal to its toughness") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Riders of the Mark") // 7/4
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Riders of the Mark" to 2))
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            // Riders returned to hand; four 1/1 tokens (toughness 4) remain under player 1's control.
+            game.isOnBattlefield("Riders of the Mark") shouldBe false
+            val p1 = game.player1Id
+            val p1Creatures = game.state.getBattlefield().count { id ->
+                game.state.projectedState.getController(id) == p1 && game.state.projectedState.isCreature(id)
+            }
+            p1Creatures shouldBe 4
+        }
+
+        test("does not bounce if it didn't attack") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Riders of the Mark")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            // It didn't attack, so it stays and no tokens are made.
+            game.isOnBattlefield("Riders of the Mark") shouldBe true
+            val p1 = game.player1Id
+            val p1Creatures = game.state.getBattlefield().count { id ->
+                game.state.projectedState.getController(id) == p1 && game.state.projectedState.isCreature(id)
+            }
+            p1Creatures shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RingsightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RingsightScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Ringsight — "The Ring tempts you. Search your library for a card that shares a color with a
+ * legendary creature you control, reveal it, put it into your hand, then shuffle." Exercises the
+ * new `SharesColorWithPermanentYouControl` filter: only cards sharing a color with the controlled
+ * legendary (mono-blue Naban) are eligible.
+ */
+class RingsightScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("only fetches a card sharing a color with a legendary creature you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Naban, Dean of Iteration") // mono-blue legendary
+                .withCardInHand(1, "Ringsight")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withCardInLibrary(1, "Glorious Gale") // mono-blue → eligible
+                .withCardInLibrary(1, "Grizzly Bears") // mono-green → not eligible
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Ringsight").error shouldBe null
+            game.resolveStack()
+
+            // First decision: the Ring temptation picks a Ring-bearer (the only creature is Naban).
+            val ringDec = game.getPendingDecision()
+            ringDec.shouldBeInstanceOf<SelectCardsDecision>()
+            game.selectCards(listOf(ringDec.options.first()))
+
+            // Second decision: the filtered library search.
+            val searchDec = game.getPendingDecision()
+            searchDec.shouldBeInstanceOf<SelectCardsDecision>()
+            val optionNames = searchDec.options.map { game.state.getEntity(it)?.get<CardComponent>()?.name }
+            optionNames shouldContain "Glorious Gale"
+            optionNames shouldNotContain "Grizzly Bears"
+
+            val gale = searchDec.options.first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Glorious Gale"
+            }
+            game.selectCards(listOf(gale))
+            game.resolveStack()
+
+            game.state.getHand(game.player1Id).count {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Glorious Gale"
+            } shouldBe 1
+            game.state.getEntity(game.player1Id)?.get<TheRingComponent>()?.temptCount shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmeagolHelpfulGuideScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmeagolHelpfulGuideScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.BirthdayEscape
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.SmeagolHelpfulGuide
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sméagol, Helpful Guide — "Whenever the Ring tempts you, target opponent reveals cards from
+ * the top of their library until they reveal a land card. Put that card onto the battlefield
+ * tapped under your control and the rest into their graveyard."
+ *
+ * Triggered by a Ring tempt (Birthday Escape). Exercises GatherUntilMatch from the target
+ * opponent's library + filtered MoveCollections (land → your battlefield tapped, rest → their
+ * graveyard).
+ */
+class SmeagolHelpfulGuideScenarioTest : FunSpec({
+
+    val TestOgre = CardDefinition.creature("Test Ogre", ManaCost.parse("{3}"), emptySet(), 3, 3)
+
+    test("a Ring tempt steals the opponent's revealed land and mills the rest") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SmeagolHelpfulGuide, BirthdayEscape, TestOgre))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val smeagol = driver.putCreatureOnBattlefield(active, "Sméagol, Helpful Guide")
+
+        // Opponent's library top: a nonland Ogre, then Mountains. Reveal until a land reveals the
+        // Ogre then a Mountain.
+        driver.putCardOnTopOfLibrary(opponent, "Test Ogre")
+
+        val spell = driver.putCardInHand(active, "Birthday Escape")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.castSpell(active, spell)
+        driver.bothPass()
+
+        // Drain: ring-bearer choice (pick Sméagol), then Sméagol's "target opponent".
+        var guard = 0
+        while (guard++ < 12) {
+            when (driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(active, listOf(smeagol))
+                is ChooseTargetsDecision -> driver.submitTargetSelection(active, listOf(opponent))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // A Mountain is now on the battlefield under the active player's control, tapped.
+        val stolen = driver.state.getBattlefield().firstOrNull { id ->
+            val c = driver.state.getEntity(id)
+            c?.get<CardComponent>()?.name == "Mountain" &&
+                c.get<ControllerComponent>()?.playerId == active
+        }
+        (stolen != null) shouldBe true
+        driver.state.getEntity(stolen!!)?.has<TappedComponent>() shouldBe true
+
+        // The non-land Ogre went into the opponent's graveyard.
+        driver.state.getGraveyard(opponent).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+        } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheGreyHavensScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheGreyHavensScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Grey Havens — "{T}: Add one mana of any color among legendary creature cards in your
+ * graveyard." Exercises the new ManaColorSet.AmongCardsInGraveyard via
+ * Effects.AddManaOfColorAmongGraveyard. A mono-green legendary in the graveyard yields green.
+ */
+class TheGreyHavensScenarioTest : ScenarioTestBase() {
+
+    private val graveyardManaAbilityId by lazy {
+        cardRegistry.requireCard("The Grey Havens").activatedAbilities[1].id
+    }
+
+    init {
+        test("adds mana of a color found among legendary creature cards in your graveyard") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "The Grey Havens")
+                .withCardInGraveyard(1, "Fangorn, Tree Shepherd") // mono-green legendary creature
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val greyHavens = game.findPermanent("The Grey Havens")!!
+            game.execute(ActivateAbility(game.player1Id, greyHavens, graveyardManaAbilityId)).error shouldBe null
+
+            // The only color among legendary creature cards in the graveyard is green.
+            game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.green shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheOneRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheOneRingScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The One Ring — {4} Legendary Artifact
+ *   Indestructible
+ *   When The One Ring enters, if you cast it, you gain protection from everything until your next turn.
+ *   At the beginning of your upkeep, you lose 1 life for each burden counter on The One Ring.
+ *   {T}: Put a burden counter on The One Ring, then draw a card for each burden counter on The One Ring.
+ *
+ * Exercises Gap 8 (player-level protection from everything) plus the burden-counter tap/upkeep loop.
+ */
+class TheOneRingScenarioTest : ScenarioTestBase() {
+
+    private val tapAbilityId by lazy {
+        cardRegistry.requireCard("The One Ring").activatedAbilities[0].id
+    }
+
+    init {
+        test("casting The One Ring grants the controller protection from everything") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "The One Ring")
+                .withLandsOnBattlefield(1, "Plains", 4)
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "The One Ring").error shouldBe null
+            game.resolveStack()
+
+            // ETB ("if you cast it") granted the controller player-level protection.
+            game.state.getEntity(game.player1Id)?.get<PlayerProtectionComponent>() shouldNotBe null
+
+            // A protected player can't be targeted: opponent's Lightning Bolt can't choose player 1.
+            // Pass priority so player 2 gets a window during player 1's main phase.
+            game.passPriority()
+            game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldNotBe null
+        }
+
+        test("tap adds a burden counter then draws that many; upkeep loses that much life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "The One Ring")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withLifeTotal(1, 20)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findPermanent("The One Ring")!!
+            val handBefore = game.handSize(1)
+
+            // Pass priority to player 1, who activates The One Ring's tap ability at instant speed.
+            game.passPriority()
+            // {T}: first activation -> 1 burden counter, draw 1.
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = ring, abilityId = tapAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+            game.handSize(1) shouldBe handBefore + 1
+
+            // Advance to player 1's upkeep (next turn): the "at the beginning of your upkeep"
+            // trigger loses 1 life for the single burden counter.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.state.activePlayerId shouldBe game.player1Id
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 19
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheOneRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheOneRingScenarioTest.kt
@@ -1,10 +1,16 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
@@ -23,7 +29,20 @@ class TheOneRingScenarioTest : ScenarioTestBase() {
         cardRegistry.requireCard("The One Ring").activatedAbilities[0].id
     }
 
+    // Puts a card from a graveyard onto the battlefield WITHOUT casting it — lets us exercise the
+    // negative branch of The One Ring's "if you cast it" intervening-if gate (CR 603.4).
+    private val reanimate = card("Test Reanimate") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            val t = target("target card in a graveyard", Targets.CardInGraveyard)
+            effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+        }
+    }
+
     init {
+        cardRegistry.register(reanimate)
+
         test("casting The One Ring grants the controller protection from everything") {
             val game = scenario()
                 .withPlayers()
@@ -77,6 +96,74 @@ class TheOneRingScenarioTest : ScenarioTestBase() {
             game.state.activePlayerId shouldBe game.player1Id
             game.resolveStack()
             game.getLifeTotal(1) shouldBe 19
+        }
+
+        test("burden grows each turn, so the draw scales — counter added before the draw (CR 608.2c)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "The One Ring")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Plains")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findPermanent("The One Ring")!!
+
+            // First activation (during the opponent's turn, at instant speed): 1 burden → draw 1.
+            game.passPriority()
+            val handBeforeFirst = game.handSize(1)
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = ring, abilityId = tapAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+            game.handSize(1) shouldBe handBeforeFirst + 1
+
+            // Advance to the controller's own turn; the Ring untaps during their untap step.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.state.activePlayerId shouldBe game.player1Id
+            game.resolveStack() // upkeep: lose 1 life for the single burden counter
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+            // Second activation: the counter is added FIRST, so the draw reads the new count of 2.
+            val handBeforeSecond = game.handSize(1)
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = ring, abilityId = tapAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+            game.handSize(1) shouldBe handBeforeSecond + 2
+        }
+
+        test("entering without being cast grants no protection (intervening-if, CR 603.4)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Test Reanimate")
+                .withCardInGraveyard(1, "The One Ring")
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ring = game.findCardsInGraveyard(1, "The One Ring").first()
+            val reanimateSpell = game.findCardsInHand(1, "Test Reanimate").first()
+            game.execute(
+                CastSpell(
+                    game.player1Id,
+                    reanimateSpell,
+                    listOf(ChosenTarget.Card(ring, game.player1Id, Zone.GRAVEYARD))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The One Ring is on the battlefield, so its ETB trigger was evaluated...
+            game.isOnBattlefield("The One Ring") shouldBe true
+            // ...but it wasn't cast, so the "if you cast it" clause did nothing — no protection.
+            game.state.getEntity(game.player1Id)?.get<PlayerProtectionComponent>() shouldBe null
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingGoesSouthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingGoesSouthScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.TheRingGoesSouth
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Ring Goes South — "The Ring tempts you. Then reveal cards from the top of your library
+ * until you reveal X land cards, where X is the number of legendary creatures you control. Put
+ * those land cards onto the battlefield tapped and the rest on the bottom of your library in a
+ * random order."
+ *
+ * Exercises GatherUntilMatch (dynamic X) + the new MoveCollection.filter (lands → battlefield
+ * tapped, the rest → bottom of library).
+ */
+class TheRingGoesSouthScenarioTest : FunSpec({
+
+    val TestLegend = CardDefinition.creature(
+        "Test Legend", ManaCost.parse("{2}"), emptySet(), 2, 2,
+        supertypes = setOf(Supertype.LEGENDARY)
+    )
+    val TestOgre = CardDefinition.creature("Test Ogre", ManaCost.parse("{3}"), emptySet(), 3, 3)
+
+    test("reveals until X lands; lands enter tapped, the rest go to the bottom") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheRingGoesSouth, TestLegend, TestOgre))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        // One legendary creature → X = 1.
+        val legend = driver.putCreatureOnBattlefield(active, "Test Legend")
+
+        // Library top (top-most last): Test Ogre (nonland), then Forest (land). Reveal until 1
+        // land reveals the Ogre then the Forest.
+        driver.putCardOnTopOfLibrary(active, "Forest")
+        driver.putCardOnTopOfLibrary(active, "Test Ogre")
+
+        val spell = driver.putCardInHand(active, "The Ring Goes South")
+        driver.giveMana(active, Color.GREEN, 4)
+        driver.castSpell(active, spell)
+        driver.bothPass()
+
+        // Drain decisions: the Ring tempt prompts a Ring-bearer choice (pick the legend); the
+        // reveal/move steps need no input. Loop until the spell fully resolves.
+        var guard = 0
+        while (guard++ < 10) {
+            val pd = driver.pendingDecision
+            if (pd is SelectCardsDecision) {
+                driver.submitCardSelection(active, listOf(legend))
+            } else if (driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else break
+        }
+
+        // The revealed Forest is on the battlefield, tapped.
+        val forestOnBf = driver.state.getBattlefield().firstOrNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+        }
+        (forestOnBf != null) shouldBe true
+        driver.state.getEntity(forestOnBf!!)?.has<TappedComponent>() shouldBe true
+
+        // The non-land Ogre did not enter the battlefield (it went to the bottom of the library).
+        driver.state.getBattlefield().any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+        } shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrollOfKhazadDumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrollOfKhazadDumScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Troll of Khazad-dûm — "can't be blocked except by three or more creatures." Exercises the new
+ * `CantBeBlockedByFewerThan(3)` static (a generalization of menace's minimum of two).
+ */
+class TrollOfKhazadDumScenarioTest : ScenarioTestBase() {
+
+    private fun trollCombat() = scenario()
+        .withPlayers()
+        .withCardOnBattlefield(1, "Troll of Khazad-dûm")
+        .withCardOnBattlefield(2, "Savannah Lions")
+        .withCardOnBattlefield(2, "Grizzly Bears")
+        .withCardOnBattlefield(2, "Goblin Guide")
+        .withCardInLibrary(1, "Swamp")
+        .withCardInLibrary(2, "Forest")
+        .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+        .build()
+
+    init {
+        test("cannot be blocked by fewer than three creatures") {
+            val game = trollCombat()
+            game.declareAttackers(mapOf("Troll of Khazad-dûm" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            // Two blockers is illegal (validation fails, state unchanged).
+            game.declareBlockers(
+                mapOf(
+                    "Savannah Lions" to listOf("Troll of Khazad-dûm"),
+                    "Grizzly Bears" to listOf("Troll of Khazad-dûm"),
+                )
+            ).error shouldNotBe null
+
+            // Three blockers is legal.
+            game.declareBlockers(
+                mapOf(
+                    "Savannah Lions" to listOf("Troll of Khazad-dûm"),
+                    "Grizzly Bears" to listOf("Troll of Khazad-dûm"),
+                    "Goblin Guide" to listOf("Troll of Khazad-dûm"),
+                )
+            ).error shouldBe null
+        }
+
+        test("may still be left unblocked") {
+            val game = trollCombat()
+            game.declareAttackers(mapOf("Troll of Khazad-dûm" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers().error shouldBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YouCannotPassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YouCannotPassScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * You Cannot Pass! — "Destroy target creature that blocked or was blocked by a legendary creature
+ * this turn." Exercises the new `BlockedOrWasBlockedByLegendaryThisTurn` predicate (stamped at
+ * block declaration) in both directions, plus rejection of a creature that never fought a legendary.
+ */
+class YouCannotPassScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("destroys a creature that blocked a legendary creature this turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Naban, Dean of Iteration") // legendary attacker
+                .withCardOnBattlefield(2, "Grizzly Bears")            // non-legendary blocker
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInHand(1, "You Cannot Pass!")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Naban, Dean of Iteration" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Grizzly Bears" to listOf("Naban, Dean of Iteration")))
+            game.passPriority() // blocking player passes; active player (P1) gets priority
+
+            val target = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "You Cannot Pass!", target).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+        }
+
+        test("destroys a creature that was blocked by a legendary creature this turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")            // non-legendary attacker
+                .withCardOnBattlefield(2, "Naban, Dean of Iteration") // legendary blocker
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInHand(1, "You Cannot Pass!")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Grizzly Bears" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Naban, Dean of Iteration" to listOf("Grizzly Bears")))
+            game.passPriority()
+
+            // The attacker (blocked by a legendary) is a legal target.
+            game.castSpell(1, "You Cannot Pass!", game.findPermanent("Grizzly Bears")!!).error shouldBe null
+            game.resolveStack()
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+        }
+
+        test("cannot target a creature that never fought a legendary this turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Naban, Dean of Iteration") // legendary attacker
+                .withCardOnBattlefield(2, "Grizzly Bears")            // blocks the legendary
+                .withCardOnBattlefield(2, "Savannah Lions")           // bystander, never in combat
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInHand(1, "You Cannot Pass!")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Naban, Dean of Iteration" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Grizzly Bears" to listOf("Naban, Dean of Iteration")))
+            game.passPriority()
+
+            // The bystander did not block or get blocked by anything — illegal target.
+            val bystander = game.findPermanent("Savannah Lions")!!
+            game.castSpell(1, "You Cannot Pass!", bystander).error shouldNotBe null
+            game.isOnBattlefield("Savannah Lions") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Adds 13 cards to The Lord of the Rings: Tales of Middle-earth (LTR). Stacked on
`ltr-pr-3` — review the 14 commits since that base. Pure card content: no new SDK
types, every card composes existing primitives.

## Cards
- **The One Ring** + **A-The One Ring** (Alchemy) — indestructible, player-level
  protection from everything (cast-gated), escalating burden draw/upkeep loss
- **Sméagol, Helpful Guide** — end-step Ring tempt + steal-a-land reveal
- **Galadriel of Lothlórien** — Ring-tempt scry; reveal-top-land-on-scry
- **The Ring Goes South** — Ring tempt + reveal X lands (X = legendary creatures)
- **Breaking of the Fellowship** — opponent's creature fights another, then tempt
- **Legolas, Master Archer** — cast-targeting triggers (counter / power-damage)
- **Glorfindel, Dauntless Rescuer** — on-scry modal pump + block restrictions
- **Gandalf's Sanction** — graveyard-scaled damage, excess to controller
- **Display of Power** — copy any number of instant/sorcery spells; can't be copied
- **Phial of Galadriel** — draw/life-gain replacements + any-color mana
- **Barrow-Blade** — equip; blocked creature loses all abilities
- **Troll of Khazad-dûm** — can't be blocked by fewer than three; swampcycling

## Testing
- A scenario test per card; rule corners pinned (protection blocks targeting,
  burden growth/608.2c, intervening-if/603.4, mode-2 block cap, excess damage,
  multi-spell copy, non-land reveal stays on top).
- All 13 scenario tests pass; CardDefinitionSnapshotTest + CardLintTest green.

All cited CR numbers (702.16, 603.4, 608.2c, 120.4a, 707.10) verified against the
Comprehensive Rules; oracle text and earliest-printing placement checked on Scryfall.