### PR TITLE
Add Memory Vessel to The Big Score (+ hand-play restriction feature)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -765,6 +765,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `BlockPhaseManager.validateMinBlockersRequirements`, mirroring the menace check. Used by Troll of
   Khazad-dûm (`CantBeBlockedByFewerThan(3)`).
 - `CantCastSpellsEffect(target, until?)` — target can't cast spells. Facade: `Effects.CantCastSpells(target, duration)`.
+- `CantPlayCardsFromHandEffect(target = Controller, duration = UntilYourNextTurn)` — target can't play cards (cast
+  spells **or** play lands) from their **hand** zone for the duration. Hand-scoped: cards in exile/graveyard with a
+  may-play permission stay playable. Facade: `Effects.CantPlayCardsFromHand(target, duration)`. Pairs with an impulse
+  grant (`ExilePatterns.impulse`) so a player swaps their hand for the top cards of their library for a turn
+  (Memory Vessel). Distinct from `CantCastSpells` (every zone, spells only).
 - `Effects.CantPlayLandsThisTurn(target = Controller)` (`PreventLandPlaysThisTurnEffect`) — the target player can't
   play lands for the rest of this turn (sets remaining land drops to 0). Defaults to the controller (Rock Jockey);
   pass `EffectTarget.ContextTarget(n)` for "target player can't play lands this turn" cards like Turf Wound.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -58,6 +58,7 @@ import com.wingedsheep.sdk.scripting.effects.SetSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantActivateLoyaltyAbilitiesEffect
 import com.wingedsheep.sdk.scripting.effects.CantCastSpellsEffect
+import com.wingedsheep.sdk.scripting.effects.CantPlayCardsFromHandEffect
 import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
@@ -2660,6 +2661,17 @@ object Effects {
      */
     fun CantCastSpells(target: EffectTarget, duration: Duration = Duration.EndOfTurn): Effect =
         CantCastSpellsEffect(target, duration)
+
+    /**
+     * Target player can't play cards from their hand for the duration (default: until your
+     * next turn). Blocks both casting spells and playing lands, but only from the hand —
+     * cards in other zones (exile via a may-play permission, etc.) stay playable. The
+     * "they can't play cards from their hand" clause of Memory Vessel.
+     */
+    fun CantPlayCardsFromHand(
+        target: EffectTarget = EffectTarget.Controller,
+        duration: Duration = Duration.UntilYourNextTurn
+    ): Effect = CantPlayCardsFromHandEffect(target, duration)
 
     /**
      * A player can't play lands for the rest of this turn (sets remaining land drops to 0).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -239,6 +239,32 @@ data class CantCastSpellsEffect(
 }
 
 /**
+ * Target player can't play cards from their hand for the specified [duration].
+ *
+ * Restricts both casting spells and playing lands, but only from the **hand** zone —
+ * the player may still play cards from other zones (exile via a may-play permission,
+ * graveyard via Muldrotha, etc.). This is the "they can't play cards from their hand"
+ * clause of Memory Vessel, which pairs the restriction with an impulse-style grant so a
+ * player swaps their hand for the top cards of their library for a turn.
+ *
+ * Distinct from [CantCastSpellsEffect], which forbids casting from *every* zone but
+ * leaves land plays untouched. This effect is hand-scoped and covers lands too.
+ *
+ * @param target The player who can't play cards from their hand (default: controller).
+ * @param duration How long the restriction lasts (default: until your next turn, matching
+ *   the impulse window it usually accompanies).
+ */
+@SerialName("CantPlayCardsFromHand")
+@Serializable
+data class CantPlayCardsFromHandEffect(
+    val target: EffectTarget = EffectTarget.Controller,
+    val duration: Duration = Duration.UntilYourNextTurn
+) : Effect {
+    override val description: String =
+        "${target.description.replaceFirstChar { it.uppercase() }} can't play cards from their hand ${duration.description}"
+}
+
+/**
  * Target player can't activate planeswalkers' loyalty abilities for the specified duration.
  * Sibling restriction to [CantCastSpellsEffect]; compose the two for cards that forbid both
  * (e.g. Revel in Silence: "Your opponents can't cast spells or activate planeswalkers' loyalty

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
@@ -16,7 +16,6 @@ object TheBigScoreSet : MtgSet {
     override val code = "BIG"
     override val displayName = "The Big Score"
     override val releaseDate = "2024-04-19"
-    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/MemoryVessel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/MemoryVessel.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.big.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Memory Vessel
+ * {3}{R}{R}
+ * Artifact
+ * {T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your
+ * next turn, players may play cards they exiled this way, and they can't play cards from their
+ * hand. Activate only as a sorcery.
+ *
+ * Per-player impulse: for each player (APNAP order, CR 101.4) gather the top seven of *their*
+ * library and exile them, then grant that player permission to play those exiled cards and bar
+ * them from playing cards from their hand. Both windows last "until your next turn" — the
+ * *activating* player's next turn, the same for everyone. `ForEachPlayer` rebinds the body's
+ * controller to each player so `Player.You` and `EffectTarget.Controller` resolve to them, while
+ * the grant/restriction executors key the turn-boundary expiry off the source's controller (the
+ * activating player) so an opponent's window doesn't lift at the start of their own turn.
+ *
+ * "Until your next turn" (not "until the end of your next turn") → the may-play window uses the
+ * "next upkeep, not this turn's" expiry shape; the can't-play-from-hand restriction uses the
+ * matching `Duration.UntilYourNextTurn`, both cleared on the activating player's next untap.
+ */
+val MemoryVessel = card("Memory Vessel") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "{T}, Exile this artifact: Each player exiles the top seven cards of their " +
+        "library. Until your next turn, players may play cards they exiled this way, and they " +
+        "can't play cards from their hand. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.ExileSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ForEachPlayer(
+            Player.ActivePlayerFirst,
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7), Player.You),
+                    storeAs = "memoryVesselExiled"
+                ),
+                MoveCollectionEffect(
+                    from = "memoryVesselExiled",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                GrantMayPlayFromExileEffect(
+                    from = "memoryVesselExiled",
+                    expiry = MayPlayExpiry.UntilControllerStep(Step.UPKEEP, includeCurrentTurn = false)
+                ),
+                Effects.CantPlayCardsFromHand(EffectTarget.Controller, Duration.UntilYourNextTurn)
+            )
+        )
+        description = "{T}, Exile this artifact: Each player exiles the top seven cards of their " +
+            "library. Until your next turn, players may play cards they exiled this way, and " +
+            "they can't play cards from their hand. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "13"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg?1739804192"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -1336,6 +1336,80 @@
     "colorIdentityOverride": []
 }
 
+// Memory Vessel
+{
+    "name": "Memory Vessel",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "ActivePlayerFirst"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 7
+                                    }
+                                },
+                                "storeAs": "memoryVesselExiled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "memoryVesselExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "memoryVesselExiled",
+                                "expiry": {
+                                    "type": "UntilControllerStep",
+                                    "step": "UPKEEP",
+                                    "includeCurrentTurn": false
+                                }
+                            },
+                            "CantPlayCardsFromHand"
+                        ]
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "MYTHIC",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg?1739804192"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Molten Duplication
 {
     "name": "Molten Duplication",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -88,6 +88,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
         composes = listOf("GrantToEnchantedCreatureTypeGroup"))
     envelope("CreateEachPermanentRuleEffectUntil", "envelope: continuous rule, each")
     envelope("CreatePlayerEffectUntil", "envelope: player-scoped continuous effect")
+    // "Until [expiration], each player gets [player effects]" (Memory Vessel) — a per-player,
+    // duration-scoped continuous effect created for every player. The real capability is the nested
+    // _PlayerEffect list (MayPlayExiledCards, CantPlayCardsFromHand), expressed inside a
+    // ForEachPlayer body that rebinds the controller to each player.
+    envelope("CreateEachPlayerEffectUntil", "envelope: per-player continuous effect (capability is the _PlayerEffect)")
     envelope("CreatePermanentLayerEffect", UNIVERSAL)
     // A continuous rule until end of turn. The nested `_PermanentRule` is the real capability: CantBlock /
     // CantAttack render to `CantBlockEffect` (SerialName "CantBlockTargetCreatures") / `CantAttackEffect`

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -169,6 +169,22 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     effect("CantActivateAbilities", "PlayersCantActivateAbilities")
     supported("AbilityOfAPermanent", "ability selector: activated abilities of permanents matching a filter")
 
+    // "Players may play cards they exiled this way" (Memory Vessel) — the nested _PlayerEffect of a
+    // CreateEachPlayerEffectUntil. Each affected player's effect grants a may-play window over the
+    // cards that player exiled this way: `GrantMayPlayFromExile` over the per-player exile
+    // collection. Capability-only — the emitter declines the per-player exile/may-play/restriction
+    // activated-ability cluster -> SCAFFOLD.
+    composed(
+        "MayPlayExiledCards",
+        "GrantMayPlayFromExile over the cards that player exiled this way",
+        composes = listOf("GrantMayPlayFromExile"),
+    )
+    // "Players can't play cards from their hand" (Memory Vessel) — the nested _PlayerEffect of a
+    // CreateEachPlayerEffectUntil. Renders to the hand-scoped player restriction
+    // `CantPlayCardsFromHand` (blocks casting spells and playing lands from the hand zone only;
+    // exile/graveyard may-play windows are unaffected).
+    effect("CantPlayCardsFromHand", "CantPlayCardsFromHand")
+
     // Rest in Peace: "exile all graveyards" (ETB) + "if a card or token would be put into a graveyard
     // from anywhere, exile it instead" (static replacement). The first composes via the Gather -> Move
     // pipeline over Player.Each graveyards; the second is the RedirectZoneChange(EXILE) replacement.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -85,6 +85,11 @@ internal fun BridgeBuilder.zoneMovement() {
     // with a GrantMayPlayFromExile window (often `withAnyManaType`). Capability-only — the emitter
     // declines the player-targeted + may-play-with-any-mana cluster -> SCAFFOLD.
     composed("ExileTheTopNumberCardsOfPlayersLibrary", "Gather(top N of target player's library) + MoveCollection -> exile (impulse from a player's library)", composes = listOf("MoveCollection"))
+    // "Each player exiles the top N cards of their library" (Memory Vessel) — the per-player impulse
+    // exile, inside a ForEachPlayer body that rebinds the controller to each player. Gather(top N of
+    // your library) + MoveCollection -> your exile, run once per player. Capability-only — the
+    // emitter declines the surrounding per-player may-play/restriction activated-ability -> SCAFFOLD.
+    composed("ExileTheTopNumberCardsOfLibrary", "ForEachPlayer { Gather(top N of your library) + MoveCollection -> exile } (per-player impulse)", composes = listOf("MoveCollection"))
     // "Put up to N land cards from your hand onto the battlefield tapped" (The Gitrog, Ravenous Ride).
     // Gather(land cards in hand) -> ChooseUpTo(N) -> MoveCollection(hand->battlefield, tapped). Same
     // shape as PutACardFromHandOnBattlefield but bounded by a dynamic count; capability-only -> SCAFFOLD.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -36,6 +36,7 @@ import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.DamageBonusComponent
 import com.wingedsheep.engine.state.components.player.DamageReceivedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
 import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
@@ -192,6 +193,19 @@ class CleanupPhaseManager(
         val protection = result.getEntity(activePlayer)?.get<PlayerProtectionComponent>()
         if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
             result = result.updateEntity(activePlayer) { it.without<PlayerProtectionComponent>() }
+        }
+        // Memory Vessel's "they can't play cards from their hand until your next turn" expires on
+        // the same post-untap hook. The window keys off the *activating* player (every affected
+        // player's restriction lifts on that player's next turn), so scan every player and remove
+        // the component when [activePlayer] matches its expiry player — the explicit
+        // [PlayerCantPlayFromHandComponent.expiresForPlayerId] when set, else the component owner.
+        for (playerId in result.turnOrder) {
+            val cantPlay = result.getEntity(playerId)?.get<PlayerCantPlayFromHandComponent>() ?: continue
+            if (cantPlay.removeOn != PlayerEffectRemoval.UntilYourNextTurn) continue
+            val expiryPlayer = cantPlay.expiresForPlayerId ?: playerId
+            if (expiryPlayer == activePlayer) {
+                result = result.updateEntity(playerId) { it.without<PlayerCantPlayFromHandComponent>() }
+            }
         }
         return result
     }
@@ -441,6 +455,10 @@ class CleanupPhaseManager(
                 val protection = result.get<PlayerProtectionComponent>()
                 if (protection?.removeOn == PlayerEffectRemoval.EndOfTurn) {
                     result = result.without<PlayerProtectionComponent>()
+                }
+                val cantPlayFromHand = result.get<PlayerCantPlayFromHandComponent>()
+                if (cantPlayFromHand?.removeOn == PlayerEffectRemoval.EndOfTurn) {
+                    result = result.without<PlayerCantPlayFromHandComponent>()
                 }
                 val cantCast = result.get<CantCastSpellsComponent>()
                 if (cantCast?.removeOn == PlayerEffectRemoval.EndOfTurn) {
@@ -708,7 +726,7 @@ class CleanupPhaseManager(
                     !permission.permanent && when {
                         permission.expiresAfterTurn != null ->
                             newState.turnNumber >= permission.expiresAfterTurn &&
-                                newState.activePlayerId == permission.controllerId
+                                newState.activePlayerId == (permission.expiryControllerId ?: permission.controllerId)
                         else -> true
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -467,6 +467,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PlayerNoMaximumHandSizeComponent::class)
         subclass(PlayerHexproofComponent::class)
         subclass(PlayerProtectionComponent::class)
+        subclass(PlayerCantPlayFromHandComponent::class)
         subclass(PlayerShroudComponent::class)
         subclass(SacrificedFoodThisTurnComponent::class)
         subclass(PermanentTypesEnteredBattlefieldThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -25,6 +25,15 @@ data class EffectContext(
     val sourceId: EntityId?,
     val controllerId: EntityId,
     /**
+     * The controller of the *overall* effect/ability, stable across per-player iteration.
+     * `ForEachEffect(IterationSpace.Players)` rebinds [controllerId] to each iterated player so
+     * `Player.You` resolves to them, but some sub-effects still need the original activating
+     * player — e.g. a "until **your** next turn" window whose "your" is the activating player for
+     * every affected player (Memory Vessel). Captured on the first Players-iteration and preserved
+     * across nested iterations. Null outside iteration; read as `effectControllerId ?: controllerId`.
+     */
+    val effectControllerId: EntityId? = null,
+    /**
      * Definition-scoped identity of the triggered/activated ability currently resolving, copied
      * from its stack component (see [com.wingedsheep.sdk.scripting.AbilityIdentity]). Lets a
      * resolution-time may-question consult the controller's persistent auto-answer yields without

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.engine.state.permissions.hasMayPlayFor
 import com.wingedsheep.engine.state.permissions.removeMayPlayPermissionsForCard
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.ConditionEvaluator
@@ -94,6 +95,12 @@ class PlayLandHandler(
             isInGraveyardWithPlayPermission(state, action.playerId, action.cardId)
         if (!inHand && !onTopOfLibrary && !mayPlayFromExile && !mayPlayFromGraveyard) {
             return "Land is not in your hand"
+        }
+
+        // Memory Vessel: "they can't play cards from their hand" — hand-scoped, so a land granted
+        // a may-play permission from exile/graveyard still resolves.
+        if (inHand && state.getEntity(action.playerId)?.has<PlayerCantPlayFromHandComponent>() == true) {
+            return "You can't play cards from your hand"
         }
 
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -65,6 +65,7 @@ import com.wingedsheep.engine.state.components.identity.PlayWithAdditionalCostCo
 import com.wingedsheep.engine.state.components.identity.PlayWithCostIncreaseComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.player.ManaSpentOnSpellsThisTurnComponent
 import com.wingedsheep.sdk.core.CardType
@@ -191,6 +192,12 @@ class CastSpellHandler(
             zoneResolver.hasCommanderCastPermission(state, action.playerId, action.cardId)
         if (!inHand && !onTopOfLibrary && !mayPlayFromExile && !mayCastFromZone && !mayCastFromGraveyard && !hasFlashback && !hasHarmonize && !hasGraveyardCast && !hasForageFromGraveyard && !hasWarpFromGraveyard && !hasCommanderCast) {
             return "Card is not in your hand"
+        }
+
+        // Memory Vessel: "they can't play cards from their hand" — hand-scoped, so casts from
+        // exile/graveyard granted by a may-play permission still resolve.
+        if (inHand && state.getEntity(action.playerId)?.has<PlayerCantPlayFromHandComponent>() == true) {
+            return "You can't play cards from your hand"
         }
 
         // Single cast-legality chokepoint: per-turn spell limit (Yawgmoth's Agenda),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -184,6 +184,10 @@ class ForEachExecutor(
         // pile), not the original caster.
         is ForEachItem.OfPlayer -> outerContext.copy(
             controllerId = item.playerId,
+            // Capture the activating player once (the outer controller before any rebinding) and
+            // carry it through nested player loops, so sub-effects that need the original effect
+            // controller (e.g. an activating-player-relative duration) can read it.
+            effectControllerId = outerContext.effectControllerId ?: outerContext.controllerId,
             pipeline = outerContext.pipeline.copy(storedCollections = emptyMap())
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -45,8 +45,17 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
         val controllerId = context.controllerId
         val collection = context.pipeline.storedCollections[effect.from] ?: emptyList()
 
+        // Turn-keyed windows ("until your next turn") follow the *activating* player, not
+        // necessarily the player who may play the cards. They coincide for a single-player
+        // impulse, but diverge when the grant runs inside a per-player loop that rebinds the
+        // controller to each card's owner (Memory Vessel): the effect controller is the
+        // activating player whose next turn closes the window for everyone. effectControllerId
+        // survives the per-player rebinding (the source itself may already be in exile from a
+        // cost, so it can't be read off the source's ControllerComponent).
+        val activatingPlayer = context.effectControllerId ?: controllerId
         val isPermanent = effect.expiry is MayPlayExpiry.Permanent
-        val expiresAfterTurn = expiresAfterTurnFor(state, controllerId, effect.expiry)
+        val expiresAfterTurn = expiresAfterTurnFor(state, activatingPlayer, effect.expiry)
+        val expiryControllerId = if (activatingPlayer != controllerId) activatingPlayer else null
 
         var newState = state
         if (collection.isNotEmpty()) {
@@ -88,6 +97,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
                     permanent = isPermanent,
                     expiresAfterTurn = expiresAfterTurn,
                     riderLinkId = riderLinkId,
+                    expiryControllerId = expiryControllerId,
                     timestamp = state.timestamp,
                 )
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantPlayCardsFromHandExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantPlayCardsFromHandExecutor.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
+import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CantPlayCardsFromHandEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [CantPlayCardsFromHandEffect] — stamps a
+ * [PlayerCantPlayFromHandComponent] on the target player for the requested duration
+ * (Memory Vessel's "they can't play cards from their hand").
+ *
+ * The restriction is read at legal-action enumeration and re-checked in the cast/play
+ * handlers; it only blocks plays from the hand zone, so cards granted a may-play
+ * permission elsewhere (the impulse-exiled cards Memory Vessel grants) stay playable.
+ */
+class CantPlayCardsFromHandExecutor : EffectExecutor<CantPlayCardsFromHandEffect> {
+
+    override val effectType: KClass<CantPlayCardsFromHandEffect> = CantPlayCardsFromHandEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: CantPlayCardsFromHandEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid target for can't-play-from-hand grant")
+
+        if (!state.turnOrder.contains(targetId)) {
+            return EffectResult.error(state, "CantPlayCardsFromHand target must be a player")
+        }
+
+        val removeOn = when (effect.duration) {
+            is Duration.Permanent -> PlayerEffectRemoval.Permanent
+            is Duration.EndOfTurn -> PlayerEffectRemoval.EndOfTurn
+            else -> PlayerEffectRemoval.UntilYourNextTurn
+        }
+
+        // "Until your next turn" keys off the *activating* player, not the player the restriction
+        // sits on — so an opponent's restriction lasts until the activating player's next turn,
+        // not the opponent's own (Memory Vessel). The activating player is the effect controller,
+        // which survives per-player iteration (context.controllerId is rebound to each player).
+        // Only meaningful when target != activating player; null otherwise (the component's own
+        // owner is used).
+        val activatingPlayer = context.effectControllerId ?: context.controllerId
+        val expiresForPlayerId =
+            if (removeOn == PlayerEffectRemoval.UntilYourNextTurn && activatingPlayer != targetId)
+                activatingPlayer else null
+
+        val newState = state.updateEntity(targetId) { container ->
+            container.with(PlayerCantPlayFromHandComponent(removeOn = removeOn, expiresForPlayerId = expiresForPlayerId))
+        }
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -44,6 +44,7 @@ class PlayerExecutors(
         AnyPlayerMayPayExecutor(executeEffect = effectExecutor),
         CantActivateLoyaltyAbilitiesExecutor(),
         CantCastSpellsExecutor(),
+        CantPlayCardsFromHandExecutor(),
         CreateGlobalTriggeredAbilityExecutor(),
         CreatePermanentEmblemExecutor(),
         EachPlayerChoosesCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
 
@@ -95,6 +96,13 @@ class EnumerationContext(
     // Loyalty-activation restriction (Revel in Silence etc.)
     val cantActivateLoyaltyAbilities: Boolean by lazy {
         state.getEntity(playerId)?.has<CantActivateLoyaltyAbilitiesComponent>() == true
+    }
+
+    // Hand-scoped play restriction (Memory Vessel's "they can't play cards from their hand").
+    // Blocks casting spells and playing lands from the hand zone only — cards in exile/graveyard
+    // with a may-play permission are unaffected. Read by CastSpellEnumerator + PlayLandEnumerator.
+    val cantPlayCardsFromHand: Boolean by lazy {
+        state.getEntity(playerId)?.has<PlayerCantPlayFromHandComponent>() == true
     }
 
     // Whether any per-spell cast restriction (Mana Maze, PlayersCantCastSpells) is in play at all —

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -46,6 +46,11 @@ class CastSpellEnumerator : ActionEnumerator {
 
         val hand = state.getHand(playerId)
 
+        // Memory Vessel: "they can't play cards from their hand." Every card iterated here is in
+        // the hand zone, so a blanket skip enforces the restriction without touching exile/graveyard
+        // casts (those are enumerated by CastFromZoneEnumerator / GraveyardAbilityEnumerator).
+        if (context.cantPlayCardsFromHand) return result
+
         // --- Normal spell casting ---
         for (cardId in hand) {
             val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
@@ -16,16 +16,19 @@ class PlayLandEnumerator : ActionEnumerator {
         val state = context.state
         val playerId = context.playerId
 
-        // Lands from hand
-        val hand = state.getHand(playerId)
-        for (cardId in hand) {
-            val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-            if (cardComponent.typeLine.isLand) {
-                result.add(LegalAction(
-                    actionType = "PlayLand",
-                    description = "Play ${cardComponent.name}",
-                    action = PlayLand(playerId, cardId)
-                ))
+        // Lands from hand — suppressed by Memory Vessel's "they can't play cards from their hand"
+        // (hand-scoped only; the graveyard/exile loops below are unaffected).
+        if (!context.cantPlayCardsFromHand) {
+            val hand = state.getHand(playerId)
+            for (cardId in hand) {
+                val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
+                if (cardComponent.typeLine.isLand) {
+                    result.add(LegalAction(
+                        actionType = "PlayLand",
+                        description = "Play ${cardComponent.name}",
+                        action = PlayLand(playerId, cardId)
+                    ))
+                }
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -439,6 +439,33 @@ data class PlayerProtectionComponent(
 ) : Component
 
 /**
+ * Marks a player as unable to play cards from their **hand** (CR 601 casting and CR 305 land
+ * plays are both blocked, but only for cards in the hand zone).
+ *
+ * Applied by Memory Vessel's "they can't play cards from their hand" clause, which it pairs
+ * with an impulse-style grant so a player effectively swaps their hand for the top cards of
+ * their library for a turn. Cards in other zones (exile via a may-play permission, graveyard
+ * via Muldrotha) stay playable — the restriction is hand-scoped.
+ *
+ * Read at legal-action enumeration (CastSpellEnumerator, PlayLandEnumerator) and re-checked
+ * authoritatively in the cast/play handlers. Defaults to the
+ * [PlayerEffectRemoval.UntilYourNextTurn] lifecycle, expired in the same post-untap hook as
+ * [PlayerProtectionComponent] and floating `UntilYourNextTurn` effects.
+ *
+ * @param removeOn When this component is removed.
+ * @param expiresForPlayerId For a [PlayerEffectRemoval.UntilYourNextTurn] lifecycle, whose
+ *   "next turn" closes the window. Null → the component's own owner (the normal case). Memory
+ *   Vessel sets this to the *activating* player so every affected player's restriction lifts on
+ *   the activating player's next turn, not on each player's own next turn (which would lift an
+ *   opponent's restriction at the start of their own turn — one turn too early).
+ */
+@Serializable
+data class PlayerCantPlayFromHandComponent(
+    val removeOn: PlayerEffectRemoval = PlayerEffectRemoval.UntilYourNextTurn,
+    val expiresForPlayerId: EntityId? = null
+) : Component
+
+/**
  * Marks a player as having the city's blessing (CR 702.131 / 700.5).
  *
  * Granted by Ascend triggers when their controller controls 10+ permanents on

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermission.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermission.kt
@@ -59,6 +59,18 @@ data class MayPlayPermission(
      * id. Null when the grant has no rider.
      */
     val riderLinkId: String? = null,
+    /**
+     * Whose turn ends a turn-keyed window ([expiresAfterTurn]), when that differs from
+     * [controllerId]. Defaults to null → the window keys off [controllerId] (the normal
+     * single-player impulse case, where the player who may play the cards is the same player
+     * whose "next turn" closes the window).
+     *
+     * Memory Vessel grants each player a permission to play *their own* exiled cards
+     * ([controllerId] = the card's owner) but the window lasts "until **your** next turn" — the
+     * activating player's next turn, the same for everyone. Setting this to the activating player
+     * makes the cleanup expiry key off that player's turn instead of each owner's.
+     */
+    val expiryControllerId: EntityId? = null,
     val timestamp: Long
 ) {
     init {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MemoryVesselTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MemoryVesselTest.kt
@@ -1,0 +1,158 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.big.cards.MemoryVessel
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Memory Vessel {3}{R}{R} — Artifact.
+ * "{T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your
+ *  next turn, players may play cards they exiled this way, and they can't play cards from their
+ *  hand. Activate only as a sorcery."
+ *
+ * Exercises the load-bearing parts:
+ *  - per-player exile of the top seven (`ForEachPlayer` + per-player Gather/Move),
+ *  - each player gets a may-play permission for *their own* exiled cards,
+ *  - each player is barred from playing cards from their hand (CantPlayCardsFromHand),
+ *  - the restriction expires on the *activating* player's next turn — not each player's own.
+ */
+class MemoryVesselTest : FunSpec({
+
+    val abilityId = MemoryVessel.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MemoryVessel))
+        return driver
+    }
+
+    fun GameTestDriver.libraryOf(playerId: com.wingedsheep.sdk.model.EntityId) =
+        state.getZone(ZoneKey(playerId, Zone.LIBRARY))
+
+    test("Each player exiles the top seven of their own library; hands are locked, exiles are playable") {
+        val driver = createDriver()
+        // Big libraries so seven can be exiled per player without decking.
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        val bob = driver.getOpponent(alice)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack a known, castable card on top of each library so we can assert it lands in
+        // exile and becomes a may-play action. (Grizzly Bears is a vanilla 2/2.)
+        val aliceTop = driver.putCardOnTopOfLibrary(alice, "Grizzly Bears")
+        val bobTop = driver.putCardOnTopOfLibrary(bob, "Grizzly Bears")
+
+        // Each player holds a creature in hand — these must become UN-castable.
+        val aliceHandCreature = driver.putCardInHand(alice, "Centaur Courser")
+        val bobHandCreature = driver.putCardInHand(bob, "Centaur Courser")
+
+        // Memory Vessel in play, untapped, no summoning sickness (artifact, but be safe).
+        val vessel = driver.putPermanentOnBattlefield(alice, "Memory Vessel")
+        driver.replaceState(
+            driver.state.updateEntity(vessel) { it.without<SummoningSicknessComponent>() }
+        )
+
+        val aliceLibBefore = driver.libraryOf(alice).size
+        val bobLibBefore = driver.libraryOf(bob).size
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = vessel,
+                abilityId = abilityId,
+                targets = emptyList(),
+                costPayment = null,
+            )
+        )
+        // Resolve the ability off the stack.
+        driver.bothPass()
+
+        // Seven cards left each library.
+        driver.libraryOf(alice).size shouldBe (aliceLibBefore - 7)
+        driver.libraryOf(bob).size shouldBe (bobLibBefore - 7)
+
+        // The stacked top card of each library is now in that player's exile.
+        driver.getExile(alice) shouldContain aliceTop
+        driver.getExile(bob) shouldContain bobTop
+
+        // Memory Vessel exiled itself as part of the cost.
+        driver.findPermanent(alice, "Memory Vessel") shouldBe null
+
+        // Both players carry the "can't play cards from hand" restriction.
+        driver.state.getEntity(alice)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+        driver.state.getEntity(bob)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+
+        // Alice can play her exiled card but NOT the creature in her hand.
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val aliceActions = enumerator.enumerate(driver.state, alice, EnumerationMode.FULL)
+        aliceActions.any { it.actionType == "CastSpell" && cardIdOf(it) == aliceTop } shouldBe true
+        aliceActions.any { it.actionType == "CastSpell" && cardIdOf(it) == aliceHandCreature } shouldBe false
+
+        // Land plays from Alice's HAND are barred (the restriction covers lands). Lands granted a
+        // may-play permission from exile are still playable, so check the hand lands specifically.
+        val aliceHandLands = driver.getHand(alice)
+        aliceActions.none { it.actionType == "PlayLand" && cardIdOf(it) in aliceHandLands } shouldBe true
+    }
+
+    test("The can't-play-from-hand restriction expires on the ACTIVATING player's next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        val bob = driver.getOpponent(alice)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val vessel = driver.putPermanentOnBattlefield(alice, "Memory Vessel")
+        driver.replaceState(
+            driver.state.updateEntity(vessel) { it.without<SummoningSicknessComponent>() }
+        )
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = vessel,
+                abilityId = abilityId,
+                targets = emptyList(),
+                costPayment = null,
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getEntity(alice)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+        driver.state.getEntity(bob)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+
+        // Advance into Bob's turn. The window keys off Alice's next turn, so BOTH restrictions
+        // must persist through Bob's whole turn (an owner-keyed lifetime would wrongly lift
+        // Bob's at the start of his own untap).
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 500)
+        driver.activePlayer shouldBe bob
+        driver.state.getEntity(alice)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+        driver.state.getEntity(bob)?.has<PlayerCantPlayFromHandComponent>() shouldBe true
+
+        // Advance to Alice's next turn — both restrictions lift at her untap.
+        driver.passPriorityUntil(Step.END, maxPasses = 500)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 500)
+        driver.activePlayer shouldBe alice
+        driver.state.getEntity(alice)?.has<PlayerCantPlayFromHandComponent>() shouldBe false
+        driver.state.getEntity(bob)?.has<PlayerCantPlayFromHandComponent>() shouldBe false
+    }
+})
+
+private fun cardIdOf(action: com.wingedsheep.engine.legalactions.LegalAction): com.wingedsheep.sdk.model.EntityId? =
+    when (val a = action.action) {
+        is com.wingedsheep.engine.core.CastSpell -> a.cardId
+        is com.wingedsheep.engine.core.PlayLand -> a.cardId
+        else -> null
+    }


### PR DESCRIPTION
## Card

**Memory Vessel** — `{3}{R}{R}` Artifact (BIG, mythic, #13)

> {T}, Exile this artifact: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.

Modeled as an activated ability with `Costs.Composite(Tap, ExileSelf)` and `TimingRule.SorcerySpeed` ("activate only as a sorcery"). The effect is a `ForEachPlayer(ActivePlayerFirst)` body that, per player, gathers the top 7 of *their* library, exiles them, grants that player a may-play window over those exiled cards, and bars them from playing cards from their hand.

## New SDK (add-feature scope)

The "they can't play cards from their hand" clause had no existing primitive, so this adds a general, reusable one:

- **`CantPlayCardsFromHandEffect`** + `Effects.CantPlayCardsFromHand(target, duration)` — a hand-scoped player restriction. Blocks both casting spells and playing lands, but **only from the hand zone** — cards granted a may-play permission from exile/graveyard stay playable. Distinct from `CantCastSpells` (every zone, spells only). Documented in `docs/card-sdk-language-reference.md`.

## Engine

- `PlayerCantPlayFromHandComponent` (UntilYourNextTurn lifecycle) + executor + serialization registration.
- Enforced at legal-action enumeration (`CastSpellEnumerator`, `PlayLandEnumerator` hand loop) and re-checked authoritatively in `CastSpellHandler` / `PlayLandHandler`.
- **Activating-player-relative durations under per-player iteration.** "Until your next turn" is *the activating player's* next turn for every affected player. `ForEachPlayer` rebinds the body's controller to each player, so a naive owner-keyed lifetime would lift an opponent's restriction at the start of *their own* turn — one turn too early. Fixed by:
  - `EffectContext.effectControllerId` — the original effect controller, preserved across `ForEachPlayer`'s controller rebinding.
  - `MayPlayPermission.expiryControllerId` and `PlayerCantPlayFromHandComponent.expiresForPlayerId` — let the turn-keyed expiry follow the activating player rather than the card owner / component owner.
  - Cleanup hooks (`CleanupPhaseManager`) key the expiry off the activating player; the component-expiry hook scans all players.

## mtgish-tooling

The probe now scores Memory Vessel **COVERABLE-NOW** via new bridge capability entries:
- `ExileTheTopNumberCardsOfLibrary` (per-player impulse), `CreateEachPlayerEffectUntil` (envelope), `MayPlayExiledCards`, `CantPlayCardsFromHand`.

**The emitter is intentionally left declined to SCAFFOLD.** Per the render-correctly-or-decline rule, the sorcery-speed exile-self activated ability wrapping a per-player impulse + a novel hand restriction is too card-specific to render faithfully; a lossy auto-draft would be worse than none. `EmitterGoldenTest` (including POR) stays 0-diff — the bridge changes affect only the capability probe, not emitter output.

## Tests

- `MemoryVesselTest` (rules-engine scenarios): per-player top-7 exile, hands locked while exiled cards remain playable, and the can't-play-from-hand restriction expiring on the *activating* player's next turn (persisting through the opponent's whole turn).
- Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets`, and `:mtgish-tooling` suites pass.
- BIG card snapshot re-blessed (`CardDefinitionSnapshotTest`); `CardLintTest` green; `check-card-printing "Memory Vessel"` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)