### PR TITLE
SOS: Transcendent/Wildgrowth Archaic, Together as One, Fractalize (+ dynamic enters-with / animate)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -836,7 +836,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `PreventDamageEffect(amount, direction, scope, sourceFilter, onPrevented, gainLifeFromColors, duration)` — prevention shield. `amount = null` prevents all. `sourceFilter` can be `ChosenSource` (player picks any source on resolution) or `ChosenColoredSource` (player picks a source on resolution, but only colored sources are offered — "a source of your choice that shares a color with the mana spent"; a colorless source qualifies for nothing, so it's never offered — Protective Sphere). `onPrevented: Effect?` is an **arbitrary follow-up effect** run when a single-instance `ChosenSource` shield prevents an instance of damage (see below). `gainLifeFromColors: Set<Color>` makes the shield's controller gain that much life whenever it prevents damage from a source of one of those colors (Samite Ministration). Facades: `Effects.PreventNextDamage`, `Effects.PreventNextDamageFromChosenSource(amount, target)`, `Effects.PreventNextDamageFromChosenSource(onPrevented)`, `Effects.PreventAllDamageFromChosenSource(target, gainLifeFromColors)`, `Effects.PreventAllDamageFromChosenColoredSource(target)`, `Effects.DeflectNextDamageFromChosenSource()`, `Effects.ReflectNextDamageFromChosenSourceToController()`. The `preventDamage` flag (default true) — when **false**, the chosen-source shield does NOT prevent the damage (it still hits in full) but still fires its `onPrevented` reaction with the captured amount; this is the "instead it still deals that damage to you AND deals that much to its controller" shape (Eye for an Eye), as opposed to the deflect/prevent shape (Deflecting Palm).
   - **Prevent-and-react (`onPrevented`)** — instead of a bespoke reaction type, the chosen-source shield runs **any composed effect** when it fires, as a real triggered ability on the stack ("When damage is prevented this way, …", CR-faithful — opponents get priority and can respond). Mechanically: on resolution the shield is created **and** a linked event-based delayed triggered ability (`CreateDelayedTriggerEffect`-style) whose `effect` is `onPrevented`; when the shield prevents an instance it emits an internal `DamagePreventedEvent` that fires only that delayed trigger (matched by id). Inside the trigger the prevented amount is `DynamicAmounts.preventedDamage()` ("that much"/"that many") and the prevented source's controller is `EffectTarget.ControllerOfTriggeringEntity` ("that source's controller") — the same pair Tephraderm uses. So Deflecting Palm's `onPrevented` = `DealDamage(ControllerOfTriggeringEntity, preventedDamage())`; New Way Forward's = `Composite(DealDamage(ControllerOfTriggeringEntity, preventedDamage()), DrawCards(preventedDamage()))`. Because the payoff is a normal stack ability, it may be interactive (targets, replacements) like any other.
-- `BecomeCreatureEffect(target, p, t, subtypes, keywords, duration)` — animate non-creature (lands, artifacts).
+- `Effects.BecomeCreature(target, power, toughness, keywords, creatureTypes, removeTypes, colors, duration)`
+  (`BecomeCreatureEffect`) — animate / "becomes a creature." Adds CREATURE (Layer 4), *sets* creature
+  subtypes to `creatureTypes` (replacing all others), removes `removeTypes`, *sets* `colors` (Layer 5,
+  replacing all others; `null` = keep), grants `keywords` (Layer 6), and sets base P/T (Layer 7b set
+  values). **`power`/`toughness` are `DynamicAmount`** (evaluated once at resolution, CR 613.4c, then
+  stamped as a fixed set-P/T floating effect); an `Int` convenience overload wraps them in
+  `DynamicAmount.Fixed`. Sarkhan's "4/4 Dragon" (fixed); Fractalize's "green and blue Fractal with
+  base power and toughness each equal to X plus 1, losing all other colors and creature types"
+  (`power = toughness = Add(XValue, Fixed(1))`, `creatureTypes = {"Fractal"}`, `colors = {GREEN, BLUE}`).
 - `BecomeArtifactEffect(target, cardTypes = {"ARTIFACT"}, subtypes, colors = emptySet(), loseAllAbilities = true, grantedAbility?, duration = Permanent)` — the general "becomes a Treasure/Food/Clue/artifact" transform: stacks continuous floating effects on `target` — Layer 4 `SetCardTypes` (replaces *all* card types) + `SetAllSubtypes` (replaces *all* subtypes), Layer 5 color (`emptySet()` = colorless), Layer 6 `RemoveAllAbilities` when `loseAllAbilities` — plus an optional single `grantedAbility` recorded durably in `grantedActivatedAbilities` (so it survives the ability wipe; the enumerators read it after the projected `lostAllAbilities` check). `Duration.Permanent` ends only when the permanent leaves the battlefield. Differs from `BecomeCreatureEffect` (which *adds* CREATURE + sets P/T): this fully replaces types/subtypes so the result is exactly the named artifact. (Vraska, the Silencer: a dead opponent's creature returns as a bare colorless Treasure with the sac-for-mana ability.)
 - `BecomeSaddledEffect(target = Self)` (facade `Effects.BecomeSaddled()`) — target permanent becomes saddled until end of turn (CR 702.171b). The resolving half of a Saddle ability: stamps the transient `SaddledComponent` marker (cleared at end of turn / on leaving the battlefield; not copiable) and emits `BecameSaddledEvent`. No P/T or type change — read the marker with `Conditions.SourceIsSaddled` / `.saddled()`.
 - `BecomePreparedEffect(target = Self)` (facade `Effects.BecomePrepared()`) — target permanent becomes prepared (Secrets of Strixhaven). The target must be a `CardLayout.PREPARE` permanent on the battlefield; becoming prepared creates a castable copy of its prepare spell in exile (shared `PreparationLogic.makePrepared`, the same path used when a `Keyword.PREPARED` creature enters prepared). A creature already prepared, not on the battlefield, or not a preparation card does nothing. Used by Leech Collector ("Whenever you gain life for the first time each turn, this creature becomes prepared").
@@ -4234,6 +4242,23 @@ replacementEffect {
   `Effects.MayRevealCardFromHand` to build SOI shadow lands or other "as ~ enters" choices.
   **Scope today:** only wired into the land-play path (`PlayLandHandler`). When the first non-land
   permanent needs this, also wire it into `StackResolver.enterPermanentOnBattlefield`.
+- `EntersWithCounters(counterType?, count, selfOnly?, condition?, appliesTo?)` /
+  `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?)` — "[permanent] enters with
+  N counters." `EntersWithCounters` takes a fixed `count: Int` (Master Biomancer, Metallic Mimic);
+  `EntersWithDynamicCounters` takes a `count: DynamicAmount` (Stag Beetle; the SOS Converge "Archaic"
+  cycle via `convergeEntersWithCounters()` → `count = DistinctColorsManaSpent`). `appliesTo` defaults
+  to "creatures you control entering the battlefield." Two scopes:
+  - **Self** (default) — applies to the permanent that owns the replacement. Reserve a *dynamic* count
+    for "this creature enters with a counter for each color of mana spent to cast **it**" / "for each X
+    it has".
+  - **`otherOnly = true`** — applies to *other* matching creatures entering (Gev, Scaled Scorch:
+    "Other creatures you control enter with additional counters"; Wildgrowth Archaic: "whenever you
+    cast a creature spell, that creature enters with X additional +1/+1 counters … where X is the
+    number of colors of mana spent to cast **it**"). The `count` is always evaluated against the
+    **entering object**, not the replacement source — so an entering-object amount like
+    `DistinctColorsManaSpent` reads the new creature's own cast (and a token / reanimated creature that
+    wasn't cast spent no mana → 0). Player-scoped counts (`TurnTracking(Player.You)`, Gev) still read
+    the replacement source's controller.
 - `EntersWithDevour(multiplier, sacrificeFilter, counterType, variant)` — Devour (CR 702.82) and its
   printed variants. As the permanent resolves from the stack, the controller is prompted to pick any
   number of their own permanents matching `sacrificeFilter`. Those permanents are sacrificed and the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -3091,9 +3091,23 @@ object Effects {
         Endure(DynamicAmount.Fixed(amount), target)
 
     /**
-     * Target permanent becomes a creature with specified characteristics.
-     * More general than AnimateLand — can remove types, grant keywords, set subtypes, change color.
+     * Target permanent becomes a creature with specified characteristics, with a **dynamic** base
+     * power/toughness. More general than AnimateLand — can remove types, grant keywords, set
+     * subtypes, change color. The base P/T amounts are evaluated once when the effect resolves
+     * (CR 613.4c) — e.g. `DynamicAmount.Add(XValue, Fixed(1))` for Fractalize's "X plus 1" Fractal.
      */
+    fun BecomeCreature(
+        target: EffectTarget = EffectTarget.Self,
+        power: DynamicAmount,
+        toughness: DynamicAmount,
+        keywords: Set<Keyword> = emptySet(),
+        creatureTypes: Set<String> = emptySet(),
+        removeTypes: Set<String> = emptySet(),
+        colors: Set<String>? = null,
+        duration: Duration = Duration.EndOfTurn
+    ): Effect = BecomeCreatureEffect(target, power, toughness, keywords, creatureTypes, removeTypes, colors, duration)
+
+    /** Fixed-P/T sugar for [BecomeCreature] — Sarkhan's "4/4 Dragon" and similar constant animates. */
     fun BecomeCreature(
         target: EffectTarget = EffectTarget.Self,
         power: Int,
@@ -3103,7 +3117,10 @@ object Effects {
         removeTypes: Set<String> = emptySet(),
         colors: Set<String>? = null,
         duration: Duration = Duration.EndOfTurn
-    ): Effect = BecomeCreatureEffect(target, power, toughness, keywords, creatureTypes, removeTypes, colors, duration)
+    ): Effect = BecomeCreatureEffect(
+        target, DynamicAmount.Fixed(power), DynamicAmount.Fixed(toughness),
+        keywords, creatureTypes, removeTypes, colors, duration,
+    )
 
     /**
      * Target permanent becomes saddled until end of turn (CR 702.171b) — the resolving effect of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -56,20 +57,26 @@ data class AnimateLandEffect(
  * - Layer.POWER_TOUGHNESS + Sublayer.SET_VALUES: SetPowerToughness
  *
  * @property target The permanent to animate
- * @property power The base power to set
- * @property toughness The base toughness to set
+ * @property power The base power to set (a [DynamicAmount]; use `DynamicAmount.Fixed(n)` for a
+ *   constant — Sarkhan's "4/4 Dragon" — or a live amount like `X plus 1` for Fractalize's Fractal).
+ *   The amount is evaluated once when the effect resolves and stamped as a fixed base-P/T floating
+ *   effect (CR 613.4c — the value is locked in when the effect starts applying), so it does not keep
+ *   recomputing if the underlying amount changes later.
+ * @property toughness The base toughness to set (a [DynamicAmount]; same evaluation as [power]).
  * @property keywords Keywords to grant (e.g., flying, indestructible, haste)
- * @property creatureTypes Creature subtypes to set (e.g., "Dragon")
+ * @property creatureTypes Creature subtypes to *set*, replacing all existing subtypes (e.g.,
+ *   "Dragon"; "Fractal" loses all other creature types — Layer 4 set effect)
  * @property removeTypes Types to remove (e.g., "PLANESWALKER")
- * @property colors Colors to set (null = keep existing)
+ * @property colors Colors to set, replacing all existing colors (null = keep existing). An explicit
+ *   set loses all other colors (e.g. green+blue for a Fractal).
  * @property duration How long the effect lasts
  */
 @SerialName("BecomeCreature")
 @Serializable
 data class BecomeCreatureEffect(
     val target: EffectTarget = EffectTarget.Self,
-    val power: Int,
-    val toughness: Int,
+    val power: DynamicAmount,
+    val toughness: DynamicAmount,
     val keywords: Set<Keyword> = emptySet(),
     val creatureTypes: Set<String> = emptySet(),
     val removeTypes: Set<String> = emptySet(),
@@ -77,10 +84,17 @@ data class BecomeCreatureEffect(
     val duration: Duration = Duration.EndOfTurn
 ) : Effect {
     override val description: String = buildString {
-        append("${target.description} becomes a $power/$toughness creature")
+        append("${target.description} becomes a ${power.description}/${toughness.description} creature")
         if (creatureTypes.isNotEmpty()) append(" ${creatureTypes.joinToString("/")}")
         if (keywords.isNotEmpty()) append(" with ${keywords.joinToString(", ") { it.name.lowercase() }}")
         if (duration.description.isNotEmpty()) append(" ${duration.description}")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newPower = power.applyTextReplacement(replacer)
+        val newToughness = toughness.applyTextReplacement(replacer)
+        return if (newPower !== power || newToughness !== toughness)
+            copy(power = newPower, toughness = newToughness) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SylvanAwakening.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SylvanAwakening.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.dsl.Effects
 
@@ -28,8 +29,8 @@ val SylvanAwakening = card("Sylvan Awakening") {
             filter = GroupFilter(GameObjectFilter.Land.youControl()),
             effect = BecomeCreatureEffect(
                 target = EffectTarget.Self,
-                power = 2,
-                toughness = 2,
+                power = DynamicAmount.Fixed(2),
+                toughness = DynamicAmount.Fixed(2),
                 keywords = setOf(Keyword.REACH, Keyword.INDESTRUCTIBLE, Keyword.HASTE),
                 creatureTypes = setOf("Elemental"),
                 duration = Duration.UntilYourNextTurn

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/TheAntiquitiesWar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/TheAntiquitiesWar.kt
@@ -77,8 +77,8 @@ val TheAntiquitiesWar = card("The Antiquities War") {
             filter = GroupFilter(GameObjectFilter.Artifact.youControl()),
             effect = BecomeCreatureEffect(
                 target = EffectTarget.Self,
-                power = 5,
-                toughness = 5,
+                power = DynamicAmount.Fixed(5),
+                toughness = DynamicAmount.Fixed(5),
                 duration = Duration.EndOfTurn
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Fractalize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/Fractalize.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fractalize
+ * {X}{U}
+ * Instant
+ *
+ * Until end of turn, target creature becomes a green and blue Fractal with base power and toughness
+ * each equal to X plus 1. (It loses all other colors and creature types.)
+ *
+ * One `BecomeCreature` (animate) transform on the target creature, until end of turn:
+ *  - **base P/T** = `DynamicAmount.Add(XValue, Fixed(1))` — X plus 1, fed through the now-dynamic
+ *    `BecomeCreatureEffect` power/toughness (evaluated once at resolution, CR 613.4c).
+ *  - **creature types** set to exactly `{Fractal}` (Layer 4 set effect → loses all other creature
+ *    types).
+ *  - **colors** set to exactly green + blue (Layer 5 set effect → loses all other colors).
+ * No keywords are granted. Cast with X = 0 it becomes a 1/1 Fractal.
+ */
+val Fractalize = card("Fractalize") {
+    manaCost = "{X}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature becomes a green and blue Fractal with base " +
+        "power and toughness each equal to X plus 1. (It loses all other colors and creature types.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.BecomeCreature(
+            target = creature,
+            power = DynamicAmount.Add(DynamicAmount.XValue, DynamicAmount.Fixed(1)),
+            toughness = DynamicAmount.Add(DynamicAmount.XValue, DynamicAmount.Fixed(1)),
+            creatureTypes = setOf("Fractal"),
+            colors = setOf(Color.GREEN.name, Color.BLUE.name),
+            duration = Duration.EndOfTurn,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Andrew Mar"
+        flavorText = "\"Return your lizards to their natural size before class ends. We don't want " +
+            "another incident.\"\n—Professor Berta"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3c3b19b-01b6-4f5a-b428-513b778c5d89.jpg?1775937264"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TogetherAsOne.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TogetherAsOne.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Together as One
+ * {6}
+ * Sorcery
+ *
+ * Converge — Target player draws X cards, Together as One deals X damage to any target, and you gain
+ * X life, where X is the number of colors of mana spent to cast this spell.
+ *
+ * A three-part Converge spell. X = [DynamicAmounts.colorsOfManaSpent]
+ * (`DynamicAmount.DistinctColorsManaSpent`), resolved while the spell is still on the stack so it
+ * reads the live per-colour payment buckets (same as Snarl Song / Arcane Omens). The two targets are
+ * declared in printed order — *target player* first, *any target* second — and the three effects are
+ * chained with `.then(...)`: the target player draws X, Together as One deals X to the any-target
+ * (damage source = the spell itself), and the controller gains X life. With an all-colourless {6}
+ * payment X = 0: the player draws nothing, no damage is dealt, and no life is gained — the spell
+ * still resolves and its targets are still chosen at cast time.
+ */
+val TogetherAsOne = card("Together as One") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Sorcery"
+    oracleText = "Converge — Target player draws X cards, Together as One deals X damage to any " +
+        "target, and you gain X life, where X is the number of colors of mana spent to cast this spell."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DrawCards(DynamicAmounts.colorsOfManaSpent(), player)
+            .then(
+                Effects.DealDamage(
+                    DynamicAmounts.colorsOfManaSpent(),
+                    anyTarget,
+                    damageSource = EffectTarget.Self,
+                ),
+            )
+            .then(Effects.GainLife(DynamicAmounts.colorsOfManaSpent()))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "By himself, Lluwen couldn't have hoped to calm the Dawning Archaic—but any " +
+            "time it really mattered, he was never alone."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac2a8a66-e38c-42ab-83e1-d2d99ee48861.jpg?1775936940"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TranscendentArchaic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TranscendentArchaic.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Transcendent Archaic
+ * {7}
+ * Creature — Avatar
+ * 6/6
+ *
+ * Vigilance
+ * Converge — When this creature enters, you may draw X cards, where X is the number of colors of
+ * mana spent to cast this spell. If you draw one or more cards this way, discard two cards.
+ *
+ * The {7} cost is all generic, so the colour count X is entirely a function of how the controller
+ * pays — X = [DynamicAmounts.colorsOfManaSpent] (`DynamicAmount.DistinctColorsManaSpent`), read off
+ * the entering creature's recorded payment (the dominant Converge shape, same as the Archaic cycle).
+ *
+ * Modelled as an [Triggers.EntersBattlefield] trigger whose body is an optional [MayEffect] draw of X
+ * cards, followed by a discard of two that is gated on "you drew one or more this way" — i.e. X >= 1.
+ * The discard sits *inside* the `may`, so declining the draw never forces the discard; and a `yes`
+ * with X = 0 (all-colourless payment) draws nothing and the `ConditionalEffect` gate suppresses the
+ * discard. (Drawing zero is not "drawing one or more.") The intervening gate is a synchronous
+ * `Compare(DistinctColorsManaSpent >= 1)` rather than an `IfYouDo` action-outcome, because the draw
+ * count is a known function of the cast and a draw isn't a zone-move shape `SuccessCriterion.Auto`
+ * can infer.
+ */
+val TranscendentArchaic = card("Transcendent Archaic") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Creature — Avatar"
+    power = 6
+    toughness = 6
+    oracleText = "Vigilance\n" +
+        "Converge — When this creature enters, you may draw X cards, where X is the number of " +
+        "colors of mana spent to cast this spell. If you draw one or more cards this way, " +
+        "discard two cards."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.DrawCards(DynamicAmounts.colorsOfManaSpent())
+                .then(
+                    ConditionalEffect(
+                        condition = Conditions.CompareAmounts(
+                            DynamicAmount.DistinctColorsManaSpent,
+                            ComparisonOperator.GTE,
+                            DynamicAmount.Fixed(1),
+                        ),
+                        effect = Effects.Discard(2),
+                    ),
+                ),
+        )
+        description = "Converge — When this creature enters, you may draw X cards, where X is the " +
+            "number of colors of mana spent to cast this spell. If you draw one or more cards this " +
+            "way, discard two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Chris Rahn"
+        flavorText = "Even as most archaics raged across Arcavios, others seemed to sink into contemplation."
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/1624c680-502b-474a-b9b2-888fe3ca008c.jpg?1775936948"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WildgrowthArchaic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WildgrowthArchaic.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.convergeEntersWithCounters
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Wildgrowth Archaic
+ * {2/G}{2/G}
+ * Creature — Avatar
+ * 0/0
+ *
+ * Trample, reach
+ * Converge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.
+ * Whenever you cast a creature spell, that creature enters with X additional +1/+1 counters on it,
+ * where X is the number of colors of mana spent to cast it.
+ *
+ * Two `EntersWithDynamicCounters` replacement effects, both fed by [DynamicAmounts.colorsOfManaSpent]
+ * (`DynamicAmount.DistinctColorsManaSpent`), which reads the *entering object's* recorded payment:
+ *
+ *  1. **Self** — the printed Converge enters-with-counters (the Archaic cycle), via
+ *     [convergeEntersWithCounters]. With a 0/0 base, the colour count is also what keeps the body
+ *     alive: all-colourless payment leaves a 0/0 that dies as a state-based action.
+ *  2. **Other creatures you cast** — `EntersWithDynamicCounters(otherOnly = true)` on creatures you
+ *     control entering the battlefield. The oracle text triggers on "whenever you cast a creature
+ *     spell" and the additional counters scale with "the number of colors of mana spent to cast
+ *     **it**" (= that creature spell), so the count is about the *entering* creature, not Wildgrowth.
+ *     The engine's global enters-with path evaluates the count against the entering object (so
+ *     `DistinctColorsManaSpent` reads the new creature's own cast), and a permanent that entered
+ *     without being cast (token / reanimation) spent no mana → 0 colours → no extra counters, which
+ *     matches the "whenever you **cast**" wording.
+ */
+val WildgrowthArchaic = card("Wildgrowth Archaic") {
+    manaCost = "{2/G}{2/G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Avatar"
+    power = 0
+    toughness = 0
+    oracleText = "Trample, reach\n" +
+        "Converge — This creature enters with a +1/+1 counter on it for each color of mana spent " +
+        "to cast it.\n" +
+        "Whenever you cast a creature spell, that creature enters with X additional +1/+1 counters " +
+        "on it, where X is the number of colors of mana spent to cast it."
+
+    keywords(Keyword.TRAMPLE, Keyword.REACH)
+
+    // 1. Converge — this creature's own enters-with counters.
+    convergeEntersWithCounters()
+
+    // 2. Other creatures you cast enter with additional +1/+1 counters equal to the colours of mana
+    //    spent on *their* cast. otherOnly = true routes this through the battlefield-scan global
+    //    enters-with path, which evaluates the count against the entering creature.
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmounts.colorsOfManaSpent(),
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl(),
+                to = Zone.BATTLEFIELD,
+            ),
+        ),
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "168"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e6e2188-7203-4d10-a838-27233f283cd5.jpg?1775938149"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/RagingRavine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/RagingRavine.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.dsl.Effects
 
 /**
@@ -58,8 +59,8 @@ val RagingRavine = card("Raging Ravine") {
             listOf(
                 BecomeCreatureEffect(
                     target = EffectTarget.Self,
-                    power = 3,
-                    toughness = 3,
+                    power = DynamicAmount.Fixed(3),
+                    toughness = DynamicAmount.Fixed(3),
                     creatureTypes = setOf("Elemental"),
                     colors = setOf(Color.RED.name, Color.GREEN.name),
                     duration = Duration.EndOfTurn,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Predefined token CardDefinitions.
@@ -267,8 +268,8 @@ object PredefinedTokens {
             cost = Costs.Mana("{1}")
             effect = BecomeCreatureEffect(
                 target = EffectTarget.Self,
-                power = 2,
-                toughness = 2,
+                power = DynamicAmount.Fixed(2),
+                toughness = DynamicAmount.Fixed(2),
                 keywords = setOf(Keyword.CHANGELING)
             )
         }

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -19537,8 +19537,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 6,
-                    "toughness": 6
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -246,8 +246,14 @@
                         "type": "BoundVariable",
                         "name": "land"
                     },
-                    "power": 3,
-                    "toughness": 3,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
                     "keywords": [
                         "HASTE"
                     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -11826,8 +11826,14 @@
             },
             "body": {
                 "type": "BecomeCreature",
-                "power": 2,
-                "toughness": 2,
+                "power": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughness": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
                 "keywords": [
                     "REACH",
                     "INDESTRUCTIBLE",
@@ -12573,8 +12579,14 @@
                     },
                     "body": {
                         "type": "BecomeCreature",
-                        "power": 5,
-                        "toughness": 5
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
                     }
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -164,8 +164,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 4,
-                    "toughness": 4,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
                     "keywords": [
                         "FLYING"
                     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -6935,8 +6935,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 2,
-                    "toughness": 3,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
                     "creatureTypes": [
                         "Kithkin",
                         "Scout"
@@ -6965,8 +6971,14 @@
                     },
                     "then": {
                         "type": "BecomeCreature",
-                        "power": 4,
-                        "toughness": 5,
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
                         "creatureTypes": [
                             "Kithkin",
                             "Soldier"
@@ -6996,8 +7008,14 @@
                     },
                     "then": {
                         "type": "BecomeCreature",
-                        "power": 7,
-                        "toughness": 8,
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 7
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 8
+                        },
                         "keywords": [
                             "PROTECTION_FROM_EACH_OPPONENT"
                         ],
@@ -7065,8 +7083,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 4,
-                    "toughness": 4
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -16309,8 +16309,14 @@
                         "type": "BoundVariable",
                         "name": "up to one other target artifact you control"
                     },
-                    "power": 2,
-                    "toughness": 2,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
                     "keywords": [
                         "FLYING"
                     ]
@@ -17626,8 +17632,14 @@
                                             "type": "ContextTarget",
                                             "index": 0
                                         },
-                                        "power": 0,
-                                        "toughness": 0,
+                                        "power": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "toughness": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
                                         "creatureTypes": [
                                             "Robot"
                                         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -2938,8 +2938,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 3,
-                    "toughness": 3,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
                     "keywords": [
                         "VIGILANCE",
                         "CHANGELING"

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -9731,8 +9731,14 @@
                 },
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 4,
-                    "toughness": 4,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
                     "keywords": [
                         "FLYING",
                         "INDESTRUCTIBLE",

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5535,8 +5535,14 @@
                 "binding": "ANY",
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 3,
-                    "toughness": 3,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
                     "keywords": [
                         "FLYING"
                     ],
@@ -12163,8 +12169,14 @@
                             "type": "ContextTarget",
                             "index": 0
                         },
-                        "power": 0,
-                        "toughness": 1,
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
                         "creatureTypes": [
                             "Rabbit"
                         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -3697,6 +3697,65 @@
     ]
 }
 
+// Fractalize
+{
+    "name": "Fractalize",
+    "manaCost": "{X}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature becomes a green and blue Fractal with base power and toughness each equal to X plus 1. (It loses all other colors and creature types.)",
+    "script": {
+        "spellEffect": {
+            "type": "BecomeCreature",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            },
+            "power": {
+                "type": "Add",
+                "left": "XValue",
+                "right": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            "toughness": {
+                "type": "Add",
+                "left": "XValue",
+                "right": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            "creatureTypes": [
+                "Fractal"
+            ],
+            "colors": [
+                "GREEN",
+                "BLUE"
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "\"Return your lizards to their natural size before class ends. We don't want another incident.\"\n—Professor Berta",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3c3b19b-01b6-4f5a-b428-513b778c5d89.jpg?1775937264"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Garrison Excavator
 {
     "name": "Garrison Excavator",
@@ -11561,6 +11620,60 @@
     ]
 }
 
+// Together as One
+{
+    "name": "Together as One",
+    "manaCost": "{6}",
+    "typeLine": "Sorcery",
+    "oracleText": "Converge — Target player draws X cards, Together as One deals X damage to any target, and you gain X life, where X is the number of colors of mana spent to cast this spell.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": "DistinctColorsManaSpent",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": "DistinctColorsManaSpent",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "damageSource": "Self"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": "DistinctColorsManaSpent"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            },
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Néstor Ossandón Leal",
+        "flavorText": "By himself, Lluwen couldn't have hoped to calm the Dawning Archaic—but any time it really mattered, he was never alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac2a8a66-e38c-42ab-83e1-d2d99ee48861.jpg?1775936940"
+    },
+    "colorIdentityOverride": []
+}
+
 // Tome Blast
 {
     "name": "Tome Blast",
@@ -11763,6 +11876,104 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Transcendent Archaic
+{
+    "name": "Transcendent Archaic",
+    "manaCost": "{7}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Vigilance\nConverge — When this creature enters, you may draw X cards, where X is the number of colors of mana spent to cast this spell. If you draw one or more cards this way, discard two cards.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": "DistinctColorsManaSpent"
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": "DistinctColorsManaSpent",
+                                        "operator": "GTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 2
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 2 cards to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Converge — When this creature enters, you may draw X cards, where X is the number of colors of mana spent to cast this spell. If you draw one or more cards this way, discard two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "Even as most archaics raged across Arcavios, others seemed to sink into contemplation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/1624c680-502b-474a-b9b2-888fe3ca008c.jpg?1775936948"
+    },
+    "colorIdentityOverride": []
 }
 
 // Traumatic Critique
@@ -12262,6 +12473,44 @@
         "collectorNumber": "167",
         "artist": "Lie Setiawan",
         "imageUri": "https://cards.scryfall.io/normal/front/0/4/04fdfabc-c247-4384-a5bb-f49035f8aae0.jpg?1775938142"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wildgrowth Archaic
+{
+    "name": "Wildgrowth Archaic",
+    "manaCost": "{2/G}{2/G}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Trample, reach\nConverge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.\nWhenever you cast a creature spell, that creature enters with X additional +1/+1 counters on it, where X is the number of colors of mana spent to cast it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "TRAMPLE",
+        "REACH"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "DistinctColorsManaSpent"
+            },
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "DistinctColorsManaSpent",
+                "otherOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "RARE",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e6e2188-7203-4d10-a838-27233f283cd5.jpg?1775938149"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -892,8 +892,14 @@
                                 "type": "BoundVariable",
                                 "name": "target non-Equipment artifact you control"
                             },
-                            "power": 3,
-                            "toughness": 3
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
                         },
                         {
                             "type": "TapUntap",

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -12569,8 +12569,14 @@
                 "binding": "ANY",
                 "effect": {
                     "type": "BecomeCreature",
-                    "power": 3,
-                    "toughness": 3,
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
                     "keywords": [
                         "HASTE"
                     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -783,8 +783,14 @@
                                         "type": "ContextTarget",
                                         "index": 0
                                     },
-                                    "power": 3,
-                                    "toughness": 3,
+                                    "power": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "toughness": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
                                     "keywords": [
                                         "FLYING"
                                     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -110,8 +110,14 @@
                     "effects": [
                         {
                             "type": "BecomeCreature",
-                            "power": 3,
-                            "toughness": 3,
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
                             "creatureTypes": [
                                 "Elemental"
                             ],

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -589,14 +589,17 @@ internal fun EmitCtx.becomeCreatureLayerEffect(
     // durationless animate path opts into the extended grants (AddCreatureType / AddCardtype Creature /
     // AddAbility <keyword>) used by "becomes a N/N [type] creature with [keyword] in addition to its
     // other types" (Emergent Haunting).
-    val baseKinds = setOf("SetPT", "SetColor", "SetCreatureType")
+    // SetPT carries fixed ints; SetPowerAndToughnessBoth carries a single dynamic GameNumber applied to
+    // both P and T ("base power and toughness each equal to X plus 1" — Fractalize's Fractal animate).
+    // BecomeCreature now takes DynamicAmount P/T, so both render through the same effect.
+    val baseKinds = setOf("SetPT", "SetPowerAndToughnessBoth", "SetColor", "SetCreatureType")
     val extendedKinds = setOf("AddCreatureType", "AddCardtype", "AddAbility")
     val recognised = if (allowExtendedGrants) baseKinds + extendedKinds else baseKinds
     val typeOrColourKinds = if (allowExtendedGrants) setOf("SetColor", "SetCreatureType", "AddCreatureType", "AddCardtype", "AddAbility")
                             else setOf("SetColor", "SetCreatureType")
     val effects = layerEffects.filterIsInstance<JsonObject>()
     if (effects.size != layerEffects.size) return null
-    if (effects.none { it.strField("_LayerEffect") == "SetPT" }) return null
+    if (effects.none { it.strField("_LayerEffect") in setOf("SetPT", "SetPowerAndToughnessBoth") }) return null
     if (effects.any { it.strField("_LayerEffect") !in recognised }) return null
     // A BARE SetPT ("becomes a 5/1 until end of turn", no type/colour/keyword change) is a base-P/T set,
     // not a "becomes a creature" — keep it as SetBasePowerToughnessEffect (the per-layer renderer). Only
@@ -604,8 +607,10 @@ internal fun EmitCtx.becomeCreatureLayerEffect(
     // to BecomeCreature.
     if (effects.none { it.strField("_LayerEffect") in typeOrColourKinds }) return null
 
-    var power: Int? = null
-    var toughness: Int? = null
+    // P/T are rendered as DynamicAmount expressions so both the fixed (SetPT → Fixed(n)) and the
+    // dynamic (SetPowerAndToughnessBoth → e.g. Add(XValue, Fixed(1))) forms feed BecomeCreature.
+    var power: Dsl? = null
+    var toughness: Dsl? = null
     val creatureTypes = mutableListOf<String>()
     val colors = mutableListOf<String>()
     val grantedKeywords = mutableListOf<String>()
@@ -614,8 +619,18 @@ internal fun EmitCtx.becomeCreatureLayerEffect(
             "SetPT" -> {
                 val pt = (le["args"] as? JsonObject)?.get("args").asArr ?: return null
                 if (pt.size != 2) return null
-                power = pt[0].asInt() ?: return null
-                toughness = pt[1].asInt() ?: return null
+                val p = pt[0].asInt() ?: return null
+                val t = pt[1].asInt() ?: return null
+                power = call("DynamicAmount.Fixed", arg("$p"))
+                toughness = call("DynamicAmount.Fixed", arg("$t"))
+            }
+            "SetPowerAndToughnessBoth" -> {
+                // A single dynamic value applied to BOTH power and toughness ("base power and
+                // toughness each equal to X plus 1"). Both must render exactly or the whole shape
+                // declines (-> SCAFFOLD) rather than emit a wrong P/T.
+                val amt = dynamicAmountExpr(le["args"]) ?: return null
+                power = amt
+                toughness = amt
             }
             "SetCreatureType", "AddCreatureType" -> {
                 val sub = le["args"].asStr() ?: return null
@@ -636,7 +651,7 @@ internal fun EmitCtx.becomeCreatureLayerEffect(
     }
     if (power == null || toughness == null) return null
 
-    val parts = mutableListOf(arg("target", Lit(target)), arg("power", "$power"), arg("toughness", "$toughness"))
+    val parts = mutableListOf(arg("target", Lit(target)), arg("power", power), arg("toughness", toughness))
     if (grantedKeywords.isNotEmpty()) {
         parts.add(arg("keywords", call("setOf", *grantedKeywords.map { arg(Lit("Keyword.$it")) }.toTypedArray())))
     }

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -103,9 +103,26 @@ class EffectHandlerTest : StringSpec({
                 """{"_LayerEffect":"SetCreatureType","args":"Rabbit"},""" +
                 """{"_LayerEffect":"SetPT","args":{"_PT":"PT","args":[0,1]}}],{"_Expiration":"UntilEndOfTurn"}]}""",
             "EffectTarget.ContextTarget(0)",
-        ) shouldBe "Effects.BecomeCreature(target = EffectTarget.ContextTarget(0), power = 0, " +
-            "toughness = 1, creatureTypes = setOf(\"Rabbit\"), colors = setOf(Color.WHITE.name), " +
+        ) shouldBe "Effects.BecomeCreature(target = EffectTarget.ContextTarget(0), " +
+            "power = DynamicAmount.Fixed(0), toughness = DynamicAmount.Fixed(1), " +
+            "creatureTypes = setOf(\"Rabbit\"), colors = setOf(Color.WHITE.name), " +
             "duration = Duration.EndOfTurn)"
+    }
+
+    "'becomes a Fractal with base P/T each equal to X plus 1' renders dynamic BecomeCreature" {
+        // SetPowerAndToughnessBoth with a dynamic GameNumber (X plus 1) applied to BOTH P and T —
+        // the WAR/Simic "Fractal" animate. BecomeCreature now takes DynamicAmount P/T.
+        layer(
+            """{"_Action":"CreatePermanentLayerEffectUntil","args":[{"_Permanent":"Ref_TargetPermanent"},""" +
+                """[{"_LayerEffect":"SetCreatureType","args":"Fractal"},""" +
+                """{"_LayerEffect":"SetPowerAndToughnessBoth","args":{"_GameNumber":"Plus","args":[""" +
+                """{"_GameNumber":"ValueX"},{"_GameNumber":"Integer","args":1}]}}],""" +
+                """{"_Expiration":"UntilEndOfTurn"}]}""",
+            "EffectTarget.ContextTarget(0)",
+        ) shouldBe "Effects.BecomeCreature(target = EffectTarget.ContextTarget(0), " +
+            "power = DynamicAmount.Add(DynamicAmount.XValue, DynamicAmount.Fixed(1)), " +
+            "toughness = DynamicAmount.Add(DynamicAmount.XValue, DynamicAmount.Fixed(1)), " +
+            "creatureTypes = setOf(\"Fractal\"), duration = Duration.EndOfTurn)"
     }
 
     // --- PutExiledCardOntoBattlefield (the return half of the exile-then-return blink) -------------

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComp
 import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
@@ -166,8 +167,8 @@ class CrewVehicleHandler(
         val baseToughness = (stats?.toughness as? CharacteristicValue.Fixed)?.value ?: 0
         val crewEffect = BecomeCreatureEffect(
             target = EffectTarget.Self,
-            power = basePower,
-            toughness = baseToughness,
+            power = DynamicAmount.Fixed(basePower),
+            toughness = DynamicAmount.Fixed(baseToughness),
             keywords = cardDef.keywords
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
@@ -168,9 +168,18 @@ object EntersWithCountersHelper {
                         if (!effect.otherOnly) continue
                         if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
                         val counterType = resolveCounterType(effect.counterType)
+                        // An "enters with N counters" count always describes the ENTERING object,
+                        // not the replacement source — the counters go on the entering permanent and
+                        // any "it" in the count refers to it (CR 121.6 / 614). Mirror the self path
+                        // (StackResolver.applyEntersWithCounters uses sourceId = the entering entity)
+                        // so amounts like DistinctColorsManaSpent ("...colors of mana spent to cast
+                        // IT") read the entering creature's own cast, not the source's. controllerId
+                        // stays the source's controller so player-scoped counts (Gev's
+                        // TurnTracking(Player.You)) keep reading the source controller's trackers.
                         val context = EffectContext(
-                            sourceId = sourceId,
+                            sourceId = enteringEntityId,
                             controllerId = sourceControllerId,
+                            affectedEntityId = enteringEntityId,
                         )
                         val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
                         if (count > 0) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureExecutor.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.effects.permanent.types
 
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
@@ -19,6 +20,8 @@ import kotlin.reflect.KClass
  * Creates all floating effects atomically to avoid validation issues with intermediate states.
  */
 class BecomeCreatureExecutor : EffectExecutor<BecomeCreatureEffect> {
+
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
 
     override val effectType: KClass<BecomeCreatureEffect> = BecomeCreatureEffect::class
 
@@ -90,11 +93,15 @@ class BecomeCreatureExecutor : EffectExecutor<BecomeCreatureEffect> {
             )
         }
 
-        // Layer 7b (POWER_TOUGHNESS, SET_VALUES): Set base P/T
+        // Layer 7b (POWER_TOUGHNESS, SET_VALUES): Set base P/T. The dynamic amounts are evaluated
+        // once, now, and stamped as a fixed set-value floating effect (CR 613.4c — the value is
+        // locked in when the effect begins to apply; it does not keep recomputing).
+        val powerValue = amountEvaluator.evaluate(newState, effect.power, context)
+        val toughnessValue = amountEvaluator.evaluate(newState, effect.toughness, context)
         newState = newState.addFloatingEffect(
             layer = Layer.POWER_TOUGHNESS,
             sublayer = Sublayer.SET_VALUES,
-            modification = SerializableModification.SetPowerToughness(effect.power, effect.toughness),
+            modification = SerializableModification.SetPowerToughness(powerValue, toughnessValue),
             affectedEntities = affectedEntities,
             duration = effect.duration,
             context = context

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FractalizeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FractalizeScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.Fractalize
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fractalize ({X}{U} instant):
+ *   "Until end of turn, target creature becomes a green and blue Fractal with base power and
+ *    toughness each equal to X plus 1. (It loses all other colors and creature types.)"
+ *
+ * Exercises the now-dynamic `BecomeCreatureEffect` base P/T (= X plus 1, evaluated once at
+ * resolution) together with the type-set (→ Fractal, losing other creature types) and color-set
+ * (→ green + blue, losing other colors) layers:
+ *  - X = 2 → a 3/3 green-and-blue Fractal; the original creature type (Centaur Warrior) and color
+ *    (green only) are replaced.
+ *  - X = 0 → a 1/1 (X plus 1 = 1).
+ */
+class FractalizeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(Fractalize))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    val projector = StateProjector()
+
+    test("X=2: target becomes a 3/3 green and blue Fractal, losing other types and colors") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        // Centaur Courser: {2}{G}, 3/3, Centaur Warrior, green.
+        val courser = driver.putCreatureOnBattlefield(p, "Centaur Courser")
+
+        val spell = driver.putCardInHand(p, "Fractalize")
+        driver.giveMana(p, Color.BLUE, 1) // {U}
+        driver.giveColorlessMana(p, 2)    // {X} with X = 2
+        driver.castXSpell(p, spell, xValue = 2, targets = listOf(courser)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Base P/T each X + 1 = 3.
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+
+        val projected = driver.state.projectedState
+        // Becomes green AND blue, loses all other colors (was green-only — now exactly G + U).
+        projected.hasColor(courser, Color.GREEN) shouldBe true
+        projected.hasColor(courser, Color.BLUE) shouldBe true
+        projected.getColors(courser).size shouldBe 2
+        // Becomes a Fractal, loses all other creature types (was Centaur Warrior).
+        projected.hasSubtype(courser, "Fractal") shouldBe true
+        projected.hasSubtype(courser, "Centaur") shouldBe false
+        projected.hasSubtype(courser, "Warrior") shouldBe false
+        projected.isCreature(courser) shouldBe true
+    }
+
+    test("X=0: target becomes a 1/1 Fractal (X plus 1 = 1)") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val courser = driver.putCreatureOnBattlefield(p, "Centaur Courser")
+
+        val spell = driver.putCardInHand(p, "Fractalize")
+        driver.giveMana(p, Color.BLUE, 1)
+        driver.castXSpell(p, spell, xValue = 0, targets = listOf(courser)).isSuccess shouldBe true
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, courser) shouldBe 1
+        projector.getProjectedToughness(driver.state, courser) shouldBe 1
+        driver.state.projectedState.hasSubtype(courser, "Fractal") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TogetherAsOneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TogetherAsOneScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.TogetherAsOne
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Together as One ({6} sorcery):
+ *   "Converge — Target player draws X cards, Together as One deals X damage to any target, and you
+ *    gain X life, where X is the number of colors of mana spent to cast this spell."
+ *
+ * X = `DynamicAmount.DistinctColorsManaSpent`, resolved on the stack. Pins all three effects scaling
+ * together, and the X = 0 (all-colourless {6}) degenerate case where the spell still resolves but
+ * does nothing.
+ */
+class TogetherAsOneScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(TogetherAsOne))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    test("3 colors spent: target player draws 3, opponent takes 3 damage, you gain 3 life") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val opp = driver.getOpponent(p)
+
+        val spell = driver.putCardInHand(p, "Together as One")
+        // {6} paid with three distinct colors → X = 3.
+        driver.giveMana(p, Color.WHITE, 2)
+        driver.giveMana(p, Color.BLUE, 2)
+        driver.giveMana(p, Color.RED, 2)
+
+        val handBefore = driver.getHandSize(p)
+        val lifeBefore = driver.getLifeTotal(p)
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        // Target player = the caster (draws X), any target = the opponent (takes X damage).
+        driver.castSpell(p, spell, targets = listOf(p, opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // -1 (cast the sorcery) + 3 (drew X) = +2 net hand.
+        driver.getHandSize(p) shouldBe (handBefore - 1 + 3)
+        driver.getLifeTotal(p) shouldBe (lifeBefore + 3)
+        driver.getLifeTotal(opp) shouldBe (oppLifeBefore - 3)
+    }
+
+    test("all colorless: X = 0, no draw, no damage, no life gain") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val opp = driver.getOpponent(p)
+
+        val spell = driver.putCardInHand(p, "Together as One")
+        driver.giveColorlessMana(p, 6) // 0 colors → X = 0
+
+        val handBefore = driver.getHandSize(p)
+        val lifeBefore = driver.getLifeTotal(p)
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        driver.castSpell(p, spell, targets = listOf(p, opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHandSize(p) shouldBe (handBefore - 1) // only the cast sorcery left hand
+        driver.getLifeTotal(p) shouldBe lifeBefore
+        driver.getLifeTotal(opp) shouldBe oppLifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TranscendentArchaicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TranscendentArchaicScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.TranscendentArchaic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Transcendent Archaic ({7}, 6/6 Avatar, Vigilance):
+ *   "Converge — When this creature enters, you may draw X cards, where X is the number of colors of
+ *    mana spent to cast this spell. If you draw one or more cards this way, discard two cards."
+ *
+ * Pins the Converge-driven ETB looter:
+ *  - X = `DynamicAmount.DistinctColorsManaSpent`, read off the entering creature's recorded payment.
+ *  - The draw is optional (a `MayEffect` yes/no). Declining draws and discards nothing.
+ *  - The discard is gated on "you drew one or more this way" — i.e. X >= 1. A `yes` with X = 0
+ *    (all-colourless payment) draws nothing and must NOT force the discard.
+ */
+class TranscendentArchaicScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(TranscendentArchaic))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): GameTestDriver {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Resolve the creature + its ETB trigger until the "may draw X" YesNo prompt surfaces. */
+    fun resolveUntilMayPrompt(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.pendingDecision == null && (driver.stackSize > 0 || guard == 0) && guard < 8) {
+            driver.bothPass()
+            guard++
+        }
+    }
+
+    test("two colors spent, accept the draw → draw 2 then discard 2 (net hand unchanged)") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Transcendent Archaic")
+        // {7} paid with mana of two distinct colors → X = 2.
+        driver.giveMana(p, Color.RED, 4)
+        driver.giveMana(p, Color.BLUE, 3)
+
+        val handBeforeCast = driver.getHandSize(p)
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        resolveUntilMayPrompt(driver)
+
+        // The "may draw X" prompt.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p, true)
+
+        // Drew X = 2 → must now discard exactly two.
+        val handAfterDraw = driver.getHandSize(p)
+        handAfterDraw shouldBe (handBeforeCast - 1 /* cast the creature */ + 2 /* drew 2 */)
+
+        val discard = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        discard.minSelections shouldBe 2
+        discard.maxSelections shouldBe 2
+        driver.submitCardSelection(p, driver.getHand(p).take(2))
+
+        // Net: -1 (creature) +2 (draw) -2 (discard) = -1 relative to before-cast hand.
+        driver.getHandSize(p) shouldBe (handBeforeCast - 1)
+    }
+
+    test("all colorless cast, accept the draw → X = 0, draw nothing, no discard") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Transcendent Archaic")
+        driver.giveColorlessMana(p, 7) // 0 colors → X = 0
+
+        val handBeforeCast = driver.getHandSize(p)
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        resolveUntilMayPrompt(driver)
+
+        // Still get the optional "draw X" prompt (X just happens to be 0).
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p, true)
+
+        // Drew zero → "draw one or more this way" is false → no discard prompt.
+        (driver.pendingDecision is SelectCardsDecision) shouldBe false
+        driver.getHandSize(p) shouldBe (handBeforeCast - 1) // only the cast creature left hand
+    }
+
+    test("decline the draw → no draw, no discard even with colors spent") {
+        val driver = createDriver()
+        startTurn(driver)
+        val p = driver.activePlayer!!
+        val spell = driver.putCardInHand(p, "Transcendent Archaic")
+        driver.giveMana(p, Color.WHITE, 3)
+        driver.giveMana(p, Color.GREEN, 4) // X would be 2 if drawn
+
+        val handBeforeCast = driver.getHandSize(p)
+        driver.castSpell(p, spell).isSuccess shouldBe true
+        resolveUntilMayPrompt(driver)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p, false) // decline
+
+        (driver.pendingDecision is SelectCardsDecision) shouldBe false
+        driver.getHandSize(p) shouldBe (handBeforeCast - 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildgrowthArchaicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildgrowthArchaicScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.WildgrowthArchaic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wildgrowth Archaic ({2/G}{2/G}, 0/0 Avatar, Trample/Reach):
+ *   Converge — This creature enters with a +1/+1 counter for each color of mana spent to cast it.
+ *   Whenever you cast a creature spell, that creature enters with X additional +1/+1 counters on it,
+ *   where X is the number of colors of mana spent to cast it.
+ *
+ * Pins both `EntersWithDynamicCounters` halves, plus the engine fix that lets the *global* (other-
+ * creatures) enters-with path read `DistinctColorsManaSpent` off the **entering** creature's cast
+ * rather than off Wildgrowth's own cast:
+ *  - Wildgrowth's own converge counters (self path).
+ *  - A second creature cast with N distinct colors → N extra +1/+1 counters (the count is about the
+ *    entering creature, NOT about Wildgrowth's payment).
+ *  - All-colourless cast of the second creature → 0 colours → no extra counters.
+ *  - A creature that enters WITHOUT being cast (e.g. put onto the battlefield) → 0 mana spent → 0
+ *    colours → no extra counters, matching the "whenever you **cast**" wording.
+ */
+class WildgrowthArchaicScenarioTest : FunSpec({
+
+    // A plain {3} colourless vanilla creature so the test fully controls how many distinct colors
+    // are spent on its cast.
+    val genericBear = CardDefinition.creature(
+        name = "Generic Test Bear",
+        manaCost = ManaCost.parse("{3}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(WildgrowthArchaic, genericBear))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /**
+     * Cast Wildgrowth Archaic and resolve it onto the battlefield, paying its {2/G}{2/G} with the
+     * supplied mana (give EXACTLY what should be spent — the auto-payer otherwise minimizes colors).
+     */
+    fun resolveWildgrowth(driver: GameTestDriver, p: EntityId, mana: Map<Color, Int> = mapOf(Color.GREEN to 2)): EntityId {
+        val wild = driver.putCardInHand(p, "Wildgrowth Archaic")
+        mana.forEach { (color, amount) -> driver.giveMana(p, color, amount) }
+        driver.castSpell(p, wild).isSuccess shouldBe true
+        driver.bothPass()
+        return wild
+    }
+
+    test("Wildgrowth's own converge: 2 colors spent → enters as a 2/2 (two +1/+1 counters)") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        // {2/G}{2/G}: one pip paid {G} (green), the other pip's {2} paid with two red → 2 colors.
+        // Give exactly that pool so the solver can't collapse it to a single color.
+        val wild = resolveWildgrowth(driver, p, mapOf(Color.GREEN to 1, Color.RED to 2))
+        plusCounters(driver, wild) shouldBe 2
+    }
+
+    test("another creature cast with 3 colors enters with 3 extra +1/+1 counters") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        resolveWildgrowth(driver, p) // Wildgrowth itself only matters as the source
+
+        val bear = driver.putCardInHand(p, "Generic Test Bear")
+        // {3} paid with three distinct colors → X = 3 for THIS creature's cast.
+        driver.giveMana(p, Color.WHITE, 1)
+        driver.giveMana(p, Color.BLUE, 1)
+        driver.giveMana(p, Color.BLACK, 1)
+        driver.castSpell(p, bear).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Base 2/2, no own enters-with counters → exactly the 3 granted by Wildgrowth.
+        plusCounters(driver, bear) shouldBe 3
+    }
+
+    test("another creature cast with all-colorless mana → 0 colors → no extra counters") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        resolveWildgrowth(driver, p)
+
+        val bear = driver.putCardInHand(p, "Generic Test Bear")
+        driver.giveColorlessMana(p, 3) // 0 distinct colors
+        driver.castSpell(p, bear).isSuccess shouldBe true
+        driver.bothPass()
+
+        plusCounters(driver, bear) shouldBe 0
+    }
+
+    test("a creature that enters without being cast gets no extra counters (whenever you CAST)") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        resolveWildgrowth(driver, p)
+
+        // Put a creature directly onto the battlefield (no cast → no mana spent → 0 colors).
+        val bear = driver.putCreatureOnBattlefield(p, "Generic Test Bear")
+        plusCounters(driver, bear) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements four **Secrets of Strixhaven (SOS)** Converge cards, with two reusable engine generalizations.

## Cards
- **Transcendent Archaic** `{7}` 6/6 Avatar, Vigilance — Converge ETB looter: *"you may draw X cards … if you draw one or more this way, discard two,"* where X = colors of mana spent. Modelled `MayEffect(DrawCards(colorsSpent) then ConditionalEffect(colorsSpent ≥ 1, Discard(2)))` so an all-colourless cast (X=0) draws nothing and skips the discard, and declining the may does neither.
- **Wildgrowth Archaic** `{2/G}{2/G}` 0/0 Avatar — its own Converge enters-with counters, **plus** *"whenever you cast a creature spell, that creature enters with X additional +1/+1 counters, where X is the colors of mana spent to cast it."*
- **Together as One** `{6}` sorcery — Converge: target player draws X, deals X damage to any target, you gain X life.
- **Fractalize** `{X}{U}` instant — target creature becomes a green-and-blue Fractal with base P/T each equal to X+1, losing all other colors and creature types.

## Engine generalizations (composition-first, no card-specific types)
- **`EntersWithDynamicCounters(otherOnly = true)` now evaluates its count against the ENTERING object**, not the replacement source. The global enters-with path (`EntersWithCountersHelper.applyGlobalEntersWithCounters`) used `sourceId = the static's source`, so `DistinctColorsManaSpent` read the *source's* colors. It now sets `sourceId = enteringEntityId` (mirroring the self path), so Wildgrowth's "that creature enters with X additional counters … to cast **it**" reads the new creature's own cast. `controllerId` stays the source's controller, so player-scoped counts (Gev, Scaled Scorch's `TurnTracking(Player.You)`) are unaffected. No existing `otherOnly` card relied on source-relative counts.
- **`BecomeCreatureEffect` power/toughness are now `DynamicAmount`** (evaluated once at resolution, CR 613.4c, then stamped as a fixed set-P/T floating effect), with an `Int` convenience overload for fixed animates (Sarkhan, crew, man-lands). Enables Fractalize's "base P/T each equal to X plus 1." All call sites updated.

## mtgish tooling
- `becomeCreatureLayerEffect` now renders `SetPowerAndToughnessBoth` (a single dynamic value applied to both P and T, e.g. `X plus 1`) through the now-dynamic `BecomeCreature` — the WAR/Simic Fractal animate. `SetPT` output also moves to `DynamicAmount.Fixed(n)`.
- Fractalize's own mtgish IR mislabels its colors as `Green/Green` (should be Green+Blue), so it **stays SCAFFOLD** rather than emit a wrong-coloured card. The other three stay SCAFFOLD (inverted `If`-on-draw IR, multi-target `CreateValueX`, cast-trigger `CreateSpellEffect`). **POR stays 0-mismatch; `EmitterGoldenTest` golden unchanged.**

## Docs
`docs/card-sdk-language-reference.md` updated for the `BecomeCreature` dynamic P/T and the `EntersWithDynamicCounters` `otherOnly` entering-object semantics.

## Tests
New scenario tests for all four cards in `rules-engine` (Converge edge cases incl. X=0, may-decline, non-cast creatures get no extra counters). Full `rules-engine`, `mtg-sets` snapshot/lint, and `mtgish-tooling` suites green. Snapshot goldens re-blessed (`BecomeCreature` P/T now serialize as `DynamicAmount.Fixed` across animate cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)