### PR TITLE
Add 4 Secrets of Strixhaven cards (Witherbloom) + ManaValueAtMostDynamic

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1583,6 +1583,16 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   color *count* rather than total mana (colorless is not a color). The **Converge** exile-by-color-count
   gate — Sundering Archaic ("exile target nonland permanent an opponent controls with mana value less than
   or equal to the number of colors of mana spent to cast this creature"), with `EntityReference.Source`.
+- `.manaValueAtMostDynamic(amount)` — mana value ≤ a resolved `DynamicAmount`. The open-ended
+  "mana value X or less, where X is <some game value>" cap, for sources no fixed/entity-derived sibling
+  covers: feed it any `DynamicAmount` (a `TurnTracking` total, a count over a filter, a life total, an
+  arithmetic composition, …) and the engine evaluates it against the controller/source at evaluation
+  time. **Moseo, Vein's New Dean** — "return … a creature card with mana value X or less from your
+  graveyard …, where X is the amount of life you gained this turn" — uses
+  `.manaValueAtMostDynamic(DynamicAmount.TurnTracking(Player.You, TurnTracker.LIFE_GAINED))`. The cap
+  fails closed (matches nothing) when there is no controller context to resolve a player-scoped amount,
+  and is `false` in the layer-projection / cost-calculation / cast-record paths (no resolution context),
+  matching the other entity-relative caps.
 - `.manaValueIsOdd()` / `.manaValueIsEven()` — mana-value parity (zero is even). Pair with modal
   spells whose modes ask the caster to choose a parity (e.g. *Mutinous Massacre*).
 - `.toughnessAtMost(n)` / `.toughnessAtLeast(n)` — toughness comparator.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
 import kotlinx.serialization.Serializable
 
@@ -294,6 +295,11 @@ data class GameObjectFilter(
     /** Mana value at most the number of colors of mana spent to cast a referenced entity (Converge). */
     fun manaValueAtMostColorsSpent(reference: EntityReference) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostColorsSpent(reference)
+    )
+
+    /** Mana value at most a resolved [DynamicAmount] (e.g. "X or less, where X is the life you gained this turn"). */
+    fun manaValueAtMostDynamic(amount: DynamicAmount) = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostDynamic(amount)
     )
 
     /** Mana value is even (zero is even). */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -369,6 +370,30 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     data class ManaValueAtMostColorsSpent(val reference: EntityReference) : CardPredicate {
         override val description: String =
             "with mana value less than or equal to the number of colors of mana spent to cast ${reference.description}"
+    }
+
+    /**
+     * Mana value at most a resolved [DynamicAmount]. The general "mana value X or less, where X is
+     * <some game value>" cap: feed it any [DynamicAmount] (a turn-tracking total, a count over a
+     * filter, a life total, an arithmetic composition, …) and the engine evaluates it at the moment
+     * the predicate is checked, comparing against the card's mana value.
+     *
+     * The sibling fixed/entity-derived caps cover their narrow cases ([ManaValueAtMost] = a constant,
+     * [ManaValueAtMostX] = the cast {X}, [ManaValueAtMostEntity] / [ManaValueAtMostEntityManaSpent] /
+     * [ManaValueAtMostColorsSpent] = values read off a referenced entity). This variant is the
+     * open-ended one for any other dynamic source — e.g. Moseo, Vein's New Dean: "return … a creature
+     * card with mana value X or less …, where X is the amount of life you gained this turn"
+     * ([DynamicAmount.TurnTracking] of `LIFE_GAINED`).
+     */
+    @SerialName("ManaValueAtMostDynamic")
+    @Serializable
+    data class ManaValueAtMostDynamic(val amount: DynamicAmount) : CardPredicate {
+        override val description: String = "with mana value ${amount.description} or less"
+
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate {
+            val newAmount = amount.applyTextReplacement(replacer)
+            return if (newAmount === amount) this else copy(amount = newAmount)
+        }
     }
 
     @SerialName("ManaValueIsEven")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BogwaterLumaret.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BogwaterLumaret.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Bogwater Lumaret — Secrets of Strixhaven #177
+ * {B}{G} · Creature — Spirit Frog · 2/2
+ *
+ * Whenever this creature or another creature you control enters, you gain 1 life.
+ *
+ * "This creature or another creature you control enters" is a single `entersBattlefield` trigger
+ * filtered to creatures you control with [TriggerBinding.ANY] — `ANY` matches both the source
+ * itself and any other creature you control, so it fires once for Bogwater's own ETB and once for
+ * each other creature you control that enters. You gain 1 life each time.
+ */
+val BogwaterLumaret = card("Bogwater Lumaret") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Spirit Frog"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature or another creature you control enters, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GainLife(1)
+        description = "Whenever this creature or another creature you control enters, you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Lie Setiawan"
+        flavorText = "\"You will hear rumors that licking lumarets grants prophetic visions. That " +
+            "is untrue. Please refrain from licking the lumarets.\"\n—Witherbloom student handbook"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a42f51a-3377-47bb-b6fb-c0515bf1dcfb.jpg?1775938216"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoseoVeinsNewDean.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MoseoVeinsNewDean.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * Moseo, Vein's New Dean — Secrets of Strixhaven #91
+ * {2}{B} · Legendary Creature — Bird Skeleton Warlock · 2/1
+ *
+ * Flying
+ * When Moseo enters, create a 1/1 black and green Pest creature token with
+ * "Whenever this token attacks, you gain 1 life."
+ * Infusion — At the beginning of your end step, if you gained life this turn, return up to one
+ * target creature card with mana value X or less from your graveyard to the battlefield, where X
+ * is the amount of life you gained this turn.
+ *
+ * The ETB Pest is the set-standard token (its own self-attack life-gain trigger via
+ * [CreateTokenEffect.triggeredAbilities]), shared with Essenceknit Scholar / Send in the Pest.
+ *
+ * Infusion is an ability word (no rules meaning) flavoring the end-step trigger. It is gated by an
+ * intervening-if on [Conditions.YouGainedLifeThisTurn] (CR 603.4 — checked both when it would trigger
+ * and again on resolution). The reanimation is an "up to one target" ([TargetObject] with
+ * `optional = true`) creature card in **your** graveyard whose mana value is at most the amount of
+ * life you gained this turn — the dynamic cap `manaValueAtMostDynamic(TurnTracking(You, LIFE_GAINED))`.
+ * [Effects.PutOntoBattlefield] reanimates the chosen card under the controller's control.
+ */
+val MoseoVeinsNewDean = card("Moseo, Vein's New Dean") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Bird Skeleton Warlock"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When Moseo enters, create a 1/1 black and green Pest creature token with \"Whenever " +
+        "this token attacks, you gain 1 life.\"\n" +
+        "Infusion — At the beginning of your end step, if you gained life this turn, return up to " +
+        "one target creature card with mana value X or less from your graveyard to the battlefield, " +
+        "where X is the amount of life you gained this turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK, Color.GREEN),
+            creatureTypes = setOf("Pest"),
+            triggeredAbilities = listOf(
+                TriggeredAbility.create(
+                    trigger = Triggers.Attacks.event,
+                    binding = Triggers.Attacks.binding,
+                    effect = Effects.GainLife(1)
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/b/a/ba854032-6ad2-4654-990a-64006e7f92fd.jpg?1777982237"
+        )
+        description = "When Moseo enters, create a 1/1 black and green Pest creature token with " +
+            "\"Whenever this token attacks, you gain 1 life.\""
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouGainedLifeThisTurn
+        val t = target(
+            "up to one target creature card with mana value X or less from your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.ownedByYou()
+                        .manaValueAtMostDynamic(
+                            DynamicAmount.TurnTracking(Player.You, TurnTracker.LIFE_GAINED)
+                        ),
+                    zone = Zone.GRAVEYARD,
+                ),
+            )
+        )
+        effect = Effects.PutOntoBattlefield(t)
+        description = "Infusion — At the beginning of your end step, if you gained life this turn, " +
+            "return up to one target creature card with mana value X or less from your graveyard to " +
+            "the battlefield, where X is the amount of life you gained this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "91"
+        artist = "Abz J Harding"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6877180c-22a1-4c4d-9178-316f4c34661b.jpg?1775937545"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PoxPlague.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PoxPlague.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Pox Plague
+ * {B}{B}{B}{B}{B}
+ * Sorcery
+ * Each player loses half their life, then discards half the cards in their hand, then sacrifices
+ * half the permanents they control of their choice. Round down each time.
+ *
+ * A modern Pox/Smallpox. Per the original Pox rulings, the effect is processed in three separate
+ * stages, in order — every player loses life, *then* every player discards, *then* every player
+ * sacrifices — and the amount for each stage is not calculated until that stage is performed (so an
+ * earlier stage's discards/sacrifices change the count for later stages). Each stage is therefore
+ * its own [ForEachPlayerEffect] over [Player.ActivePlayerFirst] (APNAP order, CR 101.4), and the
+ * three are sequenced with `then`.
+ *
+ * Within a stage the body's `controllerId` is rebound to the iterated player, so [Player.You] /
+ * [EffectTarget.Controller] resolve to that player and the per-player "half, rounded down" amount
+ * (`Divide(<count>, Fixed(2), roundUp = false)`) reads *their* own life / hand / permanents:
+ * - life loss → `Divide(LifeTotal(You), 2)` to themselves
+ * - discard → `Divide(AggregateZone(You, HAND), 2)` (player chooses which cards)
+ * - sacrifice → `Divide(AggregateBattlefield(You, Permanent), 2)` permanents "of their choice"
+ */
+val PoxPlague = card("Pox Plague") {
+    manaCost = "{B}{B}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Each player loses half their life, then discards half the cards in their hand, " +
+        "then sacrifices half the permanents they control of their choice. Round down each time."
+
+    spell {
+        effect = ForEachPlayerEffect(
+            Player.ActivePlayerFirst,
+            listOf(
+                Effects.LoseLife(
+                    amount = DynamicAmount.Divide(
+                        numerator = DynamicAmount.LifeTotal(Player.You),
+                        denominator = DynamicAmount.Fixed(2),
+                        roundUp = false,
+                    ),
+                    target = EffectTarget.Controller,
+                ),
+            ),
+        ).then(
+            ForEachPlayerEffect(
+                Player.ActivePlayerFirst,
+                listOf(
+                    Effects.Discard(
+                        count = DynamicAmount.Divide(
+                            numerator = DynamicAmount.AggregateZone(Player.You, Zone.HAND),
+                            denominator = DynamicAmount.Fixed(2),
+                            roundUp = false,
+                        ),
+                        target = EffectTarget.Controller,
+                    ),
+                ),
+            )
+        ).then(
+            ForEachPlayerEffect(
+                Player.ActivePlayerFirst,
+                listOf(
+                    Effects.Sacrifice(
+                        filter = GameObjectFilter.Permanent,
+                        count = DynamicAmount.Divide(
+                            numerator = DynamicAmount.AggregateBattlefield(
+                                Player.You,
+                                GameObjectFilter.Permanent,
+                            ),
+                            denominator = DynamicAmount.Fixed(2),
+                            roundUp = false,
+                        ),
+                        target = EffectTarget.Controller,
+                    ),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "94"
+        artist = "Camille Alquier"
+        flavorText = "The darkest corners of the Detention Bog hide natural laboratories that " +
+            "quietly spawn deadly infections."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c99c17b-ad3a-4859-97e8-469718b81cd9.jpg?1775937566"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WitherbloomCharm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/WitherbloomCharm.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Witherbloom Charm
+ * {B}{G}
+ * Instant
+ * Choose one —
+ * • You may sacrifice a permanent. If you do, draw two cards.
+ * • You gain 5 life.
+ * • Destroy target nonland permanent with mana value 2 or less.
+ *
+ * The standard `modal(chooseCount = 1)` charm shape (sibling of Silverquill / Prismari / Lorehold).
+ *
+ * Mode 1 is the optional "you may sacrifice a permanent. If you do, draw two cards": a
+ * [MayEffect] (the "you may") wrapping an [IfYouDoEffect] whose `action` is a gather → choose →
+ * sacrifice pipeline over the permanents you control, gating the two-card draw on the sacrifice
+ * actually happening (the Highway Robbery idiom — `SuccessCriterion.Auto` infers success from the
+ * terminal sacrifice move). Mode 2 is a flat life gain. Mode 3 destroys a single target nonland
+ * permanent whose mana value is 2 or less (`TargetFilter.NonlandPermanent` + `manaValueAtMost(2)`).
+ */
+val WitherbloomCharm = card("Witherbloom Charm") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• You may sacrifice a permanent. If you do, draw two cards.\n" +
+        "• You gain 5 life.\n" +
+        "• Destroy target nonland permanent with mana value 2 or less."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("You may sacrifice a permanent. If you do, draw two cards") {
+                effect = MayEffect(
+                    effect = IfYouDoEffect(
+                        action = Effects.Pipeline {
+                            val permanents = gather(GameObjectFilter.Permanent, player = Player.You)
+                            val chosen = chooseExactly(
+                                1,
+                                from = permanents,
+                                useTargetingUI = true,
+                                prompt = "Choose a permanent to sacrifice",
+                            )
+                            sacrifice(chosen)
+                        },
+                        ifYouDo = Effects.DrawCards(2),
+                    ),
+                    descriptionOverride = "You may sacrifice a permanent. If you do, draw two cards.",
+                )
+            }
+            mode("You gain 5 life") {
+                effect = Effects.GainLife(5)
+            }
+            mode("Destroy target nonland permanent with mana value 2 or less") {
+                val t = target(
+                    "target nonland permanent with mana value 2 or less",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.NonlandPermanent.manaValueAtMost(2))),
+                )
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Florian Herold"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/254437f7-7a8a-4b11-9cea-e8e7ea23c59e.jpg?1775938703"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -656,6 +656,49 @@
     ]
 }
 
+// Bogwater Lumaret
+{
+    "name": "Bogwater Lumaret",
+    "manaCost": "{B}{G}",
+    "typeLine": "Creature — Spirit Frog",
+    "oracleText": "Whenever this creature or another creature you control enters, you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever this creature or another creature you control enters, you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"You will hear rumors that licking lumarets grants prophetic visions. That is untrue. Please refrain from licking the lumarets.\"\n—Witherbloom student handbook",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a42f51a-3377-47bb-b6fb-c0515bf1dcfb.jpg?1775938216"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Borrowed Knowledge
 {
     "name": "Borrowed Knowledge",
@@ -6496,6 +6539,120 @@
     ]
 }
 
+// Moseo, Vein's New Dean
+{
+    "name": "Moseo, Vein's New Dean",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Bird Skeleton Warlock",
+    "oracleText": "Flying\nWhen Moseo enters, create a 1/1 black and green Pest creature token with \"Whenever this token attacks, you gain 1 life.\"\nInfusion — At the beginning of your end step, if you gained life this turn, return up to one target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK",
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Pest"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba854032-6ad2-4654-990a-64006e7f92fd.jpg?1777982237",
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_2",
+                            "trigger": "AttackEvent",
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Moseo enters, create a 1/1 black and green Pest creature token with \"Whenever this token attacks, you gain 1 life.\""
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature card with mana value X or less from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "ManaValueAtMostDynamic",
+                                    "amount": {
+                                        "type": "TurnTracking",
+                                        "player": "You",
+                                        "tracker": "LIFE_GAINED"
+                                    }
+                                }
+                            ],
+                            "controllerPredicate": "OwnedByYou"
+                        },
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target creature card with mana value X or less from your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Infusion — At the beginning of your end step, if you gained life this turn, return up to one target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "RARE",
+        "artist": "Abz J Harding",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6877180c-22a1-4c4d-9178-316f4c34661b.jpg?1775937545"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Muse Seeker
 {
     "name": "Muse Seeker",
@@ -7455,6 +7612,130 @@
         "rarity": "RARE",
         "artist": "Nino Vecia",
         "imageUri": "https://cards.scryfall.io/normal/front/1/7/174f5d7e-5d36-4d13-96bf-9b12cd644716.jpg?1775937558"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Pox Plague
+{
+    "name": "Pox Plague",
+    "manaCost": "{B}{B}{B}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player loses half their life, then discards half the cards in their hand, then sacrifices half the permanents they control of their choice. Round down each time.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "ActivePlayerFirst"
+                    },
+                    "body": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "LifeTotal",
+                                "player": "You"
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "roundUp": false
+                        },
+                        "target": "Controller"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "ActivePlayerFirst"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Divide",
+                                        "numerator": {
+                                            "type": "AggregateZone",
+                                            "player": "You",
+                                            "zone": "Hand"
+                                        },
+                                        "denominator": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "roundUp": false
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "ActivePlayerFirst"
+                    },
+                    "body": {
+                        "type": "ForceSacrifice",
+                        "filter": "permanent",
+                        "target": "Controller",
+                        "dynamicCount": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "permanent"
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "roundUp": false
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "RARE",
+        "artist": "Camille Alquier",
+        "flavorText": "The darkest corners of the Detention Bog hide natural laboratories that quietly spawn deadly infections.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c99c17b-ad3a-4859-97e8-469718b81cd9.jpg?1775937566"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -12392,6 +12673,119 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Witherbloom Charm
+{
+    "name": "Witherbloom Charm",
+    "manaCost": "{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• You may sacrifice a permanent. If you do, draw two cards.\n• You gain 5 life.\n• Destroy target nonland permanent with mana value 2 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.DoAction",
+                                "action": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "BattlefieldMatching",
+                                                "filter": "permanent",
+                                                "player": "You"
+                                            },
+                                            "storeAs": "gathered0"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "gathered0",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "selected1",
+                                            "prompt": "Choose a permanent to sacrifice",
+                                            "useTargetingUI": true
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "selected1",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Sacrifice"
+                                        }
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        },
+                        "descriptionOverride": "You may sacrifice a permanent. If you do, draw two cards."
+                    },
+                    "description": "You may sacrifice a permanent. If you do, draw two cards"
+                },
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    }
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target nonland permanent with mana value 2 or less"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "nonland permanent mv<=2"
+                            },
+                            "id": "target nonland permanent with mana value 2 or less"
+                        }
+                    ],
+                    "description": "Destroy target nonland permanent with mana value 2 or less"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Florian Herold",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/254437f7-7a8a-4b11-9cea-e8e7ea23c59e.jpg?1775938703"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -30,6 +30,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("FromHand", "envelope: activated ability used from hand (activateFromZone = Zone.HAND)")
     envelope("FromGraveyard", "envelope: activated ability used from graveyard (activateFromZone = Zone.GRAVEYARD)")
     envelope("And", "envelope: cost/action conjunction")
+    // A `_Trigger: "Or"` combinator — "whenever [trigger A] or [trigger B]" (Bogwater Lumaret:
+    // "whenever this creature or another creature you control enters"). Structural: the capability is
+    // the nested triggers (each a WhenAPermanentEntersTheBattlefield), scored on their own. The emitter
+    // renders the self-or-other-creature ETB shape as a single ANY-binding entersBattlefield trigger.
+    envelope("Or", "envelope: trigger disjunction ('whenever A or B')")
     // A resolution-time intervening-if (`If[cond, [then]]` inside a spell/ability ActionList) realises as
     // a `ConditionalEffect` -> `GatedEffect(gate = WhenCondition)` (SerialName "Gated") in our trees, the
     // same compiled shape as a "you may" gate; so the conditional envelope composes the Gated capability

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1672,6 +1672,37 @@ private fun EmitCtx.orTriggerBlocks(rule: JsonObject, oncePerTurn: Boolean, trig
     if (arms.size < 2) return null
     if (arms.any { it.strField("_Trigger") == null || it.strField("_Trigger") == "Or" }) return null
 
+    // "Whenever this creature OR another <filter> enters" — the self-or-other-matching ETB union
+    // (Bogwater Lumaret: "this creature or another creature you control enters"). Two arms, both
+    // WhenAPermanentEntersTheBattlefield: one is the bare self ETB (`ThisPermanent`), the other is an
+    // `Other(ThisPermanent)` ETB whose remaining filter the source itself satisfies. CR-wise this is
+    // exactly one ANY-binding trigger over that filter — `ANY` matches the source AND any other matching
+    // permanent — which is the hand-authored idiom. Collapse to a single `entersBattlefield(filter, ANY)`
+    // when the shape is exactly that (and the "other" arm's filter renders whole); otherwise fall through
+    // to the per-arm expansion below.
+    if (arms.size == 2) {
+        val selfArm = arms.firstOrNull { isBareSelfEtb(it) }
+        val otherArm = arms.firstOrNull { it !== selfArm }
+        if (selfArm != null && otherArm != null &&
+            jsonContains(otherArm, "_Trigger", "WhenAPermanentEntersTheBattlefield") &&
+            jsonContains(otherArm, "_Permanents", "Other")
+        ) {
+            // Strip the `Other(ThisPermanent)` clause from the "other" arm's subject so it becomes a
+            // plain "<filter> enters" ETB. triggerBlock then renders it as a single ANY-binding
+            // entersBattlefield trigger (ANY covers both the source and any other matching permanent),
+            // sharing the same effect body. If the stripped shape can't be rendered whole, fall through
+            // to the per-arm expansion below rather than emit a wrong card.
+            val plainOtherArm = stripOtherThisPermanentClause(otherArm)
+            if (plainOtherArm != null) {
+                val collapsedRule = buildJsonObject {
+                    rule.forEach { (k, v) -> if (k != "args") put(k, v) }
+                    put("args", JsonArray(listOf<JsonElement>(plainOtherArm) + args.drop(1)))
+                }
+                triggerBlock(collapsedRule, oncePerTurn, triggerCondition)?.let { return it }
+            }
+        }
+    }
+
     val out = mutableListOf<Stmt>()
     for (arm in arms) {
         val armRule = buildJsonObject {
@@ -1682,6 +1713,59 @@ private fun EmitCtx.orTriggerBlocks(rule: JsonObject, oncePerTurn: Boolean, trig
         out.addAll(block)
     }
     return out
+}
+
+/**
+ * True iff [arm] is the bare "this permanent enters" ETB — a `WhenAPermanentEntersTheBattlefield`
+ * whose subject is exactly `ThisPermanent` with no `Other` / type / controller constraints. The self
+ * half of a "this creature or another <filter> enters" union (Bogwater Lumaret).
+ */
+private fun isBareSelfEtb(arm: JsonObject): Boolean {
+    if (arm.strField("_Trigger") != "WhenAPermanentEntersTheBattlefield") return false
+    if (!jsonContains(arm, "_Permanent", "ThisPermanent")) return false
+    return !jsonContains(arm, "_Permanents", "Other") &&
+        !jsonContains(arm, "_Permanents", "IsCardtype") &&
+        !jsonContains(arm, "_Permanents", "ControlledByAPlayer")
+}
+
+/**
+ * Remove the `Other(ThisPermanent)` clause from [arm]'s subject filter, collapsing a now-single-element
+ * `And` to its sole child. Turns the "another creature you control enters" arm into a plain "creature
+ * you control enters" trigger (which renders as an ANY binding). Returns null if no such clause was
+ * found (so the caller falls back to the per-arm union rather than emit an unchanged tree).
+ */
+private fun stripOtherThisPermanentClause(arm: JsonObject): JsonObject? {
+    var removed = false
+    fun isOtherThisPermanent(node: JsonElement?): Boolean =
+        node is JsonObject && node.strField("_Permanents") == "Other" &&
+            jsonContains(node, "_Permanent", "ThisPermanent")
+    fun strip(node: JsonElement): JsonElement = when (node) {
+        is JsonObject -> {
+            // An `And` of permanent filters: drop any `Other(ThisPermanent)` member, recurse the rest.
+            if (node.strField("_Permanents") == "And") {
+                val kept = (node["args"].asArr ?: JsonArray(emptyList()))
+                    .filterNot { isOtherThisPermanent(it) }
+                    .map { strip(it) }
+                if (kept.size != (node["args"].asArr?.size ?: 0)) removed = true
+                when (kept.size) {
+                    0 -> node // shouldn't happen; leave untouched
+                    1 -> kept.single()
+                    else -> buildJsonObject {
+                        node.forEach { (k, v) -> if (k != "args") put(k, v) }
+                        put("args", JsonArray(kept))
+                    }
+                }
+            } else {
+                buildJsonObject {
+                    node.forEach { (k, v) -> put(k, strip(v)) }
+                }
+            }
+        }
+        is JsonArray -> JsonArray(node.map { strip(it) })
+        else -> node
+    }
+    val result = strip(arm) as? JsonObject ?: return null
+    return if (removed) result else null
 }
 
 /**

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -6700,14 +6700,9 @@ val NebelgastHerald = card("Nebelgast Herald") {
     toughness = 1
     keywords(Keyword.FLASH, Keyword.FLYING)
     triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
-        effect = Effects.Tap(t)
-    }
-    triggeredAbility {
         trigger = Triggers.entersBattlefield(
             filter = GameObjectFilter.Creature.withSubtype(Subtype.SPIRIT).youControl(),
-            binding = TriggerBinding.OTHER
+            binding = TriggerBinding.ANY
         )
         val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
         effect = Effects.Tap(t)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -38,6 +38,7 @@ import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
 import com.wingedsheep.engine.state.CastSpellRecord
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -314,6 +315,11 @@ class PredicateEvaluator {
                 val colorsSpent = ManaSpentReader.distinctColorsSpent(state, refEntityId)
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= colorsSpent
+            }
+            is CardPredicate.ManaValueAtMostDynamic -> {
+                val cap = evaluateDynamicCap(state, predicate.amount, context) ?: return false
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc <= cap
             }
             CardPredicate.ManaValueIsEven -> {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
@@ -691,6 +697,28 @@ class PredicateEvaluator {
     /**
      * Resolve an EntityReference to an EntityId using the predicate context.
      */
+    /**
+     * Resolve a [DynamicAmount] cap for [CardPredicate.ManaValueAtMostDynamic]. The amount is
+     * evaluated through [DynamicAmountEvaluator] against a minimal [EffectContext] reconstructed
+     * from the predicate context's controller/source/X. Returns null when there is no controller
+     * to resolve player-scoped amounts against (e.g. legal-action enumeration with no context), so
+     * the predicate fails closed rather than treating the cap as 0 and silently matching only
+     * mana-value-0 cards.
+     */
+    private fun evaluateDynamicCap(
+        state: GameState,
+        amount: DynamicAmount,
+        context: PredicateContext?,
+    ): Int? {
+        val controllerId = context?.controllerId ?: return null
+        val effectContext = EffectContext(
+            sourceId = context.sourceId,
+            controllerId = controllerId,
+            xValue = context.xValue,
+        )
+        return DynamicAmountEvaluator().evaluate(state, amount, effectContext)
+    }
+
     private fun resolveEntityReference(ref: EntityReference, context: PredicateContext?): EntityId? {
         return when (ref) {
             is EntityReference.Source -> context?.sourceId
@@ -1039,6 +1067,7 @@ class PredicateEvaluator {
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
             is CardPredicate.ManaValueAtMostColorsSpent -> false
+            is CardPredicate.ManaValueAtMostDynamic -> false
             CardPredicate.ManaValueIsEven -> record.manaValue % 2 == 0
             CardPredicate.ManaValueIsOdd -> record.manaValue % 2 != 0
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -571,6 +571,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.ManaValueAtMostEntity -> false
         is CardPredicate.ManaValueAtMostEntityManaSpent -> false
         is CardPredicate.ManaValueAtMostColorsSpent -> false
+        is CardPredicate.ManaValueAtMostDynamic -> false
         is CardPredicate.PowerGreaterThanEntity -> false
         is CardPredicate.PowerAtMostEntity -> false
         is CardPredicate.PowerLessThanEntity -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -926,6 +926,7 @@ class CostCalculator(
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
             is CardPredicate.ManaValueAtMostColorsSpent -> false
+            is CardPredicate.ManaValueAtMostDynamic -> false
             is CardPredicate.PowerGreaterThanEntity -> false
             is CardPredicate.PowerAtMostEntity -> false
             is CardPredicate.PowerLessThanEntity -> false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BogwaterLumaretScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BogwaterLumaretScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Bogwater Lumaret (Secrets of Strixhaven #177).
+ *
+ * Bogwater Lumaret ({B}{G}, 2/2 Spirit Frog):
+ *   Whenever this creature or another creature you control enters, you gain 1 life.
+ */
+class BogwaterLumaretScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bogwater Lumaret — gain 1 life on creature ETB") {
+
+            test("gains 1 life when it enters the battlefield itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Bogwater Lumaret")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bogwater Lumaret").error shouldBe null
+                game.resolveStack()
+
+                withClue("its own ETB triggers the 1 life gain") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+
+            test("gains 1 life when another creature you control enters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bogwater Lumaret")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("another creature's ETB triggers the 1 life gain") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+
+            test("does NOT gain life when an opponent's creature enters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bogwater Lumaret")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("opponent's creature ETB does not trigger Bogwater (you control filter)") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoseoVeinsNewDeanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoseoVeinsNewDeanScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Moseo, Vein's New Dean (Secrets of Strixhaven #91).
+ *
+ * Moseo ({2}{B}, 2/1, Legendary Bird Skeleton Warlock):
+ *   Flying
+ *   When Moseo enters, create a 1/1 black and green Pest token ("Whenever this token attacks,
+ *   you gain 1 life.").
+ *   Infusion — At the beginning of your end step, if you gained life this turn, return up to one
+ *   target creature card with mana value X or less from your graveyard to the battlefield, where
+ *   X is the amount of life you gained this turn.
+ *
+ * The Infusion end-step trigger exercises the new `manaValueAtMostDynamic` card-filter cap, with
+ * X = the amount of life gained this turn (TurnTracking LIFE_GAINED).
+ */
+class MoseoVeinsNewDeanScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Moseo, Vein's New Dean — ETB Pest + Infusion reanimation") {
+
+            test("entering creates a Pest token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Moseo, Vein's New Dean")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Moseo, Vein's New Dean")
+                withClue("Moseo should cast: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("A Pest token should have been created") {
+                    (game.findPermanent("Pest Token") != null) shouldBe true
+                }
+            }
+
+            test("with life gained, reanimates a creature card with mana value <= life gained") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Moseo, Vein's New Dean")
+                    .withCardInGraveyard(1, "Grizzly Bears")   // MV 2 — within the cap when X = 3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Gained 3 life this turn -> X = 3, so MV<=3 cards are eligible.
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(3))
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+
+                withClue("end-step Infusion trigger should ask for a target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears returned to the battlefield") {
+                    (game.findPermanent("Grizzly Bears") != null) shouldBe true
+                }
+                withClue("Grizzly Bears no longer in graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a creature card above the mana-value cap is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Moseo, Vein's New Dean")
+                    .withCardInGraveyard(1, "Hill Giant")      // MV 4 — above the cap when X = 2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Only gained 2 life -> X = 2, Hill Giant (MV 4) is over the cap.
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(2))
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                // "Up to one" with no legal target: decline (no eligible MV<=2 card to reanimate).
+                if (game.hasPendingDecision()) {
+                    game.skipTargets()
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant stays in the graveyard (MV above the cap)") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                withClue("Hill Giant did not enter the battlefield") {
+                    game.findPermanent("Hill Giant") shouldBe null
+                }
+            }
+
+            test("no life gained this turn: the Infusion trigger does not fire") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Moseo, Vein's New Dean")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("no pending target decision — intervening-if failed (no life gained)") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("Grizzly Bears stays in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoxPlagueScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoxPlagueScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pox Plague (Secrets of Strixhaven #94).
+ *
+ * Pox Plague ({B}{B}{B}{B}{B} Sorcery):
+ *   Each player loses half their life, then discards half the cards in their hand, then sacrifices
+ *   half the permanents they control of their choice. Round down each time.
+ *
+ * The three stages are processed separately and each "half" is rounded down (CR; original Pox
+ * rulings). These tests pin the round-down life loss and verify the discard/sacrifice stages
+ * reduce hand size and permanent count by the floor of half.
+ */
+class PoxPlagueScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Pox Plague — lose / discard / sacrifice half, rounded down") {
+
+            test("each player loses half their life, rounded down") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Pox Plague")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withLifeTotal(1, 21)   // half rounded down = 10 -> 11
+                    .withLifeTotal(2, 20)   // half rounded down = 10 -> 10
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pox Plague").error shouldBe null
+                game.resolveStack()
+                // No cards in hand / no nonland choices beyond lands; auto-resolve any selections.
+                repeat(8) {
+                    if (game.hasPendingDecision()) {
+                        // Pox's sacrifice stage may prompt; choose minimally via selectCards if needed.
+                        runCatching { game.selectCards(emptyList()) }
+                            .recoverCatching { game.skipTargets() }
+                        game.resolveStack()
+                    }
+                }
+
+                withClue("active player lost floor(21/2)=10 -> 11 life") {
+                    game.getLifeTotal(1) shouldBe 11
+                }
+                withClue("opponent lost floor(20/2)=10 -> 10 life") {
+                    game.getLifeTotal(2) shouldBe 10
+                }
+            }
+
+            test("each player discards half their hand and sacrifices half their permanents, rounded down") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Pox Plague")
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Island")
+                    .withCardInHand(1, "Mountain")          // after casting Pox: 3 cards -> discard floor(3/2)=1
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Swamp", 5)   // 5 swamps + 2 creatures = 7 perms -> sac floor(7/2)=3
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pox Plague").error shouldBe null
+                val handAfterCast = game.handSize(1)   // 3 (Forest/Island/Mountain)
+                val permsBefore = game.state.getBattlefield(game.player1Id).size
+                game.resolveStack()
+
+                // Walk the decision chain: discard then sacrifice selections. Each pending decision
+                // names its player; satisfy it by picking the required number of that player's
+                // eligible cards/permanents.
+                var guard = 0
+                while (game.hasPendingDecision() && guard++ < 20) {
+                    val decision = game.getPendingDecision()
+                    if (decision is com.wingedsheep.engine.core.SelectCardsDecision) {
+                        // Pick exactly the maximum required (Pox's "half") from the offered options.
+                        game.selectCards(decision.options.take(decision.maxSelections))
+                    } else {
+                        // Any other prompt (e.g. a may): take no action that changes counts.
+                        runCatching { game.skipTargets() }
+                    }
+                    game.resolveStack()
+                }
+
+                withClue("active player discarded floor(3/2)=1 card (hand 3 -> 2)") {
+                    game.handSize(1) shouldBe handAfterCast - 1
+                }
+                withClue("active player sacrificed floor(7/2)=3 permanents (7 -> 4)") {
+                    game.state.getBattlefield(game.player1Id).size shouldBe permsBefore - 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitherbloomCharmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitherbloomCharmScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Witherbloom Charm (Secrets of Strixhaven #244).
+ *
+ * Witherbloom Charm ({B}{G} Instant), Choose one —
+ *   • You may sacrifice a permanent. If you do, draw two cards.
+ *   • You gain 5 life.
+ *   • Destroy target nonland permanent with mana value 2 or less.
+ */
+class WitherbloomCharmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Witherbloom Charm — choose one") {
+
+            test("mode 1: sacrifice a permanent, then draw two cards") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Witherbloom Charm")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // sacrifice fodder
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpellWithMode(1, "Witherbloom Charm", modeIndex = 0).error shouldBe null
+                game.resolveStack()
+
+                // "You may" -> yes, then choose the permanent to sacrifice.
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                if (game.hasPendingDecision()) game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears was sacrificed") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                // hand: -1 (the charm) + 2 (drawn) = handBefore + 1
+                withClue("drew two cards after sacrificing") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("mode 1 declined: no sacrifice, no draw") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Witherbloom Charm")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpellWithMode(1, "Witherbloom Charm", modeIndex = 0).error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Grizzly Bears survives — declined the sacrifice") {
+                    (game.findPermanent("Grizzly Bears") != null) shouldBe true
+                }
+                withClue("no draw — only the charm left hand") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+
+            test("mode 2: gain 5 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Witherbloom Charm")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellWithMode(1, "Witherbloom Charm", modeIndex = 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("gained 5 life") { game.getLifeTotal(1) shouldBe 25 }
+            }
+
+            test("mode 3: destroy target nonland permanent with mana value 2 or less") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Witherbloom Charm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")     // MV 2 — legal
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpellWithMode(1, "Witherbloom Charm", modeIndex = 2, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears (MV 2) was destroyed") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("mode 3: a mana value 3+ permanent is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Witherbloom Charm")
+                    .withCardOnBattlefield(2, "Hill Giant")        // MV 4 — illegal
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val result = game.castSpellWithMode(1, "Witherbloom Charm", modeIndex = 2, targetId = giant)
+
+                withClue("Hill Giant (MV 4) is not a legal target for the destroy mode") {
+                    (result.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Secrets of Strixhaven (SOS) cards, the one small SDK primitive Moseo needs, and the mtgish-tooling support so the simplest of them auto-drafts.

## Cards

- **Moseo, Vein's New Dean** (`{2}{B}`, 2/1 Legendary Bird Skeleton Warlock) — Flying; ETB creates the set-standard Pest token; **Infusion** end-step trigger (intervening-if on "you gained life this turn") returns *up to one* target creature card with mana value ≤ X from your graveyard to the battlefield, where X is the life you gained this turn.
- **Witherbloom Charm** (`{B}{G}` Instant) — Choose one: (1) you *may* sacrifice a permanent, if you do draw two (a `MayEffect` over `IfYouDo` of a gather→choose→sacrifice pipeline so the draw is gated on the sacrifice happening); (2) gain 5 life; (3) destroy target nonland permanent with mana value 2 or less.
- **Pox Plague** (`{B}{B}{B}{B}{B}` Sorcery) — a modern Pox/Smallpox: each player loses half their life, then discards half their hand, then sacrifices half their permanents, rounded down each time. Modeled as **three separate stages**, each its own `ForEachPlayer` over `ActivePlayerFirst`, so per-player amounts are computed at that stage (faithful to the original Pox rulings: "each part is processed separately… the number isn't calculated until it's time to perform that part").
- **Bogwater Lumaret** (`{B}{G}`, 2/2 Spirit Frog) — "Whenever this creature or another creature you control enters, you gain 1 life", as a single `ANY`-binding `entersBattlefield(Creature.youControl())` trigger.

Each card has a rules-faithful Kotest scenario test in `rules-engine` (14 tests total — covers the dynamic MV cap, the "up to one" decline, the intervening-if not firing, the may-decline, the MV-2 destroy legality, per-player round-down for all three Pox stages, and the you-control trigger filter).

## SDK feature

- **`CardPredicate.ManaValueAtMostDynamic(amount: DynamicAmount)`** — a general "mana value X or less, where X is `<a DynamicAmount>`" card-filter cap (the existing siblings only cover fixed / cast-{X} / entity-derived caps). Wired in `PredicateEvaluator` (reconstructs a minimal `EffectContext` from the predicate context and evaluates via `DynamicAmountEvaluator`; fails closed without a controller; `false` in the projection / cost-calc / cast-record paths like the other entity-relative caps), plus a `manaValueAtMostDynamic(amount)` `ObjectFilter` builder. Documented in `card-sdk-language-reference.md`.

## mtgish-tooling

- **Bridge:** added an `Or` trigger envelope so a `_Trigger: "Or"` of two ETB arms scores as *coverable* (capability = the nested triggers) instead of BLOCKED — unblocks Bogwater Lumaret.
- **Emitter:** collapse "this creature or another `<filter>` enters" into a single `ANY`-binding `entersBattlefield` trigger (the hand-authored idiom) rather than two separate triggers; falls back to per-arm expansion otherwise. Re-blessed the INR emitter golden (Nebelgast Herald now renders as one `ANY` trigger).
- Moseo / Witherbloom Charm / Pox Plague correctly stay **declined-to-SCAFFOLD** (the emitter doesn't emit a wrong card for their cast-time/modal/each-player shapes).

## Tests

- All 4 scenario tests + full `:rules-engine`, `:mtg-sets` (snapshot re-blessed additively, lint clean), and `:mtgish-tooling` suites green.
- `coverage-verify` gates: **POR 158/158**, **ISD 84/84**, **INR 0-mismatch** — all still 0 gameplay-tree mismatch. SOS's pre-existing emitter mismatches (other authors' cards) are unchanged and SOS is not a gated 0-mismatch set; Bogwater's mismatch is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)