### PR TITLE
Add DSK black/blue cards (Umbral) + mtgish Eerie auto-gen support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BalemurkLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BalemurkLeech.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Balemurk Leech
+ * {1}{B}
+ * Creature — Leech
+ * 2/2
+ *
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a
+ * Room, each opponent loses 1 life.
+ */
+val BalemurkLeech = card("Balemurk Leech") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Leech"
+    power = 2
+    toughness = 2
+    oracleText = "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, each opponent loses 1 life."
+
+    keywords(Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Eerie — Whenever an enchantment you control enters, each opponent loses 1 life."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Eerie — Whenever you fully unlock a Room, each opponent loses 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "John Tedrick"
+        flavorText = "Adapted to feed on dead flesh, it's not averse to making its own when no corpses are available."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg?1726286164"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CommuneWithEvil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CommuneWithEvil.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Commune with Evil
+ * {2}{B}
+ * Sorcery
+ *
+ * Look at the top four cards of your library. Put one of them into your hand and the rest
+ * into your graveyard. You gain 3 life.
+ */
+val CommuneWithEvil = card("Commune with Evil") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain 3 life."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.lookAtTopAndKeep(count = 4, keepCount = 1),
+            Effects.GainLife(3),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Ovidio Cartagena"
+        flavorText = "Elsa swelled with euphoria and power as she stepped over her friends' corpses. She should have bargained with a demon a lot sooner."
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg?1726286174"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/VengefulPossession.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/VengefulPossession.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Vengeful Possession
+ * {2}{R}
+ * Sorcery
+ *
+ * Gain control of target creature until end of turn. Untap it. It gains haste until end of
+ * turn. You may discard a card. If you do, draw a card.
+ */
+val VengefulPossession = card("Vengeful Possession") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. You may discard a card. If you do, draw a card."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GainControl(t, Duration.EndOfTurn),
+            Effects.Untap(t),
+            Effects.GrantKeyword(Keyword.HASTE, t, Duration.EndOfTurn),
+            MayEffect(
+                effect = IfYouDoEffect(
+                    action = Patterns.Hand.discardCards(1),
+                    ifYouDo = Effects.DrawCards(1),
+                ),
+                descriptionOverride = "You may discard a card. If you do, draw a card.",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Dominik Mayer"
+        flavorText = "As the ghost clawed its way into her skin, Sarissa forgot that the rage tearing through her heart wasn't her own."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg?1726286456"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -79,6 +79,72 @@
     ]
 }
 
+// Balemurk Leech
+{
+    "name": "Balemurk Leech",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Leech",
+    "oracleText": "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, each opponent loses 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, each opponent loses 1 life."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, each opponent loses 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "John Tedrick",
+        "flavorText": "Adapted to feed on dead flesh, it's not averse to making its own when no corpses are available.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg?1726286164"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Baseball Bat
 {
     "name": "Baseball Bat",
@@ -426,6 +492,85 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Commune with Evil
+{
+    "name": "Commune with Evil",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Ovidio Cartagena",
+        "flavorText": "Elsa swelled with euphoria and power as she stepped over her friends' corpses. She should have bargained with a demon a lot sooner.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg?1726286174"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3127,6 +3272,117 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Vengeful Possession
+{
+    "name": "Vengeful Possession",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. You may discard a card. If you do, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may discard a card. If you do, draw a card."
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Dominik Mayer",
+        "flavorText": "As the ghost clawed its way into her skin, Sarissa forgot that the rage tearing through her heart wasn't her own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg?1726286456"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Veteran Survivor

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2299,6 +2299,22 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         return "Triggers.YouAttackWithFilter($filter)"
     }
 
+    // "Whenever you fully unlock a Room" — the Eerie Room half (CR 709.5h, Balemurk Leech, Optimistic
+    // Scavenger). The args are [player scope, the Room subject]. The engine's Triggers.RoomFullyUnlocked
+    // is fixed to the You scope over any Room, so only that exact shape renders: a SinglePlayer(You)
+    // scope plus an IsEnchantmentType "Room" subject. Any other player scope, or a Room subject carrying
+    // extra constraints, has no matching Triggers.* constant, so it declines -> SCAFFOLD rather than
+    // widening the trigger.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerFullyUnlocksARoom")) {
+        val argv = trig["args"].asArr ?: return null
+        val scope = castScope(argv.getOrNull(0) as? JsonObject)
+        val subject = argv.getOrNull(1) as? JsonObject
+        val bareRoomSubject = subject?.strField("_Permanents") == "IsEnchantmentType" &&
+            subject.field("args").asStr() == "Room"
+        if (scope == CastScope.YOU && bareRoomSubject) return "Triggers.RoomFullyUnlocked"
+        return null
+    }
+
     // "Whenever a [filtered] permanent enters the battlefield" (the SELF case returned above): an
     // `Other(ThisPermanent)` clause means "another …" -> OTHER binding (Elvish Vanguard's "another
     // Elf", Wretched Anurid's "another creature"); otherwise "a …" -> ANY (Wirewood Savage's "a Beast").

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -55,7 +55,7 @@ object Emitter {
         val pt = card["CardPT"].asObj
 
         val permanent = isPermanent(card)
-        val kw = if (permanent) keywordLines(card, keywords) else emptySet()
+        val kw = if (permanent) keywordLines(card, keywords, ctx.oracleText) else emptySet()
 
         // The whole card is one Block tree: the KDoc precedes it, the shell/ability lines are its body
         // statements, and the renderer turns it into source. Shell scaffolding (mana/typeline/metadata)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
@@ -135,8 +135,16 @@ internal fun findLandwalkKeywords(node: JsonElement?, keywords: Set<String>, out
     }
 }
 
-internal fun keywordLines(card: JsonObject, keywords: Set<String>): Set<String> {
+internal fun keywordLines(card: JsonObject, keywords: Set<String>, oracleText: String? = null): Set<String> {
     val out = mutableSetOf<String>()
+    // Ability words that the SDK models as a (rules-inert) Keyword but the mtgish IR carries only as the
+    // triggered/effect shape, with NO top-level `_Rule` to scan for. Eerie is the lone such word so far:
+    // it's an ability word (CR 207.2c — no rules meaning) whose Room/enchantment-enters trigger union is
+    // already rendered by triggerSpecFor, but the hand-authored golden still stamps `keywords(Keyword.EERIE)`
+    // to match Scryfall's `keywords:["Eerie"]` (Balemurk Leech, Optimistic Scavenger). Detect it from the
+    // ability-word prefix in the printed oracle text — the only place the IR exposes it — and emit it only
+    // when the SDK actually has the EERIE enum value, so the line round-trips against the golden.
+    if (oracleText != null && "EERIE" in keywords && oracleText.startsWith("Eerie —")) out.add("EERIE")
     // Only TOP-LEVEL rules are intrinsic card keywords. A keyword nested inside an Activated/Triggered
     // ability is GRANTED to a target ("target creature gains forestwalk"), not a card keyword — the old
     // whole-tree scan wrongly stamped it on the card (Elvish Pathcutter, Spurred Wolverine, Krosan Groundshaker).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BalemurkLeechScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BalemurkLeechScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Balemurk Leech (DSK #84).
+ *
+ * Balemurk Leech — {1}{B} Creature — Leech, 2/2
+ *   "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a
+ *    Room, each opponent loses 1 life."
+ *
+ * Verifies the enchantment-enters Eerie trigger drains each opponent for 1 life, and that an
+ * opponent's enchantment entering does NOT trigger it (the trigger is "an enchantment you control").
+ */
+class BalemurkLeechScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Balemurk Leech — Eerie (enchantment enters)") {
+
+            test("an enchantment you control entering drains each opponent for 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Balemurk Leech")
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Each opponent loses 1 life when an enchantment you control enters") {
+                    game.getLifeTotal(2) shouldBe opponentLifeBefore - 1
+                }
+            }
+
+            test("an opponent's enchantment entering does NOT trigger the Eerie drain") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Balemurk Leech")
+                    .withCardInHand(2, "Test Enchantment") // {1}{W}, controlled by the opponent
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val controllerLifeBefore = game.getLifeTotal(1)
+
+                val cast = game.castSpell(2, "Test Enchantment")
+                withClue("Opponent casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The Leech's controller loses no life — the enchantment isn't theirs") {
+                    game.getLifeTotal(1) shouldBe controllerLifeBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CommuneWithEvilScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CommuneWithEvilScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Commune with Evil (DSK #87).
+ *
+ * Commune with Evil — {2}{B} Sorcery
+ *   "Look at the top four cards of your library. Put one of them into your hand and the rest
+ *    into your graveyard. You gain 3 life."
+ *
+ * Verifies the look-at-top-four / keep-one-to-hand / rest-to-graveyard pipeline and the
+ * +3 life gain.
+ */
+class CommuneWithEvilScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Commune with Evil") {
+
+            test("keep one of the top four in hand, the other three to graveyard, gain 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Commune with Evil")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {2}{B}
+                    // Four distinct named cards on top so we can identify what moved where.
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+                val handCountBefore = game.findCardsInHand(1, "Commune with Evil").size
+
+                val cast = game.castSpell(1, "Commune with Evil")
+                withClue("Casting Commune with Evil should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Pick one of the four to keep in hand.
+                val decision = game.state.pendingDecision
+                withClue("A selection decision should be presented for which card to keep") {
+                    (decision != null) shouldBe true
+                }
+                val kept = game.findCardsInLibrary(1, "Grizzly Bears").firstOrNull()
+                    ?: error("expected Grizzly Bears among the looked-at cards")
+                game.selectCards(listOf(kept))
+                game.resolveStack()
+
+                withClue("The chosen card ends up in hand") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("The other three looked-at cards go to the graveyard") {
+                    game.findCardsInGraveyard(1, "Hill Giant").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Plains").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Mountain").size shouldBe 1
+                }
+                withClue("Controller gains 3 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 3
+                }
+                // Sanity: the sorcery itself went to the graveyard, not back to hand.
+                handCountBefore shouldBe 1
+                game.findCardsInGraveyard(1, "Commune with Evil").size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulPossessionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulPossessionScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Vengeful Possession (DSK #162).
+ *
+ * Vengeful Possession — {2}{R} Sorcery
+ *   "Gain control of target creature until end of turn. Untap it. It gains haste until end of
+ *    turn. You may discard a card. If you do, draw a card."
+ *
+ * Verifies the threaten effect (control swap + untap) and the optional loot rider.
+ */
+class VengefulPossessionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vengeful Possession") {
+
+            test("gains control of the target, untaps it, and loots when you choose to discard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vengeful Possession")
+                    .withCardInHand(1, "Hill Giant") // discard fodder for the loot rider
+                    .withLandsOnBattlefield(1, "Mountain", 3) // {2}{R}
+                    // Tapped so we can confirm the untap clause works.
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true) // the creature to steal
+                    .withCardInLibrary(1, "Plains") // something to draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Vengeful Possession", targetId = bears)
+                withClue("Casting Vengeful Possession should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Player 1 now controls the stolen creature (via the until-end-of-turn control effect)") {
+                    game.state.projectedState.getController(bears) shouldBe game.player1Id
+                }
+                withClue("The stolen creature is untapped") {
+                    (game.state.getEntity(bears)?.get<TappedComponent>() != null) shouldBe false
+                }
+
+                // Optional loot: choose to discard a card.
+                game.answerYesNo(true)
+                // Discard Hill Giant (the discard fodder in hand).
+                val toDiscard = game.findCardsInHand(1, "Hill Giant")
+                if (toDiscard.isNotEmpty()) {
+                    game.selectCards(toDiscard)
+                }
+                game.resolveStack()
+
+                withClue("Discarded card is in the graveyard") {
+                    game.findCardsInGraveyard(1, "Hill Giant").size shouldBe 1
+                }
+                withClue("Drew a card after discarding") {
+                    game.findCardsInHand(1, "Plains").size shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards added (Duskmourn: House of Horror, DSK)

All three use existing engine primitives — pure authoring, no new SDK surface.

- **Balemurk Leech** `{1}{B}` Creature — Leech, 2/2. *Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, each opponent loses 1 life.* Modeled with two `triggeredAbility` blocks (`Triggers.entersBattlefield(Enchantment.youControl(), ANY)` + `Triggers.RoomFullyUnlocked`) sharing `Effects.LoseLife(1, EachOpponent)`, exactly like the existing Optimistic Scavenger.
- **Commune with Evil** `{2}{B}` Sorcery. Look at the top four, keep one in hand, rest to graveyard, gain 3 life — `Patterns.Library.lookAtTopAndKeep(4, 1)` + `Effects.GainLife(3)`.
- **Vengeful Possession** `{2}{R}` Sorcery. Threaten (gain control until EOT + untap + haste) with an optional discard-to-draw loot rider — `Effects.GainControl`/`Untap`/`GrantKeyword(HASTE)` + `MayEffect(IfYouDoEffect(discard → draw))`.

Each has a Kotest scenario test in `rules-engine`.

## Swaps / skips

Of the four originally assigned cards, three need engine features that do not yet exist, so per the task's "skip + swap to a pure-authoring DSK card" rule they were swapped out:

- **Innocuous Rat** — needs **Manifest Dread** (no effect/trigger/pattern exists).
- **Clammy Prowler** — needs an absolute *"can't be blocked"* grant effect (only the filtered/color `GrantCantBeBlockedExceptBy` exists).
- **Undead Sprinter** — needs a **conditional `MayCastFromGraveyard`** gate (the static ability has no condition field).

**Commune with Evil** and **Vengeful Possession** (both already DSK AUTOGEN) were added in their place to land 3 cards.

## mtgish-tooling changes

Taught the emitter the **Eerie** shape so these cards (and the already-implemented Optimistic Scavenger) reach AUTOGEN and render gameplay-equivalent to the hand-authored golden:

- `CardStructure.triggerSpecFor`: render `WhenAPlayerFullyUnlocksARoom` (You scope + bare Room subject) as `Triggers.RoomFullyUnlocked`; decline any other scope/constraint → SCAFFOLD (never widen).
- `Shells.keywordLines` / `Emitter`: stamp `keywords(Keyword.EERIE)` from the `"Eerie —"` ability-word oracle prefix — the IR carries no rule for the ability word, so the printed oracle text is the only signal.

The enchantment-enters trigger arm and `EachPlayerAction(Opponent, LoseLife)` action were already renderable, so the `Or` trigger union now completes whole.

## Verification

- `just coverage-verify DSK` → **GATE PASS** (0 gameplay-tree mismatch; was 2 before, both the EERIE keyword).
- `just coverage-verify POR` → **GATE PASS**, 158/158, **0 mismatch** (no regression).
- `EmitterGoldenTest`, `CardLintTest`, `CardDefinitionSnapshotTest` (re-blessed DSK golden), and all three scenario tests pass.
- `check-card-printing` confirms DSK is the canonical earliest printing for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)