### PR TITLE
Add 3 Secrets of Strixhaven spells + mtgish Paradigm emitter support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AdditiveEvolution.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AdditiveEvolution.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Additive Evolution
+ * {3}{G}{G}
+ * Enchantment
+ *
+ * When this enchantment enters, create a 0/0 green and blue Fractal creature token. Put three
+ * +1/+1 counters on it.
+ * At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. It
+ * gains vigilance until end of turn.
+ *
+ * The ETB composes the standard SOS Fractal recipe (Fractal Anomaly / Ambitious Augmenter): create
+ * the 0/0 green-and-blue Fractal (published to the [CREATED_TOKENS] pipeline collection), then put
+ * three +1/+1 counters on that just-created token via `PipelineTarget(CREATED_TOKENS, 0)`. The
+ * count is fixed (three), so a plain [Effects.AddCounters].
+ *
+ * The combat trigger uses [Triggers.BeginCombat] (already restricted to the controller's combat,
+ * "on your turn"): bind one target creature you control, add a +1/+1 counter to it, then grant it
+ * vigilance until end of turn — both effects reference the same bound target.
+ */
+val AdditiveEvolution = card("Additive Evolution") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create a 0/0 green and blue Fractal creature " +
+        "token. Put three +1/+1 counters on it.\n" +
+        "At the beginning of combat on your turn, put a +1/+1 counter on target creature you " +
+        "control. It gains vigilance until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN, Color.BLUE),
+            creatureTypes = setOf("Fractal"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+        ).then(
+            Effects.AddCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                3,
+                EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+            )
+        )
+        description = "When this enchantment enters, create a 0/0 green and blue Fractal creature " +
+            "token. Put three +1/+1 counters on it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, creature))
+        description = "At the beginning of combat on your turn, put a +1/+1 counter on target " +
+            "creature you control. It gains vigilance until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Josiah \"Jo\" Cameron"
+        flavorText = "\"Numbers have no limits. Why should nature?\"\n—Emil, Quandrix fourth-year"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b44ec684-d558-45eb-bcd6-8119428634c2.jpg?1775937943"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RestorationSeminar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RestorationSeminar.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Restoration Seminar
+ * {5}{W}{W}
+ * Sorcery — Lesson
+ *
+ * Return target nonland permanent card from your graveyard to the battlefield.
+ * Paradigm (Then exile this spell. After you first resolve a spell with this name, you may cast a
+ * copy of it from exile without paying its mana cost at the beginning of each of your first main
+ * phases.)
+ *
+ * Reanimation that returns one *nonland* permanent card from the caster's graveyard to the
+ * battlefield: bind one nonland-permanent card you own in your graveyard, then move it from the
+ * graveyard to the battlefield via [Effects.Move] — the canonical reanimation shape used across the
+ * corpus (Doomed Necromancer, Unburial Rites), so it matches the mtgish emitter's output.
+ *
+ * `paradigm()` is the SOS ability word — it tags the spell so the engine exiles it on resolution
+ * and synthesizes the recurring "at the beginning of each of your first main phases, you may cast a
+ * free copy from exile" ability ([com.wingedsheep.sdk.scripting.Paradigm.recastAbility]). Each
+ * recast copy picks its own target at resolution against the then-current graveyard, so the
+ * recurrence reanimates whatever permanent card is available that turn.
+ */
+val RestorationSeminar = card("Restoration Seminar") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery — Lesson"
+    oracleText = "Return target nonland permanent card from your graveyard to the battlefield.\n" +
+        "Paradigm (Then exile this spell. After you first resolve a spell with this name, you may " +
+        "cast a copy of it from exile without paying its mana cost at the beginning of each of " +
+        "your first main phases.)"
+
+    spell {
+        val returnTarget = target(
+            "target nonland permanent card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Move(returnTarget, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+        paradigm()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "30"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ebc4ecf-2fa2-4ab8-afde-3b91cf5eadb6.jpg?1775937123"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/VisionarysDance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/VisionarysDance.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Visionary's Dance
+ * {5}{U}{R}
+ * Sorcery
+ *
+ * Create two 3/3 blue and red Elemental creature tokens with flying.
+ * {2}, Discard this card: Look at the top two cards of your library. Put one of them into your
+ * hand and the other into your graveyard.
+ *
+ * The main spell creates two 3/3 blue-and-red flying Elementals. The card also carries a
+ * hand-activated ability (CR 113.6 — usable while it sits in hand): pay {2} and discard it to
+ * look at the top two and keep one in hand, the other to the graveyard — the standard
+ * [Patterns.Library.lookAtTopAndKeep] recipe whose default destinations (kept → hand, rest →
+ * graveyard) match the oracle text exactly.
+ */
+val VisionarysDance = card("Visionary's Dance") {
+    manaCost = "{5}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Sorcery"
+    oracleText = "Create two 3/3 blue and red Elemental creature tokens with flying.\n" +
+        "{2}, Discard this card: Look at the top two cards of your library. Put one of them into " +
+        "your hand and the other into your graveyard."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.BLUE, Color.RED),
+            creatureTypes = setOf("Elemental"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/5/7/57b98846-85e3-47c7-a903-29953d0b0e8a.jpg?1775828504"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.DiscardSelf)
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = DynamicAmount.Fixed(2),
+            keepCount = DynamicAmount.Fixed(1)
+        )
+        activateFromZone = Zone.HAND
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Josiah \"Jo\" Cameron"
+        flavorText = "Choreography powers the spell, but improvisation shapes it."
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/846a0e79-a530-429e-8f7f-4b87f1b0156e.jpg?1776000377"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -57,6 +57,101 @@
     ]
 }
 
+// Additive Evolution
+{
+    "name": "Additive Evolution",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create a 0/0 green and blue Fractal creature token. Put three +1/+1 counters on it.\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. It gains vigilance until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "GREEN",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Fractal"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this enchantment enters, create a 0/0 green and blue Fractal creature token. Put three +1/+1 counters on it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. It gains vigilance until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Josiah \"Jo\" Cameron",
+        "flavorText": "\"Numbers have no limits. Why should nature?\"\n—Emil, Quandrix fourth-year",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b44ec684-d558-45eb-bcd6-8119428634c2.jpg?1775937943"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Adventurous Eater
 {
     "name": "Adventurous Eater",
@@ -9167,6 +9262,49 @@
     ]
 }
 
+// Restoration Seminar
+{
+    "name": "Restoration Seminar",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Return target nonland permanent card from your graveyard to the battlefield.\nParadigm (Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.)",
+    "keywords": [
+        "PARADIGM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent card from your graveyard"
+            },
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target nonland permanent card from your graveyard"
+            }
+        ],
+        "selfExileOnResolve": true,
+        "paradigm": true
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "MYTHIC",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ebc4ecf-2fa2-4ab8-afde-3b91cf5eadb6.jpg?1775937123"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Rubble Rouser
 {
     "name": "Rubble Rouser",
@@ -12860,6 +12998,112 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Visionary's Dance
+{
+    "name": "Visionary's Dance",
+    "manaCost": "{5}{U}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 3/3 blue and red Elemental creature tokens with flying.\n{2}, Discard this card: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 3,
+            "toughness": 3,
+            "colors": [
+                "BLUE",
+                "RED"
+            ],
+            "creatureTypes": [
+                "Elemental"
+            ],
+            "keywords": [
+                "FLYING"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/5/7/57b98846-85e3-47c7-a903-29953d0b0e8a.jpg?1775828504"
+        },
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "activateFromZone": "Hand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Josiah \"Jo\" Cameron",
+        "flavorText": "Choreography powers the spell, but improvisation shapes it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/846a0e79-a530-429e-8f7f-4b87f1b0156e.jpg?1776000377"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -45,6 +45,17 @@ internal fun BridgeBuilder.keywords() {
         "keyword: increment() -> Keyword.INCREMENT + 'whenever you cast a spell, if mana spent > power or toughness, +1/+1 counter' trigger",
         composes = listOf("AddCounters"),
     )
+    // Paradigm (Secrets of Strixhaven) — a spell ability word lowered to the `paradigm()` CardBuilder
+    // helper: it implies self-exile on resolution plus a synthesized "at the beginning of each of your
+    // first main phases, you may cast a free copy from exile" recast trigger (Paradigm.recastAbility).
+    // `composed`, not a bare effect: it has no standalone Effect, and the recast recurrence is engine-
+    // synthesized from the exile marker. The emitter strips the trailing `Paradigm(ThisSpell)` action
+    // off the spell's ActionList and emits `paradigm()` in the spell block (see CardStructure.spellBlock).
+    composed(
+        "Paradigm",
+        "spell ability word: paradigm() -> self-exile on resolve + synthesized first-main-phase free-recast trigger",
+        composes = listOf("ExileSpell"),
+    )
     // Ward (CR 702.21) — a PARAMETERIZED keyword ability: the cost rides in the rule's args
     // (`Ward—Discard a card`, `Ward {2}`, `Ward—Pay N life`, `Ward—Sacrifice <filter>`). Like Saddle,
     // it must be `supported`, not `keyword`: a bare `keywords(Keyword.WARD)` would drop the cost. The

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1314,8 +1314,20 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
     balanceEffect(card)?.let { return it }
     conditionalSpell(card)?.let { return it }
 
-    val (targets, actions) = extractEnvelope(card["Rules"])
-    if (actions == null) return null
+    val (targets, rawActions) = extractEnvelope(card["Rules"])
+    if (rawActions == null) return null
+
+    // Paradigm (Secrets of Strixhaven) lowers to the spell-envelope ability word `paradigm()`, not an
+    // effect: the IR carries a trailing `Paradigm(ThisSpell)` action after the spell's real body. Strip
+    // it here and emit `paradigm()` in the spell block; the remaining actions render through the normal
+    // body path, so every body the emitter can already render automatically gains Paradigm support. Only
+    // the trailing-action form (`Paradigm` as the last action of the spell's ActionList, scoped to
+    // ThisSpell) is recognized — anything else declines to SCAFFOLD via the normal path.
+    val paradigm = rawActions.lastOrNull()?.let { it.strField("_Action") == "Paradigm" && jsonContains(it, "_Spell", "ThisSpell") } == true
+    val actions = if (paradigm) rawActions.dropLast(1) else rawActions
+    if (actions.isEmpty()) return null
+    fun withParadigm(stmts: List<Stmt>): List<Stmt> =
+        if (paradigm) listOf<Stmt>(RawLine("        paradigm()")) + stmts else stmts
 
     // MULTI-target spell (two or more chosen targets, e.g. Skulduggery's "target creature you control …
     // and target creature an opponent controls …"). Render one `target("tN", …)` local per chosen
@@ -1335,7 +1347,7 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
             restrictions.forEach { stmts.add(RawLine(it)) }
             targetStmts.forEach { stmts.add(it) }
             stmts.add(Assign("effect", edsl))
-            return listOf(Sub(Block("spell", stmts)))
+            return listOf(Sub(Block("spell", withParadigm(stmts))))
         } finally {
             targetVars = emptyList()
             targetRefVars = emptyMap()
@@ -1350,7 +1362,7 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
     restrictions.forEach { stmts.add(RawLine(it)) }
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))
-    return listOf(Sub(Block("spell", stmts)))
+    return listOf(Sub(Block("spell", withParadigm(stmts))))
 }
 
 private fun spellOf(effect: Dsl): List<Stmt> = listOf(Sub(Block("spell", listOf(Assign("effect", effect)))))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdditiveEvolutionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdditiveEvolutionScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Additive Evolution (Secrets of Strixhaven #139).
+ *
+ * Additive Evolution ({3}{G}{G} Enchantment):
+ *   When this enchantment enters, create a 0/0 green and blue Fractal creature token. Put three
+ *     +1/+1 counters on it.
+ *   At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.
+ *     It gains vigilance until end of turn.
+ *
+ * Exercises both triggers: the ETB Fractal-with-three-counters recipe, and the begin-combat
+ * counter + vigilance grant on a chosen creature you control.
+ */
+class AdditiveEvolutionScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Additive Evolution") {
+
+            test("ETB creates a 0/0 Fractal token with three +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Additive Evolution")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Additive Evolution").error shouldBe null
+                game.resolveStack()
+
+                val fractal = game.findPermanent("Fractal Token")
+                withClue("A Fractal token should have been created by the ETB") {
+                    (fractal != null) shouldBe true
+                }
+                withClue("The Fractal enters as a 0/0 with three +1/+1 counters (= 3/3)") {
+                    plusOneCounters(game, fractal!!) shouldBe 3
+                }
+            }
+
+            test("begin-combat trigger puts a +1/+1 counter on a chosen creature and grants vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Additive Evolution")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears has no vigilance before combat") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+
+                // Advance to the begin-of-combat step; the trigger goes on the stack and pauses
+                // for target selection.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears gains a +1/+1 counter from the begin-combat trigger") {
+                    plusOneCounters(game, bears) shouldBe 1
+                }
+                withClue("Grizzly Bears gains vigilance until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RestorationSeminarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RestorationSeminarScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.ParadigmComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Restoration Seminar (Secrets of Strixhaven #30) — {5}{W}{W} Sorcery — Lesson.
+ *
+ * "Return target nonland permanent card from your graveyard to the battlefield.
+ *  Paradigm (...)"
+ *
+ * Confirms the reanimation returns the targeted nonland permanent card to the battlefield, and
+ * that — because of Paradigm — the resolved spell exiles itself (carrying the [ParadigmComponent]
+ * marker) instead of going to the graveyard, seeding the recurring free-recast ability.
+ */
+class RestorationSeminarScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Restoration Seminar") {
+
+            test("returns a nonland permanent card from graveyard and exiles itself via Paradigm") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Restoration Seminar")
+                    .withCardInGraveyard(1, "Hill Giant") // 3/3 nonland permanent card
+                    .withLandsOnBattlefield(1, "Plains", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(1, "Restoration Seminar", 1, "Hill Giant")
+                withClue("Casting Restoration Seminar should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant is returned to the battlefield") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+
+                withClue("Restoration Seminar is NOT in the graveyard (Paradigm exiles it)") {
+                    game.isInGraveyard(1, "Restoration Seminar") shouldBe false
+                }
+
+                // The resolved Paradigm spell lands in exile carrying the ParadigmComponent marker,
+                // which seeds the recurring free-recast ability.
+                val player1Id = game.state.turnOrder.first()
+                val exiled = game.state.getZone(player1Id, Zone.EXILE)
+                    .mapNotNull { game.state.getEntity(it) }
+                    .filter { it.get<CardComponent>()?.name == "Restoration Seminar" }
+                withClue("Restoration Seminar is in exile with the Paradigm marker") {
+                    exiled.any { it.get<ParadigmComponent>() != null } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VisionarysDanceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VisionarysDanceScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Visionary's Dance (Secrets of Strixhaven #242) — {5}{U}{R} Sorcery.
+ *
+ * "Create two 3/3 blue and red Elemental creature tokens with flying.
+ *  {2}, Discard this card: Look at the top two cards of your library. Put one of them into your
+ *  hand and the other into your graveyard."
+ *
+ * Exercises the main spell (two flying Elemental tokens) and the hand-activated dig ability
+ * (pay {2}, discard the card; keep one of the top two in hand, the other to the graveyard).
+ */
+class VisionarysDanceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Visionary's Dance") {
+
+            test("the spell creates two 3/3 flying Elemental tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Visionary's Dance")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Visionary's Dance").error shouldBe null
+                game.resolveStack()
+
+                withClue("Two Elemental tokens should have been created") {
+                    game.findPermanents("Elemental Token").size shouldBe 2
+                }
+            }
+
+            test("the hand ability digs two, keeping one in hand and milling the other") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Visionary's Dance")
+                    .withCardInLibrary(1, "Mountain")  // top card
+                    .withCardInLibrary(1, "Island")    // second card
+                    .withCardInLibrary(1, "Forest")    // remains in library
+                    .withLandsOnBattlefield(1, "Island", 2) // pays {2}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val danceId = game.state.getZone(game.player1Id, Zone.HAND)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == "Visionary's Dance" }
+                val abilityId = cardRegistry.getCard("Visionary's Dance")!!.script.activatedAbilities[0].id
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = danceId,
+                        abilityId = abilityId,
+                        targets = emptyList()
+                    )
+                )
+                withClue("Activating the hand ability should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+
+                // Resolution offers a selection: choose which of the top two to keep. Keep the
+                // top card (Mountain) in hand; the other (Island) goes to the graveyard.
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val mountain = game.state.getLibrary(game.player1Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Mountain"
+                    }
+                    game.selectCards(listOf(mountain))
+                    game.resolveStack()
+                }
+
+                withClue("Visionary's Dance is discarded to the graveyard (its activation cost)") {
+                    game.isInGraveyard(1, "Visionary's Dance") shouldBe true
+                }
+                withClue("Exactly one of the looked-at cards ends up in the graveyard with the spell") {
+                    // Spell + the un-kept card = 2 cards in the graveyard.
+                    game.graveyardSize(1) shouldBe 2
+                }
+                withClue("Exactly one looked-at card is kept in hand") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards implemented (Secrets of Strixhaven)

All three use existing SDK building blocks — no new engine surface — and each has a passing rules-engine scenario test.

- **Additive Evolution** `{3}{G}{G}` Enchantment — When it enters, create a 0/0 green-and-blue Fractal token and put three +1/+1 counters on it. At the beginning of combat on your turn, put a +1/+1 counter on target creature you control and it gains vigilance until end of turn. (Composes the SOS Fractal recipe + `Triggers.BeginCombat` + `Effects.GrantKeyword`.)
- **Restoration Seminar** `{5}{W}{W}` Sorcery — Lesson — Return target nonland permanent card from your graveyard to the battlefield. Paradigm. (Reanimate via `Effects.Move(...BATTLEFIELD, fromZone = GRAVEYARD)` — the corpus-canonical reanimation shape — plus `paradigm()`.)
- **Visionary's Dance** `{5}{U}{R}` Sorcery — Create two 3/3 blue-and-red flying Elemental tokens. `{2}, Discard this card`: look at the top two, keep one in hand, put the other in the graveyard. (Hand-activated ability + `Patterns.Library.lookAtTopAndKeep`.)

## mtgish-tooling changes

The probe earlier scaffolded any Paradigm card because the emitter had no Paradigm rendering.

- **Emitter** (`CardStructure.spellBlock`): generically strips a trailing `Paradigm(ThisSpell)` action off a spell's `ActionList` and emits `paradigm()` in the spell block. This unlocks Paradigm rendering for *every* spell body the emitter can already render, rather than a one-off recognizer.
- **Capability bridge** (`Keywords.kt`): added a `composed("Paradigm", … composes = ExileSpell)` entry so the probe scores Paradigm cards as coverable.
- **Result:** Additive Evolution, Restoration Seminar, and Visionary's Dance now all render **AUTO** (complete) via the emitter. The other Paradigm cards (Decorum Dissertation, Germination Practicum, Echocasting Symposium, Improvisation Capstone) remain SCAFFOLD — but now only because of their unrenderable *bodies* (e.g. `PutNumberCountersOfTypeOnEachPermanent`, multi-target), not Paradigm itself. Correct decline-on-body, not decline-on-Paradigm.

## Verification

- **POR deep gate** (`just coverage-verify POR`): 158/158 emitted & verified, **0 mismatches** (unchanged).
- **EmitterGoldenTest**: all committed fixture sets (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE) still match card-for-card.
- **SOS gate**: my three cards are AUTO and gameplay-equivalent — none appear in the remaining pre-existing SOS mismatch list (SOS was never a 0-mismatch gated set).
- **Card snapshot** (`CardDefinitionSnapshotTest`): re-blessed; diff adds only the three new cards.
- `just build` green; CardLintTest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)