### PR TITLE
Add DSK W/U cards: Exorcise, Don't Make a Sound, Spectral Snatcher (+ mtgish emitter rider)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DontMakeASound.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DontMakeASound.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Don't Make a Sound
+ * {1}{U}
+ * Instant
+ *
+ * Counter target spell unless its controller pays {2}. If they do, surveil 2.
+ *
+ * The surveil is an `onPaid` rider on [Effects.CounterUnlessPays]: it happens only when
+ * the spell's controller chooses to pay {2} (and the spell therefore resolves), not when
+ * the spell is countered.
+ */
+val DontMakeASound = card("Don't Make a Sound") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell unless its controller pays {2}. If they do, surveil 2. " +
+        "(Look at the top two cards of your library, then put any number of them into your " +
+        "graveyard and the rest on top of your library in any order.)"
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.CounterUnlessPays("{2}", onPaid = Patterns.Library.surveil(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Zezhou Chen"
+        flavorText = "Jace kept his mouth shut, but he couldn't shake the feeling that the strange creatures could hear the screaming in his mind."
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg?1726286037"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Exorcise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Exorcise.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Exorcise
+ * {1}{W}
+ * Sorcery
+ *
+ * Exile target artifact, enchantment, or creature with power 4 or greater.
+ *
+ * The "power 4 or greater" clause binds only to the creature branch (it's "artifact,
+ * enchantment, or [creature with power 4+]"), so an artifact or enchantment with any
+ * power is a legal target — modelled as a three-way OR where only the creature branch
+ * carries the [powerAtLeast] predicate.
+ */
+val Exorcise = card("Exorcise") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target artifact, enchantment, or creature with power 4 or greater."
+
+    spell {
+        val permanent = target(
+            "target artifact, enchantment, or creature with power 4 or greater",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.Creature.powerAtLeast(4)
+                )
+            )
+        )
+        effect = Effects.Exile(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Dominik Mayer"
+        flavorText = "\"Strictly speaking, you can't kill what's already dead, but trapping and disintegrating it is pretty close.\"\n—Garden, survivor technologist"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg?1726285887"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SpectralSnatcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SpectralSnatcher.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Spectral Snatcher
+ * {4}{B}{B}
+ * Creature — Spirit
+ * 6/5
+ *
+ * Ward—Discard a card. (Whenever this creature becomes the target of a spell or ability an
+ * opponent controls, counter it unless that player discards a card.)
+ * Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it,
+ * put it into your hand, then shuffle.)
+ */
+val SpectralSnatcher = card("Spectral Snatcher") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 6
+    toughness = 5
+    oracleText = "Ward—Discard a card. (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player discards a card.)\n" +
+        "Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, " +
+        "put it into your hand, then shuffle.)"
+
+    keywordAbility(KeywordAbility.wardDiscard())
+    keywordAbility(KeywordAbility.typecycling("Swamp", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Domenico Cava"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg?1726286280"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -852,6 +852,91 @@
     ]
 }
 
+// Don't Make a Sound
+{
+    "name": "Don't Make a Sound",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell unless its controller pays {2}. If they do, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "condition": {
+                "type": "CounterCondition.UnlessPaysMana",
+                "cost": "{2}",
+                "onPaid": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Zezhou Chen",
+        "flavorText": "Jace kept his mouth shut, but he couldn't shake the feeling that the strange creatures could hear the screaming in his mind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg?1726286037"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Emerge from the Cocoon
 {
     "name": "Emerge from the Cocoon",
@@ -993,6 +1078,68 @@
         "artist": "Tyler Walpole",
         "flavorText": "Clad in the light of conviction and hope, Linette strode forth to face Duskmourn's terrors without fear.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd0e8a82-0201-483e-a976-5f29764b35a4.jpg?1726285881"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Exorcise
+{
+    "name": "Exorcise",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target artifact, enchantment, or creature with power 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target artifact, enchantment, or creature with power 4 or greater"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsArtifact",
+                                            "IsEnchantment"
+                                        ]
+                                    },
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "PowerAtLeast",
+                                                "min": 4
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target artifact, enchantment, or creature with power 4 or greater"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Dominik Mayer",
+        "flavorText": "\"Strictly speaking, you can't kill what's already dead, but trapping and disintegrating it is pretty close.\"\n—Garden, survivor technologist",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg?1726285887"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -3010,6 +3157,48 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Spectral Snatcher
+{
+    "name": "Spectral Snatcher",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Ward—Discard a card. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player discards a card.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": "WardCost.Discard"
+        },
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Swamp"
+                    }
+                ]
+            },
+            "displayPrefix": "Swampcycling"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Domenico Cava",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg?1726286280"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -155,6 +155,7 @@ internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): Dsl? =
 internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): Dsl? {
     echoEffect(actions)?.let { return it }
     counterUnlessPaysEffect(actions)?.let { return it }
+    counterUnlessPaysWithRiderEffect(actions)?.let { return it }
     mayCostReflexiveDamageEffect(actions)?.let { return it }
     erodeDestroyControllerFetchEffect(actions)?.let { return it }
     heatedArgumentExileRiderEffect(actions)?.let { return it }
@@ -1178,5 +1179,44 @@ internal fun EmitCtx.counterUnlessPaysEffect(actions: List<JsonObject>): Dsl? {
     return call(
         "CounterEffect",
         arg("condition", Lit("CounterCondition.UnlessPaysMana(ManaCost.parse(\"$cost\"))"))
+    )
+}
+
+/**
+ * `[PlayerMayCost(ControllerOfSpell, PayMana {N}),
+ *   IfElse(CostWasPaid, [<onPaid actions>], [CounterSpell(Ref_TargetSpell)])]`
+ * -> `CounterEffect(condition = CounterCondition.UnlessPaysMana(ManaCost.parse("{N}"), <onPaid>))`
+ *
+ * "Counter target spell unless its controller pays {N}. If they do, <onPaid>." (Don't Make a Sound:
+ * `<onPaid>` is `Surveil 2`; Divert Disaster: create a Lander). The else-branch must be exactly the
+ * `CounterSpell` of the same targeted spell — the negative side of "unless they pay" — so the whole
+ * `IfElse` collapses into the engine's `onPaid` rider rather than two separate forks. The then-branch
+ * (the rider) renders through the normal effect-list path; if it can't render whole, decline (-> SCAFFOLD).
+ * Only a *generic* mana cost is modeled (sibling of [counterUnlessPaysEffect]); anything else declines.
+ */
+internal fun EmitCtx.counterUnlessPaysWithRiderEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (a0, a1) = actions
+    if (a0.strField("_Action") != "PlayerMayCost" || a1.strField("_Action") != "IfElse") return null
+    // The payer must be the controller of the targeted spell.
+    if (!jsonContains(a0["args"], "_Player", "ControllerOfSpell")) return null
+    val ifArgs = a1["args"].asArr ?: return null
+    if (ifArgs.size != 3) return null
+    // The gate must be exactly CostWasPaid.
+    if (!jsonContains(ifArgs[0], "_Condition", "CostWasPaid")) return null
+    val thenActions = ifArgs[1].asArr?.filterIsInstance<JsonObject>() ?: return null
+    val elseActions = ifArgs[2].asArr?.filterIsInstance<JsonObject>() ?: return null
+    // The else-branch is the "they didn't pay" outcome: a lone CounterSpell of the targeted spell.
+    if (elseActions.size != 1 || elseActions[0].strField("_Action") != "CounterSpell") return null
+    if (!jsonContains(elseActions[0]["args"], "_Spell", "Ref_TargetSpell")) return null
+    // The then-branch is the "they paid" rider; render it whole or decline.
+    if (thenActions.isEmpty()) return null
+    val onPaid = renderEffectList(thenActions, null) ?: return null
+    val payMana = (a0["args"].asArr ?: return null).firstOrNull { it.strField("_Cost") == "PayMana" } ?: return null
+    val cost = renderMana(payMana.field("args"))
+    if (cost.isEmpty() || "{?}" in cost || "{X}" in cost) return null
+    return call(
+        "CounterEffect",
+        arg("condition", Lit("CounterCondition.UnlessPaysMana(ManaCost.parse(\"$cost\"), ${render(onPaid)})"))
     )
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DontMakeASoundScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DontMakeASoundScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.DontMakeASound
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Don't Make a Sound — {1}{U} Instant
+ * Counter target spell unless its controller pays {2}. If they do, surveil 2.
+ */
+class DontMakeASoundScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DontMakeASound)
+        return driver
+    }
+
+    test("counters the spell when its controller declines to pay {2}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val spell = driver.putCardInHand(me, "Don't Make a Sound")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpellWithTargets(me, spell, listOf(ChosenTarget.Spell(boltOnStack))).isSuccess shouldBe true
+
+        // Opponent could pay {2} but will decline.
+        driver.giveColorlessMana(opponent, 2)
+        driver.bothPass()
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        (driver.pendingDecision as YesNoDecision).playerId shouldBe opponent
+
+        driver.submitYesNo(opponent, false)
+        driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+    }
+
+    test("when the controller pays {2}, the spell resolves and the caster surveils 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val spell = driver.putCardInHand(me, "Don't Make a Sound")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpellWithTargets(me, spell, listOf(ChosenTarget.Spell(boltOnStack))).isSuccess shouldBe true
+
+        // Opponent pays {2}.
+        driver.giveColorlessMana(opponent, 2)
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(opponent, true)
+
+        // Paying triggers the caster's surveil 2 → pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        (driver.pendingDecision as SelectCardsDecision).playerId shouldBe me
+
+        // The bolt was NOT countered.
+        driver.getGraveyardCardNames(opponent) shouldNotContain "Lightning Bolt"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExorciseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExorciseScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.Exorcise
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exorcise — {1}{W} Sorcery
+ * Exile target artifact, enchantment, or creature with power 4 or greater.
+ *
+ * The power restriction binds only to the creature branch: any artifact/enchantment is a
+ * legal target regardless of power, but a creature must have power 4+.
+ */
+class ExorciseScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Exorcise)
+        return driver
+    }
+
+    test("exiles a creature with power 4 or greater") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Force of Nature is a 5/5 — power 4+.
+        val bigCreature = driver.putCreatureOnBattlefield(opponent, "Force of Nature")
+        val exorcise = driver.putCardInHand(me, "Exorcise")
+
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, exorcise, listOf(bigCreature)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        driver.getExileCardNames(opponent) shouldContain "Force of Nature"
+        driver.findPermanent(opponent, "Force of Nature") shouldBe null
+    }
+
+    test("exiles an enchantment regardless of power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val enchantment = driver.putPermanentOnBattlefield(opponent, "Test Enchantment")
+        val exorcise = driver.putCardInHand(me, "Exorcise")
+
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, exorcise, listOf(enchantment)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        driver.getExileCardNames(opponent) shouldContain "Test Enchantment"
+    }
+
+    test("cannot target a creature with power less than 4") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Savannah Lions is a 2/1 — not a legal target.
+        val smallCreature = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+        val exorcise = driver.putCardInHand(me, "Exorcise")
+
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, exorcise, listOf(smallCreature)).isSuccess shouldBe false
+        driver.getExileCardNames(opponent) shouldNotContain "Savannah Lions"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpectralSnatcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpectralSnatcherScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TypecycleCard
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.SpectralSnatcher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Spectral Snatcher — {4}{B}{B} Creature — Spirit 6/5
+ * Ward—Discard a card.
+ * Swampcycling {2}.
+ */
+class SpectralSnatcherScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SpectralSnatcher)
+        return driver
+    }
+
+    test("Ward—Discard a card prompts the targeting opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(opponent, "Spectral Snatcher")
+
+        // I target it with Lightning Bolt → ward triggers, asking me to pay (discard a card).
+        driver.putCardInHand(me, "Mountain") // a spare card to discard
+        driver.giveMana(me, Color.RED, 1)
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        val snatcher = driver.findPermanent(opponent, "Spectral Snatcher")!!
+        driver.castSpellWithTargets(me, bolt, listOf(ChosenTarget.Permanent(snatcher)))
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        (driver.pendingDecision as YesNoDecision).playerId shouldBe me
+    }
+
+    test("Swampcycling {2} discards the card and searches for a Swamp") {
+        val driver = createDriver()
+        // Mountain deck so the lone Swamp on top is the unambiguous search target.
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val snatcher = driver.putCardInHand(me, "Spectral Snatcher")
+        val swamp = driver.putCardOnTopOfLibrary(me, "Swamp")
+        driver.giveColorlessMana(me, 2)
+
+        val result = driver.submit(TypecycleCard(playerId = me, cardId = snatcher))
+        (result.isSuccess || result.isPaused).shouldBeTrue()
+
+        driver.getGraveyardCardNames(me) shouldContain "Spectral Snatcher"
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldContain swamp
+
+        driver.submitDecision(me, CardsSelectedResponse(decision.id, listOf(swamp)))
+        driver.findCardInHand(me, "Swamp") shouldBe swamp
+    }
+})


### PR DESCRIPTION
## Cards added (Duskmourn: House of Horror)

| Card | Cost | Implementation | mtgish tier |
|------|------|----------------|-------------|
| **Exorcise** | {1}{W} Sorcery | Exile target artifact, enchantment, or creature with power 4+. Three-arm OR where only the creature branch carries `powerAtLeast(4)` (the power clause binds to "creature" alone). | SCAFFOLD (by design) |
| **Don't Make a Sound** | {1}{U} Instant | Counter target spell unless its controller pays {2}; if they do, surveil 2 — via `CounterUnlessPays(onPaid = surveil 2)`. | **AUTO** (newly promoted) |
| **Spectral Snatcher** | {4}{B}{B} 6/5 Spirit | Ward—Discard a card + Swampcycling {2}, both via existing keyword facades. | AUTO (already) |

Each card has a passing `rules-engine` scenario test (7 tests total, all green). The DSK card-definition snapshot golden was reblessed (only the three new cards added — no other card moved).

## Card skipped — Creeping Peeper (true capability gap)

Creeping Peeper's mana ability is *"{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up."* Faithfully modeling it needs a new `ManaRestriction` variant that ties mana spending to two special actions — **unlocking a door** (Rooms) and **turning a permanent face up** — in addition to enchantment spells, plus engine payment-path matching for those actions. That is `add-feature` engine/SDK work, not single-card authoring. A lossy approximation (enchantment-spells-only, or `AnySpend`) would either wrongly block the legal door/face-up spends or wrongly allow spending the mana on anything, so per the project's no-shortcuts rule the card is skipped and flagged here.

## mtgish-tooling change (fix the emitter, not the cards)

Added the emitter recognizer `counterUnlessPaysWithRiderEffect` (sibling of the existing `counterUnlessPaysEffect`). It recognises the IR shape

```
[PlayerMayCost(ControllerOfSpell, PayMana {N}),
 IfElse(CostWasPaid, [<rider actions>], [CounterSpell(Ref_TargetSpell)])]
```

and collapses it to `CounterEffect(condition = CounterCondition.UnlessPaysMana(ManaCost.parse("{N}"), <rider>))`. The rider renders through the normal effect-list path, so it promotes **Don't Make a Sound** SCAFFOLD → AUTO and generalises to any "counter unless pay {N}; if they do, <renderable rider>" card. When the rider can't render whole, it declines → SCAFFOLD (verified: **Divert Disaster** stays SCAFFOLD because its Lander-token rider doesn't render — no false promotion).

**Exorcise stays SCAFFOLD intentionally.** The mtgish IR encodes its filter as `And[Or[Artifact, Enchantment, Creature], PowerIs >= 4]` — i.e. power-4+ applied to *all three* types — which contradicts the oracle grammar (power binds to "creature" only; artifacts/enchantments have no power and would never match). Rendering that IR would emit a confidently-wrong filter, so the emitter correctly declines.

## Verification

- ✅ 7 scenario tests pass (`*ExorciseScenarioTest`, `*DontMakeASoundScenarioTest`, `*SpectralSnatcherScenarioTest`)
- ✅ `:mtg-sets:test` green (CardDefinitionSnapshotTest + CardLintTest)
- ✅ `:rules-engine:test` green (full suite)
- ✅ `EmitterGoldenTest` green for all vendored sets (POR, ONS, TMP, CHK, RAV, ISD, INR, 10E, EOE) — **no golden drift** from the emitter change
- ✅ `coverage-verify POR` = **GATE PASS, 0 mismatch (158/158)** — critical regression gate holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)