### PR TITLE
SOS batch 1: Quandrix Charm, Lumaret's Favor, Dina's Guidance, Run Behind

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/DinasGuidance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/DinasGuidance.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dina's Guidance — Secrets of Strixhaven #184
+ * {1}{B}{G} · Instant
+ *
+ * Search your library for a creature card, reveal it, put it into your hand or graveyard, then
+ * shuffle.
+ *
+ * A search tutor whose found card lands in a *player-chosen* zone (hand or graveyard). Modeled as
+ * an atomic gather → choose → reveal → split-move pipeline:
+ *   1. gather the creature cards in your library,
+ *   2. `chooseUpTo(1)` — the search itself (a search may always fail to find, CR 701.19c),
+ *   3. reveal the found card,
+ *   4. a binary split over the found card — selecting it sends it to your **hand**, leaving it
+ *      sends it to your **graveyard** (the "hand or graveyard" choice, with the card already
+ *      revealed so the decision is made after seeing it),
+ *   5. shuffle.
+ * No new SDK surface: the zone choice is expressed with the existing split-selection primitive.
+ */
+val DinasGuidance = card("Dina's Guidance") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Search your library for a creature card, reveal it, put it into your hand or " +
+        "graveyard, then shuffle."
+
+    spell {
+        effect = Effects.Pipeline {
+            val pool = gather(
+                CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Creature)
+            )
+            val found = chooseUpTo(
+                1,
+                from = pool,
+                prompt = "Search your library for a creature card",
+            )
+            reveal(found)
+            val placed = chooseUpToSplit(
+                1,
+                from = found,
+                prompt = "Put the creature card into your hand or graveyard",
+                selectedLabel = "Put into your hand",
+                remainderLabel = "Put into your graveyard",
+            )
+            move(placed.selected, CardDestination.ToZone(Zone.HAND))
+            move(placed.remainder, CardDestination.ToZone(Zone.GRAVEYARD))
+            run(ShuffleLibraryEffect())
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "184"
+        artist = "Manuel Castañón"
+        flavorText = "\"This last step is very important. You'll need to know if the friend you're searching for is alive or dead.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/775c1e50-08a4-413f-ab0f-f1c2a79cfe94.jpg?1775938273"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LumaretsFavor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/LumaretsFavor.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lumaret's Favor — Secrets of Strixhaven #153
+ * {1}{G} · Instant
+ *
+ * Infusion — When you cast this spell, copy it if you gained life this turn. You may choose new
+ * targets for the copy.
+ * Target creature gets +2/+4 until end of turn.
+ *
+ * Infusion here is an intervening-"if" cast trigger (CR 603.4) — the copy-spell sibling of
+ * Social Snub, but the copy is **mandatory** (not "you may") and gated on the Infusion condition
+ * `Conditions.YouGainedLifeThisTurn`. `Triggers.WhenYouCastThisSpell()` fires from the stack while
+ * the spell is still on it; `Effects.CopyTargetSpell(TriggeringEntity)` copies the triggering spell
+ * and offers new targets for the copy by default (a copy isn't cast, CR 707.10, so it doesn't
+ * re-trigger Infusion). The main spell is the plain `Effects.ModifyStats(2, 4, …)` end-of-turn pump.
+ */
+val LumaretsFavor = card("Lumaret's Favor") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Infusion — When you cast this spell, copy it if you gained life this turn. " +
+        "You may choose new targets for the copy.\n" +
+        "Target creature gets +2/+4 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        triggerCondition = Conditions.YouGainedLifeThisTurn
+        effect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)
+        description = "Infusion — When you cast this spell, copy it if you gained life this turn. " +
+            "You may choose new targets for the copy."
+    }
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 4, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "153"
+        artist = "Mariah Tekulve"
+        flavorText = "Though the lumarets were ignored by the other Witherbloom students, it was clear to Lluwen they were much more complex than they seemed."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5e7c856-8b71-44e6-8998-0b0b3ff0ef99.jpg?1775938045"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuandrixCharm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuandrixCharm.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quandrix Charm
+ * {G}{U}
+ * Instant
+ * Choose one —
+ * • Counter target spell unless its controller pays {2}.
+ * • Destroy target enchantment.
+ * • Target creature has base power and toughness 5/5 until end of turn.
+ *
+ * The standard `modal(chooseCount = 1)` charm shape (sibling of Witherbloom / Prismari).
+ * Mode 1 is the Mana Leak idiom (`Effects.CounterUnlessPays("{2}")`), mode 2 a flat destroy on a
+ * target enchantment, mode 3 sets a creature's base power and toughness to 5/5 until end of turn
+ * (`Effects.SetBasePowerAndToughness`, Layer 7b set value).
+ */
+val QuandrixCharm = card("Quandrix Charm") {
+    manaCost = "{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Counter target spell unless its controller pays {2}.\n" +
+        "• Destroy target enchantment.\n" +
+        "• Target creature has base power and toughness 5/5 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Counter target spell unless its controller pays {2}") {
+                target = Targets.Spell
+                effect = Effects.CounterUnlessPays("{2}")
+            }
+            mode("Destroy target enchantment") {
+                val t = target("target enchantment", Targets.Enchantment)
+                effect = Effects.Destroy(t)
+            }
+            mode("Target creature has base power and toughness 5/5 until end of turn") {
+                val t = target("target creature", Targets.Creature)
+                effect = Effects.SetBasePowerAndToughness(5, 5, t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Matheus Graef"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/318486e0-f255-40f5-8150-dc272eec9d7d.jpg?1775938509"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RunBehind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RunBehind.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+
+/**
+ * Run Behind — Secrets of Strixhaven #66
+ * {3}{U} · Instant
+ *
+ * This spell costs {1} less to cast if it targets an attacking creature.
+ * Target creature's owner puts it on their choice of the top or bottom of their library.
+ *
+ * The cost-reduction-when-targeting sibling of Dire Downdraft: a `ModifySpellCost` static
+ * (`CostReductionSource.FixedIfAnyTargetMatches`, generic-only) gated on the chosen target being
+ * an attacking creature (`StatePredicate.IsAttacking`), plus the existing
+ * `Effects.PutOnTopOrBottomOfLibrary` bounce where the *owner* chooses top or bottom.
+ */
+val RunBehind = card("Run Behind") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast if it targets an attacking creature.\n" +
+        "Target creature's owner puts it on their choice of the top or bottom of their library."
+
+    spell {
+        val creature = target("target creature to put on top or bottom of library", Targets.Creature)
+        effect = Effects.PutOnTopOrBottomOfLibrary(creature)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 1,
+                    filter = GameObjectFilter.Creature.copy(
+                        statePredicates = listOf(StatePredicate.IsAttacking),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Nereida"
+        flavorText = "The skycoach waits for no one."
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40ecc34b-4cd0-4998-bbf4-7faa6fd3d7e0.jpg?1775937369"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -2233,6 +2233,91 @@
     ]
 }
 
+// Dina's Guidance
+{
+    "name": "Dina's Guidance",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Search your library for a creature card, reveal it, put it into your hand or graveyard, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "creature"
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "gathered0",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "selected1",
+                    "prompt": "Search your library for a creature card"
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "selected1"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "selected1",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "selected3",
+                    "storeRemainder": "remainder3",
+                    "prompt": "Put the creature card into your hand or graveyard",
+                    "selectedLabel": "Put into your hand",
+                    "remainderLabel": "Put into your graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "selected3",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "remainder3",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                },
+                "ShuffleLibrary"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "RARE",
+        "artist": "Manuel Castañón",
+        "flavorText": "\"This last step is very important. You'll need to know if the friend you're searching for is alive or dead.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/775c1e50-08a4-413f-ab0f-f1c2a79cfe94.jpg?1775938273"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Dissection Practice
 {
     "name": "Dissection Practice",
@@ -6161,6 +6246,74 @@
     ]
 }
 
+// Lumaret's Favor
+{
+    "name": "Lumaret's Favor",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Infusion — When you cast this spell, copy it if you gained life this turn. You may choose new targets for the copy.\nTarget creature gets +2/+4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "CopyTargetSpell",
+                    "target": "TriggeringEntity"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Infusion — When you cast this spell, copy it if you gained life this turn. You may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "UNCOMMON",
+        "artist": "Mariah Tekulve",
+        "flavorText": "Though the lumarets were ignored by the other Witherbloom students, it was clear to Lluwen they were much more complex than they seemed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5e7c856-8b71-44e6-8998-0b0b3ff0ef99.jpg?1775938045"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Maelstrom Artisan
 {
     "name": "Maelstrom Artisan",
@@ -8854,6 +9007,92 @@
     ]
 }
 
+// Quandrix Charm
+{
+    "name": "Quandrix Charm",
+    "manaCost": "{G}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Counter target spell unless its controller pays {2}.\n• Destroy target enchantment.\n• Target creature has base power and toughness 5/5 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Counter",
+                        "condition": {
+                            "type": "CounterCondition.UnlessPaysMana",
+                            "cost": "{2}"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target enchantment"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "SetBasePowerToughness",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        },
+                        "power": 5,
+                        "toughness": 5,
+                        "duration": "EndOfTurn"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Target creature has base power and toughness 5/5 until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Matheus Graef",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/318486e0-f255-40f5-8150-dc272eec9d7d.jpg?1775938509"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Quill-Blade Laureate
 {
     "name": "Quill-Blade Laureate",
@@ -9610,6 +9849,55 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Run Behind
+{
+    "name": "Run Behind",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast if it targets an attacking creature.\nTarget creature's owner puts it on their choice of the top or bottom of their library.",
+    "script": {
+        "spellEffect": {
+            "type": "PutOnLibraryPositionOfChoice",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature to put on top or bottom of library"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature to put on top or bottom of library"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 1,
+                        "filter": "creature attacking"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Nereida",
+        "flavorText": "The skycoach waits for no one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40ecc34b-4cd0-4998-bbf4-7faa6fd3d7e0.jpg?1775937369"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1441,7 +1441,16 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
     balanceEffect(card)?.let { return it }
     conditionalSpell(card)?.let { return it }
 
-    val (targets, rawActions) = extractEnvelope(card["Rules"])
+    // Extract the spell body from the `SpellActions` rule specifically, not the whole `card["Rules"]`
+    // tree. A card can carry a sibling cast-trigger rule (`FromStack { TriggerA … }` — Infusion copy on
+    // Lumaret's Favor, Social Snub) whose inner `ActionList`/`Targeted` envelope precedes the
+    // `SpellActions` rule; walking the whole tree would grab THAT envelope first and render the trigger's
+    // actions as the spell body (and scaffold on them), dropping the real spell. Scope to the
+    // SpellActions rule so the spell renders its own body.
+    val spellRule = (card["Rules"].asArr ?: JsonArray(emptyList()))
+        .filterIsInstance<JsonObject>().firstOrNull { it.strField("_Rule") == "SpellActions" }
+        ?: card  // fall back to the whole card for cards whose body isn't under a SpellActions rule
+    val (targets, rawActions) = extractEnvelope(spellRule)
     if (rawActions == null) return null
 
     // Paradigm (Secrets of Strixhaven) lowers to the spell-envelope ability word `paradigm()`, not an

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -161,6 +161,8 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     manaSculptCounterWizardManaEffect(actions)?.let { return it }
     discardHandThenDrawEffect(actions)?.let { return it }
     renderSpeechlessDiscardCountersEffect(actions)?.let { return it }
+    runBehindOwnerTopOrBottomEffect(actions, tvar)?.let { return it }
+    dinasGuidanceSearchHandOrGraveyardEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
     chooseAbilityGrantEffect(actions, tvar)?.let { return it }
     chooseTypeModifyStatsEffect(actions)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -205,6 +205,14 @@ object Emitter {
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
                 rname == "FromHand" -> block = ctx.fromHandBlock(rule)
+                // A `FromStack` rule wraps a cast trigger that fires while the spell is still on the
+                // stack (Infusion copy — Lumaret's Favor). Only the exact Infusion-copy shape renders;
+                // anything else (e.g. the "can't be countered" cast effect on Scragnoth/Bruna) declines
+                // and scaffolds with `FromStack` as the unrecovered structure reason, like before.
+                rname == "FromStack" -> {
+                    block = ctx.lumaretsFavorInfusionCopyBlock(rule)
+                    if (block == null) { gap(rname, addReason = rname)?.let { return it }; continue }
+                }
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
@@ -448,6 +448,88 @@ internal fun EmitCtx.wisdomOfAgesSpell(card: JsonObject): List<Stmt>? {
  * source dealing a fixed amount of damage to its chosen target — and only when the reflexive target
  * round-trips through [targetExpr]; anything else declines (-> SCAFFOLD).
  */
+/**
+ * Run Behind (bounce arm): `[PlayerAction(OwnerOfPermanent(Ref_TargetPermanent),
+ *                              ReturnPermanentToTopOrBottomOfLibrary(Ref_TargetPermanent))]`
+ * → `Effects.PutOnTopOrBottomOfLibrary(<bound target>)`.
+ *
+ * "Target creature's owner puts it on their choice of the top or bottom of their library." The engine's
+ * `PutOnTopOrBottomOfLibrary` already pauses for the *owner* to choose top or bottom, so the IR's
+ * `PlayerAction(OwnerOfPermanent, …)` wrapper (which the per-action `PlayerAction` handler can't render)
+ * collapses onto it exactly. Renders ONLY this shape — owner-of-target choosing top/bottom for the bound
+ * permanent; any other player scope, action, or extra sibling declines (-> SCAFFOLD). The "{1} less if it
+ * targets an attacking creature" half is a separate `CastEffect` rule the cost-reduction pass renders.
+ */
+internal fun EmitCtx.runBehindOwnerTopOrBottomEffect(actions: List<JsonObject>, tvar: String?): Dsl? {
+    val only = actions.singleOrNull() ?: return null
+    if (only.strField("_Action") != "PlayerAction") return null
+    // The acting player must be the OWNER of the targeted permanent ("that creature's owner puts it…").
+    if (!jsonContains(only, "_Player", "OwnerOfPermanent")) return null
+    if (!jsonContains(only, "_Permanent", "Ref_TargetPermanent")) return null
+    val inner = innerAction(only)
+        ?.takeIf { it.strField("_Action") == "ReturnPermanentToTopOrBottomOfLibrary" } ?: return null
+    if (!jsonContains(inner, "_Permanent", "Ref_TargetPermanent")) return null
+    val target = refTarget(inner["args"], tvar) ?: return null
+    return call("Effects.PutOnTopOrBottomOfLibrary", arg(Lit(target)))
+}
+
+/**
+ * Dina's Guidance: `[SearchLibrary(FindACardOfType(Creature), RevealFoundCards,
+ *                      ChooseAnAction[PutFoundCardsIntoHand, PutFoundCardsIntoGraveyard], Shuffle)]`
+ * → the gather → choose → reveal → split-move (hand vs graveyard) pipeline the hand-authored card uses.
+ *
+ * "Search your library for a creature card, reveal it, put it into your hand or graveyard, then shuffle."
+ * The destination is a *player choice* (`ChooseAnAction[…IntoHand, …IntoGraveyard]`), which the generic
+ * `Patterns.Library.searchLibrary` (single fixed `SearchDestination`) can't express — it explicitly
+ * declines `ChooseAnAction`. Rendered here as the exact `Effects.Pipeline { }` tree the hand-authored
+ * card produces: gather creatures, `chooseUpTo(1)` (the search may fail to find), reveal, a binary split
+ * over the found card (selecting → hand, leaving → graveyard), then shuffle. Renders ONLY this exact
+ * shape (find a creature card, reveal, choose hand-or-graveyard, shuffle); any other filter, extra search
+ * arm, or destination set declines (-> SCAFFOLD).
+ */
+internal fun EmitCtx.dinasGuidanceSearchHandOrGraveyardEffect(actions: List<JsonObject>): Dsl? {
+    val only = actions.singleOrNull() ?: return null
+    if (only.strField("_Action") != "SearchLibrary") return null
+    val searchArgs = only["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    // 1. Find a creature card.
+    val find = searchArgs.getOrNull(0)?.takeIf { it.strField("_SearchLibraryAction") == "FindACardOfType" } ?: return null
+    val findBlob = compact(find)
+    if (!("IsCardtype" in findBlob && "\"Creature\"" in findBlob)) return null
+    // 2. Reveal the found card.
+    if (searchArgs.getOrNull(1)?.strField("_SearchLibraryAction") != "RevealFoundCards") return null
+    // 3. Choose: put into hand OR graveyard.
+    val choose = searchArgs.getOrNull(2)?.takeIf { it.strField("_SearchLibraryAction") == "ChooseAnAction" } ?: return null
+    val chooseArms = choose["args"].asArr?.filterIsInstance<JsonObject>()?.map { it.strField("_SearchLibraryAction") } ?: return null
+    if (chooseArms.toSet() != setOf("PutFoundCardsIntoHand", "PutFoundCardsIntoGraveyard")) return null
+    // 4. Shuffle — and nothing else.
+    if (searchArgs.getOrNull(3)?.strField("_SearchLibraryAction") != "Shuffle") return null
+    if (searchArgs.size != 4) return null
+
+    return Raw(
+        "Effects.Pipeline {\n" +
+            "            val pool = gather(\n" +
+            "                CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Creature)\n" +
+            "            )\n" +
+            "            val found = chooseUpTo(\n" +
+            "                1,\n" +
+            "                from = pool,\n" +
+            "                prompt = \"Search your library for a creature card\",\n" +
+            "            )\n" +
+            "            reveal(found)\n" +
+            "            val placed = chooseUpToSplit(\n" +
+            "                1,\n" +
+            "                from = found,\n" +
+            "                prompt = \"Put the creature card into your hand or graveyard\",\n" +
+            "                selectedLabel = \"Put into your hand\",\n" +
+            "                remainderLabel = \"Put into your graveyard\",\n" +
+            "            )\n" +
+            "            move(placed.selected, CardDestination.ToZone(Zone.HAND))\n" +
+            "            move(placed.remainder, CardDestination.ToZone(Zone.GRAVEYARD))\n" +
+            "            run(ShuffleLibraryEffect())\n" +
+            "        }",
+    )
+}
+
 internal fun EmitCtx.mayCostReflexiveDamageEffect(actions: List<JsonObject>): Dsl? {
     if (actions.size != 2) return null
     val (mayCost, ifPaid) = actions
@@ -505,5 +587,71 @@ internal fun EmitCtx.mayCostReflexiveDamageEffect(actions: List<JsonObject>): Ds
             arg("damageSource", Lit("EffectTarget.Self")),
         )),
         arg("reflexiveTargetRequirements", call("listOf", arg(reflexiveTarget))),
+    )
+}
+
+/**
+ * Lumaret's Favor (Infusion copy) — a whole `FromStack` rule recognizer (returns the
+ * `triggeredAbility { … }` statement list):
+ *
+ * `FromStack { TriggerA[
+ *     WhenAPlayerCastsASpell(You, ThisSpell),
+ *     ActionList[ If(PlayerPassesFilter(You, GainedLifeThisTurn))
+ *                   [ CopySpellAndMayChooseNewTargets(Trigger_ThatSpell) ] ] ] }`
+ * →
+ * ```
+ * triggeredAbility {
+ *     trigger = Triggers.WhenYouCastThisSpell()
+ *     triggerCondition = Conditions.YouGainedLifeThisTurn
+ *     effect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)
+ * }
+ * ```
+ *
+ * "Infusion — When you cast this spell, copy it if you gained life this turn. You may choose new targets
+ * for the copy." The Infusion copy is the cast-trigger sibling of Social Snub, but **mandatory** (no "you
+ * may") and gated by the Infusion intervening-"if" (`GainedLifeThisTurn`). The IR wraps the cast trigger
+ * in a top-level `FromStack` rule — the per-rule dispatch has no `FromStack` handler, so this fuses the
+ * whole shape. Renders ONLY this exact shape (cast-self trigger, `GainedLifeThisTurn` gate, a lone
+ * mandatory copy-with-new-targets of the triggering spell); any other trigger, condition, or body
+ * declines (-> SCAFFOLD). The "Target creature gets +2/+4" body is the separate `SpellActions` rule.
+ */
+internal fun EmitCtx.lumaretsFavorInfusionCopyBlock(rule: JsonObject): List<Stmt>? {
+    if (rule.strField("_Rule") != "FromStack") return null
+    val trigger = rule["args"] as? JsonObject ?: return null
+    if (trigger.strField("_Rule") != "TriggerA") return null
+    val trigArgs = trigger["args"].asArr ?: return null
+
+    // 1. Trigger: WhenAPlayerCastsASpell(You, ThisSpell).
+    val trig = trigArgs.getOrNull(0) as? JsonObject ?: return null
+    if (trig.strField("_Trigger") != "WhenAPlayerCastsASpell") return null
+    val whenArgs = trig["args"].asArr ?: return null
+    if (!jsonContains(whenArgs.getOrNull(0), "_Player", "You")) return null
+    if (!jsonContains(whenArgs.getOrNull(1), "_Spell", "ThisSpell")) return null
+
+    // 2. Sole action: If(PlayerPassesFilter(You, GainedLifeThisTurn))[ CopySpellAndMayChooseNewTargets ].
+    val actionsNode = trigArgs.getOrNull(1) as? JsonObject ?: return null
+    val actions = actionsNode["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    val ifAction = actions.singleOrNull()?.takeIf { it.strField("_Action") == "If" } ?: return null
+    val ifArgs = ifAction["args"].asArr ?: return null
+    val cond = ifArgs.getOrNull(0) as? JsonObject ?: return null
+    // "if you gained life this turn".
+    val condBlob = compact(cond)
+    val gainedLife = cond.strField("_Condition") == "PlayerPassesFilter" &&
+        "\"You\"" in condBlob && "GainedLifeThisTurn" in condBlob
+    if (!gainedLife) return null
+    // No else-branch (a plain intervening-if).
+    if (ifArgs.getOrNull(2) != null) return null
+
+    val thenActions = (ifArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    val copy = thenActions.singleOrNull()?.takeIf { it.strField("_Action") == "CopySpellAndMayChooseNewTargets" } ?: return null
+    // The copy is of the triggering spell.
+    if (copy["args"].strField("_Spell") != "Trigger_ThatSpell") return null
+
+    return listOf(
+        Sub(Block("triggeredAbility", listOf(
+            Assign("trigger", call("Triggers.WhenYouCastThisSpell")),
+            Assign("triggerCondition", Lit("Conditions.YouGainedLifeThisTurn")),
+            Assign("effect", call("Effects.CopyTargetSpell", arg("target", "EffectTarget.TriggeringEntity"))),
+        ))),
     )
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DinasGuidanceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DinasGuidanceScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dina's Guidance {1}{B}{G} Instant — Secrets of Strixhaven #184.
+ *
+ * "Search your library for a creature card, reveal it, put it into your hand or graveyard, then
+ *  shuffle."
+ *
+ * Exercises the gather → choose (search) → reveal → split-move (hand vs graveyard) pipeline.
+ */
+class DinasGuidanceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dina's Guidance — search to hand or graveyard") {
+
+            test("found creature can be put into hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dina's Guidance")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").first()
+
+                game.castSpell(1, "Dina's Guidance").error shouldBe null
+                game.resolveStack()
+
+                // 1. Search: pick the creature card.
+                withClue("search prompt for the creature card") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                // 2. Zone split: select the card → it goes to hand.
+                withClue("zone choice prompt") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears is now in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("not in graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("found creature can be put into graveyard (decline the zone selection)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dina's Guidance")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").first()
+
+                game.castSpell(1, "Dina's Guidance").error shouldBe null
+                game.resolveStack()
+
+                // 1. Search: pick the creature card.
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                // 2. Zone split: select NOTHing → the card falls to the remainder (graveyard).
+                game.hasPendingDecision() shouldBe true
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Grizzly Bears is now in graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("not in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("search may fail to find: no creature card in library") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dina's Guidance")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Swamp")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dina's Guidance").error shouldBe null
+                game.resolveStack()
+                // No creature to find — resolve to completion without error.
+                if (game.hasPendingDecision()) game.skipSelection()
+                game.resolveStack()
+
+                withClue("Dina's Guidance is in the graveyard after resolving") {
+                    game.isInGraveyard(1, "Dina's Guidance") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LumaretsFavorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LumaretsFavorScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lumaret's Favor {1}{G} Instant — Secrets of Strixhaven #153.
+ *
+ * "Infusion — When you cast this spell, copy it if you gained life this turn. You may choose new
+ * targets for the copy.
+ *  Target creature gets +2/+4 until end of turn."
+ *
+ * The Infusion cast trigger (`WhenYouCastThisSpell` + `Conditions.YouGainedLifeThisTurn`) copies
+ * the triggering spell and offers new targets for the copy. The main spell is a +2/+4 pump.
+ */
+class LumaretsFavorScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        // A simple life-gain spell to turn the Infusion condition on.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Healing Salve Test",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 3 life.",
+                script = CardScript.spell(effect = GainLifeEffect(3, EffectTarget.Controller)),
+            )
+        )
+
+        context("Lumaret's Favor — Infusion copy") {
+
+            test("no life gained: spell pumps a single creature, no copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lumaret's Favor")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2
+                    .withCardOnBattlefield(1, "Hill Giant")        // 3/3
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Lumaret's Favor", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("No life gained → no copy, so only the targeted Bears is pumped to 4/6") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 4
+                    projector.getProjectedToughness(game.state, bears) shouldBe 6
+                }
+                withClue("Hill Giant is untouched (the copy never happened)") {
+                    projector.getProjectedPower(game.state, giant) shouldBe 3
+                    projector.getProjectedToughness(game.state, giant) shouldBe 3
+                }
+            }
+
+            test("life gained: a copy is created and can be retargeted to a second creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lumaret's Favor")
+                    .withCardInHand(1, "Healing Salve Test")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2
+                    .withCardOnBattlefield(1, "Hill Giant")        // 3/3
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Gain life this turn so Infusion turns on.
+                game.castSpell(1, "Healing Salve Test").error shouldBe null
+                game.resolveStack()
+
+                // Cast Lumaret's Favor targeting Grizzly Bears.
+                game.castSpell(1, "Lumaret's Favor", bears).error shouldBe null
+
+                // The Infusion copy trigger resolves and pauses to let us retarget the copy.
+                game.resolveStack()
+                withClue("Infusion paused for retargeting the copy") {
+                    (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                }
+                val decision = game.getPendingDecision() as ChooseTargetsDecision
+                game.submitDecision(
+                    TargetsResponse(decision.id, mapOf(0 to listOf(giant)))
+                ).error shouldBe null
+
+                // A copy of Lumaret's Favor is on the stack, targeting the Hill Giant.
+                withClue("a spell copy exists on the stack") {
+                    val copies = game.state.stack.filter { id ->
+                        val c = game.state.getEntity(id)
+                        c?.get<SpellOnStackComponent>() != null && c.has<CopyOfComponent>()
+                    }
+                    copies.size shouldBe 1
+                }
+
+                game.resolveStack()
+
+                withClue("original target Grizzly Bears is 4/6") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 4
+                    projector.getProjectedToughness(game.state, bears) shouldBe 6
+                }
+                withClue("retargeted copy pumped Hill Giant to 5/7") {
+                    projector.getProjectedPower(game.state, giant) shouldBe 5
+                    projector.getProjectedToughness(game.state, giant) shouldBe 7
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuandrixCharmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuandrixCharmScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Quandrix Charm (Secrets of Strixhaven #217).
+ *
+ * Quandrix Charm ({G}{U} Instant), Choose one —
+ *   • Counter target spell unless its controller pays {2}.
+ *   • Destroy target enchantment.
+ *   • Target creature has base power and toughness 5/5 until end of turn.
+ */
+class QuandrixCharmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Quandrix Charm — choose one") {
+
+            test("mode 1: counters a spell whose controller cannot pay {2}") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withCardInHand(1, "Quandrix Charm")
+                    .withLandsOnBattlefield(2, "Forest", 2)        // tapped out after Bears
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Opponent casts Grizzly Bears, spending all their mana.
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.execute(PassPriority(game.player2Id))
+
+                val spellOnStack = game.state.stack.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val charmId = game.state.getHand(game.player1Id).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Quandrix Charm"
+                }
+
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        charmId,
+                        listOf(ChosenTarget.Spell(spellOnStack)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(spellOnStack))),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                // Opponent is tapped out, so the unless-pay prompt resolves to a counter.
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Grizzly Bears was countered into the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("mode 2: destroy target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Quandrix Charm")
+                    .withCardOnBattlefield(2, "Pacifism")          // an enchantment
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pacifism = game.findPermanent("Pacifism")!!
+                game.castSpellWithMode(1, "Quandrix Charm", modeIndex = 1, targetId = pacifism).error shouldBe null
+                game.resolveStack()
+
+                withClue("Pacifism was destroyed") {
+                    game.findPermanent("Pacifism") shouldBe null
+                    game.isInGraveyard(2, "Pacifism") shouldBe true
+                }
+            }
+
+            test("mode 2: a creature is not a legal target for the destroy-enchantment mode") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Quandrix Charm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpellWithMode(1, "Quandrix Charm", modeIndex = 1, targetId = bears)
+
+                withClue("Grizzly Bears is not an enchantment — illegal target") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("mode 3: target creature has base power and toughness 5/5 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Quandrix Charm")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getToughness(bears) shouldBe 2
+
+                game.castSpellWithMode(1, "Quandrix Charm", modeIndex = 2, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is now a 5/5") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RunBehindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RunBehindScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Run Behind {3}{U} Instant — Secrets of Strixhaven #66.
+ *
+ * "This spell costs {1} less to cast if it targets an attacking creature.
+ *  Target creature's owner puts it on their choice of the top or bottom of their library."
+ *
+ * The cost-reduction-when-targeting sibling of Dire Downdraft. Tests the
+ * `FixedIfAnyTargetMatches(IsAttacking)` reduction and the top/bottom library bounce.
+ */
+class RunBehindScenarioTest : ScenarioTestBase() {
+
+    private val calculator = CostCalculator(cardRegistry)
+
+    init {
+        context("Run Behind") {
+
+            test("base cost is {3}{U} = 4 mana with no target chosen") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Run Behind")
+                    .build()
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Run Behind"), game.player1Id,
+                )
+                cost.cmc shouldBe 4
+            }
+
+            test("targeting a non-attacking creature does not reduce the cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Run Behind")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Run Behind"), game.player1Id, listOf(bears),
+                )
+                withClue("Grizzly Bears is not attacking, so the {1} discount should not apply") {
+                    cost.cmc shouldBe 4
+                }
+            }
+
+            test("targeting an attacking creature reduces the cost by {1} → 3 mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Run Behind")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                // Player 1 attacks with Grizzly Bears.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Run Behind"), game.player2Id, listOf(bears),
+                )
+                withClue("Grizzly Bears is attacking, so the {1} discount applies: {2}{U}") {
+                    cost.cmc shouldBe 3
+                }
+            }
+
+            test("resolution: owner puts the creature on top of their library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Run Behind")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Run Behind", bears).error shouldBe null
+                game.resolveStack()
+
+                // The owner (player 2) chooses top or bottom of their library.
+                withClue("owner chooses top/bottom") {
+                    (game.getPendingDecision() is ChooseOptionDecision) shouldBe true
+                }
+                val decision = game.getPendingDecision() as ChooseOptionDecision
+                game.submitDecision(OptionChosenResponse(decision.id, 0)) // first option (top)
+                game.resolveStack()
+
+                withClue("Grizzly Bears left the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Grizzly Bears is back in player 2's library") {
+                    game.findCardsInLibrary(2, "Grizzly Bears").isNotEmpty() shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements four **Secrets of Strixhaven (SOS)** cards and extends the mtgish auto-gen tooling so all four render at fidelity tier **AUTO**. SOS is the earliest printing for all four, so each is canonical in `definitions/sos/cards/`. No new SDK surface was added — every card composes existing facades.

## Cards

| Card | Cost | Notes |
|------|------|-------|
| **Quandrix Charm** | `{G}{U}` Instant | Modal charm: counter-unless-pay `{2}` / destroy enchantment / set base P/T 5/5 until EOT. Sibling of Witherbloom/Prismari Charm. |
| **Lumaret's Favor** | `{1}{G}` Instant | Infusion — `WhenYouCastThisSpell` + `YouGainedLifeThisTurn` intervening-if gates a **mandatory** `CopyTargetSpell` of the triggering spell (offers new targets); body is a +2/+4 EOT pump. |
| **Dina's Guidance** | `{1}{B}{G}` Instant | Search a creature card, reveal, put into **hand or graveyard** (player's choice), shuffle. Modeled as gather → `chooseUpTo(1)` (search may fail) → reveal → binary split (select → hand, leave → graveyard) → shuffle, using existing pipeline primitives. |
| **Run Behind** | `{3}{U}` Instant | Costs `{1}` less if it targets an attacking creature; target's **owner** puts it on top or bottom of their library. Reuses `ModifySpellCost(FixedIfAnyTargetMatches IsAttacking)` + `Effects.PutOnTopOrBottomOfLibrary` (sibling of Dire Downdraft). |

Each card has a passing scenario test in `rules-engine`. The SOS card-snapshot golden was re-blessed (diff is only the four new card trees); `CardLintTest` passes.

## mtgish tooling changes

Three exact-shape recognizers (render the whole card or decline → SCAFFOLD, never a lossy approximation):

- `runBehindOwnerTopOrBottomEffect` — `PlayerAction(OwnerOfPermanent, ReturnPermanentToTopOrBottomOfLibrary)` → `Effects.PutOnTopOrBottomOfLibrary`.
- `dinasGuidanceSearchHandOrGraveyardEffect` — `SearchLibrary[…, ChooseAnAction[IntoHand, IntoGraveyard], Shuffle]` → the hand-or-graveyard split pipeline (the generic `searchLibrary` declines `ChooseAnAction`).
- `lumaretsFavorInfusionCopyBlock` — a new `FromStack` rule dispatch case for the Infusion copy-on-cast trigger.

Plus a general emitter fix: **`spellBlock` now extracts the spell body from the `SpellActions` rule specifically**, not the whole `Rules` tree. A sibling cast-trigger rule (`FromStack { TriggerA … }`) used to steal the spell envelope (its inner `ActionList` was found first), scaffolding the wrong actions and dropping the real spell. This unblocked Lumaret's Favor and is a general fix for `FromStack` + `SpellActions` cards (e.g. Social Snub).

All four cards now emit at **AUTO**.

## Verification

- All 4 scenario tests pass; SOS `CardDefinitionSnapshotTest` + `CardLintTest` pass.
- POR fidelity gate: **0-mismatch (158/158)**.
- `EmitterGoldenTest`: passes all 9 committed sets **unchanged** — the emitter change is golden-neutral (no rebless needed).
- Full `:mtgish-tooling` test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)