### PR TITLE
Add SOS creatures batch (5 cards) + mtgish autogen support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -521,6 +521,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `MoveChosenCountersToTarget(source, destination, drawCardOnMove?)` — Goldberry, River-Daughter (ability B) —
   player chooses how many of each kind to move from `source` onto `destination` (one `ChooseNumberDecision` per
   kind). When `drawCardOnMove` is true, the controller draws a card if any counter was moved ("if you do, draw").
+- `MoveCounters(counterType, amount, source, destination)` — Tester of the Tangential — deterministic,
+  count-carrying move of a single counter kind: moves `amount` (a `DynamicAmount`, e.g. `DynamicAmount.XValue`
+  from a may-pay-{X} reflexive) of `counterType` from `source` onto `destination`. The count is capped at the
+  number actually on `source`, and adding to `destination` honors counter-placement replacement effects
+  (Hardened Scales). No-op when source/destination missing, they're the same permanent, amount ≤ 0, or source has
+  none of that kind. The count-fixed counterpart to the interactive `MoveChosenCountersToTarget`.
 - `Counters.ANY` — wildcard counter-type string for "counters of any type" triggers/events (e.g.
   `Triggers.countersPlacedOn`); not a real placeable counter, only a matcher sentinel.
 - `DistributeCountersFromSelf(type?, count?)` — split source's counters among creatures you control.
@@ -3346,6 +3352,11 @@ answer it and would silently return `false`.
 - `APlayerLifeAtMost(n)` — *some* player in the game has ≤N life (existential over `state.turnOrder`; distinct from `LifeAtMost`, which is `Player.You`). Used by enters-tapped-unless lands like Razortrap Gorge.
 - `YouLostLife` — you lost life this turn.
 - `OpponentLostLife` — an opponent lost life this turn.
+- `YouGainedLifeThisTurn` — you gained ≥1 life this turn (intervening-if / static gate; backed by the
+  `LIFE_GAINED` turn tracker). Used by Ulna Alley Shopkeep's Infusion buff.
+- `YouGainedLifeThisTurnAtLeast(n)` — you gained ≥`n` life this turn. The threshold form of
+  `YouGainedLifeThisTurn` (`Compare(TurnTracking(You, LIFE_GAINED), GTE, n)`). Used by Scheming
+  Silvertongue's "if you gained 2 or more life this turn" prepared trigger.
 
 ### Cast / cost
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -875,6 +875,13 @@ object Conditions {
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_GAINED)
 
     /**
+     * If you gained [atLeast] or more life this turn.
+     * Used for Scheming Silvertongue ("if you gained 2 or more life this turn").
+     */
+    fun YouGainedLifeThisTurnAtLeast(atLeast: Int): ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_GAINED, atLeast)
+
+    /**
      * As long as you attacked with [atLeast] or more creatures matching [filter] this turn.
      * Used for cards like Deepway Navigator: "as long as you attacked with three or more
      * Merfolk this turn".

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1136,6 +1136,21 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.MoveCountersEachKindMissingEffect(source, destination)
 
     /**
+     * Move a dynamic [amount] of [counterType] counters from [source] onto [destination].
+     * Deterministic, count-carrying counterpart to [MoveChosenCountersToTarget] — the count
+     * can be a [DynamicAmount] (e.g. `DynamicAmount.XValue` from a may-pay-{X} reflexive), and
+     * is capped at the number actually on the source. Used by Tester of the Tangential's
+     * "move X +1/+1 counters from this creature onto another target creature".
+     */
+    fun MoveCounters(
+        counterType: String,
+        amount: DynamicAmount,
+        source: EffectTarget,
+        destination: EffectTarget
+    ): Effect =
+        com.wingedsheep.sdk.scripting.effects.MoveCountersEffect(counterType, amount, source, destination)
+
+    /**
      * Move a player-chosen set (one or more) of counters from [source] onto [destination]
      * (one prompt per counter kind on the source). When [drawCardOnMove] is true, the
      * controller draws a card if any counter was moved. Used by Goldberry, River-Daughter's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -209,6 +209,40 @@ data class MoveChosenCountersToTargetEffect(
 }
 
 /**
+ * Move a dynamic number of counters of a single kind from a [source] permanent onto a
+ * [destination] permanent.
+ *
+ * "Move X +1/+1 counters from this creature onto another target creature." (Tester of the
+ * Tangential — where X is paid via a may-pay-{X} reflexive.)
+ *
+ * The deterministic, count-carrying counterpart to the interactive [MoveChosenCountersToTargetEffect]
+ * (player chooses per kind) and the each-kind [MoveCountersEachKindMissingEffect]: this one moves a
+ * fixed-at-resolution [amount] of exactly one [counterType], so the count can come from a
+ * [DynamicAmount] (e.g. [com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue]). The executor
+ * caps the moved count at the number actually present on the source (you can't move more counters
+ * than are there), removes that many from the source, and adds them to the destination — honoring
+ * counter-placement replacement effects on the destination. No-op when source/destination is
+ * missing, they're the same permanent, the amount resolves to <= 0, or the source has none of
+ * [counterType].
+ *
+ * @property counterType The kind of counter to move (e.g. "+1/+1")
+ * @property amount How many to move (resolved at execution; capped at the source's current count)
+ * @property source The permanent counters are moved *from*
+ * @property destination The permanent counters are moved *onto*
+ */
+@SerialName("MoveCounters")
+@Serializable
+data class MoveCountersEffect(
+    val counterType: String,
+    val amount: DynamicAmount,
+    val source: EffectTarget,
+    val destination: EffectTarget
+) : Effect {
+    override val description: String =
+        "Move ${amount.description} $counterType counters from ${source.description} onto ${destination.description}"
+}
+
+/**
  * Distribute any number of counters from this creature onto other creatures.
  * "At the beginning of your upkeep, you may move any number of +1/+1 counters
  * from Forgotten Ancient onto other creatures."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MageTowerReferee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MageTowerReferee.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mage Tower Referee — Secrets of Strixhaven #249
+ * {2} · Artifact Creature — Construct · 2/1
+ *
+ * Whenever you cast a multicolored spell, put a +1/+1 counter on this creature.
+ */
+val MageTowerReferee = card("Mage Tower Referee") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast a multicolored spell, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Multicolored)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Nino Vecia"
+        flavorText = "Incapable of choosing a favorite and invulnerable to the influence of magic, " +
+            "it is an ideal and obnoxiously accurate referee."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1ceb704a-97a8-49f9-b799-30f001404144.jpg?1775938737"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ScathingShadelock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ScathingShadelock.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Scathing Shadelock // Venomous Words — Secrets of Strixhaven #98
+ * {4}{B} · Creature — Snake Warlock · 4/6
+ *
+ * At the beginning of your first main phase, this creature becomes prepared.
+ * (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+ * //
+ * Venomous Words — {B} · Sorcery: Target creature you control gets +2/+0 and gains
+ * deathtouch until end of turn.
+ *
+ * Prepare (Secrets of Strixhaven): Scathing Shadelock does NOT enter prepared (no PREPARED
+ * keyword). It becomes prepared via its first-main-phase trigger through [Effects.BecomePrepared].
+ * Becoming prepared creates a copy of its prepare spell ("Venomous Words") in exile that its
+ * controller may cast for {B}; casting that copy unprepares the creature. Modeled via
+ * `CardLayout.PREPARE` + the `prepare(name) { }` DSL, like Maelstrom Artisan / Leech Collector.
+ */
+val ScathingShadelock = card("Scathing Shadelock") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Snake Warlock"
+    power = 4
+    toughness = 6
+    oracleText = "At the beginning of your first main phase, this creature becomes prepared. " +
+        "(While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.BecomePrepared(EffectTarget.Self)
+    }
+
+    // Venomous Words — the prepare spell.
+    prepare("Venomous Words") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        oracleText = "Target creature you control gets +2/+0 and gains deathtouch until end of turn."
+        spell {
+            val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+            effect = Effects.Composite(
+                Effects.ModifyStats(2, 0, t),
+                Effects.GrantKeyword(Keyword.DEATHTOUCH, t),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03e664cd-c3a6-4263-b2d8-dd99058fb8ec.jpg?1775937593"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SchemingSilvertongue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/SchemingSilvertongue.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Scheming Silvertongue // Sign in Blood — Secrets of Strixhaven #99
+ * {1}{B} · Creature — Vampire Warlock · 1/3
+ *
+ * Flying, lifelink
+ * At the beginning of your second main phase, if you gained 2 or more life this turn, this
+ * creature becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so
+ * unprepares it.)
+ * //
+ * Sign in Blood — {B}{B} · Sorcery: Target player draws two cards and loses 2 life.
+ *
+ * Prepare (Secrets of Strixhaven): Scheming Silvertongue does NOT enter prepared (no PREPARED
+ * keyword). It becomes prepared via its postcombat-main intervening-if trigger (gained 2+ life
+ * this turn) through [Effects.BecomePrepared]. Becoming prepared creates a copy of its prepare
+ * spell ("Sign in Blood") in exile that its controller may cast for {B}{B}; casting that copy
+ * unprepares the creature. Modeled via `CardLayout.PREPARE` + the `prepare(name) { }` DSL.
+ */
+val SchemingSilvertongue = card("Scheming Silvertongue") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warlock"
+    power = 1
+    toughness = 3
+    oracleText = "Flying, lifelink\n" +
+        "At the beginning of your second main phase, if you gained 2 or more life this turn, " +
+        "this creature becomes prepared. (While it's prepared, you may cast a copy of its spell. " +
+        "Doing so unprepares it.)"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.YouGainedLifeThisTurnAtLeast(2)
+        effect = Effects.BecomePrepared(EffectTarget.Self)
+    }
+
+    // Sign in Blood — the prepare spell.
+    prepare("Sign in Blood") {
+        manaCost = "{B}{B}"
+        typeLine = "Sorcery"
+        oracleText = "Target player draws two cards and loses 2 life."
+        spell {
+            val player = target("target player", TargetPlayer())
+            effect = Effects.Composite(
+                Effects.DrawCards(2, player),
+                Effects.LoseLife(2, player),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "99"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe85a124-0d8b-4a29-8df1-65888a39147f.jpg?1778165124"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TesterOfTheTangential.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TesterOfTheTangential.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.increment
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayXForEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Tester of the Tangential — Secrets of Strixhaven #69
+ * {1}{U} · Creature — Djinn Wizard · 1/1
+ *
+ * Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this
+ * creature's power or toughness, put a +1/+1 counter on this creature.)
+ * At the beginning of combat on your turn, you may pay {X}. When you do, move X +1/+1 counters
+ * from this creature onto another target creature.
+ *
+ * The second ability is a may-pay-{X} reflexive: [MayPayXForEffect] pauses for the X chooser and
+ * binds the chosen X into [DynamicAmount.XValue], then resolves its inner pipeline — select
+ * "another target creature", then [Effects.MoveCounters] moves X +1/+1 counters from this creature
+ * (capped at the number present) onto the selected target. Targeting happens after the payment, as
+ * the "When you do" reflexive prescribes.
+ */
+val TesterOfTheTangential = card("Tester of the Tangential") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Increment (Whenever you cast a spell, if the amount of mana you spent is greater " +
+        "than this creature's power or toughness, put a +1/+1 counter on this creature.)\n" +
+        "At the beginning of combat on your turn, you may pay {X}. When you do, move X +1/+1 " +
+        "counters from this creature onto another target creature."
+
+    increment()
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = MayPayXForEffect(
+            effect = Effects.SelectTarget(TargetCreature(filter = TargetFilter.OtherCreature), "moveTarget")
+                .then(
+                    Effects.MoveCounters(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        amount = DynamicAmount.XValue,
+                        source = EffectTarget.Self,
+                        destination = EffectTarget.PipelineTarget("moveTarget"),
+                    )
+                )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Lorenzo Mastroianni"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbd708ec-eef4-4f45-99dd-60e1cec4b991.jpg?1775937389"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/UlnaAlleyShopkeep.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/UlnaAlleyShopkeep.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ulna Alley Shopkeep — Secrets of Strixhaven #103
+ * {2}{B} · Creature — Goblin Warlock · 2/3
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Infusion — This creature gets +2/+0 as long as you gained life this turn.
+ *
+ * Infusion is an ability word (no rules meaning) — the mechanic is a conditional self-buff
+ * static ability gated on [Conditions.YouGainedLifeThisTurn], applied to this creature only via
+ * [GroupFilter.source].
+ */
+val UlnaAlleyShopkeep = card("Ulna Alley Shopkeep") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Warlock"
+    power = 2
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Infusion — This creature gets +2/+0 as long as you gained life this turn."
+
+    keywords(Keyword.MENACE)
+
+    staticAbility {
+        condition = Conditions.YouGainedLifeThisTurn
+        ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Inkognit"
+        flavorText = "\"This one's from my private stock.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c25e1ae5-f17c-4eee-98f1-5681981af31c.jpg?1775937633"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -6702,6 +6702,46 @@
     ]
 }
 
+// Mage Tower Referee
+{
+    "name": "Mage Tower Referee",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Whenever you cast a multicolored spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Nino Vecia",
+        "flavorText": "Incapable of choosing a favorite and invulnerable to the influence of magic, it is an ideal and obnoxiously accurate referee.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1ceb704a-97a8-49f9-b799-30f001404144.jpg?1775938737"
+    }
+}
+
 // Magmablood Archaic
 {
     "name": "Magmablood Archaic",
@@ -10333,6 +10373,183 @@
     ]
 }
 
+// Scathing Shadelock
+{
+    "name": "Scathing Shadelock",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Snake Warlock",
+    "oracleText": "At the beginning of your first main phase, this creature becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": "BecomePrepared"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "UNCOMMON",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03e664cd-c3a6-4263-b2d8-dd99058fb8ec.jpg?1775937593"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Venomous Words",
+            "manaCost": "{B}",
+            "typeLine": "Sorcery",
+            "oracleText": "Target creature you control gets +2/+0 and gains deathtouch until end of turn.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DEATHTOUCH",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+// Scheming Silvertongue
+{
+    "name": "Scheming Silvertongue",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Warlock",
+    "oracleText": "Flying, lifelink\nAt the beginning of your second main phase, if you gained 2 or more life this turn, this creature becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": "BecomePrepared",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe85a124-0d8b-4a29-8df1-65888a39147f.jpg?1778165124"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Sign in Blood",
+            "manaCost": "{B}{B}",
+            "typeLine": "Sorcery",
+            "oracleText": "Target player draws two cards and loses 2 life.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Scolding Administrator
 {
     "name": "Scolding Administrator",
@@ -12848,6 +13065,120 @@
     ]
 }
 
+// Tester of the Tangential
+{
+    "name": "Tester of the Tangential",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Djinn Wizard",
+    "oracleText": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)\nAt the beginning of combat on your turn, you may pay {X}. When you do, move X +1/+1 counters from this creature onto another target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "INCREMENT"
+    ],
+    "keywordAbilities": [
+        "Increment"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayPayX",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "storeAs": "moveTarget"
+                            },
+                            {
+                                "type": "MoveCounters",
+                                "counterType": "+1/+1",
+                                "amount": "XValue",
+                                "source": "Self",
+                                "destination": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "moveTarget"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbd708ec-eef4-4f45-99dd-60e1cec4b991.jpg?1775937389"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Textbook Tabulator
 {
     "name": "Textbook Tabulator",
@@ -13697,6 +14028,59 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Ulna Alley Shopkeep
+{
+    "name": "Ulna Alley Shopkeep",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Goblin Warlock",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nInfusion — This creature gets +2/+0 as long as you gained life this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Inkognit",
+        "flavorText": "\"This one's from my private stock.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c25e1ae5-f17c-4eee-98f1-5681981af31c.jpg?1775937633"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -508,6 +508,28 @@ private fun youGainedLifeConditionDsl(condNode: JsonElement?): String? {
 }
 
 /**
+ * "if you gained N or more life this turn" — `PlayerPassesFilter(You, GainedLifeAmountThisTurn(
+ * [Comparison GreaterThanOrEqualTo Integer N]))` -> `Conditions.YouGainedLifeThisTurnAtLeast(N)`.
+ * The quantified sibling of [youGainedLifeConditionDsl]. Backs Scheming Silvertongue's second-main
+ * intervening-if ("if you gained 2 or more life this turn"). Only the You scope with a
+ * `GreaterThanOrEqualTo` comparison over a fixed integer renders; any other player scope or
+ * comparator declines -> SCAFFOLD rather than miscount.
+ */
+private fun youGainedLifeAtLeastConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val players = args.getOrNull(1) as? JsonObject ?: return null
+    if (players.strField("_Players") != "GainedLifeAmountThisTurn") return null
+    val comparison = players["args"] as? JsonObject ?: return null
+    if (comparison.strField("_Comparison") != "GreaterThanOrEqualTo") return null
+    val n = (comparison["args"] as? JsonObject)?.takeIf { it.strField("_GameNumber") == "Integer" }
+        ?.get("args").asInt() ?: return null
+    return "Conditions.YouGainedLifeThisTurnAtLeast($n)"
+}
+
+/**
  * "you control N or more [filter]" condition (`PlayerPassesFilter(You, ControlsNum([Comparison
  * GreaterThanOrEqualTo Integer N], <filter>))`) -> `Conditions.YouControlAtLeast(N, <filter>)`, or null
  * when the player isn't You, the comparison isn't `>= N` (a fixed integer), or the filter doesn't render
@@ -813,6 +835,9 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
             ?: youCommittedCrimeConditionDsl(cond)
             ?: sourceCounterCountAtLeastConditionDsl(cond)
             ?: deliriumConditionDsl(cond)
+            // "as long as you gained life this turn" gating a self-only buff (Ulna Alley Shopkeep's
+            // Infusion +2/+0). Same condition the EachPermanentLayerEffect lord branch already uses.
+            ?: youGainedLifeConditionDsl(cond)
             ?: run { reasons.add("If"); return null }
         val layerEffects = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
             ?: run { reasons.add("If"); return null }
@@ -2250,6 +2275,11 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
             perms.field("args").strField("_Permanent") == "ThisPermanent"
         return if (isThisPermanent) "Conditions.SourceReceivedCounterThisTurn" else null
     }
+    // "if you gained N or more life this turn" — PlayerPassesFilter(You, GainedLifeAmountThisTurn(
+    // [Comparison GreaterThanOrEqualTo Integer N])) (Scheming Silvertongue's "if you gained 2 or more
+    // life this turn") -> Conditions.YouGainedLifeThisTurnAtLeast(N). Only the >= comparison with a
+    // fixed integer renders; any other comparator declines -> SCAFFOLD rather than miscount.
+    youGainedLifeAtLeastConditionDsl(cond)?.let { return it }
     // "if you gained life this turn" — PlayerPassesFilter(You, GainedLifeThisTurn) (Foolish Fate's
     // Infusion clause). No count/amount sub-clause, so the bare "you gained life this turn" maps to
     // Conditions.YouGainedLifeThisTurn.
@@ -2753,6 +2783,8 @@ private fun spellCastCategory(spells: JsonObject?): String? = when (spells?.strF
         else -> null
     }
     "IsNonCardtype" -> if (spells.field("args").asStr() == "Creature") "noncreature" else null
+    // "a multicolored spell" (Mage Tower Referee). Maps to GameObjectFilter.Multicolored.
+    "IsMulticolored" -> "multicolored"
     // "an instant or sorcery spell" — an Or of exactly the two cardtype clauses, nothing else.
     "Or" -> {
         val parts = spells["args"].asArr.orEmpty().map { it as? JsonObject }
@@ -2771,6 +2803,7 @@ private fun categoryFilter(category: String): String? = when (category) {
     "instantOrSorcery" -> "GameObjectFilter.InstantOrSorcery"
     "historic" -> "GameObjectFilter.Historic"
     "outlaw" -> "GameObjectFilter.Any.withAnyOfSubtypes(Subtype.OUTLAW_TYPES)"
+    "multicolored" -> "GameObjectFilter.Multicolored"
     else -> null
 }
 
@@ -2817,6 +2850,7 @@ private fun castTriggerDsl(scope: CastScope, category: String, targetsMatching: 
             "instantOrSorcery" -> "Triggers.YouCastInstantOrSorcery"
             "historic" -> "Triggers.YouCastHistoric"
             "outlaw" -> "Triggers.youCastSpell(spellFilter = ${categoryFilter("outlaw")})"
+            "multicolored" -> "Triggers.youCastSpell(spellFilter = ${categoryFilter("multicolored")})"
             else -> null
         }
         CastScope.ANY -> if (filter == null) "Triggers.AnyPlayerCastsSpell" else "Triggers.anyPlayerCasts($filter)"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.counters.AddCountersToC
 import com.wingedsheep.engine.handlers.effects.permanent.counters.AddDynamicCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.MoveAllLastKnownCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.MoveCountersEachKindMissingExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.counters.MoveCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.MoveChosenCountersToTargetExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.DistributeCountersAmongTargetsExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.DoubleCountersExecutor
@@ -114,6 +115,7 @@ class PermanentExecutors(
         RemoveCountersExecutor(),
         RemoveAnyNumberOfCountersExecutor(),
         MoveCountersEachKindMissingExecutor(),
+        MoveCountersExecutor(),
         MoveChosenCountersToTargetExecutor(),
         RemoveAllCountersExecutor(),
         DistributeCountersFromSelfExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveCountersExecutor.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.handlers.effects.permanent.counters
+
+import com.wingedsheep.engine.core.CountersAddedEvent
+import com.wingedsheep.engine.core.CountersRemovedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.MoveCountersEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [MoveCountersEffect].
+ *
+ * "Move X +1/+1 counters from this creature onto another target creature." (Tester of the
+ * Tangential.) Deterministic — the count is fixed at resolution from a [DynamicAmount]
+ * (e.g. the X paid via a may-pay-{X} reflexive), then capped at the number actually on the
+ * source so the engine never removes counters that aren't there.
+ *
+ * Removes the (capped) amount of [MoveCountersEffect.counterType] from the source and adds the
+ * same number to the destination, honoring counter-placement replacement effects on the
+ * destination (Hardened Scales etc.) via [ReplacementEffectUtils.applyCounterPlacementModifiers].
+ * No-op when source/destination is missing, they're the same permanent, the amount resolves to
+ * <= 0, or the source has none of [counterType].
+ */
+class MoveCountersExecutor : EffectExecutor<MoveCountersEffect> {
+
+    override val effectType: KClass<MoveCountersEffect> = MoveCountersEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: MoveCountersEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.resolveTarget(effect.source, state)
+            ?: return EffectResult.success(state, emptyList())
+        val destinationId = context.resolveTarget(effect.destination, state)
+            ?: return EffectResult.success(state, emptyList())
+        if (sourceId == destinationId) return EffectResult.success(state, emptyList())
+
+        val counterType = resolveCounterType(effect.counterType)
+
+        val requested = DynamicAmountEvaluator().evaluate(state, effect.amount, context)
+        if (requested <= 0) return EffectResult.success(state, emptyList())
+
+        val sourceCounters = state.getEntity(sourceId)?.get<CountersComponent>() ?: CountersComponent()
+        val present = sourceCounters.counters[counterType] ?: 0
+        val moveCount = minOf(requested, present)
+        if (moveCount <= 0) return EffectResult.success(state, emptyList())
+
+        val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: ""
+        val destName = state.getEntity(destinationId)?.get<CardComponent>()?.name ?: ""
+
+        // Remove from the source first so a destination counter-placement modifier can't read
+        // stale source state.
+        val afterRemoval = state.updateEntity(sourceId) { container ->
+            container.with(sourceCounters.withRemoved(counterType, moveCount))
+        }
+
+        // Adding to the destination honors counter-placement replacement effects (Hardened Scales).
+        val placedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
+            afterRemoval, destinationId, counterType, moveCount, placerId = context.controllerId
+        )
+        val destCounters = afterRemoval.getEntity(destinationId)?.get<CountersComponent>() ?: CountersComponent()
+        val firstThisTurn = DamageUtils.isFirstCounterThisTurn(afterRemoval, destinationId)
+
+        val newState = afterRemoval.updateEntity(destinationId) { container ->
+            container.with(destCounters.withAdded(counterType, placedCount))
+        }.let { DamageUtils.markCounterPlacedOnCreature(it, context.controllerId, destinationId) }
+
+        return EffectResult.success(
+            newState,
+            listOf(
+                CountersRemovedEvent(sourceId, effect.counterType, moveCount, sourceName),
+                CountersAddedEvent(destinationId, effect.counterType, placedCount, destName, firstThisTurn)
+            )
+        )
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoveCountersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoveCountersTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [com.wingedsheep.sdk.scripting.effects.MoveCountersEffect] — moving a dynamic count
+ * of a single counter kind from one permanent onto another (the engine gap behind Tester of the
+ * Tangential's "move X +1/+1 counters from this creature onto another target creature").
+ *
+ * An inline instant "Counter Mover" selects a target creature and moves a fixed number of +1/+1
+ * counters from the caster's own source creature (modeled with a second targeted creature here for
+ * test simplicity) onto it. It pins:
+ *  - the happy path (N counters leave the source, N arrive on the destination),
+ *  - the cap-at-present rule (you can't move more counters than the source has),
+ *  - the no-op when the source has none of that kind.
+ */
+class MoveCountersTest : FunSpec({
+
+    // "Move up to <amount> +1/+1 counters from the first target onto the second target."
+    fun mover(amount: Int) = card("Counter Mover $amount") {
+        manaCost = "{G}"
+        typeLine = "Instant"
+        oracleText = "Move $amount +1/+1 counters from target creature onto another target creature."
+        spell {
+            val source = target("source", TargetCreature())
+            val dest = target("destination", TargetCreature(filter = TargetFilter.OtherCreature))
+            effect = Effects.MoveCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmount.Fixed(amount),
+                source = source,
+                destination = dest,
+            )
+        }
+    }
+
+    fun createDriver(amount: Int): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(mover(amount)))
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, entityId: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("moves N +1/+1 counters from source to destination") {
+        val driver = createDriver(2)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(p1, "Counter Mover 2")
+        val src = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val dst = driver.putCreatureOnBattlefield(p1, "Savannah Lions")
+        driver.addComponent(src, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 4)))
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.castSpell(p1, spell, targets = listOf(src, dst))
+        driver.bothPass()
+
+        plusCounters(driver, src) shouldBe 2  // 4 - 2
+        plusCounters(driver, dst) shouldBe 2  // 0 + 2
+    }
+
+    test("moving more than present is capped at the source's actual count") {
+        val driver = createDriver(5)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(p1, "Counter Mover 5")
+        val src = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val dst = driver.putCreatureOnBattlefield(p1, "Savannah Lions")
+        driver.addComponent(src, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.castSpell(p1, spell, targets = listOf(src, dst))
+        driver.bothPass()
+
+        plusCounters(driver, src) shouldBe 0  // all 3 moved, not 5
+        plusCounters(driver, dst) shouldBe 3
+    }
+
+    test("no-op when the source has no +1/+1 counters") {
+        val driver = createDriver(2)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(p1, "Counter Mover 2")
+        val src = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val dst = driver.putCreatureOnBattlefield(p1, "Savannah Lions")
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.castSpell(p1, spell, targets = listOf(src, dst))
+        driver.bothPass()
+
+        plusCounters(driver, src) shouldBe 0
+        plusCounters(driver, dst) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCreaturesBatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosCreaturesBatchScenarioTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Secrets of Strixhaven creatures batch:
+ *  - Mage Tower Referee     — "whenever you cast a multicolored spell, put a +1/+1 counter on it"
+ *  - Scathing Shadelock     — becomes prepared at your first main phase (prepare: Venomous Words)
+ *  - Scheming Silvertongue  — becomes prepared at your second main phase IF you gained 2+ life
+ *  - Ulna Alley Shopkeep    — Infusion: +2/+0 as long as you gained life this turn
+ *
+ * (Tester of the Tangential's move-X-counters reflexive is covered separately in
+ * TesterOfTheTangentialScenarioTest.)
+ */
+class SosCreaturesBatchScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.plusCounters(name: String): Int {
+        val id = findPermanent(name) ?: return 0
+        return state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Mage Tower Referee — multicolored cast trigger") {
+            test("gets a +1/+1 counter when you cast a multicolored spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mage Tower Referee", summoningSickness = false)
+                    .withCardInHand(1, "Llanowar Knight") // {G}{W} multicolored creature
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("starts with no +1/+1 counters") { game.plusCounters("Mage Tower Referee") shouldBe 0 }
+
+                game.castSpell(1, "Llanowar Knight").error shouldBe null
+                game.resolveStack()
+
+                withClue("casting a multicolored spell adds one +1/+1 counter") {
+                    game.plusCounters("Mage Tower Referee") shouldBe 1
+                }
+            }
+
+            test("does NOT trigger on a monocolored spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mage Tower Referee", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears") // {1}{G} monocolored
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("a monocolored spell does not add a counter") {
+                    game.plusCounters("Mage Tower Referee") shouldBe 0
+                }
+            }
+        }
+
+        context("Scathing Shadelock — becomes prepared at first main phase") {
+            test("becomes prepared at the beginning of your first main phase") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scathing Shadelock", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+
+                val shadelock = game.findPermanent("Scathing Shadelock")!!
+                withClue("not prepared during upkeep") {
+                    game.state.getEntity(shadelock)?.get<PreparedComponent>() shouldBe null
+                }
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("the first-main-phase trigger makes it prepared") {
+                    game.state.getEntity(shadelock)?.get<PreparedComponent>() shouldNotBe null
+                }
+            }
+        }
+
+        context("Scheming Silvertongue — prepared at second main phase if you gained 2+ life") {
+            test("becomes prepared when you gained 2 or more life this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scheming Silvertongue", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.END_COMBAT)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(2))
+                }
+
+                val silvertongue = game.findPermanent("Scheming Silvertongue")!!
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("gained 2+ life → second-main trigger makes it prepared") {
+                    game.state.getEntity(silvertongue)?.get<PreparedComponent>() shouldNotBe null
+                }
+            }
+
+            test("does NOT become prepared when you gained only 1 life this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scheming Silvertongue", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.END_COMBAT)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(1))
+                }
+
+                val silvertongue = game.findPermanent("Scheming Silvertongue")!!
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("only 1 life gained → intervening-if fails, stays unprepared") {
+                    game.state.getEntity(silvertongue)?.get<PreparedComponent>() shouldBe null
+                }
+            }
+        }
+
+        context("Ulna Alley Shopkeep — Infusion conditional buff") {
+            test("gets +2/+0 only while you gained life this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ulna Alley Shopkeep", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shopkeep = game.findPermanent("Ulna Alley Shopkeep")!!
+                withClue("base 2/3 with no life gained this turn") {
+                    game.state.projectedState.getPower(shopkeep) shouldBe 2
+                    game.state.projectedState.getToughness(shopkeep) shouldBe 3
+                }
+
+                game.state = game.state.updateEntity(game.player1Id) {
+                    it.withComponent(LifeGainedAmountThisTurnComponent(1))
+                }
+
+                withClue("after gaining life this turn, Infusion grants +2/+0 → 4/3") {
+                    game.state.projectedState.getPower(shopkeep) shouldBe 4
+                    game.state.projectedState.getToughness(shopkeep) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TesterOfTheTangentialScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TesterOfTheTangentialScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.TesterOfTheTangential
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Tester of the Tangential (SOS #69) — specifically its second ability:
+ * "At the beginning of combat on your turn, you may pay {X}. When you do, move X +1/+1 counters
+ * from this creature onto another target creature."
+ *
+ * The ability is a may-pay-{X} reflexive: the begin-combat trigger pauses on a number chooser
+ * (`Gate.MayPayX`); the chosen X is paid in generic mana and bound into `DynamicAmount.XValue`,
+ * which then drives `Effects.MoveCounters` after the controller selects "another target creature".
+ * (Increment's own counter-growth trigger is covered by IncrementMechanicScenarioTest.)
+ */
+class TesterOfTheTangentialScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TesterOfTheTangential))
+        return driver
+    }
+
+    fun GameTestDriver.advanceToPlayer1BeginCombat() {
+        passPriorityUntil(Step.BEGIN_COMBAT)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.BEGIN_COMBAT)
+            safety++
+        }
+    }
+
+    fun plusCounters(driver: GameTestDriver, entityId: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("paying X=2 moves two +1/+1 counters from the Tester onto the chosen target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+
+        val tester = driver.putCreatureOnBattlefield(driver.player1, "Tester of the Tangential")
+        // Two other creatures, so "another target creature" is a real choice (not auto-selected).
+        val chosen = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val decoy = driver.putCreatureOnBattlefield(driver.player1, "Savannah Lions")
+        driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
+        driver.giveMana(driver.player1, Color.BLUE, 5)
+
+        driver.advanceToPlayer1BeginCombat()
+
+        // BeginCombat trigger goes on the stack; resolving it presents the MayPayX number chooser.
+        driver.bothPass()
+        val payDecision = driver.pendingDecision
+        payDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+        driver.submitDecision(driver.player1, NumberChosenResponse(payDecision.id, 2))
+
+        // After paying X=2, the reflexive effect selects "another target creature".
+        val targetDecision = driver.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(driver.player1, listOf(chosen))
+
+        plusCounters(driver, tester) shouldBe 1   // 3 - 2
+        plusCounters(driver, chosen) shouldBe 2   // 0 + 2
+        plusCounters(driver, decoy) shouldBe 0
+    }
+
+    test("with exactly one other creature, the target auto-selects and X=2 moves the counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+
+        val tester = driver.putCreatureOnBattlefield(driver.player1, "Tester of the Tangential")
+        val other = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
+        driver.giveMana(driver.player1, Color.BLUE, 5)
+
+        driver.advanceToPlayer1BeginCombat()
+
+        driver.bothPass()
+        val payDecision = driver.pendingDecision
+        payDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+        driver.submitDecision(driver.player1, NumberChosenResponse(payDecision.id, 2))
+
+        // Single "other creature" → auto-selected, no target decision.
+        plusCounters(driver, tester) shouldBe 1
+        plusCounters(driver, other) shouldBe 2
+    }
+
+    test("declining the payment (X=0) moves no counters and asks for no target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+
+        val tester = driver.putCreatureOnBattlefield(driver.player1, "Tester of the Tangential")
+        val other = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
+        driver.giveMana(driver.player1, Color.BLUE, 5)
+
+        driver.advanceToPlayer1BeginCombat()
+
+        driver.bothPass()
+        val payDecision = driver.pendingDecision
+        payDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+        driver.submitDecision(driver.player1, NumberChosenResponse(payDecision.id, 0))
+
+        // X=0 → nothing happens; no target selection.
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+        plusCounters(driver, tester) shouldBe 3
+        plusCounters(driver, other) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary

Implements five Secrets of Strixhaven (SOS) cards via the `add-card` flow, adds the one engine primitive they needed via `add-feature`, and teaches the mtgish generator to draft four of them at AUTO tier.

| Card | Mechanic | mtgish tier |
|------|----------|-------------|
| Mage Tower Referee | +1/+1 counter when you cast a multicolored spell | AUTO (new) |
| Scathing Shadelock // Venomous Words | becomes prepared at your first main phase | AUTO (already) |
| Scheming Silvertongue // Sign in Blood | becomes prepared at second main if you gained 2+ life | AUTO (new) |
| Ulna Alley Shopkeep | Menace + Infusion conditional +2/+0 | AUTO (new) |
| Tester of the Tangential | Increment + "may pay {X}. When you do, move X +1/+1 counters onto another target creature" | SCAFFOLD (declined) |

## Engine / SDK

- **New `MoveCountersEffect(counterType, amount: DynamicAmount, source, destination)`** — the deterministic, count-carrying counterpart to the interactive `MoveChosenCountersToTarget` and the each-kind `MoveCountersEachKindMissing`. Moves a `DynamicAmount` (e.g. `DynamicAmount.XValue` from a may-pay-{X} reflexive) of one counter kind between two permanents, **capped at the source's current count**, honoring counter-placement replacement effects (Hardened Scales) on the destination. SDK type + executor (registered) + `Effects.MoveCounters` facade + SDK reference doc.
- **New `Conditions.YouGainedLifeThisTurnAtLeast(n)`** — threshold form of `YouGainedLifeThisTurn` (Scheming Silvertongue's "gained 2 or more life this turn").

Tester of the Tangential composes the existing `MayPayXForEffect` (binds X into `DynamicAmount.XValue`) with `SelectTarget("another target creature").then(MoveCounters(XValue, Self, target))` — no new reflexive machinery; the scenario test proves X propagates into both the count and the target choice.

## mtgish-tooling (faithful, additive)

Three emitter additions, all on IR tags absent from every calibrated golden fixture, so they are purely additive:
- Render "whenever you cast a multicolored spell" cast triggers (`IsMulticolored` → `GameObjectFilter.Multicolored`).
- Render self-only conditional buffs gated on "you gained life this turn" in the self-`PermanentLayerEffect` `If` branch.
- Render quantified "if you gained N or more life this turn" intervening-ifs → `YouGainedLifeThisTurnAtLeast(N)`.

**Tester of the Tangential stays SCAFFOLD on purpose** — it is the engine's known-sloppy may-pay-{X} value-selection shape; per the module's decline-don't-approximate rule the emitter is left returning `null` rather than rendering a lossy approximation.

## Tests

- `MoveCountersTest` — happy path, cap-at-present, no-op-when-empty for the new effect.
- `TesterOfTheTangentialScenarioTest` — full begin-combat → pay-X → target → move-counters flow (X=2 with a real target choice, single-other auto-select, X=0 decline).
- `SosCreaturesBatchScenarioTest` — Mage Tower Referee (multicolored vs monocolored), Scathing Shadelock (first-main prepare), Scheming Silvertongue (2+ life gate true/false), Ulna Alley Shopkeep (Infusion buff on/off).
- `coverage-verify POR` → GATE PASS 158/158 (0-mismatch); `EmitterGoldenTest` green for all calibrated sets (no rebless needed); full `mtgish-tooling`, `mtg-sdk`, `mtg-sets` (snapshot re-blessed — only the 5 new cards added — + lint + round-trip), and `rules-engine` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)