### PR TITLE
Add DSK Toy/Doll cluster (Friendly Teddy, Splitskin Doll, Twitching Doll) + mtgish autogen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3232,7 +3232,9 @@ answer it and would silently return `false`.
 
 ### Battlefield state
 
-- `YouControl(filter)` — you control ≥1 matching permanent.
+- `YouControl(filter, negate = false, excludeSelf = false)` — you control ≥1 matching permanent.
+  Set `excludeSelf = true` for "another …" wording, which excludes the resolving source from the
+  search (e.g. Splitskin Doll's "another creature with power 2 or less").
 - `YouControlAtLeast(count, filter)` — you control `count` or more matching permanents (the
   filtered-count generalization of `ControlCreaturesAtLeast`/`ControlLandsAtLeast`; e.g.
   `YouControlAtLeast(3, GameObjectFilter.Creature.attacking())` for Stormbeacon Blade).
@@ -4399,9 +4401,11 @@ substitution.
   — a permanent with one doesn't untap during its controller's untap step; model the restriction with
   `GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, GroupFilter(... .withCounter(Counters.HOURGLASS)))` so it stays
   projection-scoped.) (`hope` / `verse` / `influence` / `burden`: LTR — Dawn of a New Age / Lost Isle Calling /
-  Palantír of Orthanc / The One Ring. `loot`: OTJ — Bandit's Haul. Pure passive counters with no inherent rule; the
-  cards that use them accumulate/spend them via their own abilities and read the count via
-  `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.X))`.)
+  Palantír of Orthanc / The One Ring. `loot`: OTJ — Bandit's Haul. `nest` (`Counters.NEST`): DSK — Twitching Doll,
+  whose mana ability accumulates one per activation and whose sacrifice ability reads the count to scale a token
+  payoff. Pure passive counters with no inherent rule; the cards that use them accumulate/spend them via their own
+  abilities and read the count via `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.X))` — or, when a
+  self-sacrifice/exile cost wipes them first, `DynamicAmounts.lastKnownSourceCounters(...)` (CR 112.7a; see §13).)
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -50,7 +50,8 @@ enum class CounterType {
     INFLUENCE,
     BURDEN,
     LOOT,
-    WIND
+    WIND,
+    NEST
 }
 
 /**
@@ -142,6 +143,13 @@ object Counters {
      * count to scale its pay-or-sacrifice cost and the damage it deals. No inherent rule.
      */
     const val WIND = "wind"
+
+    /**
+     * Nest counter (DSK — Twitching Doll). Passive storage counter with no inherent rule; the
+     * card's own abilities accumulate it (a mana-ability adds one per activation) and read the
+     * count to scale a token-creation payoff. No inherent rule.
+     */
+    const val NEST = "nest"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -188,9 +188,16 @@ object Conditions {
      * General-purpose battlefield existence check — pass any [GameObjectFilter]
      * (e.g. `GameObjectFilter.Creature.copy(statePredicates = listOf(StatePredicate.HasAnyCounter))`
      * for "a creature with a counter on it").
+     *
+     * Set [excludeSelf] for "another …" wording — the resolving source is excluded from the
+     * search (e.g. Splitskin Doll's "another creature with power 2 or less").
      */
-    fun YouControl(filter: GameObjectFilter, negate: Boolean = false): ConditionInterface =
-        Exists(Player.You, Zone.BATTLEFIELD, filter, negate = negate)
+    fun YouControl(
+        filter: GameObjectFilter,
+        negate: Boolean = false,
+        excludeSelf: Boolean = false
+    ): ConditionInterface =
+        Exists(Player.You, Zone.BATTLEFIELD, filter, negate = negate, excludeSelf = excludeSelf)
 
     /**
      * If you control an enchantment.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FriendlyTeddy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FriendlyTeddy.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Friendly Teddy
+ * {2}
+ * Artifact Creature — Bear Toy
+ * 2/2
+ * When this creature dies, each player draws a card.
+ */
+val FriendlyTeddy = card("Friendly Teddy") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Bear Toy"
+    oracleText = "When this creature dies, each player draws a card."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Johann Bodin"
+        flavorText = "Best friends are great to share secrets with—like where the matches are, or how to find a human heart."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg?1726286797"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SplitskinDoll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SplitskinDoll.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Splitskin Doll
+ * {1}{W}
+ * Artifact Creature — Toy
+ * 2/1
+ * When this creature enters, draw a card. Then discard a card unless you control
+ * another creature with power 2 or less.
+ */
+val SplitskinDoll = card("Splitskin Doll") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Toy"
+    oracleText = "When this creature enters, draw a card. Then discard a card unless you control another creature with power 2 or less."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // "draw a card. Then discard a card unless you control another creature with power 2 or
+        // less." Modeled as draw, then a conditional discard gated on NOT controlling such a
+        // creature — the discard only happens when the "unless" clause is unmet.
+        effect = Effects.Composite(
+            DrawCardsEffect(1),
+            ConditionalEffect(
+                condition = Conditions.Not(
+                    Conditions.YouControl(
+                        GameObjectFilter.Creature.powerAtMost(2),
+                        excludeSelf = true
+                    )
+                ),
+                effect = Patterns.Hand.discardCards(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Diana Franco"
+        flavorText = "Those who mock its ragged surface and seeping eyes have a curious tendency to go missing."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg?1726285979"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TwitchingDoll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TwitchingDoll.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Twitching Doll
+ * {1}{G}
+ * Artifact Creature — Spider Toy
+ * 2/2
+ * {T}: Add one mana of any color. Put a nest counter on this creature.
+ * {T}, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for each
+ * counter on this creature. Activate only as a sorcery.
+ */
+val TwitchingDoll = card("Twitching Doll") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Spider Toy"
+    oracleText = "{T}: Add one mana of any color. Put a nest counter on this creature.\n{T}, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for each counter on this creature. Activate only as a sorcery."
+    power = 2
+    toughness = 2
+
+    // {T}: Add one mana of any color. Put a nest counter on this creature.
+    // This is still a mana ability (CR 605.1a): no target, and it could add mana.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddManaOfChoice(),
+            Effects.AddCounters(Counters.NEST, 1, EffectTarget.Self)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {T}, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for
+    // each counter on this creature. Activate only as a sorcery.
+    //
+    // The sacrifice is paid as a cost, which wipes the doll's counters before the effect
+    // resolves (CR 122.2). "for each counter on this creature" therefore reads the pre-cost
+    // count as last-known information (CR 112.7a) — the engine snapshots the source's counters
+    // at cost-payment time, read here via DynamicAmount.LastKnownSourceCounters over every
+    // counter kind (CounterTypeFilter.Any). This mirrors Lost Isle Calling.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.lastKnownSourceCounters(CounterTypeFilter.Any),
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH),
+            imageUri = "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg?1726236714"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "201"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg?1726286615"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1591,6 +1591,48 @@
     ]
 }
 
+// Friendly Teddy
+{
+    "name": "Friendly Teddy",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Bear Toy",
+    "oracleText": "When this creature dies, each player draws a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Johann Bodin",
+        "flavorText": "Best friends are great to share secrets with—like where the matches are, or how to find a human heart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg?1726286797"
+    },
+    "colorIdentityOverride": []
+}
+
 // Give In to Violence
 {
     "name": "Give In to Violence",
@@ -3549,6 +3591,102 @@
     ]
 }
 
+// Splitskin Doll
+{
+    "name": "Splitskin Doll",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Toy",
+    "oracleText": "When this creature enters, draw a card. Then discard a card unless you control another creature with power 2 or less.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Not",
+                                    "condition": {
+                                        "type": "Exists",
+                                        "player": "You",
+                                        "zone": "Battlefield",
+                                        "filter": "creature pow<=2",
+                                        "excludeSelf": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Diana Franco",
+        "flavorText": "Those who mock its ragged surface and seeping eyes have a curious tendency to go missing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg?1726285979"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // The Wandering Rescuer
 {
     "name": "The Wandering Rescuer",
@@ -3648,6 +3786,79 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "GREEN"
+    ]
+}
+
+// Twitching Doll
+{
+    "name": "Twitching Doll",
+    "manaCost": "{1}{G}",
+    "typeLine": "Artifact Creature — Spider Toy",
+    "oracleText": "{T}: Add one mana of any color. Put a nest counter on this creature.\n{T}, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for each counter on this creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "AddManaOfChoice",
+                        {
+                            "type": "AddCounters",
+                            "counterType": "nest",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "LastKnownSourceCounters",
+                        "counterType": "CounterAny"
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg?1726236714"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "RARE",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg?1726286615"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3165,7 +3165,17 @@ private fun EmitCtx.activatedAbilityStmts(
     hasWaterbend: Boolean = false,
 ): List<Stmt>? {
     val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
-    val edsl = renderEffectList(actions, tvar) ?: return null
+    // When the activation cost sacrifices/exiles the source, its counters are wiped before the
+    // effect resolves; flag that so a "for each counter on this" count renders as last-known
+    // information rather than reading the (now-zero) live count. Scoped to this ability's effect
+    // rendering only.
+    val prevSacrificed = sourceSacrificedByCost
+    sourceSacrificedByCost = cost.contains("SacrificeSelf") || cost.contains("ExileSelf")
+    val edsl = try {
+        renderEffectList(actions, tvar) ?: return null
+    } finally {
+        sourceSacrificedByCost = prevSacrificed
+    }
     val stmts = mutableListOf<Stmt>(Assign("cost", Lit(cost)))
     if (hasWaterbend) stmts.add(Assign("hasWaterbend", Lit("true")))
     activationRestrictionLines(rule)?.let { lines -> lines.forEach { stmts.add(RawLine(it)) } } ?: return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -109,6 +109,17 @@ class EmitCtx(val keywords: Set<String>, val oracleText: String? = null) {
      * Set/cleared only by [triggerBlock]; default false on every other path.
      */
     var triggeringEntityIsSpell: Boolean = false
+
+    /**
+     * True while rendering the effect of an activated ability whose cost sacrifices or exiles the
+     * source itself. In that context the source's counters are wiped at cost-payment time
+     * (CR 122.2), so "for each counter on this creature" must read the pre-cost count as last-known
+     * information (`DynamicAmount.LastKnownSourceCounters`, snapshotted by the engine at activation)
+     * rather than `countersOnSelf`, which would read zero. Set/cleared only by [activatedAbilityStmts];
+     * default false on every other path (the source is still on the battlefield). Twitching Doll,
+     * Lost Isle Calling.
+     */
+    var sourceSacrificedByCost: Boolean = false
 }
 
 internal val SELF_REFS = setOf(
@@ -367,6 +378,23 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
             return if (creaturesYouControl) {
                 call("DynamicAmounts.battlefield", arg("Player.You"), arg("GameObjectFilter.Creature")).dot("maxPower")
             } else null
+        }
+        // "the number of counters on this creature" (Twitching Doll's "a Spider token for each counter
+        // on this creature"). When no counter kind is named the count spans ALL counter kinds. The
+        // source-relative reader depends on whether the enclosing ability sacrifices/exiles the source:
+        // when it does (Twitching Doll's "{T}, Sacrifice this creature"), the cost wipes the counters
+        // before the effect resolves, so the count must read the pre-cost snapshot via
+        // DynamicAmounts.lastKnownSourceCounters; otherwise the source is still present and
+        // DynamicAmounts.countersOnSelf reads the live count. Only the ThisPermanent subject with no
+        // named counter type renders; a specific counter kind or any other permanent subject declines
+        // (-> SCAFFOLD) rather than miscount.
+        "NumCountersOnPermanent" -> {
+            if (!jsonContains(node["args"], "_Permanent", "ThisPermanent") ||
+                "_CounterType" in compact(node["args"])
+            ) return null
+            val reader = if (sourceSacrificedByCost) "DynamicAmounts.lastKnownSourceCounters"
+                         else "DynamicAmounts.countersOnSelf"
+            return call(reader, arg("CounterTypeFilter.Any"))
         }
         "LifeTotalOfPlayer" -> {
             val player = if (jsonContains(node, "_Player", "Opponent")) "Player.EachOpponent" else "Player.You"
@@ -753,8 +781,20 @@ internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
         if (args != null && (args.getOrNull(0) as? JsonObject)?.strField("_Player") == "You") {
             val controls = args.getOrNull(1) as? JsonObject
             if (controls?.strField("_Players") == "ControlsA") {
-                val filter = gameObjectFilterDsl(controls["args"])
-                if (filter != null) return render(call("Conditions.YouControl", arg(Lit(filter))))
+                // "you control ANOTHER <filter>" (Splitskin Doll's "another creature with power 2 or
+                // less"): the filter's `And` carries an `Other(<self>)` clause. The flat GameObjectFilter
+                // can't carry excludeSelf, so peel that clause off and render the remaining filter under
+                // Conditions.YouControl(filter, excludeSelf = true). Without this the "another" restriction
+                // would be silently dropped.
+                val (innerFilter, excludeSelf) = stripSelfOtherClause(controls["args"])
+                val filter = gameObjectFilterDsl(innerFilter)
+                if (filter != null) {
+                    return render(
+                        if (excludeSelf)
+                            call("Conditions.YouControl", arg(Lit(filter)), arg("excludeSelf", "true"))
+                        else call("Conditions.YouControl", arg(Lit(filter)))
+                    )
+                }
             }
             // "if you have no cards in hand" -> Conditions.EmptyHand. Only the exact
             // `NumCardsInHandIs(EqualTo 0)` shape renders; any other comparator/count declines.
@@ -787,6 +827,32 @@ internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
     // another instant or sorcery this turn", …) reuse the shared condition renderer; declining beats
     // widening. These power the resolution-time `on("If")` action handler.
     return interveningIfDsl(cond)
+}
+
+/**
+ * Peel a self-`Other` clause off a permanent filter. A filter for "another <thing>" carries an
+ * `Other(<self ref>)` clause (e.g. `And(Other(ThatEnteringPermanent), IsCardtype Creature, …)`) the
+ * flat GameObjectFilter can't represent. Returns the filter with that clause removed and `true` when an
+ * `And` contained exactly one self-`Other` clause (so the caller can render `excludeSelf = true`);
+ * otherwise returns the filter unchanged with `false`. Any non-self `Other` (e.g. `Other(You)`, handled
+ * elsewhere as a controller predicate) is left in place so it isn't misread as excludeSelf.
+ */
+internal fun stripSelfOtherClause(filterNode: JsonElement?): Pair<JsonElement?, Boolean> {
+    val obj = filterNode as? JsonObject ?: return filterNode to false
+    if (obj.strField("_Permanents") != "And") return filterNode to false
+    val arms = obj["args"].asArr ?: return filterNode to false
+    fun isSelfOther(arm: JsonElement?): Boolean {
+        val a = arm as? JsonObject ?: return false
+        return a.strField("_Permanents") == "Other" &&
+            (a["args"] as? JsonObject)?.strField("_Permanent") in SELF_REFS
+    }
+    if (arms.none { isSelfOther(it) }) return filterNode to false
+    val remaining = arms.filterNot { isSelfOther(it) }
+    val rebuilt = buildJsonObject {
+        put("_Permanents", JsonPrimitive("And"))
+        put("args", buildJsonArray { remaining.forEach { add(it) } })
+    }
+    return rebuilt to true
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -322,6 +322,16 @@ internal fun EmitCtx.renderEachPlayer(node: JsonObject): Dsl? {
             arg("effects", "Patterns.Library.mill($amt).effects"),
         )
     }
+    // "each player draws a card" (Friendly Teddy's dies trigger) — AnyPlayer scope + DrawACard (a
+    // fixed single draw). Scoped to every player via EffectTarget.PlayerRef(Player.Each); the
+    // dynamic/X-count variants are handled by the eachPlayerDrawsX shape below.
+    if (jsonContains(node, "_Players", "AnyPlayer") && jsonContains(node, "_Action", "DrawACard")) {
+        val inner = node["args"].asArr?.filterIsInstance<JsonObject>()
+            ?.firstOrNull { it.strField("_Action") == "DrawACard" } ?: return null
+        // Only the bare "draw a card" renders here; any richer draw action declines.
+        if (inner["args"] != null) return null
+        return call("Effects.DrawCards", arg("1"), arg("EffectTarget.PlayerRef(Player.Each)"))
+    }
     if (jsonContains(node, "_Action", "DrawNumberCards") || jsonContains(node, "_GameNumber", "ValueX"))
         return call("Patterns.Hand.eachPlayerDrawsX", arg("includeController", "true"), arg("includeOpponents", "true"))
     return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -368,6 +368,10 @@ internal fun counterTypeDsl(counterNode: JsonElement?): String? {
         // rule; the card's own static ability reads the count ("as long as there are five or more
         // growth counters …"). Adding one is a plain AddCounters(Counters.GROWTH, …).
         "GrowthCounter" -> "Counters.GROWTH"
+        // Nest counter (DSK — Twitching Doll): a passive storage counter with no inherent rule; the
+        // card's own abilities accumulate it and read the count to scale a token payoff. Adding one
+        // is a plain AddCounters(Counters.NEST, …).
+        "NestCounter" -> "Counters.NEST"
         else -> null
     }
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -371,6 +371,34 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         )
     }
 
+    // Inline `Unless{cond}[actions]` action -> a `ConditionalEffect` that runs [actions] only when the
+    // condition is FALSE ("do X unless <cond>"). The condition resolves via [actionConditionDsl]; the
+    // "unless" is the negation, so it renders as `Conditions.Not(<cond>)`. Splitskin Doll: "draw a card.
+    // Then discard a card unless you control another creature with power 2 or less." — the discard runs
+    // only when you DON'T control such a creature. Anything the condition or the actions can't render
+    // declines (-> SCAFFOLD) rather than dropping the clause. The cost-side `Unless` (CostWasPaid +
+    // sacrifice/counter) is collapsed by the MayCost/PlayerMayCost pair recognizers before reaching here.
+    on("Unless") { _, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val cond = a.getOrNull(0) as? JsonObject ?: return@on null
+        // Only the resolution-time state conditions actionConditionDsl renders are supported. A
+        // CostWasPaid condition belongs to the echo / counter-unless-pays pair handlers, not here.
+        if (cond.strField("_Condition") == "CostWasPaid") return@on null
+        val condDsl = actionConditionDsl(cond) ?: return@on null
+        val inner = when (val second = a.getOrNull(1)) {
+            is JsonArray -> second.filterIsInstance<JsonObject>()
+            is JsonObject -> listOf(second)
+            else -> return@on null
+        }
+        if (inner.isEmpty()) return@on null
+        val edsl = renderEffectList(inner, tvar) ?: return@on null
+        call(
+            "ConditionalEffect",
+            arg("condition", call("Conditions.Not", arg(Lit(condDsl)))),
+            arg("effect", edsl),
+        )
+    }
+
     on("Scry") { _, args, _ ->  // "Scry N" -> look-top, reorder/bottom pipeline
         (findInteger(args) as? Int)?.let { call("Patterns.Library.scry", arg("$it")) }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FriendlyTeddyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FriendlyTeddyScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Friendly Teddy (DSK #247) — {2} Artifact Creature — Bear Toy 2/2.
+ *
+ * "When this creature dies, each player draws a card."
+ *
+ * Exercises the dies trigger fanning a single card draw over every player
+ * (Effects.DrawCards(1, Player.Each)).
+ */
+class FriendlyTeddyScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("when Friendly Teddy dies, each player draws a card") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.player2
+
+        val teddy = driver.putCreatureOnBattlefield(player, "Friendly Teddy")
+        val handBefore = driver.getHandSize(player)
+        val oppHandBefore = driver.getHandSize(opponent)
+
+        // Destroy the Teddy via a Lightning Bolt to the face... actually bolt the 2/2 directly.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(teddy)).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt — Teddy dies, queuing the dies trigger
+        driver.bothPass() // resolve the dies trigger
+
+        driver.isPaused shouldBe false
+        driver.findPermanent(player, "Friendly Teddy") shouldBe null
+
+        // Both players drew exactly one card from the dies trigger.
+        driver.getHandSize(player) shouldBe handBefore + 1
+        driver.getHandSize(opponent) shouldBe oppHandBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplitskinDollScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplitskinDollScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Splitskin Doll (DSK #33) — {1}{W} Artifact Creature — Toy 2/1.
+ *
+ * "When this creature enters, draw a card. Then discard a card unless you control another creature
+ *  with power 2 or less."
+ *
+ * Exercises the enters trigger draw + the conditional discard gated on
+ * `Conditions.Not(YouControl(Creature.powerAtMost(2), excludeSelf = true))` — the discard happens
+ * only when you don't control ANOTHER creature with power 2 or less (the Doll itself, power 2, must
+ * not satisfy the clause).
+ */
+class SplitskinDollScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("no other low-power creature: draw then must discard") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        // A 3/3 (power > 2) does NOT satisfy the "power 2 or less" clause.
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val doll = driver.putCardInHand(player, "Splitskin Doll")
+        driver.giveMana(player, Color.WHITE, 2)
+        val handBefore = driver.getHandSize(player) - 1 // the doll itself leaves hand on cast
+
+        driver.castSpell(player, doll).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell -> enters trigger goes on the stack
+        driver.bothPass() // resolve the enters trigger: draw, then conditional discard
+
+        // The draw happened, then a discard is required (no other power<=2 creature).
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(player, CardsSelectedResponse(decision.id, listOf(driver.getHand(player).first())))
+        driver.isPaused shouldBe false
+
+        // Net hand size: +1 draw, -1 discard = unchanged from pre-cast (excluding the doll).
+        driver.getHandSize(player) shouldBe handBefore
+    }
+
+    test("another power-2-or-less creature: draw with no discard") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        // A 1/1 (power 2 or less) satisfies the "unless" clause, so no discard.
+        driver.putCreatureOnBattlefield(player, "Savannah Lions")
+
+        val doll = driver.putCardInHand(player, "Splitskin Doll")
+        driver.giveMana(player, Color.WHITE, 2)
+        val handBefore = driver.getHandSize(player) - 1
+
+        driver.castSpell(player, doll).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // resolve the enters trigger: draw only, no discard
+
+        driver.pendingDecision shouldBe null
+        driver.isPaused shouldBe false
+        // Only the draw happened: +1 over pre-cast hand.
+        driver.getHandSize(player) shouldBe handBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwitchingDollScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwitchingDollScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.TwitchingDoll
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Twitching Doll (DSK #201) — {1}{G} Artifact Creature — Spider Toy 2/2.
+ *
+ * "{T}: Add one mana of any color. Put a nest counter on this creature.
+ *  {T}, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for each
+ *  counter on this creature. Activate only as a sorcery."
+ *
+ * Exercises the new NEST passive counter, the mana ability that adds it, and the sacrifice ability
+ * that reads the pre-cost counter count as last-known information
+ * (`DynamicAmount.LastKnownSourceCounters`) to scale the token payoff.
+ */
+class TwitchingDollScenarioTest : FunSpec({
+
+    val manaAbilityId = TwitchingDoll.activatedAbilities[0].id
+    val sacAbilityId = TwitchingDoll.activatedAbilities[1].id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun spiderTokenCount(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.getCreatures(player).count {
+            driver.state.getEntity(it)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?.typeLine?.subtypes
+                ?.any { s -> s.value.equals("Spider", ignoreCase = true) } == true
+        }
+
+    test("mana ability puts a nest counter on the doll") {
+        val driver = newDriver()
+        val player = driver.player1
+        val doll = driver.putCreatureOnBattlefield(player, "Twitching Doll")
+        driver.removeSummoningSickness(doll)
+
+        driver.submit(ActivateAbility(playerId = player, sourceId = doll, abilityId = manaAbilityId))
+        // The mana ability pauses to ask which color of mana to add; answer it so the rest of the
+        // composite (the nest counter) resolves.
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseColorDecision>()
+        driver.submitDecision(player, ColorChosenResponse(decision.id, com.wingedsheep.sdk.core.Color.GREEN))
+
+        val counters = driver.state.getEntity(doll)?.get<CountersComponent>()?.counters ?: emptyMap()
+        counters[CounterType.NEST] shouldBe 1
+    }
+
+    test("sacrifice ability creates a Spider token for each counter (read as last-known info)") {
+        val driver = newDriver()
+        val player = driver.player1
+        val doll = driver.putCreatureOnBattlefield(player, "Twitching Doll")
+        driver.removeSummoningSickness(doll)
+
+        // Seed two nest counters directly, then sacrifice: the cost wipes the counters, so the
+        // token count must come from the pre-cost snapshot (LastKnownSourceCounters).
+        driver.addComponent(doll, CountersComponent(mapOf(CounterType.NEST to 2)))
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = doll, abilityId = sacAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the activated ability
+
+        driver.isPaused shouldBe false
+        // The doll was sacrificed as a cost.
+        driver.findPermanent(player, "Twitching Doll") shouldBe null
+        // Two nest counters -> two 2/2 Spider tokens.
+        spiderTokenCount(driver, player) shouldBe 2
+    }
+
+    test("with no counters, the sacrifice ability creates no tokens") {
+        val driver = newDriver()
+        val player = driver.player1
+        val doll = driver.putCreatureOnBattlefield(player, "Twitching Doll")
+        driver.removeSummoningSickness(doll)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = doll, abilityId = sacAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe false
+        driver.findPermanent(player, "Twitching Doll") shouldBe null
+        spiderTokenCount(driver, player) shouldBe 0
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -106,4 +106,5 @@ export const counterManaClass: Record<string, string> = {
   BURDEN: 'counter-doom',
   LOOT: 'counter-charge',
   WIND: 'counter-vortex',
+  NEST: 'counter-fungus',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -667,6 +667,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.BURDEN,
   CounterType.LOOT,
   CounterType.WIND,
+  CounterType.NEST,
 ]
 
 /**

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1780,6 +1780,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   BURDEN: { bg: 'rgba(60, 25, 15, 0.95)', border: 'rgba(220, 160, 60, 0.7)', color: '#e8b860', glow: 'rgba(220, 160, 60, 0.6)' },
   LOOT: { bg: 'rgba(70, 55, 15, 0.95)', border: 'rgba(230, 200, 90, 0.7)', color: '#e8cf68', glow: 'rgba(230, 200, 90, 0.55)' },
   WIND: { bg: 'rgba(20, 60, 55, 0.95)', border: 'rgba(120, 220, 200, 0.6)', color: '#9ce0d0' },
+  NEST: { bg: 'rgba(25, 55, 25, 0.95)', border: 'rgba(120, 200, 110, 0.65)', color: '#a8e090', glow: 'rgba(120, 200, 110, 0.55)' },
 }
 
 const fallbackCounterPalette: CounterBadgePalette = { bg: 'rgba(40, 40, 40, 0.95)', border: 'rgba(180, 180, 180, 0.6)', color: '#e0e0e0' }

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -362,6 +362,7 @@ export enum CounterType {
   BURDEN = 'BURDEN',
   LOOT = 'LOOT',
   WIND = 'WIND',
+  NEST = 'NEST',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -407,6 +408,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.BURDEN]: 'Burden',
   [CounterType.LOOT]: 'Loot',
   [CounterType.WIND]: 'Wind',
+  [CounterType.NEST]: 'Nest',
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements three Duskmourn: House of Horror Toy/Doll permanents (canonical in DSK) and extends the
`:mtgish-tooling` emitter so all three classify as **AUTOGEN** (complete render — the emitter renders
each whole compiling card).

### Cards
- **Friendly Teddy** `{2}` 2/2 Artifact Creature — Bear Toy: "When this creature dies, each player draws a card."
- **Splitskin Doll** `{1}{W}` 2/1 Artifact Creature — Toy: "When this creature enters, draw a card. Then discard a card unless you control another creature with power 2 or less."
- **Twitching Doll** `{1}{G}` 2/2 Artifact Creature — Spider Toy: "`{T}`: Add one mana of any color. Put a nest counter on this creature. / `{T}`, Sacrifice this creature: Create a 2/2 green Spider creature token with reach for each counter on this creature. Activate only as a sorcery."

Twitching Doll's sacrifice cost wipes its counters before the effect resolves, so "for each counter on
this creature" reads the pre-cost count as **last-known information** (`DynamicAmount.LastKnownSourceCounters`,
CR 112.7a — the same primitive Lost Isle Calling uses), not the live count.

### SDK additions
- `CounterType.NEST` / `Counters.NEST` — a passive storage counter (no inherent rule), wired across the
  SDK and web-client (enum, display name, mana-font icon, passive-counter badge palette + render list).
- `Conditions.YouControl(filter, negate, excludeSelf)` — `excludeSelf` threads the "another …" wording
  through to the underlying `Exists` condition.

### mtgish emitter changes (render correctly or decline — never lossy)
- `renderEachPlayer`: "each player draws a card" (`AnyPlayer` + `DrawACard`) → `Effects.DrawCards(1, Player.Each)`.
- `on("Unless")`: "do X unless &lt;cond&gt;" → `ConditionalEffect(Conditions.Not(<cond>), X)`; a new
  `stripSelfOtherClause` peels an `Other(self)` clause off the `ControlsA` filter so the "another"
  restriction renders as `excludeSelf` instead of being silently dropped.
- `counterTypeDsl`: `NestCounter` → `Counters.NEST`.
- `dynamicAmountExpr`: `NumCountersOnPermanent(ThisPermanent)` → `countersOnSelf`, or
  `lastKnownSourceCounters` when the enclosing ability's cost sacrifices/exiles the source.

The `docs/card-sdk-language-reference.md` catalog is updated for both new building blocks.

## Testing
- New scenario tests (rules-engine), all passing: `FriendlyTeddyScenarioTest`, `SplitskinDollScenarioTest`,
  `TwitchingDollScenarioTest` (covers the NEST counter, mana-ability accumulation, and the LKI token count).
- `CardLintTest` + `CardDefinitionSnapshotTest` (mtg-sets) pass; the snapshot diff adds **only** the three
  new cards (no other card moved).
- `just coverage-verify DSK` → **GATE PASS** (all emitted cards compile + gameplay-tree match).
- `just coverage-verify POR` stays **0-mismatch** (158/158). `EmitterGoldenTest` goldens unchanged.
- `just check-card-printing` confirms all three are canonical in their earliest real printing (DSK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)