### PR TITLE
Add DSK cards: Gremlin Tamer, Tunnel Surveyor, Lionheart Glimmer

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GremlinTamer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GremlinTamer.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Gremlin Tamer
+ * {W}{U}
+ * Creature — Human Scout
+ * 2/2
+ *
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room,
+ * create a 1/1 red Gremlin creature token.
+ */
+val GremlinTamer = card("Gremlin Tamer") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, " +
+        "create a 1/1 red Gremlin creature token."
+
+    keywords(Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Gremlin"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1726236661",
+        )
+        description = "Eerie — Whenever an enchantment you control enters, create a 1/1 red Gremlin creature token."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room.
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Gremlin"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1726236661",
+        )
+        description = "Eerie — Whenever you fully unlock a Room, create a 1/1 red Gremlin creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Billy Christian"
+        flavorText = "\"Do they cause trouble? Sure. But if you're nice to them, the trouble happens to other folks.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg?1726286668"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LionheartGlimmer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LionheartGlimmer.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lionheart Glimmer
+ * {3}{W}{W}
+ * Enchantment Creature — Cat Glimmer
+ * 2/5
+ *
+ * Ward {2}
+ * Whenever you attack, creatures you control get +1/+1 until end of turn.
+ */
+val LionheartGlimmer = card("Lionheart Glimmer") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Cat Glimmer"
+    power = 2
+    toughness = 5
+    oracleText = "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent " +
+        "controls, counter it unless that player pays {2}.)\n" +
+        "Whenever you attack, creatures you control get +1/+1 until end of turn."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    // Whenever you attack, creatures you control get +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = Effects.ModifyStats(1, 1, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Josu Hernaiz"
+        flavorText = "The survivors would no longer be picked off one by one. It was their turn to hunt."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg?1726285926"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TunnelSurveyor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TunnelSurveyor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tunnel Surveyor
+ * {2}{U}
+ * Creature — Human Detective
+ * 2/2
+ *
+ * When this creature enters, create a 1/1 white Glimmer enchantment creature token.
+ */
+val TunnelSurveyor = card("Tunnel Surveyor") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Detective"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create a 1/1 white Glimmer enchantment creature token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Glimmer"),
+            enchantmentToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1754930946",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "John Stanko"
+        flavorText = "Though he needed to know what lay beyond the intersection, Harp couldn't suppress a shiver " +
+            "of disquiet as his glimmer disappeared into the darkness ahead."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg?1726286136"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2109,6 +2109,76 @@
     ]
 }
 
+// Gremlin Tamer
+{
+    "name": "Gremlin Tamer",
+    "manaCost": "{W}{U}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 1/1 red Gremlin creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Gremlin"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1726236661"
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, create a 1/1 red Gremlin creature token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Gremlin"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1726236661"
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, create a 1/1 red Gremlin creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Billy Christian",
+        "flavorText": "\"Do they cause trouble? Sure. But if you're nice to them, the trouble happens to other folks.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg?1726286668"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Hardened Escort
 {
     "name": "Hardened Escort",
@@ -2529,6 +2599,70 @@
         "rarity": "RARE",
         "artist": "Sergey Glushakov",
         "imageUri": "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg?1726285926"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lionheart Glimmer
+{
+    "name": "Lionheart Glimmer",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Enchantment Creature — Cat Glimmer",
+    "oracleText": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhenever you attack, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "The survivors would no longer be picked off one by one. It was their turn to hunt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg?1726285926"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -4099,6 +4233,51 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Tunnel Surveyor
+{
+    "name": "Tunnel Surveyor",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "When this creature enters, create a 1/1 white Glimmer enchantment creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Glimmer"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1754930946",
+                    "enchantmentToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "John Stanko",
+        "flavorText": "Though he needed to know what lay beyond the intersection, Harp couldn't suppress a shiver of disquiet as his glimmer disappeared into the darkness ahead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg?1726286136"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlimmerClusterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlimmerClusterScenarioTest.kt
@@ -113,6 +113,26 @@ class GlimmerClusterScenarioTest : ScenarioTestBase() {
             }
         }
 
+        context("Tunnel Surveyor") {
+            test("creates a 1/1 white Glimmer enchantment creature token when it enters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Tunnel Surveyor")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Tunnel Surveyor")
+                withClue("Casting Tunnel Surveyor should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.findPermanent("Tunnel Surveyor").shouldNotBeNull()
+                val token = game.findPermanent("Glimmer Token").shouldNotBeNull()
+                game.assertGlimmerToken(token)
+            }
+        }
+
         context("Glimmer Seeker") {
             test("creates a Glimmer token at second main if tapped and you control no Glimmer creature") {
                 val game = scenario()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GremlinTamerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GremlinTamerScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Gremlin Tamer (DSK #215).
+ *
+ * Gremlin Tamer — {W}{U} Creature — Human Scout, 2/2
+ *   "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a
+ *    Room, create a 1/1 red Gremlin creature token."
+ *
+ * Verifies the enchantment-enters Eerie trigger creates a 1/1 red Gremlin, and that an
+ * opponent's enchantment entering does NOT trigger it (the trigger is "an enchantment you control").
+ */
+class GremlinTamerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun TestGame.assertGremlinToken(tokenId: com.wingedsheep.sdk.model.EntityId) {
+        val card = state.getEntity(tokenId)!!.get<CardComponent>()!!
+        card.colors shouldBe setOf(Color.RED)
+        withClue("Gremlin token must have the Gremlin subtype") {
+            card.typeLine.subtypes.any { it.value == "Gremlin" } shouldBe true
+        }
+        val projected = projector.project(state)
+        projected.getPower(tokenId) shouldBe 1
+        projected.getToughness(tokenId) shouldBe 1
+    }
+
+    init {
+        context("Gremlin Tamer — Eerie (enchantment enters)") {
+
+            test("an enchantment you control entering creates a 1/1 red Gremlin token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gremlin Tamer")
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val token = game.findPermanent("Gremlin Token").shouldNotBeNull()
+                game.assertGremlinToken(token)
+            }
+
+            test("an opponent's enchantment entering does NOT create a Gremlin token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gremlin Tamer")
+                    .withCardInHand(2, "Test Enchantment") // {1}{W}, controlled by the opponent
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(2, "Test Enchantment")
+                withClue("Opponent casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The Tamer's controller gets no token — the enchantment isn't theirs") {
+                    game.findPermanent("Gremlin Token") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LionheartGlimmerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LionheartGlimmerScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lionheart Glimmer (DSK #19).
+ *
+ * Lionheart Glimmer — {3}{W}{W} Enchantment Creature — Cat Glimmer, 2/5
+ *   "Ward {2}
+ *    Whenever you attack, creatures you control get +1/+1 until end of turn."
+ *
+ * Verifies the attack trigger buffs every creature the attacking player controls (not just
+ * attackers) until end of turn, and that the Ward keyword is granted.
+ */
+class LionheartGlimmerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Lionheart Glimmer — Whenever you attack") {
+
+            test("buffs all creatures you control +1/+1 until end of turn, including a non-attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lionheart Glimmer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glimmer = game.findPermanent("Lionheart Glimmer").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // Attack with only the Glimmer; the Bears stays back as a non-attacker.
+                val attack = game.declareAttackers(mapOf("Lionheart Glimmer" to 2))
+                withClue("Declaring attackers should succeed: ${attack.error}") { attack.error shouldBe null }
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                withClue("Lionheart Glimmer should be 3/6 (2/5 +1/+1)") {
+                    projected.getPower(glimmer) shouldBe 3
+                    projected.getToughness(glimmer) shouldBe 6
+                }
+                withClue("Non-attacking Grizzly Bears should also be buffed to 3/3 (2/2 +1/+1)") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("the buff wears off at end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lionheart Glimmer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glimmer = game.findPermanent("Lionheart Glimmer").shouldNotBeNull()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Lionheart Glimmer" to 2))
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val projected = projector.project(game.state)
+                withClue("After the turn ends, Lionheart Glimmer is back to its printed 2/5") {
+                    projected.getPower(glimmer) shouldBe 2
+                    projected.getToughness(glimmer) shouldBe 5
+                }
+            }
+
+            test("has Ward as a granted keyword") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lionheart Glimmer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glimmer = game.findPermanent("Lionheart Glimmer").shouldNotBeNull()
+                val projected = projector.project(game.state)
+                withClue("Lionheart Glimmer has Ward") {
+                    projected.hasKeyword(glimmer, Keyword.WARD).shouldBeTrue()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements three **Duskmourn: House of Horror (DSK)** cards via the `add-card` skill. All three are pure card-authoring — no SDK or engine changes.

| Card | Cost | Type | Ability |
|------|------|------|---------|
| **Gremlin Tamer** | {W}{U} | Human Scout 2/2 | Eerie — create a 1/1 red Gremlin token whenever an enchantment you control enters and whenever you fully unlock a Room |
| **Tunnel Surveyor** | {2}{U} | Human Detective 2/2 | ETB — create a 1/1 white Glimmer enchantment creature token |
| **Lionheart Glimmer** | {3}{W}{W} | Cat Glimmer 2/5 | Ward {2}; whenever you attack, creatures you control get +1/+1 until end of turn |

All three reuse established building blocks (Eerie keyword + `Triggers.RoomFullyUnlocked`, `CreateToken` enchantment flag, `KeywordAbility.Ward`, `Triggers.YouAttack` + `ForEachInGroup` team-buff). No `card-sdk-language-reference.md` change needed.

## Substitutions

- **Acrobatic Cheerleader (assigned #1) — skipped.** Its *"This ability triggers only once"* (once per game) has no SDK support — only `oncePerTurn` exists, which would resolve the card incorrectly (a new flying counter every turn). That is `add-feature` territory.
- **Inquisitive Glimmer (backup #1) — skipped.** Its *"Unlock costs you pay cost {1} less"* has no cost-reduction hook in `UnlockRoomDoorHandler` (pays the printed cost directly). Also `add-feature` territory.
- **Lionheart Glimmer (backup #2) — implemented** instead, landing 3 cards total.

## mtgish-tooling

No emitter change required: all three cards already emit at **AUTO** fidelity from existing handlers, and the emitter output matches the hand-written implementations. `coverage-verify`:
- **POR: GATE PASS, 0 mismatch** — no regression (the calibrated gate).
- **DSK:** the new cards emit cleanly (now in "emitted outside golden"). The single DSK `GATE FAIL` is the **pre-existing Glimmer Seeker** emitter/golden mismatch (committed on `main`, unrelated to these cards).

## Tests

- `rules-engine`: `GremlinTamerScenarioTest`, `LionheartGlimmerScenarioTest`, and a Tunnel Surveyor case folded into the existing `GlimmerClusterScenarioTest` — all pass.
- `mtg-sets`: snapshot re-blessed (additive — only the 3 new cards, +179/-0 lines on `DSK.json`); `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)