### PR TITLE
Add Insidious Fungus, Rootwise Survivor, Scrabbling Skullcrab (DSK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InsidiousFungus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InsidiousFungus.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Insidious Fungus
+ * {G}
+ * Creature — Fungus
+ * 1/2
+ *
+ * {2}, Sacrifice this creature: Choose one —
+ * • Destroy target artifact.
+ * • Destroy target enchantment.
+ * • Draw a card. Then you may put a land card from your hand onto the battlefield tapped.
+ *
+ * Modal activated ability (CR 700.2 — choose one). Cost is `{2}` plus sacrificing this
+ * creature; the modes are chosen at resolution via [ModalEffect.chooseOne]. The first two
+ * modes target an artifact / enchantment; the third draws then optionally puts a land from
+ * hand onto the battlefield tapped via [Patterns.Hand.putFromHand] (the "you may" is the
+ * choose-up-to-one selection inside that pattern).
+ */
+val InsidiousFungus = card("Insidious Fungus") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus"
+    power = 1
+    toughness = 2
+    oracleText = "{2}, Sacrifice this creature: Choose one —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target enchantment.\n" +
+        "• Draw a card. Then you may put a land card from your hand onto the battlefield tapped."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.Destroy(EffectTarget.ContextTarget(0)),
+                Targets.Artifact,
+                "Destroy target artifact"
+            ),
+            Mode.withTarget(
+                Effects.Destroy(EffectTarget.ContextTarget(0)),
+                Targets.Enchantment,
+                "Destroy target enchantment"
+            ),
+            Mode.noTarget(
+                Effects.Composite(
+                    Effects.DrawCards(1),
+                    Patterns.Hand.putFromHand(GameObjectFilter.Land, entersTapped = true)
+                ),
+                "Draw a card. Then you may put a land card from your hand onto the battlefield tapped"
+            )
+        )
+        description = "{2}, Sacrifice this creature: Choose one — Destroy target artifact; " +
+            "or destroy target enchantment; or draw a card, then you may put a land card from " +
+            "your hand onto the battlefield tapped."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "186"
+        artist = "Slawomir Maniak"
+        flavorText = "Wherever it grows, wood rots, walls turn gray, and flesh becomes fertilizer."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg?1726286558"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RootwiseSurvivor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RootwiseSurvivor.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Rootwise Survivor
+ * {3}{G}{G}
+ * Creature — Human Survivor
+ * 3/4
+ *
+ * Haste
+ * Survival — At the beginning of your second main phase, if this creature is tapped, put
+ * three +1/+1 counters on up to one target land you control. That land becomes a 0/0
+ * Elemental creature in addition to its other types. It gains haste until your next turn.
+ *
+ * "Survival" is an ability word (no rules meaning) — modeled as a postcombat-main-phase
+ * trigger ([Triggers.YourPostcombatMain]) with an intervening-if ([Conditions.SourceIsTapped],
+ * CR 603.4 — checked both when it would trigger and on resolution). The target is "up to one"
+ * land you control (`optional = true`), so the ability still resolves with no target chosen.
+ * The animation is permanent — the land stays a 0/0 Elemental creature (in addition to its
+ * land type) with the three +1/+1 counters; only the granted haste is bounded to
+ * [Duration.UntilYourNextTurn].
+ */
+val RootwiseSurvivor = card("Rootwise Survivor") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Survivor"
+    power = 3
+    toughness = 4
+    oracleText = "Haste\n" +
+        "Survival — At the beginning of your second main phase, if this creature is tapped, " +
+        "put three +1/+1 counters on up to one target land you control. That land becomes a " +
+        "0/0 Elemental creature in addition to its other types. It gains haste until your next turn."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        val land = target("target land you control", TargetObject(filter = TargetFilter.Land.youControl(), optional = true))
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, land),
+            Effects.BecomeCreature(
+                target = land,
+                power = 0,
+                toughness = 0,
+                creatureTypes = setOf("Elemental"),
+                duration = Duration.Permanent,
+            ),
+            Effects.GrantKeyword(Keyword.HASTE, land, Duration.UntilYourNextTurn),
+        )
+        description = "Survival — At the beginning of your second main phase, if this creature " +
+            "is tapped, put three +1/+1 counters on up to one target land you control. That land " +
+            "becomes a 0/0 Elemental creature in addition to its other types. It gains haste " +
+            "until your next turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "196"
+        artist = "Joseph Weston"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg?1726286598"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ScrabblingSkullcrab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ScrabblingSkullcrab.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Scrabbling Skullcrab
+ * {U}
+ * Creature — Crab Skeleton
+ * 0/3
+ *
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room,
+ * target player mills two cards.
+ *
+ * Eerie is modeled as two triggered abilities (CR — the keyword ability word covers both an
+ * enchantment-you-control entering and fully unlocking a Room). Each independently picks a
+ * target player and mills two via [Patterns.Library.mill].
+ */
+val ScrabblingSkullcrab = card("Scrabbling Skullcrab") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab Skeleton"
+    power = 0
+    toughness = 3
+    oracleText = "Eerie — Whenever an enchantment you control enters and whenever you fully " +
+        "unlock a Room, target player mills two cards. (They put the top two cards of their " +
+        "library into their graveyard.)"
+
+    keywords(Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val target = target("target", Targets.Player)
+        effect = Patterns.Library.mill(2, target)
+        description = "Eerie — Whenever an enchantment you control enters, target player mills two cards."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        val target = target("target", Targets.Player)
+        effect = Patterns.Library.mill(2, target)
+        description = "Eerie — Whenever you fully unlock a Room, target player mills two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "71"
+        artist = "John Tedrick"
+        flavorText = "With sandy beaches in short supply, Duskmourn's crabs have adapted to " +
+            "burrow into everything from carpet to flesh."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg?1726286116"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2385,6 +2385,144 @@
     ]
 }
 
+// Insidious Fungus
+{
+    "name": "Insidious Fungus",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Fungus",
+    "oracleText": "{2}, Sacrifice this creature: Choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Draw a card. Then you may put a land card from your hand onto the battlefield tapped.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target artifact"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "enchantment"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target enchantment"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "FromZone",
+                                                    "zone": "Hand",
+                                                    "filter": "land"
+                                                },
+                                                "storeAs": "put_candidates"
+                                            },
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "put_candidates",
+                                                "selection": {
+                                                    "type": "ChooseUpTo",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeSelected": "putting"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "putting",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Battlefield",
+                                                    "placement": "Tapped"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "description": "Draw a card. Then you may put a land card from your hand onto the battlefield tapped"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{2}, Sacrifice this creature: Choose one — Destroy target artifact; or destroy target enchantment; or draw a card, then you may put a land card from your hand onto the battlefield tapped."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "UNCOMMON",
+        "artist": "Slawomir Maniak",
+        "flavorText": "Wherever it grows, wood rots, walls turn gray, and flesh becomes fertilizer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg?1726286558"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Irreverent Gremlin
 {
     "name": "Irreverent Gremlin",
@@ -3443,6 +3581,215 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Rootwise Survivor
+{
+    "name": "Rootwise Survivor",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Human Survivor",
+    "oracleText": "Haste\nSurvival — At the beginning of your second main phase, if this creature is tapped, put three +1/+1 counters on up to one target land you control. That land becomes a 0/0 Elemental creature in addition to its other types. It gains haste until your next turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            }
+                        },
+                        {
+                            "type": "BecomeCreature",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            },
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "creatureTypes": [
+                                "Elemental"
+                            ],
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            },
+                            "duration": "UntilYourNextTurn"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "land ctrl:you"
+                    },
+                    "id": "target land you control"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "descriptionOverride": "Survival — At the beginning of your second main phase, if this creature is tapped, put three +1/+1 counters on up to one target land you control. That land becomes a 0/0 Elemental creature in addition to its other types. It gains haste until your next turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Weston",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg?1726286598"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Scrabbling Skullcrab
+{
+    "name": "Scrabbling Skullcrab",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Crab Skeleton",
+    "oracleText": "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, target player mills two cards. (They put the top two cards of their library into their graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, target player mills two cards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, target player mills two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "UNCOMMON",
+        "artist": "John Tedrick",
+        "flavorText": "With sandy beaches in short supply, Duskmourn's crabs have adapted to burrow into everything from carpet to flesh.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg?1726286116"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InsidiousFungusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InsidiousFungusScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.InsidiousFungus
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Insidious Fungus (DSK #186).
+ *
+ * Insidious Fungus — {G} Creature — Fungus, 1/2
+ *   "{2}, Sacrifice this creature: Choose one —
+ *    • Destroy target artifact.
+ *    • Destroy target enchantment.
+ *    • Draw a card. Then you may put a land card from your hand onto the battlefield tapped."
+ *
+ * Exercises the modal *activated* ability: paying the cost (mana + sacrifice), the
+ * resolution-time mode choice, and each mode's effect. The sacrifice cost moves the Fungus
+ * to the graveyard regardless of which mode is chosen.
+ */
+class InsidiousFungusScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = InsidiousFungus.activatedAbilities.first().id
+
+    init {
+        context("Insidious Fungus — modal activated ability") {
+
+            test("mode 1 destroys target artifact; the Fungus is sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Insidious Fungus")
+                    .withCardOnBattlefield(2, "Bonesplitter")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fungus = game.findPermanent("Insidious Fungus")!!
+                val artifact = game.findPermanent("Bonesplitter")!!
+
+                val act = game.execute(ActivateAbility(game.player1Id, fungus, abilityId))
+                withClue("Activating the ability should succeed: ${act.error}") {
+                    act.error shouldBe null
+                }
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision after mode pick; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(artifact))))
+                game.resolveStack()
+
+                withClue("The artifact is destroyed") {
+                    game.isInGraveyard(2, "Bonesplitter") shouldBe true
+                }
+                withClue("The Fungus was sacrificed as a cost") {
+                    game.isInGraveyard(1, "Insidious Fungus") shouldBe true
+                }
+            }
+
+            test("mode 2 destroys target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Insidious Fungus")
+                    .withCardOnBattlefield(2, "Pacifism") // an enchantment
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fungus = game.findPermanent("Insidious Fungus")!!
+                val pacifism = game.findPermanent("Pacifism")!!
+
+                game.execute(ActivateAbility(game.player1Id, fungus, abilityId)).error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision after mode pick")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(pacifism))))
+                game.resolveStack()
+
+                withClue("The enchantment is destroyed") {
+                    game.isInGraveyard(2, "Pacifism") shouldBe true
+                }
+            }
+
+            test("mode 3 draws a card and may put a land from hand onto the battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Insidious Fungus")
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fungus = game.findPermanent("Insidious Fungus")!!
+                val handBefore = game.handSize(1)
+
+                game.execute(ActivateAbility(game.player1Id, fungus, abilityId)).error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 2))
+                game.resolveStack()
+
+                // Drew Grizzly Bears (+1 to hand); the optional land put surfaces a selection.
+                if (game.hasPendingDecision()) {
+                    val land = game.findCardsInHand(1, "Mountain").firstOrNull()
+                    if (land != null) game.selectCards(listOf(land)) else game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Drew a card (Grizzly Bears in hand)") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("The Mountain was put onto the battlefield tapped") {
+                    game.isOnBattlefield("Mountain") shouldBe true
+                }
+                // hand: -Mountain (put to battlefield) +Grizzly Bears = net unchanged
+                game.handSize(1) shouldBe handBefore
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RootwiseSurvivorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RootwiseSurvivorScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rootwise Survivor (DSK #196).
+ *
+ * Rootwise Survivor — {3}{G}{G} Creature — Human Survivor, 3/4
+ *   "Haste
+ *    Survival — At the beginning of your second main phase, if this creature is tapped, put
+ *    three +1/+1 counters on up to one target land you control. That land becomes a 0/0
+ *    Elemental creature in addition to its other types. It gains haste until your next turn."
+ *
+ * Verifies the intervening-if (only when the Survivor is tapped), the three +1/+1 counters,
+ * the permanent animate-into-Elemental (still a land), the granted haste, and that an
+ * untapped Survivor produces no trigger.
+ */
+class RootwiseSurvivorScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Rootwise Survivor — Survival trigger") {
+
+            test("a tapped Survivor animates a target land into a 3/3 Elemental land with haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rootwise Survivor", tapped = true)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+
+                // Advance to the second main phase — the Survival trigger fires (source is tapped).
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                var guard = 0
+                while (game.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+                    game.resolveStack()
+                    guard++
+                }
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the Survival trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(forest))))
+                game.resolveStack()
+
+                withClue("The land has three +1/+1 counters") {
+                    val counters = game.state.getEntity(forest)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 3
+                }
+
+                val projected = projector.project(game.state)
+                withClue("The land is now an Elemental creature, still a land") {
+                    projected.hasType(forest, "LAND") shouldBe true
+                    projected.hasType(forest, "CREATURE") shouldBe true
+                }
+                withClue("Base 0/0 plus three +1/+1 counters = 3/3") {
+                    projected.getPower(forest) shouldBe 3
+                    projected.getToughness(forest) shouldBe 3
+                }
+                withClue("The land gains haste") {
+                    projected.hasKeyword(forest, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("an untapped Survivor does NOT fire the Survival trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rootwise Survivor", tapped = false)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(5) { if (game.hasPendingDecision()) Unit else game.resolveStack() }
+
+                withClue("No Survival trigger — the Survivor is untapped, so the intervening-if fails") {
+                    (game.state.pendingDecision is ChooseTargetsDecision) shouldBe false
+                    val counters = game.state.getEntity(forest)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe null
+                    projector.project(game.state).hasType(forest, "CREATURE") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrabblingSkullcrabScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrabblingSkullcrabScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Scrabbling Skullcrab (DSK #71).
+ *
+ * Scrabbling Skullcrab — {U} Creature — Crab Skeleton, 0/3
+ *   "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a
+ *    Room, target player mills two cards."
+ *
+ * Verifies the enchantment-enters Eerie trigger mills the chosen target player two cards,
+ * and that an opponent's enchantment entering does NOT trigger it ("an enchantment you control").
+ */
+class ScrabblingSkullcrabScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Scrabbling Skullcrab — Eerie (enchantment enters)") {
+
+            test("an enchantment you control entering mills the chosen target player two cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scrabbling Skullcrab")
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentLibraryBefore = game.librarySize(2)
+                val opponentGraveBefore = game.graveyardSize(2)
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                // Resolving the enchantment surfaces the Eerie trigger's target choice.
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the Eerie mill trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(game.player2Id))))
+                game.resolveStack()
+
+                withClue("The targeted opponent mills two cards") {
+                    game.librarySize(2) shouldBe opponentLibraryBefore - 2
+                    game.graveyardSize(2) shouldBe opponentGraveBefore + 2
+                }
+            }
+
+            test("an opponent's enchantment entering does NOT trigger the Eerie mill") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scrabbling Skullcrab")
+                    .withCardInHand(2, "Test Enchantment") // {1}{W}, controlled by the opponent
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val p1LibraryBefore = game.librarySize(1)
+                val p2LibraryBefore = game.librarySize(2)
+
+                val cast = game.castSpell(2, "Test Enchantment")
+                withClue("Opponent casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("No Eerie mill trigger — the enchantment isn't the Skullcrab controller's") {
+                    game.hasPendingDecision() shouldBe false
+                    game.librarySize(1) shouldBe p1LibraryBefore
+                    game.librarySize(2) shouldBe p2LibraryBefore
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards added (Duskmourn: House of Horror)

All three are pure card-authoring over existing SDK facades — no engine/SDK changes.

### Insidious Fungus — {G} Creature — Fungus, 1/2
`{2}, Sacrifice this creature: Choose one —` modeled as a modal **activated** ability via `ModalEffect.chooseOne` (cost = `Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)`):
- Destroy target artifact.
- Destroy target enchantment.
- Draw a card, then you may put a land from your hand onto the battlefield tapped (`Patterns.Hand.putFromHand(GameObjectFilter.Land, entersTapped = true)`).

### Rootwise Survivor — {3}{G}{G} Creature — Human Survivor, 3/4
Haste + the **Survival** ability word: a postcombat-main trigger (`Triggers.YourPostcombatMain`) with an intervening-if (`Conditions.SourceIsTapped`, CR 603.4) that puts three +1/+1 counters on up to one target land you control, permanently animates it into a 0/0 Elemental (still a land) via `BecomeCreature`, and grants haste until your next turn.

### Scrabbling Skullcrab — {U} Creature — Crab Skeleton, 0/3
**Eerie** — two triggers (an enchantment you control enters + `Triggers.RoomFullyUnlocked`), each milling the chosen target player two cards. Mirrors the existing `BalemurkLeech` Eerie shape.

## Tests
- New scenario tests for all three (each mode/branch + negatives: opponent's enchantment does not trigger Eerie; an untapped Survivor does not fire). All pass.
- `:mtg-sets:test` (snapshot + lint nets) green; DSK golden re-blessed — diff is **only** the three new cards (+347 lines, no other card moved).

## mtgish-tooling
No change required:
- **Scrabbling Skullcrab** already renders **AUTO** from the existing Eerie / `RoomFullyUnlocked` + mill handlers.
- **Insidious Fungus** (`modal-activated`) and **Rootwise Survivor** (animate-land layer effect with counters/types) correctly remain **SCAFFOLD** — both fall in the engine's known-sloppy activation-time / layer-effect shapes that the emitter deliberately declines rather than render lossily (per `mtgish-tooling/CLAUDE.md`).
- `just coverage-verify POR` stays **GATE PASS — 158/158, 0 mismatch** (no regression). The DSK gate's pre-existing `Glimmer Seeker` mismatch is unrelated to this change (DSK is not a golden-verified set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)