### PR TITLE
Add SOS Lifegain & Graveyard batch (Blech, Tenured Concocter, Colossus, Cauldron)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BlechLoafingPest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BlechLoafingPest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blech, Loafing Pest — Secrets of Strixhaven #176
+ * {1}{B}{G} · Legendary Creature — Pest · 3/4
+ *
+ * Whenever you gain life, put a +1/+1 counter on each Pest, Bat, Insect, Snake,
+ * and Spider you control.
+ *
+ * The [Triggers.YouGainLife] trigger fires on any life-gaining event you have. Its
+ * effect fans out via [Effects.ForEachInGroup] over every creature you control whose
+ * subtype is one of the five tribes ([GameObjectFilter.withAnySubtype]) — including
+ * Blech itself, who is a Pest. Inside the per-creature iteration the counter targets
+ * [EffectTarget.Self] (the current iteration entity), not a context target.
+ */
+val BlechLoafingPest = card("Blech, Loafing Pest") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Pest"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever you gain life, put a +1/+1 counter on each Pest, Bat, " +
+        "Insect, Snake, and Spider you control."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(
+                        listOf(Subtype("Pest"), Subtype.BAT, Subtype.INSECT, Subtype.SNAKE, Subtype.SPIDER)
+                    )
+                    .youControl()
+            ),
+            effect = AddCountersEffect(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                count = 1,
+                target = EffectTarget.Self
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Ilse Gort"
+        flavorText = "Despite Blex's passing, Witherbloom students still continued the " +
+            "tradition of a yearly search in his honor. His son, however, took little " +
+            "effort to find."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f588fa50-7cc5-41ba-90df-2d252eb5c785.jpg?1775938208"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/CauldronOfEssence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/CauldronOfEssence.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cauldron of Essence — Secrets of Strixhaven #179
+ * {1}{B}{G} · Artifact
+ *
+ * Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.
+ * {1}{B}{G}, {T}, Sacrifice a creature: Return target creature card from your graveyard
+ * to the battlefield. Activate only as a sorcery.
+ *
+ * The drain trigger is [Triggers.YourCreatureDies] (fires for any creature you control
+ * entering your graveyard from the battlefield), composing a 1-life loss for each opponent
+ * and a 1-life gain for you. The activated ability mirrors the Doomed Necromancer reanimator
+ * shape — mana + tap + sacrifice a creature, returning a targeted creature card from your
+ * graveyard — restricted to sorcery speed via [TimingRule.SorcerySpeed].
+ */
+val CauldronOfEssence = card("Cauldron of Essence") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Artifact"
+    oracleText = "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\n" +
+        "{1}{B}{G}, {T}, Sacrifice a creature: Return target creature card from your graveyard " +
+        "to the battlefield. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}{G}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        timing = TimingRule.SorcerySpeed
+        val t = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "179"
+        artist = "Craig J Spearing"
+        flavorText = "In the gloomy depths of Widdershins Hall sits an iron belly—always " +
+            "hungry, but generous to those who feed it."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7091740-e70c-4cf2-8d3d-b8e1ac1fbbdd.jpg?1775938230"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ColossusOfTheBloodAge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ColossusOfTheBloodAge.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Colossus of the Blood Age — Secrets of Strixhaven #181
+ * {4}{R}{W} · Artifact Creature — Construct · 6/6
+ *
+ * When this creature enters, it deals 3 damage to each opponent and you gain 3 life.
+ * When this creature dies, discard any number of cards, then draw that many cards plus one.
+ *
+ * The ETB ability is a composite of [Effects.DealDamage] to each opponent (the source is
+ * the construct via `damageSource = EffectTarget.Self`) and a 3-life gain. The death
+ * ability is an inline Gather → Select(any number) → Discard → Draw pipeline over the
+ * controller's own hand: the draw count reads the discarded collection's count plus one
+ * ([DynamicAmount.Add]). Discarding zero is legal — you then draw exactly one card.
+ */
+val ColossusOfTheBloodAge = card("Colossus of the Blood Age") {
+    manaCost = "{4}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Artifact Creature — Construct"
+    power = 6
+    toughness = 6
+    oracleText = "When this creature enters, it deals 3 damage to each opponent and you gain 3 life.\n" +
+        "When this creature dies, discard any number of cards, then draw that many cards plus one."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // No explicit damageSource: the engine attributes the damage to the ability's source
+        // (Colossus itself) by default, matching the "it deals damage" self-source convention.
+        effect = Effects.Composite(
+            Effects.DealDamage(3, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(3)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Pipeline {
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.You))
+            val discarded = chooseAnyNumber(
+                from = hand,
+                prompt = "Choose any number of cards to discard"
+            )
+            move(
+                discarded,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                moveType = MoveType.Discard
+            )
+            run(
+                DrawCardsEffect(
+                    DynamicAmount.Add(
+                        DynamicAmount.VariableReference("${discarded.key}_count"),
+                        DynamicAmount.Fixed(1)
+                    ),
+                    EffectTarget.Controller
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa7f0a4-6b65-4e53-ba00-848df260d8e3.jpg?1775938248"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TenuredConcocter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TenuredConcocter.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tenured Concocter — Secrets of Strixhaven #163
+ * {4}{G} · Creature — Troll Druid · 4/5
+ *
+ * Vigilance
+ * Whenever this creature becomes the target of a spell or ability an opponent controls,
+ * you may draw a card.
+ * Infusion — This creature gets +2/+0 as long as you gained life this turn.
+ *
+ * The targeting trigger is the self-bound [Triggers.BecomesTargetByOpponent] with
+ * `optional = true` for the "you may" draw (Cactarantula idiom). Infusion is an ability
+ * word (no rules meaning, CR 207.2c) — the +2/+0 is a conditional self-buff static gated
+ * on [Conditions.YouGainedLifeThisTurn], scoped to this creature via [GroupFilter.source].
+ */
+val TenuredConcocter = card("Tenured Concocter") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll Druid"
+    power = 4
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Whenever this creature becomes the target of a spell or ability an opponent " +
+        "controls, you may draw a card.\n" +
+        "Infusion — This creature gets +2/+0 as long as you gained life this turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetByOpponent
+        optional = true
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        condition = Conditions.YouGainedLifeThisTurn
+        ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Lie Setiawan"
+        flavorText = "\"Potential can be augmented. Imagination cannot.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/376c8b7d-1c90-47e1-bd01-e4c67f3fc4fc.jpg?1775938116"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1010,6 +1010,68 @@
     ]
 }
 
+// Blech, Loafing Pest
+{
+    "name": "Blech, Loafing Pest",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Pest",
+    "oracleText": "Whenever you gain life, put a +1/+1 counter on each Pest, Bat, Insect, Snake, and Spider you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasAnyOfSubtypes",
+                                        "subtypes": [
+                                            "Pest",
+                                            "Bat",
+                                            "Insect",
+                                            "Snake",
+                                            "Spider"
+                                        ]
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Ilse Gort",
+        "flavorText": "Despite Blex's passing, Witherbloom students still continued the tradition of a yearly search in his honor. His son, however, took little effort to find.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f588fa50-7cc5-41ba-90df-2d252eb5c785.jpg?1775938208"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Bogwater Lumaret
 {
     "name": "Bogwater Lumaret",
@@ -1403,6 +1465,107 @@
     ]
 }
 
+// Cauldron of Essence
+{
+    "name": "Cauldron of Essence",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\n{1}{B}{G}, {T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "RARE",
+        "artist": "Craig J Spearing",
+        "flavorText": "In the gloomy depths of Widdershins Hall sits an iron belly—always hungry, but generous to those who feed it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7091740-e70c-4cf2-8d3d-b8e1ac1fbbdd.jpg?1775938230"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Charging Strifeknight
 {
     "name": "Charging Strifeknight",
@@ -1790,6 +1953,113 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Colossus of the Blood Age
+{
+    "name": "Colossus of the Blood Age",
+    "manaCost": "{4}{R}{W}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "When this creature enters, it deals 3 damage to each opponent and you gain 3 life.\nWhen this creature dies, discard any number of cards, then draw that many cards plus one.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "selected1",
+                            "prompt": "Choose any number of cards to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Add",
+                                "left": {
+                                    "type": "VariableReference",
+                                    "variableName": "selected1_count"
+                                },
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Leon Tukker",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfa7f0a4-6b65-4e53-ba00-848df260d8e3.jpg?1775938248"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -13823,6 +14093,76 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "GREEN"
+    ]
+}
+
+// Tenured Concocter
+{
+    "name": "Tenured Concocter",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Troll Druid",
+    "oracleText": "Vigilance\nWhenever this creature becomes the target of a spell or ability an opponent controls, you may draw a card.\nInfusion — This creature gets +2/+0 as long as you gained life this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "byOpponent": true
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "optional": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"Potential can be augmented. Imagination cannot.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/376c8b7d-1c90-47e1-bd01-e4c67f3fc4fc.jpg?1775938116"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -172,6 +172,7 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     heatedArgumentExileRiderEffect(actions)?.let { return it }
     manaSculptCounterWizardManaEffect(actions)?.let { return it }
     discardHandThenDrawEffect(actions)?.let { return it }
+    discardAnyNumberThenDrawEffect(actions)?.let { return it }
     renderSpeechlessDiscardCountersEffect(actions)?.let { return it }
     runBehindOwnerTopOrBottomEffect(actions, tvar)?.let { return it }
     dinasGuidanceSearchHandOrGraveyardEffect(actions)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
@@ -209,6 +209,53 @@ internal fun EmitCtx.discardHandThenDrawEffect(actions: List<JsonObject>): Dsl? 
 }
 
 /**
+ * Colossus of the Blood Age (dies trigger): `[DiscardAnyNumberOfCards,
+ *   DrawNumberCards(Plus(NumCardsDiscardedThisWay, <k>))]`
+ * → the inline Gather → ChooseAnyNumber(discard) → draw "that many plus <k>" pipeline.
+ *
+ * "Discard any number of cards, then draw that many cards plus <k>." The controller discards any
+ * subset of their own hand, then draws the discarded count plus a fixed bonus. Rendered as the exact
+ * `gathered0 / selected1` raw-step Composite the inline `Effects.Pipeline { }` builder produces (the
+ * same idiom as ReturnAnyNumberOfPermanentsToTheirOwnersHands), so the serialized tree matches the
+ * hand-authored card. The discard is always the controller's own hand (no chooser/target variants); the
+ * draw count is `selected1_count` (+ the bonus). Any other discard scope or a non-`NumCardsDiscardedThisWay`
+ * /-non-integer draw shape declines (→ SCAFFOLD) rather than approximate.
+ *
+ * Tried inside [renderEffectList], so it covers both spell bodies and triggered-ability bodies.
+ */
+internal fun EmitCtx.discardAnyNumberThenDrawEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (discard, draw) = actions
+    if (discard.strField("_Action") != "DiscardAnyNumberOfCards") return null
+    if (draw.strField("_Action") != "DrawNumberCards") return null
+    val countNode = draw["args"] as? JsonObject ?: return null
+    // The draw count must be Plus(NumCardsDiscardedThisWay, <integer bonus>).
+    if (countNode.strField("_GameNumber") != "Plus") return null
+    val terms = countNode["args"].asArr ?: return null
+    if (terms.size != 2) return null
+    val hasDiscardedRef = terms.any {
+        (it as? JsonObject)?.strField("_GameNumber") == "NumCardsDiscardedThisWay"
+    }
+    if (!hasDiscardedRef) return null
+    val bonus = terms.firstNotNullOfOrNull { findInteger(it) as? Int } ?: return null
+    val drawCount = "DynamicAmount.Add(" +
+        "DynamicAmount.VariableReference(\"selected1_count\"), DynamicAmount.Fixed($bonus))"
+    return call(
+        "Effects.Composite",
+        arg(Lit("GatherCardsEffect(CardSource.FromZone(Zone.HAND, Player.You), storeAs = \"gathered0\")")),
+        arg(Lit(
+            "SelectFromCollectionEffect(from = \"gathered0\", selection = SelectionMode.ChooseAnyNumber, " +
+                "storeSelected = \"selected1\", prompt = \"Choose any number of cards to discard\")"
+        )),
+        arg(Lit(
+            "MoveCollectionEffect(from = \"selected1\", " +
+                "destination = CardDestination.ToZone(Zone.GRAVEYARD), moveType = MoveType.Discard)"
+        )),
+        arg(Lit("DrawCardsEffect($drawCount)")),
+    )
+}
+
+/**
  * Render Speechless: `[PlayerAction(Ref_TargetPlayer,
  *                        RevealHandAndPlayerChoosesACardToDiscard(You, IsNonCardtype Land)),
  *                      PutNumberCountersOfTypeOnPermanent(2, PTCounter(1,1), Ref_TargetPermanent)]`

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosLifegainGraveyardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SosLifegainGraveyardScenarioTest.kt
@@ -1,0 +1,249 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.sos.cards.CauldronOfEssence
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the SOS Lifegain & Graveyard batch:
+ *  - Blech, Loafing Pest        — "Whenever you gain life, put a +1/+1 counter on each Pest, Bat,
+ *                                  Insect, Snake, and Spider you control."
+ *  - Tenured Concocter          — becomes-targeted-by-opponent "may draw"; Infusion +2/+0 conditional.
+ *  - Colossus of the Blood Age  — ETB 3 damage to each opponent + gain 3 life; dies discard-any-then-draw+1.
+ *  - Cauldron of Essence        — creature-you-control-dies drain; sorcery-speed sac-reanimate.
+ *
+ * Lifegain is driven by Sacred Nectar ("You gain 4 life"); deaths are driven through the engine
+ * via Doom Blade ("Destroy target creature") so the real ZoneChange/LifeGain events fire the triggers.
+ */
+class SosLifegainGraveyardScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.plusCounters(name: String): Int {
+        val id = findPermanent(name) ?: return 0
+        return state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        // -----------------------------------------------------------------------------------------
+        // Blech, Loafing Pest
+        // -----------------------------------------------------------------------------------------
+        context("Blech, Loafing Pest") {
+            test("gaining life puts a +1/+1 counter on each matching tribe you control (incl. Blech)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blech, Loafing Pest", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Pincer Spider", summoningSickness = false) // a Spider
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)    // a Bear, no match
+                    .withCardInHand(1, "Sacred Nectar")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Sacred Nectar").error shouldBe null
+                game.resolveStack()
+
+                withClue("Blech is a Pest — gets a counter") { game.plusCounters("Blech, Loafing Pest") shouldBe 1 }
+                withClue("Pincer Spider is a Spider — gets a counter") { game.plusCounters("Pincer Spider") shouldBe 1 }
+                withClue("Grizzly Bears is not a matching tribe — no counter") { game.plusCounters("Grizzly Bears") shouldBe 0 }
+            }
+
+            test("does nothing when no life is gained") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blech, Loafing Pest", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                game.resolveStack()
+                game.plusCounters("Blech, Loafing Pest") shouldBe 0
+            }
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Tenured Concocter
+        // -----------------------------------------------------------------------------------------
+        context("Tenured Concocter") {
+            test("opponent targeting it with a spell lets you may-draw a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Player 2 controls the Concocter; Player 1 (active) targets it with removal.
+                    .withCardOnBattlefield(2, "Tenured Concocter", summoningSickness = false)
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .build()
+
+                val concocter = game.findPermanent("Tenured Concocter")!!
+                val libBefore = game.librarySize(2)
+
+                game.castSpell(1, "Doom Blade", targetId = concocter).error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Player 2 drew from the may-draw trigger") {
+                    game.librarySize(2) shouldBe (libBefore - 1)
+                }
+            }
+
+            test("Infusion grants +2/+0 only after you have gained life this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tenured Concocter", summoningSickness = false)
+                    .withCardInHand(1, "Sacred Nectar")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val concocter = game.findPermanent("Tenured Concocter")!!
+                withClue("base 4/5 before any life gain") {
+                    game.state.projectedState.getPower(concocter) shouldBe 4
+                    game.state.projectedState.getToughness(concocter) shouldBe 5
+                }
+
+                game.castSpell(1, "Sacred Nectar").error shouldBe null
+                game.resolveStack()
+
+                withClue("after gaining life this turn, Infusion grants +2/+0 → 6/5") {
+                    game.state.projectedState.getPower(concocter) shouldBe 6
+                    game.state.projectedState.getToughness(concocter) shouldBe 5
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Colossus of the Blood Age
+        // -----------------------------------------------------------------------------------------
+        context("Colossus of the Blood Age") {
+            test("ETB: deals 3 to each opponent and you gain 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Colossus of the Blood Age")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Colossus of the Blood Age").error shouldBe null
+                game.resolveStack()
+
+                withClue("each opponent took 3 damage") { game.getLifeTotal(2) shouldBe 17 }
+                withClue("you gained 3 life") { game.getLifeTotal(1) shouldBe 23 }
+            }
+
+            test("dies: discard any number, then draw that many plus one (declining = draw one)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Colossus of the Blood Age", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears") // a hand card so the discard-any-number decision is raised
+                    .withCardInHand(2, "Doom Blade")
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val colossus = game.findPermanent("Colossus of the Blood Age")!!
+                val handBefore = game.handSize(1)
+
+                game.castSpell(2, "Doom Blade", targetId = colossus).error shouldBe null
+                game.resolveStack()
+
+                // Dies trigger: discard-any-number decision — choose zero cards.
+                withClue("a discard-any-number decision should be pending") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(emptyList())
+                game.resolveStack()
+
+                withClue("discarded 0 → drew 0 + 1 = 1 card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Cauldron of Essence
+        // -----------------------------------------------------------------------------------------
+        context("Cauldron of Essence") {
+            test("a creature you control dying drains each opponent 1 and you gain 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cauldron of Essence")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Doom Blade", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("each opponent lost 1 life") { game.getLifeTotal(2) shouldBe 19 }
+                withClue("you gained 1 life") { game.getLifeTotal(1) shouldBe 21 }
+            }
+
+            test("sorcery-speed: sacrifice a creature to reanimate a creature card from your graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cauldron of Essence")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // sacrifice fodder
+                    .withCardInGraveyard(1, "Savannah Lions")                              // reanimation target
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1) // generic {1}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cauldron = game.findPermanent("Cauldron of Essence")!!
+                val fodder = game.findPermanent("Grizzly Bears")!!
+                val reanimee = game.state.getGraveyard(game.player1Id)
+                    .first { game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Savannah Lions" }
+
+                val abilityId = CauldronOfEssence.activatedAbilities.first().id
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = cauldron,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Card(reanimee, game.player1Id, Zone.GRAVEYARD)),
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the reanimated Savannah Lions is on the battlefield") {
+                    game.findPermanent("Savannah Lions") shouldBe reanimee
+                }
+                withClue("it is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Savannah Lions") shouldBe false
+                }
+                withClue("the sacrificed Grizzly Bears is gone from the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## SOS — Lifegain & Graveyard batch (Agent 2)

Four Secrets of Strixhaven cards, all built from existing SDK building blocks (no new effects/triggers/conditions, so no SDK-reference change):

| Card | Mechanics | mtgish tier |
|------|-----------|-------------|
| **Blech, Loafing Pest** | `Triggers.YouGainLife` → `ForEachInGroup` over the five tribes (`withAnyOfSubtypes`) adding a +1/+1 counter to each (incl. Blech itself). | **AUTOGEN** |
| **Tenured Concocter** | Vigilance; `Triggers.BecomesTargetByOpponent` optional draw; Infusion +2/+0 conditional static gated on `Conditions.YouGainedLifeThisTurn`. | **AUTOGEN** |
| **Colossus of the Blood Age** | ETB `DealDamage(each opponent)` + `GainLife`; dies trigger = inline Gather → ChooseAnyNumber(discard) → draw "that many plus one" pipeline. | **AUTOGEN** (newly, via emitter change) |
| **Cauldron of Essence** | `Triggers.YourCreatureDies` drain; sorcery-speed sacrifice-a-creature reanimate (Doomed Necromancer shape, `TimingRule.SorcerySpeed`). | **SCAFFOLD** (by design — see below) |

### Tests
`SosLifegainGraveyardScenarioTest` (rules-engine, 8 tests, all green) covers: tribe counters on lifegain (and the no-lifegain no-op), the opponent-targets may-draw, the Infusion +2/+0 only-after-lifegain buff, ETB 3-to-each-opponent + gain 3, dies discard-any-then-draw+1 (declining = draw one), the creature-you-control-dies drain, and the sacrifice-to-reanimate activation. Card snapshot golden re-blessed; `CardLintTest` + `CardDefinitionSnapshotTest` pass; `check-card-printing` ok for all four.

### mtgish-tooling
Added the `discardAnyNumberThenDrawEffect` emitter recognizer: `DiscardAnyNumberOfCards` + `DrawNumberCards(Plus(NumCardsDiscardedThisWay, k))` → the faithful `gathered0 / selected1` discard-then-draw pipeline (same idiom as `ReturnAnyNumberOfPermanentsToTheirOwnersHands`). This promotes **Colossus** from SCAFFOLD to AUTOGEN. Two hand-card tweaks aligned the implemented cards with the emitter's canonical output: Blech now uses `withAnyOfSubtypes(...)` (single `HasAnyOfSubtypes` predicate), and Colossus's ETB drops the explicit `damageSource = Self` (the engine self-source default, which the emitter convention deliberately omits).

**Cauldron stays SCAFFOLD on purpose, not for lack of effort:**
1. Its trigger IR is the non-self "creature you control dies" node, which the emitter deliberately declines (`triggerSpecFor`) because the IR can't distinguish the once-per-batch (`OneOrMoreCreaturesYouControlDie`) from per-each (`YourCreatureDies`) forms shared by ~55 cards — that's a documented human call.
2. Its activated ability carries a **Sacrifice additional cost**, the known-sloppy extra-cost area the tooling README says to keep at SCAFFOLD rather than guess.

Forcing it to AUTOGEN would override a guardrail protecting other cards, so the correct outcome is to decline. The hand-authored card + scenario test is the real gate, and it's implemented and green.

### Gates
- `coverage-verify POR` — **0 mismatch, 158/158** (unchanged).
- `coverage-verify SOS` — gameplay-tree mismatches drop **13 → 11**; the remaining 11 are pre-existing, unrelated to this batch (Artistic Process, Lorehold Charm, Muse Seeker, …).
- `mtgish-tooling` test suite (EmitterGoldenTest regression net) green; no vendored fixture golden changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
