### PR TITLE
Add SOS card-advantage spells + HasXInManaCost predicate

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1630,6 +1630,11 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   matching the other entity-relative caps.
 - `.manaValueIsOdd()` / `.manaValueIsEven()` — mana-value parity (zero is even). Pair with modal
   spells whose modes ask the caster to choose a parity (e.g. *Mutinous Massacre*).
+- `.hasXInManaCost()` — the card's **printed** mana cost contains an `{X}` symbol (inspects
+  `manaCost.hasX`, not the computed mana value), so a spell cast with X=0 still matches by its
+  printed cost. Face-down objects (no mana cost) never match; the cast-record path returns `false`
+  (a record stores the resolved mana value, not the printed cost). Used by *Paradox Surveyor*
+  ("a card with {X} in its mana cost"). Underlying predicate: `CardPredicate.HasXInManaCost`.
 - `.toughnessAtMost(n)` / `.toughnessAtLeast(n)` — toughness comparator.
 - `.toughnessAtMostX()` — toughness ≤ the X chosen for the source spell/ability. Resolves
   against `PredicateContext.xValue` at evaluation time, so it works at the spell's resolution

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -312,6 +312,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueIsOdd
     )
 
+    /** Printed mana cost contains an {X} symbol (Paradox Surveyor). */
+    fun hasXInManaCost() = copy(
+        cardPredicates = cardPredicates + CardPredicate.HasXInManaCost
+    )
+
     /** Power equals */
     fun power(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.PowerEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -408,6 +408,18 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "with odd mana value"
     }
 
+    /**
+     * Matches a card whose printed mana cost contains an {X} symbol (e.g. "a card with {X} in its
+     * mana cost", Paradox Surveyor). This inspects the printed cost's `hasX` flag, not the computed
+     * mana value — so a card on the stack cast with X=0 still matches by its printed cost, and a
+     * face-down object (no mana cost) never matches.
+     */
+    @SerialName("HasXInManaCost")
+    @Serializable
+    data object HasXInManaCost : CardPredicate {
+        override val description: String = "with {X} in its mana cost"
+    }
+
     // =============================================================================
     // Power/Toughness Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AntiquitiesOnTheLoose.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/AntiquitiesOnTheLoose.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Antiquities on the Loose — Secrets of Strixhaven #7
+ * {1}{W}{W} · Sorcery
+ *
+ * Create two 2/2 red and white Spirit creature tokens. Then if this spell was cast from anywhere
+ * other than your hand, put a +1/+1 counter on each Spirit you control.
+ * Flashback {4}{W}{W}.
+ *
+ * "Cast from anywhere other than your hand" is `Conditions.Not(Conditions.WasCastFromHand)` — true
+ * for the flashback (graveyard) cast and any other non-hand origin, false for a normal hand cast.
+ * The gated payoff fans the +1/+1 counter over every Spirit you control via `Effects.ForEachInGroup`
+ * (which snapshots the group first, so the two just-made Spirits are included). Flashback is the
+ * stock `KeywordAbility.flashback`.
+ */
+val AntiquitiesOnTheLoose = card("Antiquities on the Loose") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create two 2/2 red and white Spirit creature tokens. Then if this spell was cast " +
+        "from anywhere other than your hand, put a +1/+1 counter on each Spirit you control.\n" +
+        "Flashback {4}{W}{W} (You may cast this card from your graveyard for its flashback cost. " +
+        "Then exile it.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED, Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/8/7/877f7ddb-ed70-41a0-b845-d9bf8ac65f9b.jpg?1775828448"
+        ) then ConditionalEffect(
+            condition = Conditions.Not(Conditions.WasCastFromHand),
+            effect = Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl().withSubtype("Spirit")),
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{4}{W}{W}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "7"
+        artist = "Andreas Zafiratos"
+        flavorText = "Raising spirits is easier than taming them."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68ee92cd-51af-4de5-bcc8-34d0bb2fd398.jpg?1775936960"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FollowTheLumarets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/FollowTheLumarets.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Follow the Lumarets — Secrets of Strixhaven #148
+ * {1}{G} · Sorcery
+ *
+ * Infusion — Look at the top four cards of your library. You may reveal a creature or land card
+ * from among them and put it into your hand. If you gained life this turn, you may instead reveal
+ * two creature and/or land cards from among them and put them into your hand. Put the rest on the
+ * bottom of your library in a random order.
+ *
+ * Infusion (SOS ability word, no keyword): the bonus is gated on `Conditions.YouGainedLifeThisTurn`.
+ * It folds into the single reveal step as a conditional upper bound on how many creature/land cards
+ * you may take — up to 2 if you gained life this turn, otherwise up to 1 — via
+ * `SelectionMode.ChooseUpTo(DynamicAmount.Conditional(...))`. This is the look-at-top reveal pipeline
+ * (`Patterns.Library.lookAtTopRevealMatchingToHand` shape) inlined so the keep count can be dynamic.
+ */
+val FollowTheLumarets = card("Follow the Lumarets") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Infusion — Look at the top four cards of your library. You may reveal a creature or " +
+        "land card from among them and put it into your hand. If you gained life this turn, you may " +
+        "instead reveal two creature and/or land cards from among them and put them into your hand. " +
+        "Put the rest on the bottom of your library in a random order."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    // Infusion: up to two creature/land cards if you gained life this turn, else up to one.
+                    selection = SelectionMode.ChooseUpTo(
+                        DynamicAmount.Conditional(
+                            condition = Conditions.YouGainedLifeThisTurn,
+                            ifTrue = DynamicAmount.Fixed(2),
+                            ifFalse = DynamicAmount.Fixed(1)
+                        )
+                    ),
+                    filter = GameObjectFilter.CreatureOrLand,
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    prompt = "You may reveal creature and/or land cards to put into your hand.",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9488480-2b6c-40bc-a93e-29fb1292a2e4.jpg?1776990222"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MindIntoMatter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MindIntoMatter.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mind into Matter — Secrets of Strixhaven #202
+ * {X}{G}{U} · Sorcery
+ *
+ * Draw X cards. Then you may put a permanent card with mana value X or less from your hand onto the
+ * battlefield tapped.
+ *
+ * X flows through the resolution context (`DynamicAmount.XValue` for the draw; the chosen X is
+ * stamped on the context, exactly as for Mind Spring / Nature's Rhythm). The optional put is the
+ * stock `Patterns.Hand.putFromHand` pipeline (Gather hand → optional `ChooseUpTo(1)` Select → Move
+ * to battlefield tapped); the candidate filter is `Permanent.manaValueAtMostX()`, which reads the
+ * same chosen X at selection time. Drawing first matters: a card just drawn this turn is a legal
+ * choice to put onto the battlefield.
+ */
+val MindIntoMatter = card("Mind into Matter") {
+    manaCost = "{X}{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Sorcery"
+    oracleText = "Draw X cards. Then you may put a permanent card with mana value X or less from " +
+        "your hand onto the battlefield tapped."
+
+    spell {
+        effect = Effects.DrawCards(DynamicAmount.XValue) then Patterns.Hand.putFromHand(
+            filter = GameObjectFilter.Permanent.manaValueAtMostX(),
+            count = 1,
+            entersTapped = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Joe Slucher"
+        flavorText = "\"What the mind conceives,\" began Dean Adrix. \"Magic can achieve,\" assured Dean Nev."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a7f0fdf-1d4b-4458-a19c-274611e8a59a.jpg?1775938403"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ParadoxSurveyor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ParadoxSurveyor.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Paradox Surveyor — Secrets of Strixhaven #208
+ * {G}{G/U}{U} · Creature — Elf Druid · 3/3
+ *
+ * Reach
+ * When this creature enters, look at the top five cards of your library. You may reveal a land card
+ * or a card with {X} in its mana cost from among them and put it into your hand. Put the rest on the
+ * bottom of your library in a random order.
+ *
+ * "A card with {X} in its mana cost" is the new `CardPredicate.HasXInManaCost` (inspects the printed
+ * cost's {X} symbol, not the computed mana value), OR'd with `IsLand`. The reveal-and-take is the
+ * look-at-top filtered-keep / bottom pipeline (Gather top 5 → optional `ChooseUpTo(1)` filtered
+ * Select → kept revealed to hand, rest to the bottom in a random order).
+ */
+val ParadoxSurveyor = card("Paradox Surveyor") {
+    manaCost = "{G}{G/U}{U}"
+    colorIdentity = "UG"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Reach\nWhen this creature enters, look at the top five cards of your library. " +
+        "You may reveal a land card or a card with {X} in its mana cost from among them and put it " +
+        "into your hand. Put the rest on the bottom of your library in a random order."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(listOf(
+            GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(5)), storeAs = "looked"),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.Or(listOf(CardPredicate.IsLand, CardPredicate.HasXInManaCost))
+                    )
+                ),
+                storeSelected = "kept",
+                storeRemainder = "rest",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Put on bottom"
+            ),
+            MoveCollectionEffect(from = "kept", destination = CardDestination.ToZone(Zone.HAND), revealed = true),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Elizabeth Peiró"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7cb1af2-0302-46ff-8303-ae9d07541a01.jpg?1775938445"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -427,6 +427,82 @@
     ]
 }
 
+// Antiquities on the Loose
+{
+    "name": "Antiquities on the Loose",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 2/2 red and white Spirit creature tokens. Then if this spell was cast from anywhere other than your hand, put a +1/+1 counter on each Spirit you control.\nFlashback {4}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "RED",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/7/877f7ddb-ed70-41a0-b845-d9bf8ac65f9b.jpg?1775828448"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Not",
+                            "condition": "WasCastFromHand"
+                        }
+                    },
+                    "then": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature Spirit ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "RARE",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "Raising spirits is easier than taming them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68ee92cd-51af-4de5-bcc8-34d0bb2fd398.jpg?1775936960"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Applied Geometry
 {
     "name": "Applied Geometry",
@@ -4504,6 +4580,95 @@
     ]
 }
 
+// Follow the Lumarets
+{
+    "name": "Follow the Lumarets",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Conditional",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "TurnTracking",
+                                    "player": "You",
+                                    "tracker": "LIFE_GAINED"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifTrue": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "ifFalse": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "filter": "creature|land",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may reveal creature and/or land cards to put into your hand.",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Olivier Bernard",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9488480-2b6c-40bc-a93e-29fb1292a2e4.jpg?1776990222"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Foolish Fate
 {
     "name": "Foolish Fate",
@@ -7977,6 +8142,76 @@
     ]
 }
 
+// Mind into Matter
+{
+    "name": "Mind into Matter",
+    "manaCost": "{X}{G}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw X cards. Then you may put a permanent card with mana value X or less from your hand onto the battlefield tapped.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": "XValue"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsPermanent",
+                                        "ManaValueAtMostX"
+                                    ]
+                                }
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "putting"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "RARE",
+        "artist": "Joe Slucher",
+        "flavorText": "\"What the mind conceives,\" began Dean Adrix. \"Magic can achieve,\" assured Dean Nev.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a7f0fdf-1d4b-4458-a19c-274611e8a59a.jpg?1775938403"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Mindful Biomancer
 {
     "name": "Mindful Biomancer",
@@ -8945,6 +9180,103 @@
         "artist": "Leon Tukker",
         "flavorText": "A vast expanse that alters the rules of nature, offering a glimpse into the very structure of reality.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbc3447e-1329-4ea1-b4ca-b321b0ffec8f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
+// Paradox Surveyor
+{
+    "name": "Paradox Surveyor",
+    "manaCost": "{G}{G/U}{U}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Reach\nWhen this creature enters, look at the top five cards of your library. You may reveal a land card or a card with {X} in its mana cost from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsLand",
+                                            "HasXInManaCost"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Elizabeth Peiró",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7cb1af2-0302-46ff-8303-ae9d07541a01.jpg?1775938445"
     },
     "colorIdentityOverride": [
         "BLUE",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -828,6 +828,18 @@ internal fun EmitCtx.actionConditionDsl(cond: JsonObject?): String? {
             }
         }
     }
+    // "if this spell was cast from anywhere other than your hand" (Antiquities on the Loose) — a
+    // resolution-time gate on the resolving spell's cast-origin zone. The IR is
+    // `CastSpellPassesFilter(WasntCastFromTheirHand)`: cast from any zone but the caster's hand, which
+    // is exactly `Not(WasCastFromHand)` (true for a flashback/graveyard cast, false for a normal hand
+    // cast). Only this exact spell-origin filter renders; any other CastSpellPassesFilter shape
+    // declines (-> SCAFFOLD).
+    if (cond.strField("_Condition") == "CastSpellPassesFilter") {
+        if (cond["args"].strField("_Spells") == "WasntCastFromTheirHand") {
+            return render(call("Conditions.Not", arg("Conditions.WasCastFromHand")))
+        }
+        return null
+    }
     // "If [N] or more mana was spent to cast that spell, …" — the Opus 5+ mana tier
     // (Elemental Mascot, Expressive Firedancer, Muse Seeker). Renders a Compare over the triggering
     // spell's mana. See [spellManaSpentConditionDsl] for the exact shape constraints.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -992,6 +992,8 @@ private fun cardsPredicateDsl(node: JsonElement?): String? {
             "Planeswalker" -> "CardPredicate.IsPlaneswalker"
             else -> null
         }
+        // "a card with {X} in its mana cost" (Paradox Surveyor) — inspects the printed cost's {X}.
+        "HasXInManaCost" -> "CardPredicate.HasXInManaCost"
         // Subtype filters all route through HasSubtype(Subtype("X")); use the named SDK constant when
         // one exists ("Plains" -> Subtype.PLAINS) so the output matches hand-authored convention.
         "IsCreatureType", "IsLandType", "IsArtifactType", "IsEnchantmentType" ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -876,6 +876,9 @@ class TriggerMatcher(
                 val cmc = if (isFaceDown) 0 else cardComponent.manaValue
                 cmc % 2 != 0
             }
+            com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasXInManaCost ->
+                // Printed cost's {X} symbol, not the computed CMC. Face-down has no mana cost.
+                if (isFaceDown) false else cardComponent.manaCost.hasX
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerAtLeast -> {
                 val power = if (isFaceDown) 2
                     else lastKnownPower ?: projected.getPower(entityId) ?: cardComponent.baseStats?.basePower ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -329,6 +329,11 @@ class PredicateEvaluator {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc % 2 != 0
             }
+            CardPredicate.HasXInManaCost -> {
+                // Inspect the printed cost's {X} symbol, not the computed CMC. Face-down objects
+                // (Rule 708.2 — no mana cost) never match.
+                if (projectedValues?.isFaceDown == true) false else card.manaCost.hasX
+            }
 
             // Power/toughness predicates - use projected P/T
             is CardPredicate.PowerEquals -> {
@@ -1070,6 +1075,9 @@ class PredicateEvaluator {
             is CardPredicate.ManaValueAtMostDynamic -> false
             CardPredicate.ManaValueIsEven -> record.manaValue % 2 == 0
             CardPredicate.ManaValueIsOdd -> record.manaValue % 2 != 0
+            // A cast-spell record stores the resolved mana value, not the printed cost, so we
+            // cannot recover whether {X} was in the printed cost.
+            CardPredicate.HasXInManaCost -> false
 
             // Power/toughness — not meaningful for cast records
             is CardPredicate.PowerEquals, is CardPredicate.PowerAtMost, is CardPredicate.PowerAtLeast,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -577,6 +577,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.PowerLessThanEntity -> false
         CardPredicate.ManaValueIsEven -> card.manaValue % 2 == 0
         CardPredicate.ManaValueIsOdd -> card.manaValue % 2 != 0
+        CardPredicate.HasXInManaCost -> if (isFaceDown) false else card.manaCost.hasX
         is CardPredicate.NameEquals -> card.name == predicate.name
         is CardPredicate.HasBasicLandType -> if (isFaceDown) false else subtypes.any { it.equals(predicate.landType, ignoreCase = true) }
         is CardPredicate.And -> predicate.predicates.all { matchesCardPredicateForProjection(it, card, container, projected, types, subtypes, colors, keywords, isFaceDown) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -932,6 +932,7 @@ class CostCalculator(
             is CardPredicate.PowerLessThanEntity -> false
             CardPredicate.ManaValueIsEven -> cardDef.manaCost.cmc % 2 == 0
             CardPredicate.ManaValueIsOdd -> cardDef.manaCost.cmc % 2 != 0
+            CardPredicate.HasXInManaCost -> cardDef.manaCost.hasX
 
             is CardPredicate.PowerEquals -> cardDef.creatureStats?.basePower == predicate.value
             // CostCalculator has no X context; predicate has no static answer here.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiquitiesOnTheLooseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiquitiesOnTheLooseScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Antiquities on the Loose — {1}{W}{W} Sorcery.
+ * Create two 2/2 red and white Spirit creature tokens. Then if this spell was cast from anywhere
+ * other than your hand, put a +1/+1 counter on each Spirit you control.
+ * Flashback {4}{W}{W}.
+ *
+ * Covers the hand cast (two tokens, no counters) and the flashback cast (two tokens + a +1/+1
+ * counter on every Spirit, since the graveyard origin satisfies "cast from anywhere other than your
+ * hand").
+ */
+class AntiquitiesOnTheLooseScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Antiquities on the Loose") {
+
+            test("hand cast makes two Spirit tokens and adds no counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Antiquities on the Loose")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Antiquities on the Loose").error shouldBe null
+                game.resolveStack()
+
+                val spirits = game.findPermanents("Spirit Token")
+                withClue("Two Spirit tokens were created") {
+                    spirits.size shouldBe 2
+                }
+                withClue("Hand cast → no +1/+1 counters") {
+                    spirits.all { plusOneCounters(game, it) == 0 } shouldBe true
+                }
+            }
+
+            test("flashback (graveyard) cast makes two Spirits and puts a +1/+1 counter on each Spirit you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Antiquities on the Loose")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellFromGraveyard(1, "Antiquities on the Loose").error shouldBe null
+                game.resolveStack()
+
+                val spirits = game.findPermanents("Spirit Token")
+                withClue("Two Spirit tokens were created") {
+                    spirits.size shouldBe 2
+                }
+                withClue("Non-hand cast → each Spirit gets one +1/+1 counter") {
+                    spirits.all { plusOneCounters(game, it) == 1 } shouldBe true
+                }
+                withClue("Flashback exiles the card, so it leaves the graveyard") {
+                    game.isInGraveyard(1, "Antiquities on the Loose") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FollowTheLumaretsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FollowTheLumaretsScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.FollowTheLumarets
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private val LifeGainTestSpell = CardDefinition(
+    name = "Lumaret Healing Test",
+    manaCost = ManaCost.parse("{W}"),
+    typeLine = TypeLine.instant(),
+    oracleText = "You gain 3 life.",
+    script = CardScript.spell(effect = GainLifeEffect(3, EffectTarget.Controller))
+)
+
+/**
+ * Follow the Lumarets — {1}{G} Sorcery.
+ * Infusion — Look at the top four cards of your library. You may reveal a creature or land card and
+ * put it into your hand. If you gained life this turn, you may instead reveal two creature and/or
+ * land cards and put them into your hand. Put the rest on the bottom of your library in a random
+ * order.
+ *
+ * Verifies the Infusion bonus: the per-reveal upper bound is 1 normally and 2 when life was gained
+ * this turn (`DynamicAmount.Conditional(YouGainedLifeThisTurn, 2, 1)`).
+ */
+class FollowTheLumaretsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + FollowTheLumarets + LifeGainTestSpell)
+        return driver
+    }
+
+    test("without life gained this turn, at most one creature/land card may be taken") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top four (deeper-to-shallower puts): identify the four exact cards looked at.
+        val c3 = driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        val c4 = driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        val c1 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val c2 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val lookedAt = setOf(c1, c2, c3, c4)
+
+        val spell = driver.putCardInHand(player, "Follow the Lumarets")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 1)
+
+        driver.castSpell(player, spell)
+        driver.bothPass() // resolve → pauses on the reveal selection
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.minSelections shouldBe 0
+        decision.maxSelections shouldBe 1 // Infusion bonus not active
+
+        driver.submitCardSelection(player, listOf(c1))
+        driver.isPaused shouldBe false
+        // Exactly the one chosen looked-at card reached hand; the others were bottomed.
+        driver.getHand(player).count { it in lookedAt } shouldBe 1
+        driver.getHand(player).contains(c1) shouldBe true
+    }
+
+    test("Infusion: with life gained this turn, up to two creature/land cards may be taken") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Gain life this turn so the Infusion condition turns on.
+        val healSpell = driver.putCardInHand(player, "Lumaret Healing Test")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.castSpell(player, healSpell)
+        driver.bothPass()
+
+        driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        val c1 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val c2 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(player, "Follow the Lumarets")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 1)
+
+        driver.castSpell(player, spell)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.maxSelections shouldBe 2 // Infusion bonus active
+
+        driver.submitCardSelection(player, listOf(c1, c2))
+        driver.isPaused shouldBe false
+        driver.getHand(player).contains(c1) shouldBe true
+        driver.getHand(player).contains(c2) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindIntoMatterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindIntoMatterScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.MindIntoMatter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Mind into Matter — {X}{G}{U} Sorcery.
+ * Draw X cards. Then you may put a permanent card with mana value X or less from your hand onto the
+ * battlefield tapped.
+ *
+ * Verifies the chosen X drives both halves: the draw count and the "mana value X or less" filter on
+ * the optional put-from-hand-onto-battlefield-tapped step.
+ */
+class MindIntoMatterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + MindIntoMatter)
+        return driver
+    }
+
+    test("X=2 draws two and lets a MV<=2 permanent enter tapped; a MV>2 card is not selectable") {
+        val driver = createDriver()
+        // Library has Grizzly Bears ({1}{G}, MV 2) on top, then a 5-mana Force of Nature.
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Force of Nature ({2}{G}{G}{G}, MV 5) will be drawn but is too expensive to put down at X=2.
+        driver.putCardOnTopOfLibrary(player, "Force of Nature")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(player, "Mind into Matter")
+        val handBefore = driver.getHand(player).size
+
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2) // pays {X} with X=2
+
+        driver.castXSpell(player, spell, xValue = 2)
+        driver.bothPass() // resolve → draw 2, then pause on the optional put selection
+
+        // Hand grew by 2 (drawn) minus the spell that left hand (net +1 from before-cast hand,
+        // but we measure after cast so just confirm the drawn cards arrived).
+        driver.getHand(player).size shouldBe (handBefore - 1 + 2)
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.minSelections shouldBe 0
+        // Grizzly Bears (MV 2) is a legal choice; Force of Nature (MV 5) is not.
+        val bears = decision.options.firstOrNull { driver.getCardName(it) == "Grizzly Bears" }
+        bears shouldNotBe null
+        decision.options.none { driver.getCardName(it) == "Force of Nature" } shouldBe true
+
+        driver.submitCardSelection(player, listOf(bears!!))
+        driver.isPaused shouldBe false
+
+        // The chosen Grizzly Bears is on the battlefield, tapped.
+        val bearsOnBattlefield = driver.findPermanent(player, "Grizzly Bears")
+        bearsOnBattlefield shouldBe bears
+        driver.isTapped(bears) shouldBe true
+    }
+
+    test("the put is optional — declining leaves the drawn cards in hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(player, "Mind into Matter")
+        // A Plains (MV 0) in hand is a legal put candidate at X=1, so the optional select pauses.
+        val plains = driver.putCardInHand(player, "Plains")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 1) // X=1
+
+        driver.castXSpell(player, spell, xValue = 1)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.options.contains(plains) shouldBe true
+        driver.submitCardSelection(player, emptyList()) // decline
+
+        driver.isPaused shouldBe false
+        // Declined: the Plains stays in hand, nothing entered the battlefield from the put.
+        driver.getHand(player).contains(plains) shouldBe true
+        driver.findPermanent(player, "Plains") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParadoxSurveyorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParadoxSurveyorScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.MindIntoMatter
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ParadoxSurveyor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Paradox Surveyor — {G}{G/U}{U} Creature — Elf Druid 3/3, Reach.
+ * When this creature enters, look at the top five cards of your library. You may reveal a land card
+ * or a card with {X} in its mana cost from among them and put it into your hand. Put the rest on the
+ * bottom of your library in a random order.
+ *
+ * Exercises the new `CardPredicate.HasXInManaCost` (a "card with {X} in its mana cost") OR'd with
+ * land, surfaced as the optional reveal-to-hand selection.
+ */
+class ParadoxSurveyorScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        // Mind into Matter ({X}{G}{U}) is the {X}-in-cost card we expect to be revealable.
+        driver.registerCards(TestCards.all + ParadoxSurveyor + MindIntoMatter)
+        return driver
+    }
+
+    test("an {X}-cost card and a land are offered; chosen card goes to hand, rest to bottom") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top five from the top: Grizzly Bears, Mind into Matter ({X}{G}{U}), Forest, Grizzly Bears, Grizzly Bears
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val land = driver.putCardOnTopOfLibrary(player, "Forest")
+        val xCard = driver.putCardOnTopOfLibrary(player, "Mind into Matter")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val surveyor = driver.putCardInHand(player, "Paradox Surveyor")
+        driver.giveMana(player, Color.GREEN, 2)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.castSpell(player, surveyor)
+        driver.bothPass() // resolve creature; ETB trigger goes on the stack
+        driver.bothPass() // resolve ETB trigger → pauses on the optional reveal selection
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        // Only the land and the {X}-cost card are selectable; plain Grizzly Bears are not.
+        decision.options.contains(land) shouldBe true
+        decision.options.contains(xCard) shouldBe true
+        decision.minSelections shouldBe 0
+
+        // Reveal the {X}-cost card → it goes to hand.
+        driver.submitCardSelection(player, listOf(xCard))
+        driver.isPaused shouldBe false
+
+        driver.getHand(player).contains(xCard) shouldBe true
+        // The land we didn't pick was bottomed, not in hand.
+        driver.getHand(player).contains(land) shouldBe false
+        val library = driver.state.getZone(ZoneKey(player, Zone.LIBRARY))
+        library.contains(land) shouldBe true
+
+        driver.findPermanent(player, "Paradox Surveyor") shouldNotBe null
+    }
+
+    test("the reveal is optional — declining keeps every looked-at card in the library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = driver.putCardOnTopOfLibrary(player, "Forest")
+        val surveyor = driver.putCardInHand(player, "Paradox Surveyor")
+        driver.giveMana(player, Color.GREEN, 2)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.castSpell(player, surveyor)
+        driver.bothPass()
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.minSelections shouldBe 0
+        driver.submitCardSelection(player, emptyList()) // decline
+
+        driver.isPaused shouldBe false
+        driver.getHand(player).contains(land) shouldBe false
+        val library = driver.state.getZone(ZoneKey(player, Zone.LIBRARY))
+        library.contains(land) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements four **Secrets of Strixhaven (SOS)** card-advantage / spells cards (Agent 3 batch), the one new SDK primitive they needed, and mtgish-tooling support so two of them draft at AUTOGEN tier.

## Cards

| Card | Cost | Summary |
|------|------|---------|
| **Paradox Surveyor** | `{G}{G/U}{U}` | Elf Druid 3/3, Reach. ETB: look at top five, may reveal a **land or a card with {X} in its mana cost** to hand, rest to bottom in a random order. |
| **Follow the Lumarets** | `{1}{G}` | Sorcery, **Infusion**. Look at top four, may reveal up to **one** creature/land card (or **two** if you gained life this turn) to hand; rest to bottom at random. |
| **Antiquities on the Loose** | `{1}{W}{W}` | Sorcery, **Flashback {4}{W}{W}**. Make two 2/2 R/W Spirits, then if cast from anywhere other than your hand, +1/+1 counter on each Spirit you control. |
| **Mind into Matter** | `{X}{G}{U}` | Sorcery. Draw X, then may put a permanent with mana value X or less from hand onto the battlefield tapped. |

All four use existing facades wherever possible — the look-at-top reveal pipeline, `ConditionalEffect`, `Effects.ForEachInGroup`, `KeywordAbility.flashback`, `Patterns.Hand.putFromHand`, `DynamicAmount.XValue` / `DynamicAmount.Conditional`, and the existing `Conditions.YouGainedLifeThisTurn` (Infusion) / `Conditions.Not(WasCastFromHand)` ("cast from anywhere other than your hand").

## New SDK primitive

`CardPredicate.HasXInManaCost` (fluent `.hasXInManaCost()`) — "a card with {X} in its mana cost". Inspects the **printed** cost's `{X}` symbol (`manaCost.hasX`), not the computed mana value, so a spell cast with X=0 still matches by its printed cost; face-down objects never match. Wired into every `CardPredicate` evaluator (`PredicateEvaluator` main + cast-record paths, `TriggerMatcher`, `AffectsFilterResolver`, `CostCalculator`) and documented in `docs/card-sdk-language-reference.md`.

## Tests

Scenario tests (rules-engine) for all four cards — happy path, optional "may" decline, and the Infusion / flashback / cast-X branches. Full rules-engine and mtg-sets suites green (lint, snapshot, facade boundary). SOS snapshot golden re-blessed (adds only the four new cards).

## mtgish-tooling

Taught the emitter the two clean shapes so they tier **AUTOGEN**, gameplay-equivalent to their golden:
- `HasXInManaCost` in the look-at-top reveal filter (`cardsPredicateDsl`) → **Paradox Surveyor** AUTO.
- "cast from anywhere other than your hand" — `CastSpellPassesFilter(WasntCastFromTheirHand)` → `Conditions.Not(Conditions.WasCastFromHand)` in `actionConditionDsl` → **Antiquities on the Loose** AUTO.

**Stayed below AUTOGEN (by design):**
- **Follow the Lumarets** — SCAFFOLD: the Infusion bonus is a conditional reveal-count *inside* a look-at-top (`IfElse` branch); the emitter deliberately scaffolds conditional looks.
- **Mind into Matter** — SCAFFOLD: the put-from-hand filter reads the **cast-time `X`** inherited into a later effect — the engine's known value-inheritance gap the tooling intentionally keeps at SCAFFOLD.

**Gates:** `coverage-verify POR` stays GATE PASS (158/158, 0 mismatch); `EmitterGoldenTest` unchanged across all vendored sets; SOS's pre-existing 11 mismatches are unaffected (Paradox + Antiquities are not among them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)