### PR TITLE
Add DSK batch C: Demonic Counsel, House Cartographer (+ reveal-until emitter)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DemonicCounsel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DemonicCounsel.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Demonic Counsel
+ * {1}{B}
+ * Sorcery
+ * Search your library for a Demon card, reveal it, put it into your hand, then shuffle.
+ * Delirium — If there are four or more card types among cards in your graveyard, instead search
+ * your library for any card, put it into your hand, then shuffle.
+ */
+val DemonicCounsel = card("Demonic Counsel") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium — If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle."
+    spell {
+        effect = ConditionalEffect(
+            condition = Conditions.Delirium(4),
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                destination = SearchDestination.HAND
+            ),
+            elseEffect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any.withSubtype("Demon"),
+                destination = SearchDestination.HAND,
+                reveal = true
+            )
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Babs Webb"
+        flavorText = "Valgavoth whispered into Marina's ear until he was all she could hear."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg?1726286193"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HouseCartographer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HouseCartographer.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * House Cartographer
+ * {1}{G}
+ * Creature — Human Scout Survivor
+ * 2/2
+ * Survival — At the beginning of your second main phase, if this creature is tapped, reveal
+ * cards from the top of your library until you reveal a land card. Put that card into your hand
+ * and the rest on the bottom of your library in a random order.
+ *
+ * "Survival" is an ability word (no rules meaning) — modeled as a postcombat-main-phase trigger
+ * ([Triggers.YourPostcombatMain]) with an intervening-if ([Conditions.SourceIsTapped], CR 603.4 —
+ * checked both when it would trigger and on resolution). The reveal-until-land body reuses the
+ * Clifftop Lookout pipeline (GatherUntilMatch → Reveal → Filter → Move), but lands the found card
+ * in hand rather than onto the battlefield.
+ */
+val HouseCartographer = card("House Cartographer") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout Survivor"
+    power = 2
+    toughness = 2
+    oracleText = "Survival — At the beginning of your second main phase, if this creature is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order."
+
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = Effects.Composite(
+            listOf(
+                GatherUntilMatchEffect(
+                    filter = GameObjectFilter.Land,
+                    storeMatch = "revealedLand",
+                    storeRevealed = "allRevealed"
+                ),
+                RevealCollectionEffect(from = "allRevealed"),
+                // allRevealed includes the matched land, so subtract it before bottoming.
+                FilterCollectionEffect(
+                    from = "allRevealed",
+                    filter = CollectionFilter.ExcludeOtherCollection("revealedLand"),
+                    storeMatching = "nonLandRevealed"
+                ),
+                MoveCollectionEffect(
+                    from = "revealedLand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "nonLandRevealed",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+        description = "Survival — At the beginning of your second main phase, if this creature is " +
+            "tapped, reveal cards from the top of your library until you reveal a land card. Put " +
+            "that card into your hand and the rest on the bottom of your library in a random order."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "185"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg?1726286553"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -875,6 +875,116 @@
     ]
 }
 
+// Demonic Counsel
+{
+    "name": "Demonic Counsel",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium — If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            "then": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "GatherCards",
+                        "source": {
+                            "type": "FromZone",
+                            "zone": "Library"
+                        },
+                        "storeAs": "searchable"
+                    },
+                    {
+                        "type": "SelectFromCollection",
+                        "from": "searchable",
+                        "selection": {
+                            "type": "ChooseUpTo",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "storeSelected": "found"
+                    },
+                    {
+                        "type": "MoveCollection",
+                        "from": "found",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Hand"
+                        }
+                    },
+                    "ShuffleLibrary"
+                ]
+            },
+            "otherwise": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "GatherCards",
+                        "source": {
+                            "type": "FromZone",
+                            "zone": "Library",
+                            "filter": "Demon"
+                        },
+                        "storeAs": "searchable"
+                    },
+                    {
+                        "type": "SelectFromCollection",
+                        "from": "searchable",
+                        "selection": {
+                            "type": "ChooseUpTo",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "storeSelected": "found"
+                    },
+                    {
+                        "type": "MoveCollection",
+                        "from": "found",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Hand"
+                        },
+                        "revealed": true
+                    },
+                    "ShuffleLibrary"
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "RARE",
+        "artist": "Babs Webb",
+        "flavorText": "Valgavoth whispered into Marina's ear until he was all she could hear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg?1726286193"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Diversion Specialist
 {
     "name": "Diversion Specialist",
@@ -2321,6 +2431,87 @@
         "artist": "Chris Cold",
         "flavorText": "\"We set it on fire. It lived. We cut off its head. It lived. We fell to it, one by one. It lives.\"\n—Sunrise, survivor sentry",
         "imageUri": "https://cards.scryfall.io/normal/front/c/1/c175c998-7b80-4187-bdbc-5b6e0d7eac91.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// House Cartographer
+{
+    "name": "House Cartographer",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Scout Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if this creature is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "land",
+                            "storeMatch": "revealedLand",
+                            "storeRevealed": "allRevealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "allRevealed"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "allRevealed",
+                            "filter": {
+                                "type": "ExcludeOtherCollection",
+                                "otherCollectionName": "revealedLand"
+                            },
+                            "storeMatching": "nonLandRevealed"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "revealedLand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "nonLandRevealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "descriptionOverride": "Survival — At the beginning of your second main phase, if this creature is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "UNCOMMON",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg?1726286553"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -58,6 +58,10 @@ internal fun BridgeBuilder.zoneMovement() {
 
     composed("LookAtTheTopNumberCardsOfLibrary", "Patterns.Library.lookAtTopAndKeep/Reorder -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
     composed("LookAtTheTopNumberCardsOfPlayersLibrary", "look pipeline on opponent library -> MoveCollection", composes = listOf("MoveCollection"))
+    // "Reveal cards from the top until you reveal a <type> card. Put it [in hand|onto the battlefield
+    // tapped] and the rest on the bottom in a random/any order." (House Cartographer, Clifftop Lookout)
+    // -> GatherUntilMatch -> Reveal -> Filter(exclude match) -> MoveCollection(match) -> MoveCollection(rest).
+    composed("RevealCardsFromTheTopOfLibraryUntilACardOfTypeIsRevealed", "GatherUntilMatch -> Reveal -> Filter -> MoveCollection x2", composes = listOf("MoveCollection"))
 
     composed("ExilePermanent", UNIVERSAL, composes = listOf("MoveToZone"))
     // "[A player] exiles a [filter] they control" — the exile flavor of an edict, where the affected

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -483,6 +483,7 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("SearchLibrary") { _, args, _ -> renderSearch(args) }
     on("LookAtTheTopNumberCardsOfLibrary", "LookAtTheTopNumberCardsOfPlayersLibrary") { node, args, tvar -> renderLook(node, args, tvar) }
+    on("RevealCardsFromTheTopOfLibraryUntilACardOfTypeIsRevealed") { node, _, _ -> renderRevealUntil(node) }
 
     on("PutGraveyardCardOnBottomOfLibrary") { _, args, tvar ->
         // "Put target card from your graveyard on the bottom of your library" (Tomb Trawler). The
@@ -732,6 +733,83 @@ private fun cardTypeUnionFilter(types: List<String>): String? {
         sortedSetOf("creature", "planeswalker") to "CreatureOrPlaneswalker",
     )[set] ?: return null
     return "GameObjectFilter.$constant"
+}
+
+/**
+ * "Reveal cards from the top of your library until you reveal a <type> card. Put that card
+ * [into your hand | onto the battlefield tapped] and the rest on the bottom of your library
+ * in a random/any order." (House Cartographer — to hand; Clifftop Lookout — onto the battlefield
+ * tapped). This is the reveal-UNTIL-a-type dig, distinct from the look-at-top-N shapes above.
+ *
+ * Renders the atomic GatherUntilMatch -> Reveal -> Filter(exclude match) -> Move(match) ->
+ * Move(rest, bottom) pipeline — the same shape the hand-authored cards use. Only a single card-type
+ * filter (Land/Creature/...) and the two recognised destinations (hand, battlefield-tapped) render;
+ * any richer filter, an unrecognised destination, or any extra enter-flag declines (-> SCAFFOLD)
+ * rather than drop a constraint.
+ */
+internal fun EmitCtx.renderRevealUntil(node: JsonObject): Dsl? {
+    val args = node.field("args").asArr ?: return null
+    // args[0] is the "until you reveal" type filter; only a bare IsCardtype renders.
+    val filterNode = args.getOrNull(0) as? JsonObject ?: return null
+    if (filterNode.strField("_Cards") != "IsCardtype") return null
+    val gameObjectFilter = when (filterNode.field("args").asStr()) {
+        "Land" -> "GameObjectFilter.Land"
+        "Creature" -> "GameObjectFilter.Creature"
+        "Artifact" -> "GameObjectFilter.Artifact"
+        "Enchantment" -> "GameObjectFilter.Enchantment"
+        "Planeswalker" -> "GameObjectFilter.Planeswalker"
+        else -> return null
+    }
+
+    val subActions = args.getOrNull(1).asArr ?: return null
+    fun sub(kind: String): JsonObject? = subActions.firstOrNull {
+        it.strField("_RevealTheTopNumberCardsOfLibraryAction") == kind
+    } as? JsonObject
+
+    // The destination of the matched card: hand, or battlefield tapped.
+    val toHand = sub("PutTheCardFoundThisWayIntoHand")
+    val toBattlefield = sub("PutTheCardFoundThisWayOntoTheBattlefield")
+    val matchDestination = when {
+        toHand != null -> "CardDestination.ToZone(Zone.HAND)"
+        toBattlefield != null -> {
+            // Only EntersTapped renders; any other (or missing) enter flag declines.
+            val flags = (toBattlefield.field("args").asArr)
+                ?.mapNotNull { (it as? JsonObject)?.strField("_EnterFlag") } ?: emptyList()
+            if (flags != listOf("EntersTapped")) return null
+            "CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped)"
+        }
+        else -> return null
+    }
+
+    // The destination of the remaining reveals: bottom of library, random or controller-chosen order.
+    val restOrder = when {
+        sub("PutTheRemainingCardsOnTheBottomOfLibraryInARandomOrder") != null -> "CardOrder.Random"
+        sub("PutTheRemainingCardsOnTheBottomOfLibraryInAnyOrder") != null -> "CardOrder.ControllerChooses"
+        else -> return null
+    }
+
+    return Composite(listOf(
+        Lit(
+            "GatherUntilMatchEffect(filter = $gameObjectFilter, " +
+                "storeMatch = \"revealedMatch\", storeRevealed = \"allRevealed\")"
+        ),
+        Lit("RevealCollectionEffect(from = \"allRevealed\")"),
+        Raw(
+            "FilterCollectionEffect(\n" +
+                "                from = \"allRevealed\",\n" +
+                "                filter = CollectionFilter.ExcludeOtherCollection(\"revealedMatch\"),\n" +
+                "                storeMatching = \"rest\"\n" +
+                "            )",
+        ),
+        Lit("MoveCollectionEffect(from = \"revealedMatch\", destination = $matchDestination)"),
+        Raw(
+            "MoveCollectionEffect(\n" +
+                "                from = \"rest\",\n" +
+                "                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),\n" +
+                "                order = $restOrder\n" +
+                "            )",
+        ),
+    ))
 }
 
 internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: String?): Dsl? {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicCounselScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicCounselScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.DemonicCounsel
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Demonic Counsel (DSK #92) — {1}{B} Sorcery.
+ *
+ * "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.
+ *  Delirium — If there are four or more card types among cards in your graveyard, instead search
+ *  your library for any card, put it into your hand, then shuffle."
+ *
+ * Exercises a [Conditions.Delirium]-gated [ConditionalEffect] choosing between a Demon-only tutor
+ * (default) and an unrestricted tutor (Delirium active).
+ */
+class DemonicCounselScenarioTest : FunSpec({
+
+    // A Demon creature usable as a search target.
+    val TestDemon = CardDefinition(
+        name = "Test Demon",
+        manaCost = ManaCost.parse("{3}{B}{B}"),
+        typeLine = TypeLine(cardTypes = setOf(CardType.CREATURE), subtypes = setOf(Subtype("Demon"))),
+        creatureStats = CreatureStats(6, 6),
+        oracleText = ""
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DemonicCounsel)
+        driver.registerCard(TestDemon)
+        return driver
+    }
+
+    test("without Delirium, can only find a Demon card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Library has a Demon and a non-Demon on top.
+        val demon = driver.putCardOnTopOfLibrary(activePlayer, "Test Demon")
+        driver.putCardOnTopOfLibrary(activePlayer, "Island")
+
+        val spell = driver.putCardInHand(activePlayer, "Demonic Counsel")
+        driver.giveMana(activePlayer, Color.BLACK, 2)
+
+        driver.castSpell(activePlayer, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Only the Demon is a legal choice (no Demons besides the one we seeded).
+        decision.options.size shouldBe 1
+        decision.options.contains(demon) shouldBe true
+
+        driver.submitCardSelection(activePlayer, listOf(demon))
+
+        driver.state.getZone(ZoneKey(activePlayer, Zone.HAND)).contains(demon) shouldBe true
+    }
+
+    test("with Delirium (four card types in graveyard), can find any card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Four distinct card types in the graveyard: creature, instant, sorcery, land.
+        driver.putCardInGraveyard(activePlayer, "Grizzly Bears")
+        driver.putCardInGraveyard(activePlayer, "Lightning Bolt")
+        driver.putCardInGraveyard(activePlayer, "Demonic Counsel")
+        driver.putCardInGraveyard(activePlayer, "Forest")
+
+        // A non-Demon card on top of the library; Delirium lets us grab it.
+        val island = driver.putCardOnTopOfLibrary(activePlayer, "Island")
+
+        val spell = driver.putCardInHand(activePlayer, "Demonic Counsel")
+        driver.giveMana(activePlayer, Color.BLACK, 2)
+
+        driver.castSpell(activePlayer, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Delirium active — every library card is a legal choice (not just Demons).
+        decision.options.contains(island) shouldBe true
+
+        driver.submitCardSelection(activePlayer, listOf(island))
+
+        driver.state.getZone(ZoneKey(activePlayer, Zone.HAND)).contains(island) shouldBe true
+    }
+
+    test("may fail to find") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val demon = driver.putCardOnTopOfLibrary(activePlayer, "Test Demon")
+
+        val spell = driver.putCardInHand(activePlayer, "Demonic Counsel")
+        driver.giveMana(activePlayer, Color.BLACK, 2)
+
+        driver.castSpell(activePlayer, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision shouldNotBe null
+
+        // Decline to find anything.
+        driver.submitCardSelection(activePlayer, emptyList())
+
+        driver.state.getZone(ZoneKey(activePlayer, Zone.HAND)).contains(demon) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HouseCartographerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HouseCartographerScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for House Cartographer (DSK #185).
+ *
+ * House Cartographer — {1}{G} Creature — Human Scout Survivor, 2/2
+ *   "Survival — At the beginning of your second main phase, if this creature is tapped, reveal
+ *    cards from the top of your library until you reveal a land card. Put that card into your hand
+ *    and the rest on the bottom of your library in a random order."
+ *
+ * Verifies the intervening-if (only when the Cartographer is tapped, CR 603.4), the reveal-until-land
+ * dig, the land landing in hand, the non-land reveals going to the bottom of the library, and that an
+ * untapped Cartographer produces no trigger.
+ */
+class HouseCartographerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("House Cartographer — Survival trigger") {
+
+            test("a tapped Cartographer reveals until a land, puts it in hand, bottoms the rest") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "House Cartographer", tapped = true)
+                    // Top of library: two nonlands, then a Forest, then a deeper card.
+                    .withCardInLibrary(1, "Grizzly Bears") // top
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Forest") // first land revealed → to hand
+                    .withCardInLibrary(1, "Island") // never revealed (below the matched land)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player1 = game.player1Id
+
+                // Advance to the second main phase — the Survival trigger fires (source is tapped).
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(8) { if (game.state.stack.isNotEmpty()) game.resolveStack() }
+
+                val hand = game.state.getZone(ZoneKey(player1, Zone.HAND))
+                val handNames = hand.mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+                withClue("the revealed land is put into hand") {
+                    handNames.contains("Forest") shouldBe true
+                }
+
+                val library = game.state.getZone(ZoneKey(player1, Zone.LIBRARY))
+                val libraryNames = library.mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+                withClue("the two non-land reveals are bottomed back into the library") {
+                    libraryNames.contains("Grizzly Bears") shouldBe true
+                    libraryNames.contains("Centaur Courser") shouldBe true
+                }
+                withClue("the deeper unrevealed card stays in the library") {
+                    libraryNames.contains("Island") shouldBe true
+                }
+                withClue("the revealed non-lands didn't end up in hand or graveyard") {
+                    handNames.contains("Grizzly Bears") shouldBe false
+                    handNames.contains("Centaur Courser") shouldBe false
+                    game.state.getZone(ZoneKey(player1, Zone.GRAVEYARD)).isEmpty() shouldBe true
+                }
+            }
+
+            test("an untapped Cartographer does NOT fire the Survival trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "House Cartographer", tapped = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player1 = game.player1Id
+                val handBefore = game.state.getZone(ZoneKey(player1, Zone.HAND)).size
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(5) { if (game.state.stack.isNotEmpty()) game.resolveStack() }
+
+                withClue("no Survival trigger — the Cartographer is untapped, so the intervening-if fails") {
+                    game.state.getZone(ZoneKey(player1, Zone.HAND)).size shouldBe handBefore
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a batch of Duskmourn: House of Horror (DSK) cards and extends the mtgish auto-gen emitter so the new shapes draft automatically.

## Cards implemented
- **Demonic Counsel** ({1}{B} Sorcery, #92) — "Search your library for a Demon card... Delirium — ...instead search for any card." Modeled as a `Conditions.Delirium(4)`-gated `ConditionalEffect` over `Patterns.Library.searchLibrary` (Demon-only tutor by default, unrestricted tutor when four+ card types are in the graveyard). Uses only existing facades. Scenario test covers both modes plus fail-to-find.
- **House Cartographer** ({1}{G} 2/2 Human Scout Survivor, #185) — "Survival — At the beginning of your second main phase, if this creature is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order." Survival = `Triggers.YourPostcombatMain` + intervening-if `Conditions.SourceIsTapped` (CR 603.4); body reuses the Clifftop Lookout `GatherUntilMatch → Reveal → Filter → Move` pipeline but lands the card in hand. Scenario test covers the tapped dig and the untapped no-trigger case.

## Cards skipped
- **Break Down the Door** — modal spell whose third mode is **manifest dread**.
- **Disturbing Mirth** — its core "when you sacrifice this, **manifest dread**" payoff.

Both require the **manifest dread** mechanic (face-down 2/2 creatures from the top of library, turn-face-up for mana cost). That mechanic does not exist in the engine and is a substantial `add-feature` task (face-down permanents, manifest, turn-face-up). Skipped per the batch instructions rather than ship a half-faithful card or leave the build broken.

## mtgish tooling changes
- **Emitter** (`ZoneHandlers.kt`): new `renderRevealUntil` handler for the `RevealCardsFromTheTopOfLibraryUntilACardOfTypeIsRevealed` action. Renders the atomic `GatherUntilMatch → Reveal → Filter(exclude match) → Move(match) → Move(rest, bottom)` pipeline, covering both recognised destinations — into hand (House Cartographer) and onto the battlefield tapped (Clifftop Lookout) — with random / controller-chosen rest ordering. Declines to `null` (→ SCAFFOLD) on any richer filter, an unrecognised destination, or an unexpected enter-flag, per the fidelity policy. House Cartographer and Clifftop Lookout now both emit at **AUTO** tier.
- **Capability bridge** (`ZoneMovement.kt`): matching `composed(...)` entry so the probe scores the action as coverable.

No SDK surface changed, so `docs/card-sdk-language-reference.md` needs no update.

## Verification
- `DemonicCounselScenarioTest` + `HouseCartographerScenarioTest` pass.
- `:mtg-sets:test` green; DSK card snapshot re-blessed (only the two new cards added — no unrelated card moved).
- `:mtgish-tooling:test` green; `EmitterGoldenTest` unchanged across all 9 committed sets (no emitter regression).
- `just coverage-verify POR` → **GATE PASS, 158/158** (0-mismatch maintained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)