### PR TITLE
DSK Batch B: Clammy Prowler + Get Out (+ mtgish emitter fixes)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ClammyProwler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ClammyProwler.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Clammy Prowler
+ * {3}{U}
+ * Enchantment Creature — Horror
+ * 2/5
+ * Whenever this creature attacks, another target attacking creature can't be blocked this turn.
+ *
+ * "Another target attacking creature" = [TargetOther] wrapping an attacking-creature target,
+ * which auto-excludes the source (Clammy Prowler itself). "Can't be blocked this turn" routes
+ * through the projected CANT_BE_BLOCKED ability flag — the same channel the static
+ * [com.wingedsheep.sdk.scripting.CantBeBlocked] ability uses — via a floating end-of-turn grant.
+ */
+val ClammyProwler = card("Clammy Prowler") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Horror"
+    oracleText = "Whenever this creature attacks, another target attacking creature can't be blocked this turn."
+    power = 2
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target(
+            "another target attacking creature",
+            TargetOther(baseRequirement = TargetCreature(filter = TargetFilter.AttackingCreature))
+        )
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "John Tedrick"
+        flavorText = "Sometimes, survivors in the Floodpits hear their own drowning voices crying out for help. Only the ones who flee immediately live to speak of it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg?1726286023"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GetOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GetOut.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Get Out
+ * {U}{U}
+ * Instant
+ * Choose one —
+ * • Counter target creature or enchantment spell.
+ * • Return one or two target creatures and/or enchantments you own to your hand.
+ *
+ * Modal "choose one" (mirrors Amazing Acrobatics' ModalEffect shape):
+ * - Mode 1 counters a target creature-or-enchantment spell on the stack
+ *   (`TargetFilter.CreatureOrEnchantment` scoped to the stack).
+ * - Mode 2 bounces one or two target creatures/enchantments you own
+ *   (`TargetObject(count = 2, minCount = 1)` over the same type filter, owned by you),
+ *   returning each via `ForEachTargetEffect(ReturnToHand)`.
+ */
+val GetOut = card("Get Out") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Counter target creature or enchantment spell.\n" +
+        "• Return one or two target creatures and/or enchantments you own to your hand."
+
+    spell {
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.withTarget(
+                    effect = Effects.CounterSpell(),
+                    target = TargetSpell(
+                        filter = TargetFilter(GameObjectFilter.CreatureOrEnchantment, zone = Zone.STACK)
+                    ),
+                    description = "Counter target creature or enchantment spell."
+                ),
+                Mode.withTarget(
+                    effect = ForEachTargetEffect(
+                        listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+                    ),
+                    target = TargetObject(
+                        count = 2,
+                        minCount = 1,
+                        filter = TargetFilter.CreatureOrEnchantment.ownedByYou()
+                    ),
+                    description = "Return one or two target creatures and/or enchantments you own to your hand."
+                )
+            ),
+            chooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Mirko Failoni"
+        flavorText = "Kaito's blade brought the light of another plane into Duskmourn, and with it, a brief chance to escape."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg?1726286080"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -727,6 +727,53 @@
     ]
 }
 
+// Clammy Prowler
+{
+    "name": "Clammy Prowler",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment Creature — Horror",
+    "oracleText": "Whenever this creature attacks, another target attacking creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOther",
+                    "baseRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        }
+                    },
+                    "id": "another target attacking creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "John Tedrick",
+        "flavorText": "Sometimes, survivors in the Floodpits hear their own drowning voices crying out for help. Only the ones who flee immediately live to speak of it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg?1726286023"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Clockwork Percussionist
 {
     "name": "Clockwork Percussionist",
@@ -1785,6 +1832,69 @@
         "imageUri": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg?1726286797"
     },
     "colorIdentityOverride": []
+}
+
+// Get Out
+{
+    "name": "Get Out",
+    "manaCost": "{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Counter target creature or enchantment spell.\n• Return one or two target creatures and/or enchantments you own to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature|enchantment",
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "description": "Counter target creature or enchantment spell."
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "minCount": 1,
+                            "filter": {
+                                "baseFilter": "creature|enchantment own:you"
+                            }
+                        }
+                    ],
+                    "description": "Return one or two target creatures and/or enchantments you own to your hand."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "flavorText": "Kaito's blade brought the light of another plane into Duskmourn, and with it, a brief chance to escape.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg?1726286080"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Give In to Violence

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -720,12 +720,32 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
                 "\"Opponent\"" in blob -> Link("opponentControls")
                 else -> return null
             }
-            val filter: Dsl = if (controller == null) {
-                Lit(namedTargetFilter.getValue(types))
-            } else {
-                Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.$union").dot(controller))))
+            // "creatures and/or enchantments YOU OWN" (Get Out mode 2) — an OwnedByAPlayer(You) clause.
+            // Render `.ownedByYou()` so the ownership restriction isn't silently dropped (which would let
+            // the spell bounce an opponent's permanents); any other owner shape declines (-> SCAFFOLD).
+            val owner: Link? = when {
+                "OwnedByAPlayer" !in blob -> null
+                "\"You\"" in blob -> Link("ownedByYou")
+                else -> return null
             }
-            return Call("TargetPermanent", listOf(arg("filter", filter)))
+            // Controller and owner narrowings are independent — a card carrying both would need a composed
+            // shape the named constant can't express. Only one narrowing at a time renders here.
+            if (controller != null && owner != null) return null
+            val filter: Dsl = when {
+                controller == null && owner == null -> Lit(namedTargetFilter.getValue(types))
+                controller != null -> Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.$union").dot(controller))))
+                else -> Lit(namedTargetFilter.getValue(types)).dot(owner!!)
+            }
+            // "one or two target creatures and/or enchantments" (Get Out) needs an explicit minCount, which
+            // the TargetPermanent factory doesn't expose — emit the underlying TargetObject(count, minCount)
+            // directly for that shape. Every other count/optional shape renders via TargetPermanent.
+            if (ttype == "OneOrTwoTargetPermanents") {
+                return Call("TargetObject", listOf(arg("count", "2"), arg("minCount", "1"), arg("filter", filter)))
+            }
+            val parts = mutableListOf(arg("filter", filter))
+            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
+            if (ttype == "UptoNumberTargetPermanents" || isUpToOne) parts.add(0, arg("optional", "true"))
+            return Call("TargetPermanent", parts)
         }
         return null  // unusual filters: not rendered yet -> SCAFFOLD
     }
@@ -762,6 +782,13 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         if (colors.isNotEmpty()) return null  // colour + type combo not rendered yet -> SCAFFOLD
         if (types == setOf("Creature", "Sorcery")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.CreatureOrSorcerySpellOnStack")))
         if (types == setOf("Instant", "Sorcery")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.InstantOrSorcerySpellOnStack")))
+        // "counter target creature or enchantment spell" (Get Out) — no named convenience filter exists,
+        // so emit the GameObjectFilter.CreatureOrEnchantment shape scoped to the stack, matching the
+        // hand-written card's gameplay tree exactly.
+        if (types == setOf("Creature", "Enchantment")) {
+            val f = Call("TargetFilter", listOf(arg("GameObjectFilter.CreatureOrEnchantment"), arg("zone", "Zone.STACK")))
+            return Call("TargetSpell", listOf(arg("filter", f)))
+        }
         if (types == setOf("Creature")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.CreatureSpellOnStack")))
         if (types.isEmpty()) {
             // "counter target spell with mana value N or less" (Thoughtbind) -> SpellOnStack.manaValueAtMost(N).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClammyProwlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClammyProwlerScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.ClammyProwler
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Clammy Prowler — {3}{U} Enchantment Creature — Horror 2/5
+ * Whenever this creature attacks, another target attacking creature can't be blocked this turn.
+ */
+class ClammyProwlerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ClammyProwler)
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Forest" to 20),
+            startingLife = 20,
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("the chosen other attacking creature can't be blocked, but Clammy Prowler can") {
+        val driver = createDriver()
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val prowler = driver.putCreatureOnBattlefield(attacker, "Clammy Prowler")
+        driver.removeSummoningSickness(prowler)
+        val bears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(bears)
+
+        // Opponent has two blockers.
+        val wall = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(wall)
+        val wall2 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(wall2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // Both creatures attack. Clammy Prowler's attack trigger fires.
+        driver.declareAttackers(attacker, listOf(prowler, bears), defender)
+
+        // The trigger asks for "another target attacking creature" — only the Bears is legal
+        // (Clammy Prowler itself is excluded by TargetOther).
+        val chooseTargets = driver.pendingDecision
+        chooseTargets.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(attacker, listOf(bears))
+
+        // Resolve the trigger, then advance into the declare-blockers step.
+        driver.bothPass()
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.currentStep shouldBe Step.DECLARE_BLOCKERS
+
+        // Blocking the Bears (now unblockable) must fail.
+        val blockBears = driver.submitExpectFailure(
+            DeclareBlockers(defender, mapOf(wall to listOf(bears)))
+        )
+        blockBears.isSuccess shouldBe false
+        blockBears.error shouldContainIgnoringCase "can't be blocked"
+
+        // Blocking Clammy Prowler (which is NOT unblockable) succeeds.
+        val blockProwler = driver.declareBlockers(defender, mapOf(wall2 to listOf(prowler)))
+        blockProwler.isSuccess shouldBe true
+    }
+
+    test("Clammy Prowler attacking with no other attacker yields no legal target") {
+        val driver = createDriver()
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val prowler = driver.putCreatureOnBattlefield(attacker, "Clammy Prowler")
+        driver.removeSummoningSickness(prowler)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(prowler), defender)
+
+        // No other attacking creature exists, so the trigger has no legal target and
+        // is removed from the stack (no targeting decision is pending).
+        driver.pendingDecision.let { it !is ChooseTargetsDecision } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GetOutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GetOutScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.GetOut
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Get Out — {U}{U} Instant
+ * Choose one —
+ * • Counter target creature or enchantment spell.
+ * • Return one or two target creatures and/or enchantments you own to your hand.
+ */
+class GetOutScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GetOut)
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Forest" to 20),
+            startingLife = 20,
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("mode 1 counters a creature spell on the stack") {
+        val driver = createDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // The active player casts the (sorcery-speed) creature spell; their opponent counters it.
+        val caster = driver.activePlayer!!
+        val me = driver.getOpponent(caster)
+
+        driver.giveMana(caster, Color.GREEN, 2)
+        val bears = driver.putCardInHand(caster, "Grizzly Bears")
+        driver.castSpell(caster, bears)
+        val bearsSpell = driver.state.stack.first()
+        driver.state.stack.size shouldBe 1
+        driver.passPriority(caster)
+
+        // I respond with Get Out (mode 1), countering it.
+        driver.giveMana(me, Color.BLUE, 2)
+        val getOut = driver.putCardInHand(me, "Get Out")
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = getOut,
+                targets = listOf(ChosenTarget.Spell(bearsSpell)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(bearsSpell)))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass() // resolve Get Out (counters Grizzly Bears)
+        driver.bothPass() // Grizzly Bears is countered, no permanent enters
+
+        driver.state.stack.size shouldBe 0
+        driver.findPermanent(caster, "Grizzly Bears") shouldBe null
+        driver.getGraveyardCardNames(caster) shouldContain "Grizzly Bears"
+    }
+
+    test("mode 2 returns two of my own creatures/enchantments to hand") {
+        val driver = createDriver()
+        val me = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val enchantment = driver.putPermanentOnBattlefield(me, "Test Enchantment")
+
+        driver.giveMana(me, Color.BLUE, 2)
+        val getOut = driver.putCardInHand(me, "Get Out")
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = getOut,
+                targets = listOf(
+                    ChosenTarget.Permanent(bears),
+                    ChosenTarget.Permanent(enchantment)
+                ),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(
+                    listOf(
+                        ChosenTarget.Permanent(bears),
+                        ChosenTarget.Permanent(enchantment)
+                    )
+                )
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(me, "Grizzly Bears") shouldBe null
+        driver.findPermanent(me, "Test Enchantment") shouldBe null
+        // Both were returned to my hand (zone change mints a new entity id, so match by name).
+        driver.findCardInHand(me, "Grizzly Bears") shouldNotBe null
+        driver.findCardInHand(me, "Test Enchantment") shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Cards implemented (2)

- **Clammy Prowler** — `{3}{U}` Enchantment Creature — Horror 2/5. *Whenever this creature attacks, another target attacking creature can't be blocked this turn.* Uses `TargetOther(baseRequirement = TargetCreature(filter = AttackingCreature))` (auto-excludes the source) + the `CANT_BE_BLOCKED` ability flag via a floating end-of-turn grant.
- **Get Out** — `{U}{U}` Instant, "choose one": *Counter target creature or enchantment spell* / *Return one or two target creatures and/or enchantments you own to your hand.* Modal `ModalEffect` (chooseCount = 1); mode 2 bounces via `TargetObject(count = 2, minCount = 1, …ownedByYou())` + `ForEachTargetEffect(ReturnToHand)`.

Both have scenario tests in `rules-engine`. The DSK card snapshot was re-blessed and the diff shows **only** these two cards added.

## Cards skipped (2) — need add-feature mechanics too large to do cleanly here

- **Bashful Beastie** — needs **manifest dread** (look at top 2, put one face-down as a 2/2, mill the other, turn face up for its mana cost if a creature). No manifest / manifest-dread support exists in the engine yet.
- **Creeping Peeper** — needs **multi-context restricted mana** ("spend only to cast an enchantment spell, **unlock a door, or turn a permanent face up**"). The `ManaRestriction` system models spell-type spends but not the door-unlock / turn-face-up non-cast spend contexts.

## mtgish emitter changes (`TargetRecovery.kt`)

To let Get Out auto-generate faithfully:

- `TargetSpell` over a **Creature+Enchantment** `Or` → `TargetFilter(GameObjectFilter.CreatureOrEnchantment, zone = STACK)` (no named convenience exists).
- The two-cardtype permanent-union branch now honors an `OwnedByAPlayer(You)` clause (`.ownedByYou()`) and the `OneOrTwoTargetPermanents` count (`TargetObject(count = 2, minCount = 1, …)`) instead of **silently dropping both** — a constraint-drop fix that also closes a latent silent-widening bug for any "creature or enchantment you own" bounce.

Get Out now renders **AUTO** (complete). **Clammy Prowler stays SCAFFOLD**: its "another target attacking creature" needs a `TargetOther` recovery path the emitter doesn't have, so it correctly **declines** rather than emit a wrong target (per the "render correctly or decline" policy).

## Gates

- `EmitterGoldenTest` — green for all 9 committed sets (no existing card's output shifted).
- `coverage-verify POR` — **GATE PASS, 158/158, 0-mismatch**.
- `coverage-verify DSK` — the 3 gameplay-tree mismatches (Glimmer Seeker / Razorkin Needlehead / Skullsnap Nuisance) are **pre-existing** (Survival / first-strike-damage / Eerie) and untouched by this change; Get Out is "emitted outside golden" (DSK isn't a calibrated 0-mismatch set).
- `just test-rules` green; `:mtg-sets:test` green after snapshot re-bless; `:mtgish-tooling:test` green.

No SDK type was added, so `docs/card-sdk-language-reference.md` needs no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)