### PR TITLE
Add SOS Witherbloom batch: Potioner's Trove, Arnyn, Nita, Echocasting Symposium

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -471,7 +471,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ReturnLinkedExileUnderOwnersControl()` — return under each card's owner.
 - `ReturnLinkedExileToHand()` — return all from linked exile to hand.
 - `ReturnOneFromLinkedExile()` — return one chosen card.
-- `GrantMayPlayFromExile(from, expiry?, withAnyManaType?, condition?, landEntersTapped?, onPlayRider?, ownerControls?)` — controller may play matching cards from exile. `withAnyManaType=true` relaxes the colored pips so mana of any type can pay them (Laughing Jasper Flint, Cruelclaw's Heist); the grant works whether the card stays in exile *or* in a graveyard (Tinybones, the Pickpocket grants over a card the trigger gathered straight from a graveyard via `CardSource.ChosenTargets`), and the relaxation is applied both in the legal-action enumerator and in the cast handler's payment. `landEntersTapped=true` forces a played land tapped regardless of its own ETB script (Lightstall Inquisitor); PlayLandHandler reads the flag off the active `MayPlayPermission` at play time and stamps `TappedComponent` before the card's intrinsic `EntersTapped` branch runs. `onPlayRider` is a "When you play a card this way, …" payoff: the engine registers a linked event-based delayed triggered ability alongside the permission, and casting/playing a granted card emits a `CardPlayedFromPermissionEvent` (link-id-scoped, like `DamagePreventedEvent`) that fires the rider on the stack as a triggered ability of the granting source. Expires with the grant (end of turn). Used by Fires of Mount Doom ("…When you play a card this way, Fires of Mount Doom deals 2 damage to each player."). `ownerControls=true` grants the permission to each exiled card's *owner* instead of the effect controller — the collection is grouped by owner into one permission per owner, and any turn-keyed `expiry` (e.g. `MayPlayExpiry.UntilEndOfNextTurn`) is measured against each owner's own turns. Use for "for each of those cards, its owner may play it until the end of their next turn" wording where the exiled cards may belong to different players (Suspend Aggression: exile a target nonland permanent + your top library card, each owner may replay the one they own). Mirrors `MakePlottedEffect.ownerControls`; prefer it (composed in a gather → exile → grant pipeline) over the monolithic `ExileAndGrantOwnerPlayPermission` when the expiry is turn-bounded or more than one card is exiled.
+- `GrantMayPlayFromExile(from, expiry?, withAnyManaType?, condition?, landEntersTapped?, onPlayRider?, ownerControls?, exileAfterResolve?)` — controller may play matching cards from exile. `exileAfterResolve=true` stamps `ExileAfterResolveComponent` on each granted card so a spell cast from the permission is exiled instead of going to a graveyard (on resolution, when countered, or when it fizzles) — the "If that spell would be put into a graveyard, exile it instead" rider on borrow-a-spell-you-don't-own cards (Nita, Forum Conciliator); the same mechanism as `GrantFreeCastTargetFromExile.exileAfterResolve` but for a *paid* cast. `withAnyManaType=true` relaxes the colored pips so mana of any type can pay them (Laughing Jasper Flint, Cruelclaw's Heist); the grant works whether the card stays in exile *or* in a graveyard (Tinybones, the Pickpocket grants over a card the trigger gathered straight from a graveyard via `CardSource.ChosenTargets`), and the relaxation is applied both in the legal-action enumerator and in the cast handler's payment. `landEntersTapped=true` forces a played land tapped regardless of its own ETB script (Lightstall Inquisitor); PlayLandHandler reads the flag off the active `MayPlayPermission` at play time and stamps `TappedComponent` before the card's intrinsic `EntersTapped` branch runs. `onPlayRider` is a "When you play a card this way, …" payoff: the engine registers a linked event-based delayed triggered ability alongside the permission, and casting/playing a granted card emits a `CardPlayedFromPermissionEvent` (link-id-scoped, like `DamagePreventedEvent`) that fires the rider on the stack as a triggered ability of the granting source. Expires with the grant (end of turn). Used by Fires of Mount Doom ("…When you play a card this way, Fires of Mount Doom deals 2 damage to each player."). `ownerControls=true` grants the permission to each exiled card's *owner* instead of the effect controller — the collection is grouped by owner into one permission per owner, and any turn-keyed `expiry` (e.g. `MayPlayExpiry.UntilEndOfNextTurn`) is measured against each owner's own turns. Use for "for each of those cards, its owner may play it until the end of their next turn" wording where the exiled cards may belong to different players (Suspend Aggression: exile a target nonland permanent + your top library card, each owner may replay the one they own). Mirrors `MakePlottedEffect.ownerControls`; prefer it (composed in a gather → exile → grant pipeline) over the monolithic `ExileAndGrantOwnerPlayPermission` when the expiry is turn-bounded or more than one card is exiled.
 - `GrantPlayWithoutPayingCost(from)` — same, without paying mana costs.
 - `GrantPlayWithCostIncrease(from, amount)` — stamp `PlayWithCostIncreaseComponent(controllerId, amount)` on every card in the collection, so the next cast pays `{amount}` extra generic. Pair with `GrantMayPlayFromExile` for "each spell cast this way costs {N} more" clauses (Lightstall Inquisitor); for target-based "exile this permanent, owner may play it, opponents tax" effects use `Effects.ExileAndGrantOwnerPlayPermission` instead.
 - `GrantFreeCastTargetFromExile(target)` — cast specific exiled card for free.
@@ -641,7 +641,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `CreateChosenTokenEffect`; under the hood it sets `CreateTokenEffect.colorsFromChoice` /
   `creatureTypesFromChoice`.)
 - `CreateTokenCopyOfSelf(count?, tapped?)` — token copies of source.
-- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, addedSubtypes?, overrideCardTypes?, activatedAbilities?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?, exileAtStep?, exileUnlessSourceIsRingBearer?)` —
+- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?, addedSubtypes?, overrideCardTypes?, activatedAbilities?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?, exileAtStep?, exileUnlessSourceIsRingBearer?, controller?)` —
   token copy of another permanent (or a card in any zone — the executor copies the target's `CardComponent`,
   so a graveyard/exile card works; pass `EffectTarget.PipelineTarget("name")` to copy a card a prior pipeline
   step exiled/stored, as Nexus of Becoming and Mardu Siegebreaker do).
@@ -667,6 +667,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   so it is skipped while the source is the controller's Ring-bearer at fire time (CR 701.54e) — "create a
   tapped and attacking token that's a copy of that card … at the beginning of the next end step, exile that
   token unless ~ is your Ring-bearer" (Sauron, the Necromancer).
+  `controller` (an `EffectTarget` player ref) overrides who creates — and so controls and owns — the token;
+  `null` defaults to the effect's controller. Set it for "**Target player** creates a token that's a copy of
+  target creature you control" (Echocasting Symposium): the chosen creature is copied but the token enters
+  under the named player's control. Mirrors `CreateTokenEffect.controller`.
   Like `CreateToken`, both `CreateTokenCopyOfTarget` and `CreateTokenCopyOfSource` publish their created token
   entity IDs to the `CREATED_TOKENS` pipeline collection, so a sibling effect in a `CompositeEffect` can address
   the new copy — e.g. Applied Geometry's "Create a token that's a copy … Put six +1/+1 counters on it" composes
@@ -1636,6 +1640,12 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   (a record stores the resolved mana value, not the printed cost). Used by *Paradox Surveyor*
   ("a card with {X} in its mana cost"). Underlying predicate: `CardPredicate.HasXInManaCost`.
 - `.toughnessAtMost(n)` / `.toughnessAtLeast(n)` — toughness comparator.
+- `.powerOrToughnessAtLeast(n)` / `.powerOrToughnessAtMost(n)` — **OR** caps over power and
+  toughness: matches when *either* power or toughness is ≥ (resp. ≤) `n`. `powerOrToughnessAtMost`
+  backs Arnyn, Deathbloom Botanist ("a creature you control with power or toughness 1 or less
+  dies"). Honored in all four evaluation sites (resolution predicate, trigger matcher with
+  last-known stats, layer projection, cost calculation). Underlying predicates:
+  `CardPredicate.PowerOrToughnessAtLeast` / `CardPredicate.PowerOrToughnessAtMost`.
 - `.toughnessAtMostX()` — toughness ≤ the X chosen for the source spell/ability. Resolves
   against `PredicateContext.xValue` at evaluation time, so it works at the spell's resolution
   filter pass (e.g. Zero Point Ballad's mass destruction). Layer projection / trigger matching
@@ -2128,6 +2138,12 @@ matcher branch — `SpellCastEvent` does not grow a new field per axis.
 - `SpellCastPredicate.TargetsMatching(filter)` — the cast spell has ≥1 chosen target matching
   `filter` (evaluated relative to the trigger controller). Used by Legolas, Master Archer
   ("a spell that targets a creature you don't control").
+- `SpellCastPredicate.NotOwnedByController` — the cast spell is owned by someone other than its
+  controller (the trigger's controller, i.e. "you"). True precisely for "a spell you don't own":
+  a card you cast out of exile / a graveyard that belongs to another player (Nita, Forum
+  Conciliator; Gonti's-style borrow effects). Matches when the spell entity's `OwnerComponent`
+  (fixed at game start, CR 108.3) differs from the controller; a spell cast from your own zones
+  (owner == controller) never satisfies it.
 
 Examples:
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -777,9 +777,16 @@ object Effects {
         withAnyManaType: Boolean = false,
         condition: com.wingedsheep.sdk.scripting.conditions.Condition? = null,
         landEntersTapped: Boolean = false,
-        onPlayRider: Effect? = null
+        onPlayRider: Effect? = null,
+        exileAfterResolve: Boolean = false
     ): Effect = GrantMayPlayFromExileEffect(
-        from, expiry, withAnyManaType, condition, landEntersTapped, onPlayRider
+        from = from,
+        expiry = expiry,
+        withAnyManaType = withAnyManaType,
+        condition = condition,
+        landEntersTapped = landEntersTapped,
+        onPlayRider = onPlayRider,
+        exileAfterResolve = exileAfterResolve
     )
 
     /**
@@ -1608,7 +1615,8 @@ object Effects {
         sacrificeOnlyOnControllersTurn: Boolean = false,
         addCardTypes: Set<String> = emptySet(),
         exileAtStep: com.wingedsheep.sdk.core.Step? = null,
-        exileUnlessSourceIsRingBearer: Boolean = false
+        exileUnlessSourceIsRingBearer: Boolean = false,
+        controller: EffectTarget? = null
     ): Effect = CreateTokenCopyOfTargetEffect(
         target = target,
         count = DynamicAmount.Fixed(count),
@@ -1629,7 +1637,8 @@ object Effects {
         sacrificeOnlyOnControllersTurn = sacrificeOnlyOnControllersTurn,
         addCardTypes = addCardTypes,
         exileAtStep = exileAtStep,
-        exileUnlessSourceIsRingBearer = exileUnlessSourceIsRingBearer
+        exileUnlessSourceIsRingBearer = exileUnlessSourceIsRingBearer,
+        controller = controller
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -1121,7 +1121,17 @@ data class GrantMayPlayFromExileEffect(
      * its owner may play it until the end of their next turn."). Defaults to controller-controls,
      * matching impulse-draw effects where you exile and play cards you own.
      */
-    val ownerControls: Boolean = false
+    val ownerControls: Boolean = false,
+    /**
+     * When true, each granted card is stamped so that, if a spell cast from this permission would
+     * be put into a graveyard (on resolution, when countered, or when it fizzles), it is exiled
+     * instead. Models the "If that spell would be put into a graveyard, exile it instead" rider on
+     * cards that let you cast a card you don't own out of exile (Nita, Forum Conciliator) — the
+     * same `ExileAfterResolveComponent` mechanism behind [GrantFreeCastTargetFromExileEffect.exileAfterResolve],
+     * but for a *paid* cast rather than a free one. Defaults to off (impulse-draw cards leave the
+     * card to go to its owner's graveyard normally).
+     */
+    val exileAfterResolve: Boolean = false
 ) : Effect {
     override val description: String = buildString {
         val who = if (ownerControls) "its owner" else "you"
@@ -1132,6 +1142,7 @@ data class GrantMayPlayFromExileEffect(
         }
         if (withAnyManaType) append(", and mana of any type can be spent to cast them")
         if (landEntersTapped) append(". Each land played this way enters tapped")
+        if (exileAfterResolve) append(". If a spell cast this way would be put into a graveyard, exile it instead")
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -424,7 +424,16 @@ data class CreateTokenCopyOfTargetEffect(
      * controller's Ring-bearer at the time the trigger fires (CR 701.54e) — i.e. "exile that
      * token unless [source] is your Ring-bearer" (Sauron, the Necromancer).
      */
-    val exileUnlessSourceIsRingBearer: Boolean = false
+    val exileUnlessSourceIsRingBearer: Boolean = false,
+    /**
+     * The player who creates (and so controls and owns) the token copy. `null` defaults to the
+     * effect's controller — the normal "you create a token that's a copy of …" case. Set it to a
+     * resolved player target for "**Target player** creates a token that's a copy of target
+     * creature you control" (Echocasting Symposium): the chosen permanent is copied, but the new
+     * token is put onto the battlefield under the named player's control. Mirrors
+     * [CreateTokenEffect.controller].
+     */
+    val controller: EffectTarget? = null
 ) : Effect {
     override val description: String = buildString {
         append("Create ${count.description} token copies of target permanent")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -437,6 +437,20 @@ sealed interface SpellCastPredicate {
     data class TargetsMatching(val filter: GameObjectFilter) : SpellCastPredicate {
         override val description = "that targets ${filter.description}"
     }
+
+    /**
+     * The just-cast spell is **owned by a player other than the trigger's controller** — the
+     * card's owner (CR 108.3, fixed at game start) differs from who cast it. This is true when
+     * you cast a spell that isn't yours: a card exiled from an opponent's graveyard/hand that you
+     * may cast (Nita, Forum Conciliator; Gonti, Lord of Luxury), a spell stolen with control of
+     * the stack object, etc. A spell you cast from your own zones (owner == controller) does not
+     * satisfy it. Resolved against the spell entity's owner record vs. the trigger controller.
+     */
+    @SerialName("SpellNotOwnedByController")
+    @Serializable
+    data object NotOwnedByController : SpellCastPredicate {
+        override val description = "you don't own"
+    }
 }
 
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -371,6 +371,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.PowerOrToughnessAtLeast(min)
     )
 
+    /** Power or toughness at most */
+    fun powerOrToughnessAtMost(max: Int) = copy(
+        cardPredicates = cardPredicates + CardPredicate.PowerOrToughnessAtMost(max)
+    )
+
     /** Total power and toughness (sum) at most */
     fun totalPowerAndToughnessAtMost(max: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.TotalPowerAndToughnessAtMost(max)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -493,6 +493,13 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "with power or toughness $min or greater"
     }
 
+    /** Power or toughness is at most the given value (OR logic) */
+    @SerialName("PowerOrToughnessAtMost")
+    @Serializable
+    data class PowerOrToughnessAtMost(val max: Int) : CardPredicate {
+        override val description: String = "with power or toughness $max or less"
+    }
+
     /** Total power and toughness (sum) is at most the given value */
     @SerialName("TotalPowerAndToughnessAtMost")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ArnynDeathbloomBotanist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ArnynDeathbloomBotanist.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Arnyn, Deathbloom Botanist — Secrets of Strixhaven #74
+ * {2}{B} · Legendary Creature — Vampire Druid · 2/2
+ *
+ * Deathtouch
+ * Whenever a creature you control with power or toughness 1 or less dies, target opponent
+ * loses 2 life and you gain 2 life.
+ *
+ * The trigger matches a creature you control whose **power OR toughness** is 1 or less (the OR
+ * cap is modeled by [GameObjectFilter.powerOrToughnessAtMost], evaluated against last-known
+ * battlefield stats when the dies event fires). The triggering creature can be Arnyn itself if
+ * it qualifies. "Target opponent loses 2 life and you gain 2 life" is a single chosen-opponent
+ * target plus a controller life gain.
+ */
+val ArnynDeathbloomBotanist = card("Arnyn, Deathbloom Botanist") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Vampire Druid"
+    power = 2
+    toughness = 2
+    oracleText = "Deathtouch\n" +
+        "Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().powerOrToughnessAtMost(1),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD,
+            ),
+            binding = TriggerBinding.ANY,
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            Effects.LoseLife(2, opponent),
+            Effects.GainLife(2),
+        )
+        description = "Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Anna Steinbauer"
+        flavorText = "\"My lovelies need meat, just like any other carnivore.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/6168b472-0930-4db5-9920-407340b99050.jpg?1775937426"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/EchocastingSymposium.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/EchocastingSymposium.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Echocasting Symposium — Secrets of Strixhaven #44
+ * {4}{U}{U} · Sorcery — Lesson
+ *
+ * Target player creates a token that's a copy of target creature you control.
+ * Paradigm (Then exile this spell. After you first resolve a spell with this name, you may cast
+ *   a copy of it from exile without paying its mana cost at the beginning of each of your first
+ *   main phases.)
+ *
+ * Two targets: the player who creates (and controls) the token, and the creature you control to
+ * copy. `CreateTokenCopyOfTarget(target = <creature>, controller = <player>)` copies the chosen
+ * creature but puts the token under the chosen player's control. `paradigm()` exiles the spell on
+ * resolution and arms the recurring free-cast copy.
+ */
+val EchocastingSymposium = card("Echocasting Symposium") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery — Lesson"
+    oracleText = "Target player creates a token that's a copy of target creature you control.\n" +
+        "Paradigm (Then exile this spell. After you first resolve a spell with this name, you may " +
+        "cast a copy of it from exile without paying its mana cost at the beginning of each of your " +
+        "first main phases.)"
+
+    spell {
+        val player = target("target player", Targets.Player)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = creature,
+            controller = player,
+        )
+        paradigm()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "44"
+        artist = "Fajareka Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d7086a7-dc42-468a-a2cf-a6f89030f947.jpg?1775937216"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/NitaForumConciliator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/NitaForumConciliator.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Nita, Forum Conciliator — Secrets of Strixhaven #206
+ * {1}{W}{B} · Legendary Creature — Human Advisor · 2/3
+ *
+ * Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control.
+ * {2}, Sacrifice another creature: Exile target instant or sorcery card from an opponent's
+ *   graveyard. You may cast it this turn, and mana of any type can be spent to cast that spell.
+ *   If that spell would be put into a graveyard, exile it instead. Activate only as a sorcery.
+ *
+ * "A spell you don't own" is gated by the new [SpellCastPredicate.NotOwnedByController] cast-time
+ * predicate (the spell's owner — fixed at game start — differs from its controller, i.e. you).
+ * It would be true precisely for the card Nita's own activated ability lets you cast.
+ *
+ * The activated ability targets an instant/sorcery in an opponent's graveyard, moves it to exile,
+ * then grants a may-play-from-exile permission with `withAnyManaType = true` (the "you may cast it
+ * this turn / mana of any type" clause — you still pay the cost). `exileAfterResolve = true` carries
+ * the "if it would be put into a graveyard, exile it instead" rider so the borrowed card never
+ * returns to its owner's graveyard.
+ */
+val NitaForumConciliator = card("Nita, Forum Conciliator") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control.\n" +
+        "{2}, Sacrifice another creature: Exile target instant or sorcery card from an opponent's graveyard. " +
+        "You may cast it this turn, and mana of any type can be spent to cast that spell. If that spell would " +
+        "be put into a graveyard, exile it instead. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(requires = setOf(SpellCastPredicate.NotOwnedByController))
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature),
+        )
+        target = TargetObject(
+            filter = TargetFilter.InstantOrSorceryInGraveyard.ownedByOpponent(),
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            // Exile the targeted card from the opponent's graveyard.
+            Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE),
+            // Gather it back into a named collection so the may-play grant can key off it.
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "borrowed"),
+            // "You may cast it this turn, mana of any type" + "if it would be put into a graveyard,
+            // exile it instead."
+            Effects.GrantMayPlayFromExile(
+                from = "borrowed",
+                expiry = MayPlayExpiry.EndOfTurn,
+                withAnyManaType = true,
+                exileAfterResolve = true,
+            ),
+        )
+        description = "{2}, Sacrifice another creature: Exile target instant or sorcery card from an " +
+            "opponent's graveyard. You may cast it this turn, and mana of any type can be spent to cast " +
+            "that spell. If that spell would be put into a graveyard, exile it instead. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        artist = "Jodie Muir"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd80a87d-35d3-4ad1-8172-c85e93032d1d.jpg?1775938431"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PotionersTrove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PotionersTrove.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Potioner's Trove — Secrets of Strixhaven #251
+ * {3} · Artifact
+ *
+ * {T}: Add one mana of any color.
+ * {T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn.
+ *
+ * First ability is a vanilla any-color mana ability (`AddManaOfChoice` — the player picks the
+ * color). Second is a lifegain ability gated on the SOS "spells matter" tracker:
+ * `Conditions.YouCastSpellsThisTurn(atLeast = 1, filter = InstantOrSorcery)` reads the
+ * controller's cast history, so the {T}: gain 2 life ability is only activatable once an instant
+ * or sorcery has been cast this turn (countered/fizzled spells still count). Both abilities tap the
+ * same permanent, so only one can be used per turn — modeled faithfully as two separate {T} costs.
+ */
+val PotionersTrove = card("Potioner's Trove") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add one mana of any color.\n" +
+        "{T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.GainLife(2)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouCastSpellsThisTurn(
+                    atLeast = 1,
+                    filter = GameObjectFilter.InstantOrSorcery,
+                ),
+            ),
+        )
+        description = "{T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "251"
+        artist = "Alessandra Pisano"
+        flavorText = "The shops of Ribtruss Town sell anything that can be gathered within Titan's Grave. " +
+            "Just don't ask where they acquired their goods."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/2123b349-4649-4a15-a8b5-b54414d2b1b7.jpg?1775938752"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -705,6 +705,82 @@
     ]
 }
 
+// Arnyn, Deathbloom Botanist
+{
+    "name": "Arnyn, Deathbloom Botanist",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Vampire Druid",
+    "oracleText": "Deathtouch\nWhenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "PowerOrToughnessAtMost",
+                                "max": 1
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"My lovelies need meat, just like any other carnivore.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/6168b472-0930-4db5-9920-407340b99050.jpg?1775937426"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Artistic Process
 {
     "name": "Artistic Process",
@@ -3180,6 +3256,54 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Echocasting Symposium
+{
+    "name": "Echocasting Symposium",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Target player creates a token that's a copy of target creature you control.\nParadigm (Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.)",
+    "keywords": [
+        "PARADIGM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature you control"
+            },
+            "controller": {
+                "type": "BoundVariable",
+                "name": "target player"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ],
+        "selfExileOnResolve": true,
+        "paradigm": true
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "MYTHIC",
+        "artist": "Fajareka Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d7086a7-dc42-468a-a2cf-a6f89030f947.jpg?1775937216"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -9169,6 +9293,118 @@
     ]
 }
 
+// Nita, Forum Conciliator
+{
+    "name": "Nita, Forum Conciliator",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control.\n{2}, Sacrifice another creature: Exile target instant or sorcery card from an opponent's graveyard. You may cast it this turn, and mana of any type can be spent to cast that spell. If that spell would be put into a graveyard, exile it instead. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellNotOwnedByController"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "borrowed"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "borrowed",
+                            "withAnyManaType": true,
+                            "exileAfterResolve": true
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "instant|sorcery own:opponent",
+                            "zone": "Graveyard"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{2}, Sacrifice another creature: Exile target instant or sorcery card from an opponent's graveyard. You may cast it this turn, and mana of any type can be spent to cast that spell. If that spell would be put into a graveyard, exile it instead. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "RARE",
+        "artist": "Jodie Muir",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd80a87d-35d3-4ad1-8172-c85e93032d1d.jpg?1775938431"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Noxious Newt
 {
     "name": "Noxious Newt",
@@ -10024,6 +10260,55 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Potioner's Trove
+{
+    "name": "Potioner's Trove",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add one mana of any color.\n{T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "PlayerCastSpellsThisTurn",
+                            "filter": "instant|sorcery",
+                            "atLeast": 1
+                        }
+                    }
+                ],
+                "descriptionOverride": "{T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "artist": "Alessandra Pisano",
+        "flavorText": "The shops of Ribtruss Town sell anything that can be gathered within Titan's Grave. Just don't ask where they acquired their goods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/2123b349-4649-4a15-a8b5-b54414d2b1b7.jpg?1775938752"
+    },
+    "colorIdentityOverride": []
 }
 
 // Pox Plague

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3602,6 +3602,40 @@ private fun EmitCtx.activationRestrictionLines(rule: JsonObject): List<String>? 
             }
         }
     }
+    // "Activate only if you've cast an instant or sorcery spell this turn" (Potioner's Trove): the
+    // sole modifier is an ActivateOnlyIf whose condition is PlayerPassesFilter(You,
+    // CastASpellThisTurn(Or(IsCardtype Instant, IsCardtype Sorcery))) ->
+    // ActivationRestriction.OnlyIfCondition(Conditions.YouCastSpellsThisTurn(1,
+    // GameObjectFilter.InstantOrSorcery)). Match the exact shape (You + the instant-or-sorcery spell
+    // filter) so any other player, count, or spell filter still scaffolds.
+    run {
+        val mods = (rule["args"].asArr ?: emptyList()).filterIsInstance<JsonObject>()
+            .filter { it.strField("_ActivateModifier") != null }
+        val only = mods.singleOrNull()
+        if (only != null && only.strField("_ActivateModifier") == "ActivateOnlyIf") {
+            val cond = only["args"] as? JsonObject
+            if (cond?.strField("_Condition") == "PlayerPassesFilter") {
+                val cArgs = cond["args"].asArr ?: emptyList()
+                val player = cArgs.getOrNull(0) as? JsonObject
+                val playerFilter = cArgs.getOrNull(1) as? JsonObject
+                if (jsonContains(player, "_Player", "You") &&
+                    playerFilter?.strField("_Players") == "CastASpellThisTurn" &&
+                    isInstantOrSorcerySpellFilter(playerFilter["args"] as? JsonObject)
+                ) {
+                    return listOf(
+                        "        restrictions = listOf(",
+                        "            ActivationRestriction.OnlyIfCondition(",
+                        "                Conditions.YouCastSpellsThisTurn(",
+                        "                    atLeast = 1,",
+                        "                    filter = GameObjectFilter.InstantOrSorcery,",
+                        "                ),",
+                        "            ),",
+                        "        )",
+                    )
+                }
+            }
+        }
+    }
     // Per-turn activation caps -> ActivationRestriction frequency rules. Render only when EVERY
     // modifier present is a recognised per-turn cap, so an unrecognised modifier still scaffolds:
     //  - "Activate only once each turn"  (Mindful Biomancer)              -> OncePerTurn

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -920,6 +920,13 @@ class TriggerMatcher(
                     else lastKnownToughness ?: projected.getToughness(entityId) ?: cardComponent.baseStats?.baseToughness ?: 0
                 power >= predicate.min || toughness >= predicate.min
             }
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerOrToughnessAtMost -> {
+                val power = if (isFaceDown) 2
+                    else lastKnownPower ?: projected.getPower(entityId) ?: cardComponent.baseStats?.basePower ?: 0
+                val toughness = if (isFaceDown) 2
+                    else lastKnownToughness ?: projected.getToughness(entityId) ?: cardComponent.baseStats?.baseToughness ?: 0
+                power <= predicate.max || toughness <= predicate.max
+            }
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.TotalPowerAndToughnessAtMost -> {
                 val power = if (isFaceDown) 2
                     else lastKnownPower ?: projected.getPower(entityId) ?: cardComponent.baseStats?.basePower ?: 0
@@ -1351,6 +1358,12 @@ class TriggerMatcher(
                     state, state.projectedState, targetId, predicate.filter, predicateContext
                 )
             }
+        }
+        SpellCastPredicate.NotOwnedByController -> {
+            val ownerId = state.getEntity(event.spellEntityId)
+                ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()
+                ?.playerId
+            ownerId != null && ownerId != controllerId
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -388,6 +388,11 @@ class PredicateEvaluator {
                 val toughness = projectedValues?.toughness ?: card.baseStats?.baseToughness ?: 0
                 power >= predicate.min || toughness >= predicate.min
             }
+            is CardPredicate.PowerOrToughnessAtMost -> {
+                val power = projectedValues?.power ?: card.baseStats?.basePower ?: 0
+                val toughness = projectedValues?.toughness ?: card.baseStats?.baseToughness ?: 0
+                power <= predicate.max || toughness <= predicate.max
+            }
             is CardPredicate.TotalPowerAndToughnessAtMost -> {
                 val power = projectedValues?.power ?: card.baseStats?.basePower ?: 0
                 val toughness = projectedValues?.toughness ?: card.baseStats?.baseToughness ?: 0
@@ -1085,6 +1090,7 @@ class PredicateEvaluator {
             is CardPredicate.ToughnessEquals, is CardPredicate.ToughnessAtMost, is CardPredicate.ToughnessAtLeast,
             CardPredicate.ToughnessAtMostX,
             is CardPredicate.PowerOrToughnessAtLeast,
+            is CardPredicate.PowerOrToughnessAtMost,
             is CardPredicate.TotalPowerAndToughnessAtMost,
             is CardPredicate.PowerGreaterThanEntity,
             is CardPredicate.PowerAtMostEntity,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ExileAfterResolveComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithCostIncreaseComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.components.identity.PlottedComponent
@@ -57,6 +58,17 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
         val isPermanent = effect.expiry is MayPlayExpiry.Permanent
 
         var newState = state
+
+        // "If a spell cast this way would be put into a graveyard, exile it instead" (Nita,
+        // Forum Conciliator). Stamp the granted cards now; StackResolver honors
+        // ExileAfterResolveComponent on resolution / counter / fizzle, redirecting to exile.
+        if (effect.exileAfterResolve) {
+            for (cardId in collection) {
+                newState = newState.updateEntity(cardId) { container ->
+                    container.with(ExileAfterResolveComponent())
+                }
+            }
+        }
 
         // ownerControls (Suspend Aggression): each exiled card's *owner* — not the effect's
         // controller — may play it, and any turn-keyed expiry ("until the end of their next turn")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -68,7 +68,12 @@ class CreateTokenCopyOfTargetExecutor(
         val count = amountEvaluator.evaluate(state, effect.count, context)
         if (count <= 0) return EffectResult.success(state)
 
-        val controllerId = context.controllerId
+        // Who creates (controls + owns) the token. Defaults to the effect's controller; a player
+        // target (e.g. "Target player creates a token …" — Echocasting Symposium) puts the token
+        // under that player's control instead.
+        val controllerId = effect.controller
+            ?.let { context.resolvePlayerTargets(it, state).firstOrNull() }
+            ?: context.controllerId
 
         // Check for token creation replacement effects (e.g., Mirrormind Crown).
         // Mirrormind's replacement copies the equipped creature instead of this

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -556,6 +556,11 @@ internal class AffectsFilterResolver {
             val toughness = projected?.toughness ?: card.baseStats?.baseToughness ?: 0
             power >= predicate.min || toughness >= predicate.min
         }
+        is CardPredicate.PowerOrToughnessAtMost -> {
+            val power = projected?.power ?: card.baseStats?.basePower ?: 0
+            val toughness = projected?.toughness ?: card.baseStats?.baseToughness ?: 0
+            power <= predicate.max || toughness <= predicate.max
+        }
         is CardPredicate.TotalPowerAndToughnessAtMost -> {
             val power = projected?.power ?: card.baseStats?.basePower ?: 0
             val toughness = projected?.toughness ?: card.baseStats?.baseToughness ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -949,6 +949,11 @@ class CostCalculator(
                 val toughness = cardDef.creatureStats?.baseToughness ?: 0
                 power >= predicate.min || toughness >= predicate.min
             }
+            is CardPredicate.PowerOrToughnessAtMost -> {
+                val power = cardDef.creatureStats?.basePower ?: 0
+                val toughness = cardDef.creatureStats?.baseToughness ?: 0
+                power <= predicate.max || toughness <= predicate.max
+            }
             is CardPredicate.TotalPowerAndToughnessAtMost -> {
                 val power = cardDef.creatureStats?.basePower ?: 0
                 val toughness = cardDef.creatureStats?.baseToughness ?: 0

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArnynDeathbloomBotanistTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArnynDeathbloomBotanistTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ArnynDeathbloomBotanist
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Arnyn, Deathbloom Botanist {2}{B} — Legendary Creature — Vampire Druid 2/2
+ *   Deathtouch
+ *   Whenever a creature you control with power or toughness 1 or less dies,
+ *   target opponent loses 2 life and you gain 2 life.
+ *
+ * Exercises the new [CardPredicate.PowerOrToughnessAtMost] OR cap on a dies trigger:
+ *  - a 1-toughness creature dying triggers Arnyn (toughness 1 ≤ 1, even though power is 2),
+ *  - a 2/2 creature dying does NOT trigger (neither power nor toughness ≤ 1).
+ */
+class ArnynDeathbloomBotanistTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ArnynDeathbloomBotanist))
+        return driver
+    }
+
+    fun drainStack(driver: GameTestDriver, opponentToTarget: com.wingedsheep.sdk.model.EntityId) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 30) {
+            val pending = driver.state.pendingDecision
+            if (pending != null) {
+                // The trigger's "target opponent" choice — pick the lone opponent.
+                driver.submitTargetSelection(pending.playerId, listOf(opponentToTarget))
+            } else {
+                driver.bothPass()
+            }
+            safety++
+        }
+    }
+
+    test("creature with toughness 1 or less dying triggers the drain") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youLifeBefore = driver.getLifeTotal(you)
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Arnyn, Deathbloom Botanist")
+        // Goblin Guide is 2/1 → toughness 1 ≤ 1 qualifies (power is 2, proving the OR cap
+        // matches on toughness alone).
+        val frail = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+
+        // Opponent bolts the 1/1 you control.
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(you)
+        driver.castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(frail))).error shouldBe null
+
+        drainStack(driver, opponent)
+
+        // Drain resolved: opponent lost 2, you gained 2.
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 2)
+        driver.getLifeTotal(you) shouldBe (youLifeBefore + 2)
+    }
+
+    test("creature with both power and toughness above 1 dying does NOT trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youLifeBefore = driver.getLifeTotal(you)
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Arnyn, Deathbloom Botanist")
+        val bears = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+
+        // Kill the 2/2 with two bolts (3 damage > 2 toughness, one bolt suffices).
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(you)
+        driver.castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(bears))).error shouldBe null
+
+        // Drain whatever is on the stack (just the bolt — no Arnyn trigger expected).
+        var safety = 0
+        while (driver.stackSize > 0 && driver.state.pendingDecision == null && safety < 20) {
+            driver.bothPass(); safety++
+        }
+
+        // No drain happened.
+        driver.getLifeTotal(opponent) shouldBe oppLifeBefore
+        driver.getLifeTotal(you) shouldBe youLifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchocastingSymposiumTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchocastingSymposiumTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.ParadigmComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.EchocastingSymposium
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Echocasting Symposium (SOS) — {4}{U}{U} Sorcery — Lesson.
+ *
+ * "Target player creates a token that's a copy of target creature you control. Paradigm (...)"
+ *
+ * Pins: the token copy of the caster's creature is created under the *target player's* control
+ * (here, the opponent), proving the `controller` override on the copy effect; and the resolved
+ * spell self-exiles with the Paradigm marker.
+ */
+class EchocastingSymposiumTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + EchocastingSymposium)
+        return driver
+    }
+
+    fun tokenCopiesOf(driver: GameTestDriver, playerId: EntityId, name: String): List<EntityId> =
+        driver.state.getZone(playerId, Zone.BATTLEFIELD).filter { id ->
+            val e = driver.state.getEntity(id)
+            e?.has<TokenComponent>() == true && e.get<CardComponent>()?.name == name
+        }
+
+    test("target player (the opponent) gets a token copy of your creature; spell self-exiles via Paradigm") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myCreature = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+
+        val spell = driver.putCardInHand(me, "Echocasting Symposium")
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.BLUE, 2)
+
+        // Targets: target player = opponent, target creature you control = my Centaur Courser.
+        driver.castSpellWithTargets(
+            me, spell,
+            listOf(ChosenTarget.Player(opponent), ChosenTarget.Permanent(myCreature)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        // The opponent (target player) controls a token copy of Centaur Courser.
+        tokenCopiesOf(driver, opponent, "Centaur Courser").size shouldBe 1
+        // I do not get a token.
+        tokenCopiesOf(driver, me, "Centaur Courser").size shouldBe 0
+
+        // Paradigm: the resolved spell self-exiles with the marker.
+        val exiled = driver.state.getZone(me, Zone.EXILE)
+            .mapNotNull { driver.state.getEntity(it) }
+            .filter { it.get<CardComponent>()?.name == "Echocasting Symposium" }
+        exiled.any { it.get<ParadigmComponent>() != null } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NitaForumConciliatorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NitaForumConciliatorTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.NitaForumConciliator
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nita, Forum Conciliator (SOS) — {1}{W}{B} Legendary Creature — Human Advisor 2/3.
+ *
+ * "Whenever you cast a spell you don't own, put a +1/+1 counter on each creature you control.
+ *  {2}, Sacrifice another creature: Exile target instant or sorcery card from an opponent's
+ *  graveyard. You may cast it this turn, and mana of any type can be spent to cast that spell.
+ *  If that spell would be put into a graveyard, exile it instead. Activate only as a sorcery."
+ *
+ * Exercises the full borrow-and-cast loop end-to-end: the activated ability steals an opponent's
+ * instant/sorcery into exile and grants a may-play permission; casting that "spell you don't own"
+ * fires Nita's +1/+1 trigger; and after resolving, the borrowed card lands in exile instead of the
+ * opponent's graveyard (the exile-after-resolve rider).
+ */
+class NitaForumConciliatorTest : FunSpec({
+
+    // An off-color instant ({R}) the opponent owns. Casting it via Nita with white/black mana
+    // proves "mana of any type can be spent".
+    val borrowedInstant = card("Nita Test Spark") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        oracleText = "Nita Test Spark deals 2 damage to any target."
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(NitaForumConciliator)
+        driver.registerCard(borrowedInstant)
+        driver.initMirrorMatch(Deck.of("Plains" to 20, "Swamp" to 20), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.counters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("steal an opponent's instant, cast it with any mana → triggers +1/+1, then exiles instead of graveyard") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        val nita = driver.putCreatureOnBattlefield(me, "Nita, Forum Conciliator")
+        driver.removeSummoningSickness(nita)
+        // Another creature to feed the sacrifice cost.
+        val fodder = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        // The opponent's instant in their graveyard.
+        val instant = driver.putCardInGraveyard(opponent, "Nita Test Spark")
+        // White/black mana to pay {2} for the ability and {R} for the borrowed spell with any mana.
+        repeat(4) { driver.putLandOnBattlefield(me, "Plains") }
+
+        val abilityId = driver.cardRegistry.getCard("Nita, Forum Conciliator")!!
+            .activatedAbilities.first().id
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = nita,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Card(instant, opponent, Zone.GRAVEYARD)),
+            )
+        )
+
+        // Resolve any sacrifice / payment decisions, then the ability itself.
+        run {
+            repeat(25) {
+                if (driver.state.mayPlayPermissions.any { instant in it.cardIds }) return@run
+                when (val pending = driver.pendingDecision) {
+                    null -> driver.bothPass()
+                    is ChooseTargetsDecision -> driver.submitTargetSelection(pending.playerId, listOf(instant))
+                    else -> driver.autoResolveDecision()
+                }
+            }
+        }
+        withClue("Activation should not error: ${result.error}") { result.error shouldBe null }
+
+        // The instant left the opponent's graveyard for exile and is castable by me with any mana.
+        driver.getGraveyard(opponent).contains(instant) shouldBe false
+        val perm = driver.state.mayPlayPermissions.single { instant in it.cardIds }
+        perm.withAnyManaType shouldBe true
+
+        // Fodder was sacrificed.
+        driver.findPermanent(me, "Savannah Lions") shouldBe null
+
+        // Cast the borrowed instant (owner = opponent, controller = me) → Nita's trigger fires.
+        driver.castSpell(me, instant, listOf(opponent))
+        run {
+            repeat(25) {
+                val onBattlefield = driver.findPermanent(me, "Nita, Forum Conciliator")
+                val nitaCounters = onBattlefield?.let { driver.counters(it) } ?: 0
+                if (nitaCounters > 0 &&
+                    driver.state.getZone(opponent, Zone.EXILE).contains(instant)
+                ) return@run
+                if (driver.pendingDecision != null) driver.autoResolveDecision() else driver.bothPass()
+            }
+        }
+
+        // Nita got a +1/+1 counter from casting "a spell you don't own".
+        driver.counters(nita) shouldBe 1
+
+        // The borrowed spell went to exile (its owner's exile), not the opponent's graveyard.
+        driver.state.getZone(opponent, Zone.EXILE).contains(instant).shouldBeTrue()
+        driver.getGraveyard(opponent).contains(instant) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PotionersTroveTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PotionersTroveTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.PotionersTrove
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Potioner's Trove {3} — Artifact
+ *   {T}: Add one mana of any color.
+ *   {T}: You gain 2 life. Activate only if you've cast an instant or sorcery spell this turn.
+ *
+ * Exercises the `ActivationRestriction.OnlyIfCondition(YouCastSpellsThisTurn(InstantOrSorcery))`
+ * gate on the second ability:
+ *  - before any instant/sorcery is cast, the lifegain ability can't be activated,
+ *  - after casting Lightning Bolt (an instant), the lifegain ability resolves and gains 2 life.
+ */
+class PotionersTroveTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PotionersTrove))
+        return driver
+    }
+
+    test("lifegain ability is gated until an instant or sorcery is cast this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val lifeBefore = driver.getLifeTotal(you)
+
+        val trove = driver.putPermanentOnBattlefield(you, "Potioner's Trove")
+        driver.removeSummoningSickness(trove)
+
+        val lifegainAbilityId =
+            driver.cardRegistry.requireCard("Potioner's Trove").activatedAbilities[1].id
+
+        // No instant/sorcery cast yet → the lifegain ability is illegal.
+        val blocked = driver.submit(
+            ActivateAbility(playerId = you, sourceId = trove, abilityId = lifegainAbilityId),
+        )
+        (blocked.error != null) shouldBe true
+        driver.getLifeTotal(you) shouldBe lifeBefore
+
+        // Cast an instant (Lightning Bolt) at the opponent to satisfy the condition.
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+
+        // Resolve the bolt off the stack.
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass(); safety++
+        }
+
+        // Now the lifegain ability is activatable.
+        driver.submit(
+            ActivateAbility(playerId = you, sourceId = trove, abilityId = lifegainAbilityId),
+        ).error shouldBe null
+
+        safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass(); safety++
+        }
+
+        driver.getLifeTotal(you) shouldBe (lifeBefore + 2)
+    }
+})


### PR DESCRIPTION
Implements four **Secrets of Strixhaven** (SOS) cards, the supporting SDK/engine work, and one mtgish-tooling emitter handler.

## Cards

- **Potioner's Trove** (#251) — `{3}` Artifact.
  - `{T}`: Add one mana of any color.
  - `{T}`: You gain 2 life. *Activate only if you've cast an instant or sorcery spell this turn.*
  - Composed entirely from existing primitives: `AddManaOfChoice()` + `GainLife(2)` + `ActivationRestriction.OnlyIfCondition(Conditions.YouCastSpellsThisTurn(atLeast = 1, filter = InstantOrSorcery))`.
- **Arnyn, Deathbloom Botanist** (#74) — Deathtouch; when a creature you control with **power or toughness 1 or less** dies, target opponent loses 2 / you gain 2.
- **Nita, Forum Conciliator** (#206) — "cast a spell you don't own" lord trigger; activated ability borrows an instant/sorcery from an opponent's graveyard (cast it this turn with any mana, exile-instead-of-graveyard rider).
- **Echocasting Symposium** (#44) — target player creates a token that's a copy of target creature you control + Paradigm.

## SDK / engine

- `CardPredicate.PowerOrToughnessAtMost` + `GameObjectFilter.powerOrToughnessAtMost(n)` — OR cap over power/toughness, honored in all four evaluation sites (resolution predicate, trigger matcher with last-known stats, layer projection, cost calculation). Backs Arnyn.
- `SpellCastPredicate.NotOwnedByController` — "a spell you don't own" cast trigger, matched against the spell's `OwnerComponent` (fixed at game start, CR 108.3) vs the trigger controller. Backs Nita.
- `GrantMayPlayFromExile(exileAfterResolve = true)` — stamps `ExileAfterResolveComponent` so a *paid* cast from the permission is exiled instead of hitting a graveyard; same mechanism as `GrantFreeCastTargetFromExile.exileAfterResolve` but for a paid cast. Backs Nita's "if it would be put into a graveyard, exile it instead" rider.
- `CreateTokenCopyOfTarget(controller = …)` — the copy enters under a chosen player's control rather than the effect controller's (mirrors `CreateTokenEffect.controller`). Backs Echocasting Symposium's "target player creates a token…".

`docs/card-sdk-language-reference.md` updated for all four SDK additions.

## mtgish-tooling

- Emitter (`CardStructure.kt`) now renders the **"Activate only if you've cast an instant or sorcery spell this turn"** activated-ability modifier (`ActivateOnlyIf → PlayerPassesFilter(You, CastASpellThisTurn(Or(IsCardtype Instant, IsCardtype Sorcery)))` → `ActivationRestriction.OnlyIfCondition(Conditions.YouCastSpellsThisTurn(1, InstantOrSorcery))`). **Potioner's Trove now emits as a complete (AUTO) render.**
- The other three cards remain **SCAFFOLD declines** per the fidelity policy (decline rather than emit a lossy approximation): Arnyn's `PlayerAction` ref-target drain, Echocasting's `PlayerAction` + `multi-target` + Paradigm, and Nita's borrow-a-spell activated ability are genuinely card-specific shapes.

## Tests

- Scenario tests for all four cards (`rules-engine`), green.
- SOS card snapshot re-blessed (`SOS.json`, additions only — no other card moved).
- `EmitterGoldenTest` green; `coverage-verify POR` deep gate stays 0-mismatch (158/158). `just test-rules`, `:mtg-sets:test`, `:mtgish-tooling:test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)