### PR TITLE
DSK Batch A: Acrobatic Cheerleader, Cracked Skull, Beastie Beatdown (+ triggersOnce)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -25,15 +25,19 @@ class SealedDeckGenerator(
     /**
      * Picks a random set code that can actually produce a sealed deck.
      *
-     * Only [BoosterGenerator.SetConfig.fullyImplemented] sets are eligible: a partial set
-     * (incomplete, or not curated for sealed) can have a card pool too thin for the single-set
-     * booster strategy, which then throws `No cards available for booster generation`. Random
-     * quick/AI games have no host to opt into a partial set, so they must draw from a playable one.
-     * Falls back to all available sets only if — unexpectedly — none are fully implemented.
+     * Eligible sets must be both [BoosterGenerator.SetConfig.fullyImplemented] *and* large enough to
+     * open 8 boosters on their own. A partial set, or a small supplementary set like "The Big Score"
+     * (BIG, ~30 cards), has a pool too thin for the single-set booster strategy and throws
+     * `No cards available for booster generation`. Random quick/AI games have no host to opt into a
+     * partial set, so they must draw from a full standalone set. The fallbacks widen the pool only if
+     * — unexpectedly — nothing qualifies, so this never throws on an empty pool.
      */
     fun randomSetCode(): String {
-        val playable = boosterGenerator.availableSets.values.filter { it.fullyImplemented }
-        val pool = playable.ifEmpty { boosterGenerator.availableSets.values.toList() }
+        val sets = boosterGenerator.availableSets.values
+        val standalone = sets.filter { it.fullyImplemented && it.distinctCardCount >= MIN_STANDALONE_SET_SIZE }
+        val pool = standalone
+            .ifEmpty { sets.filter { it.fullyImplemented } }
+            .ifEmpty { sets.toList() }
         return pool.random().setCode
     }
 
@@ -85,5 +89,13 @@ class SealedDeckGenerator(
 
     private companion object {
         private val logger = LoggerFactory.getLogger(SealedDeckGenerator::class.java)
+
+        /**
+         * Minimum distinct-card count for a set to be opened as a standalone sealed pool. Excludes
+         * small supplementary sets (e.g. "The Big Score", BIG, ~30 cards) that can't fill 8 boosters
+         * on their own. A full draftable set is ~250+ cards, so 200 leaves headroom while still
+         * rejecting anything too thin.
+         */
+        private const val MIN_STANDALONE_SET_SIZE = 200
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
@@ -32,11 +32,19 @@ class SealedDeckGeneratorTest : FunSpec({
         metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity, inBooster = inBooster),
     )
 
-    // A pool deep enough to fill 8 standard boosters without exhausting any rarity.
+    // A pool deep enough to fill 8 standard boosters without exhausting any rarity. Small enough
+    // (28 cards) to model a bonus sheet like "The Big Score" — below the standalone size threshold.
     fun viablePool(prefix: String): List<CardDefinition> =
         (1..15).map { card("$prefix Common $it", Rarity.COMMON) } +
             (1..8).map { card("$prefix Uncommon $it", Rarity.UNCOMMON) } +
             (1..5).map { card("$prefix Rare $it", Rarity.RARE) }
+
+    // A full-size set (260 distinct cards) — above the standalone size threshold, so it is a valid
+    // random quick/AI sealed source.
+    fun largePool(prefix: String): List<CardDefinition> =
+        (1..200).map { card("$prefix Common $it", Rarity.COMMON) } +
+            (1..40).map { card("$prefix Uncommon $it", Rarity.UNCOMMON) } +
+            (1..20).map { card("$prefix Rare $it", Rarity.RARE) }
 
     fun config(code: String, cards: List<CardDefinition>, sealedSupported: Boolean, incomplete: Boolean = false) =
         BoosterGenerator.SetConfig(
@@ -64,6 +72,33 @@ class SealedDeckGeneratorTest : FunSpec({
 
         val drawn = (1..500).map { gen.randomSetCode() }.toSet()
         drawn.toList() shouldContainExactly listOf("FULL")
+    }
+
+    test("randomSetCode skips small complete sets in favour of full standalone sets") {
+        // "BIG" is a complete, sealed-supported bonus sheet (28 cards) that can't fill 8 boosters on
+        // its own; "FULL" is a full-size set. Only FULL is a valid standalone random source.
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf(
+                    "FULL" to config("FULL", largePool("FULL"), sealedSupported = true),
+                    "BIG" to config("BIG", viablePool("BIG"), sealedSupported = true),
+                )
+            )
+        )
+
+        val drawn = (1..500).map { gen.randomSetCode() }.toSet()
+        drawn.toList() shouldContainExactly listOf("FULL")
+    }
+
+    test("falls back to any complete set when none meet the standalone size threshold") {
+        // Only small complete sets exist — pick one rather than throw on an empty pool.
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf("SMALL" to config("SMALL", viablePool("SMALL"), sealedSupported = true))
+            )
+        )
+
+        gen.randomSetCode() shouldBe "SMALL"
     }
 
     test("generate(randomSetCode()) never throws even when partial sets are unviable") {

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1783,7 +1783,16 @@ work for abilities-on-stack (which carry no `CardComponent`).
 
 ## 8. Triggered abilities (`Triggers.*`)
 
-`triggeredAbility { trigger; effect; target?; triggerCondition?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController? }`.
+`triggeredAbility { trigger; effect; target?; triggerCondition?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController?; oncePerTurn?; triggersOnce? }`.
+
+**`oncePerTurn` vs `triggersOnce` — two firing caps.** `oncePerTurn = true` caps the ability to one
+fire per turn ("This ability triggers only once each turn", e.g. Scavenger's Talent), tracked by a
+per-turn component cleared in cleanup. `triggersOnce = true` is the lifetime cap ("This ability
+triggers only once", e.g. Acrobatic Cheerleader): once the source has fired it, it never fires again
+while that permanent stays on the battlefield — tracked by a `TriggeredAbilityFiredEverComponent`
+that is **not** cleared at end of turn (it lives on the entity, so re-entering the battlefield as a
+new object — a distinct game object — triggers afresh). Both caps share one detection-time filter and
+collapse simultaneous fires of the same `(source, ability)` to a single instance.
 
 **`optional` + `elseEffect` = "you may [effect]. If you don't, [elseEffect]."** For a **targeted**
 trigger, `optional` lets the player choose 0 targets to decline, and `elseEffect` runs on decline or

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1157,6 +1157,9 @@ class TriggeredAbilityBuilder {
     var controlledByTriggeringEntityController: Boolean = false
     /** When true, this triggered ability triggers at most once each turn. */
     var oncePerTurn: Boolean = false
+    /** When true, this triggered ability triggers at most once over the source's lifetime on the
+     * battlefield ("This ability triggers only once"). Unlike [oncePerTurn] it is never reset. */
+    var triggersOnce: Boolean = false
     /** Optional human-readable description that overrides the auto-generated one. */
     var description: String? = null
 
@@ -1196,6 +1199,7 @@ class TriggeredAbilityBuilder {
             triggerCondition = triggerCondition,
             controlledByTriggeringEntityController = controlledByTriggeringEntityController,
             oncePerTurn = oncePerTurn,
+            triggersOnce = triggersOnce,
             descriptionOverride = description
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
@@ -37,6 +37,11 @@ data class TriggeredAbility(
     /** When true, this triggered ability triggers at most once each turn.
      * Used for cards like Scavenger's Talent: "This ability triggers only once each turn." */
     val oncePerTurn: Boolean = false,
+    /** When true, this triggered ability triggers at most once over the source permanent's
+     * lifetime on the battlefield — a permanent (not per-turn) cap. Used for cards like
+     * Acrobatic Cheerleader: "This ability triggers only once." Tracked by a component that,
+     * unlike the [oncePerTurn] tracker, is NOT cleared at end of turn. */
+    val triggersOnce: Boolean = false,
     /** Optional human-readable description that overrides the auto-generated one. */
     val descriptionOverride: String? = null
 ) : TextReplaceable<TriggeredAbility> {
@@ -104,6 +109,7 @@ data class TriggeredAbility(
             triggerCondition: Condition? = null,
             controlledByTriggeringEntityController: Boolean = false,
             oncePerTurn: Boolean = false,
+            triggersOnce: Boolean = false,
             descriptionOverride: String? = null
         ): TriggeredAbility =
             TriggeredAbility(
@@ -119,6 +125,7 @@ data class TriggeredAbility(
                 triggerCondition = triggerCondition,
                 controlledByTriggeringEntityController = controlledByTriggeringEntityController,
                 oncePerTurn = oncePerTurn,
+                triggersOnce = triggersOnce,
                 descriptionOverride = descriptionOverride
             )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AcrobaticCheerleader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AcrobaticCheerleader.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Acrobatic Cheerleader
+ * {1}{W}
+ * Creature — Human Survivor
+ * 2/2
+ * Survival — At the beginning of your second main phase, if this creature is tapped, put a
+ * flying counter on it. This ability triggers only once.
+ */
+val AcrobaticCheerleader = card("Acrobatic Cheerleader") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Survivor"
+    power = 2
+    toughness = 2
+    oracleText = "Survival — At the beginning of your second main phase, if this creature is " +
+        "tapped, put a flying counter on it. This ability triggers only once."
+
+    // Survival — At the beginning of your second main phase, if this creature is tapped, put a
+    // flying counter on it. "This ability triggers only once" → triggersOnce caps it for the
+    // permanent's lifetime (a flying counter grants flying via the keyword-counter projection).
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        triggersOnce = true
+        effect = Effects.AddCounters(Counters.FLYING, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Julia Metzger"
+        flavorText = "\"I used to cheat death every day in practice. This is nothing.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg?1726285858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BeastieBeatdown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BeastieBeatdown.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Beastie Beatdown
+ * {R}{G}
+ * Sorcery
+ * Choose target creature you control and target creature an opponent controls.
+ * Delirium — If there are four or more card types among cards in your graveyard, put two
+ * +1/+1 counters on the creature you control.
+ * The creature you control deals damage equal to its power to the creature an opponent controls.
+ *
+ * One-sided "fight": only the controlled creature deals damage. The Delirium counters are placed
+ * before the damage step so the (possibly buffed) power is used. `targetPower(0)` reads the first
+ * declared target (the controlled creature, also the damage source).
+ */
+val BeastieBeatdown = card("Beastie Beatdown") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Sorcery"
+    oracleText = "Choose target creature you control and target creature an opponent controls.\n" +
+        "Delirium — If there are four or more card types among cards in your graveyard, put two " +
+        "+1/+1 counters on the creature you control.\n" +
+        "The creature you control deals damage equal to its power to the creature an opponent controls."
+
+    spell {
+        val yours = target("creature you control", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        val theirs = target("creature an opponent controls", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.Composite(
+            // Delirium — counters land first so the damage uses the buffed power.
+            ConditionalEffect(
+                condition = Conditions.Delirium(),
+                effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 2, target = yours),
+            ),
+            DealDamageEffect(DynamicAmounts.targetPower(0), theirs, damageSource = yours),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg?1726286652"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CrackedSkull.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CrackedSkull.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cracked Skull
+ * {2}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, look at target player's hand. You may choose a nonland card from it.
+ * That player discards that card.
+ * When enchanted creature is dealt damage, destroy it.
+ */
+val CrackedSkull = card("Cracked Skull") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, look at target player's hand. You may choose a nonland card " +
+        "from it. That player discards that card.\n" +
+        "When enchanted creature is dealt damage, destroy it."
+
+    auraTarget = Targets.Creature
+
+    // When this Aura enters, look at target player's hand. You may choose a nonland card from it.
+    // That player discards that card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            listOf(
+                LookAtTargetHandEffect(player),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "targetHand",
+                ),
+                SelectFromCollectionEffect(
+                    from = "targetHand",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "You may choose a nonland card for that player to discard",
+                    showAllCards = true,
+                    alwaysPrompt = true,
+                ),
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard,
+                ),
+            ),
+        )
+    }
+
+    // When enchanted creature is dealt damage, destroy it.
+    triggeredAbility {
+        trigger = Triggers.takesDamage(binding = TriggerBinding.ATTACHED)
+        effect = Effects.Destroy(EffectTarget.EnchantedCreature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Mirko Failoni"
+        flavorText = "Ears ringing and head throbbing, all Tarvin could do was wait to see what would finish the job."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg?1726286178"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1,3 +1,48 @@
+// Acrobatic Cheerleader
+{
+    "name": "Acrobatic Cheerleader",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if this creature is tapped, put a flying counter on it. This ability triggers only once.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "flying",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "triggersOnce": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Julia Metzger",
+        "flavorText": "\"I used to cheat death every day in practice. This is nothing.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg?1726285858"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Appendage Amalgam
 {
     "name": "Appendage Amalgam",
@@ -381,6 +426,92 @@
         "imageUri": "https://cards.scryfall.io/normal/front/e/2/e27c27d6-dc3a-4420-bb35-d97dc216e002.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Beastie Beatdown
+{
+    "name": "Beastie Beatdown",
+    "manaCost": "{R}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose target creature you control and target creature an opponent controls.\nDelirium — If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control.\nThe creature you control deals damage equal to its power to the creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateZone",
+                                "player": "You",
+                                "zone": "Graveyard",
+                                "aggregation": "DISTINCT_TYPES"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 2,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature an opponent controls"
+                    },
+                    "damageSource": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Inkognit",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg?1726286652"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
 }
 
 // Blazemire Verge
@@ -869,6 +1000,108 @@
         "artist": "Ovidio Cartagena",
         "flavorText": "Elsa swelled with euphoria and power as she stepped over her friends' corpses. She should have bargained with a demon a lot sooner.",
         "imageUri": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg?1726286174"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cracked Skull
+{
+    "name": "Cracked Skull",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, look at target player's hand. You may choose a nonland card from it. That player discards that card.\nWhen enchanted creature is dealt damage, destroy it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LookAtTargetHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "targetHand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "targetHand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "nonland",
+                            "storeSelected": "toDiscard",
+                            "prompt": "You may choose a nonland card for that player to discard",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toDiscard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "DamageReceivedEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "EnchantedCreature",
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Mirko Failoni",
+        "flavorText": "Ears ringing and head throbbing, all Tarvin could do was wait to see what would finish the job.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg?1726286178"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -22,6 +22,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     // unrenderable condition declines to a scaffold (Canyon Crab's "if you haven't cast a spell from
     // your hand this turn").
     envelope("TriggerI", "envelope: triggered ability with intervening-if condition")
+    // TriggerIOnce — a TriggerI ([trigger, condition, actions]) that ALSO carries the lifetime cap
+    // "This ability triggers only once" (the SDK's `triggersOnce = true`). Same intervening-if recovery
+    // as TriggerI, plus a `triggersOnce = true` rider; an unrenderable condition declines to a scaffold
+    // (DSK Survival cards: Acrobatic Cheerleader, Pearl Collector, Jet Collector).
+    envelope("TriggerIOnce", "envelope: triggered ability with intervening-if that triggers only once (lifetime)")
     envelope("TriggerOnceEachTurn", "envelope: triggered ability that triggers only once each turn")
     // "you may [do X]. Do this only once each turn." — a once-per-turn triggered ability whose body the
     // once-each-turn tag also frames as a "you may". The capability is the nested actions (the emitter

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1799,10 +1799,17 @@ private fun isFiveOrMoreManaSpentCondition(cond: JsonObject): Boolean {
 
 /** A TriggerA rule (self-triggered) -> triggeredAbility { trigger; [triggerCondition]; [target]; effect }.
  *  [oncePerTurn] is set by the `TriggerOnceEachTurn` rule envelope, whose body is otherwise shaped
- *  identically to a TriggerA. [triggerCondition] is an optional intervening-if condition DSL (CR 603.4)
- *  supplied by an enclosing gate (e.g. the "while saddled" `If` wrapper passes
+ *  identically to a TriggerA. [triggersOnce] is the lifetime cap ("This ability triggers only once"),
+ *  set by the `TriggerIOnce` envelope; like oncePerTurn it just rides through as a `triggersOnce = true`
+ *  line on an otherwise TriggerA-shaped body. [triggerCondition] is an optional intervening-if condition
+ *  DSL (CR 603.4) supplied by an enclosing gate (e.g. the "while saddled" `If` wrapper passes
  *  `Conditions.SourceIsSaddled`); it renders as a `triggerCondition = …` line. */
-internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false, triggerCondition: String? = null): List<Stmt>? {
+internal fun EmitCtx.triggerBlock(
+    rule: JsonObject,
+    oncePerTurn: Boolean = false,
+    triggerCondition: String? = null,
+    triggersOnce: Boolean = false,
+): List<Stmt>? {
     // A "choose one —" modal triggered ability hosts its modal as a plain effect:
     // `triggeredAbility { trigger = …; effect = ModalEffect.chooseOne(Mode.…, Mode.…) }`. Render the
     // `Modal_ChooseOne` arms via [modalChooseOneEffectExpr] (the inline `Mode.*` form), per-mode targets
@@ -1878,6 +1885,7 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     val triggerCond = effTriggerCondition ?: condFromIf
     if (triggerCond != null) stmts.add(Assign("triggerCondition", Lit(triggerCond)))
     if (oncePerTurn) stmts.add(Assign("oncePerTurn", Lit("true")))
+    if (triggersOnce) stmts.add(Assign("triggersOnce", Lit("true")))
     if (mayWrapped && !selfOptional) stmts.add(Assign("optional", Lit("true")))
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))
@@ -2080,6 +2088,25 @@ internal fun EmitCtx.triggerIBlock(rule: JsonObject): List<Stmt>? {
         put("args", JsonArray(listOfNotNull(args.getOrNull(0)) + listOfNotNull(args.getOrNull(2))))
     }
     return triggerBlock(triggerA, triggerCondition = condDsl)
+}
+
+/**
+ * A `TriggerIOnce` rule — a TriggerI ([trigger, condition, actions]) that ALSO carries the lifetime cap
+ * "This ability triggers only once" (CR 603.6e-style permanent latch). Same recovery path as
+ * [triggerIBlock] (intervening-if condition lifted out, body re-keyed to a TriggerA), with the extra
+ * `triggersOnce = true` rider threaded through. The DSK Survival cards Acrobatic Cheerleader / Pearl
+ * Collector / Jet Collector use this shape: "Survival — At the beginning of your second main phase, if
+ * <condition>, <effect>. This ability triggers only once."
+ */
+internal fun EmitCtx.triggerIOnceBlock(rule: JsonObject): List<Stmt>? {
+    val args = rule["args"].asArr ?: run { reasons.add("TriggerIOnce"); return null }
+    val cond = args.getOrNull(1) as? JsonObject
+    val condDsl = interveningIfDsl(cond) ?: run { reasons.add("TriggerIOnce"); return null }
+    val triggerA = buildJsonObject {
+        put("_Rule", JsonPrimitive("TriggerA"))
+        put("args", JsonArray(listOfNotNull(args.getOrNull(0)) + listOfNotNull(args.getOrNull(2))))
+    }
+    return triggerBlock(triggerA, triggerCondition = condDsl, triggersOnce = true)
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -190,6 +190,7 @@ object Emitter {
                 rname == "SpellActions_Spree" -> block = ctx.spreeSpellBlock(rule)
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "TriggerI" -> block = ctx.triggerIBlock(rule)
+                rname == "TriggerIOnce" -> block = ctx.triggerIOnceBlock(rule)
                 rname == "TriggerOnceEachTurn" -> block = ctx.triggerBlock(rule, oncePerTurn = true)
                 rname == "TriggerMayOnceEachTurn" -> block = ctx.triggerMayOnceEachTurnBlock(rule)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -397,6 +397,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TargetedByControllerThisTurnComponent::class)
         subclass(ReceivedCountersThisTurnComponent::class)
         subclass(TriggeredAbilityFiredThisTurnComponent::class)
+        subclass(TriggeredAbilityFiredEverComponent::class)
         subclass(StateTriggerLatchesComponent::class)
         subclass(WarpedComponent::class)
         subclass(EvokedComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -366,14 +367,23 @@ class TriggerDetector(
         state: GameState,
         triggers: List<PendingTrigger>
     ): List<PendingTrigger> {
-        val seenOncePerTurn = HashSet<Pair<EntityId, com.wingedsheep.sdk.scripting.AbilityId>>()
+        val seenCapped = HashSet<Pair<EntityId, com.wingedsheep.sdk.scripting.AbilityId>>()
         return triggers.filter { trigger ->
-            if (!trigger.ability.oncePerTurn) return@filter true
+            val ability = trigger.ability
+            // Same capping logic for "once each turn" (per-turn tracker) and "triggers only once"
+            // (lifetime tracker): drop if already fired, then collapse simultaneous fires.
+            if (!ability.oncePerTurn && !ability.triggersOnce) return@filter true
             val entity = state.getEntity(trigger.sourceId)
-            val tracker = entity?.get<TriggeredAbilityFiredThisTurnComponent>()
-            if (tracker != null && tracker.hasFired(trigger.ability.id)) return@filter false
+            if (ability.oncePerTurn) {
+                val tracker = entity?.get<TriggeredAbilityFiredThisTurnComponent>()
+                if (tracker != null && tracker.hasFired(ability.id)) return@filter false
+            }
+            if (ability.triggersOnce) {
+                val everTracker = entity?.get<TriggeredAbilityFiredEverComponent>()
+                if (everTracker != null && everTracker.hasFired(ability.id)) return@filter false
+            }
             // Collapse simultaneous fires of the same ability from the same source.
-            seenOncePerTurn.add(trigger.sourceId to trigger.ability.id)
+            seenCapped.add(trigger.sourceId to ability.id)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.abilityIdentityOf
@@ -269,6 +270,11 @@ class TriggerProcessor(
         // Mark once-per-turn triggers as fired so they don't trigger again this turn
         if (ability.oncePerTurn) {
             currentState = markTriggerFired(currentState, trigger.sourceId, ability.id)
+        }
+        // Mark "triggers only once" abilities as fired so they never trigger again while the
+        // source stays on the battlefield (tracker persists across turns, unlike oncePerTurn).
+        if (ability.triggersOnce) {
+            currentState = markTriggerFiredEver(currentState, trigger.sourceId, ability.id)
         }
 
         val targetRequirement = ability.targetRequirement
@@ -890,6 +896,18 @@ class TriggerProcessor(
         val entity = state.getEntity(sourceId) ?: return state
         val tracker = entity.get<TriggeredAbilityFiredThisTurnComponent>()
             ?: TriggeredAbilityFiredThisTurnComponent()
+        val updated = tracker.withFired(abilityId)
+        return state.updateEntity(sourceId) { it.with(updated) }
+    }
+
+    /**
+     * Mark a "triggers only once" triggered ability as fired on its source entity. The tracker
+     * persists for the permanent's lifetime (not cleared at end of turn).
+     */
+    private fun markTriggerFiredEver(state: GameState, sourceId: EntityId, abilityId: AbilityId): GameState {
+        val entity = state.getEntity(sourceId) ?: return state
+        val tracker = entity.get<TriggeredAbilityFiredEverComponent>()
+            ?: TriggeredAbilityFiredEverComponent()
         val updated = tracker.withFired(abilityId)
         return state.updateEntity(sourceId) { it.with(updated) }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -460,6 +460,24 @@ data class TriggeredAbilityFiredThisTurnComponent(
 }
 
 /**
+ * Tracks which triggered abilities have fired over this permanent's lifetime on the battlefield,
+ * for "This ability triggers only once" restrictions (e.g. Acrobatic Cheerleader).
+ * Unlike [TriggeredAbilityFiredThisTurnComponent] this is NOT cleared at end of turn — it persists
+ * for as long as the permanent stays on the battlefield. It lives on the entity, so it is dropped
+ * automatically when the permanent leaves (the permanent re-enters as a new game object, which
+ * triggers afresh).
+ */
+@Serializable
+data class TriggeredAbilityFiredEverComponent(
+    val abilityIds: Set<AbilityId> = emptySet()
+) : Component {
+    fun withFired(abilityId: AbilityId): TriggeredAbilityFiredEverComponent =
+        copy(abilityIds = abilityIds + abilityId)
+
+    fun hasFired(abilityId: AbilityId): Boolean = abilityId in abilityIds
+}
+
+/**
  * Per-permanent latch state for [com.wingedsheep.sdk.scripting.StateTriggeredAbility]
  * instances (CR 603.8). An [AbilityId] is in [latched] iff the engine has fired this
  * state trigger and the condition has not yet become false again — preventing repeat

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AcrobaticCheerleaderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AcrobaticCheerleaderScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Acrobatic Cheerleader (DSK #1) — {1}{W} 2/2 Creature — Human Survivor.
+ *
+ * "Survival — At the beginning of your second main phase, if this creature is tapped, put a
+ *  flying counter on it. This ability triggers only once."
+ *
+ * Exercises the `triggersOnce` lifetime cap: the Survival trigger places a flying counter exactly
+ * once while the creature stays on the battlefield, even if it is tapped at a later second main.
+ */
+class AcrobaticCheerleaderScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun flyingCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.FLYING) ?: 0
+
+    test("puts a flying counter at the second main phase while tapped") {
+        val driver = newDriver()
+        val cheerleader = driver.putCreatureOnBattlefield(driver.player1, "Acrobatic Cheerleader")
+        driver.tapPermanent(cheerleader)
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.bothPass()
+
+        flyingCounters(driver, cheerleader) shouldBe 1
+    }
+
+    test("does not place a counter if untapped at the second main phase") {
+        val driver = newDriver()
+        val cheerleader = driver.putCreatureOnBattlefield(driver.player1, "Acrobatic Cheerleader")
+        // Left untapped — the intervening-if (this creature is tapped) is false.
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        flyingCounters(driver, cheerleader) shouldBe 0
+    }
+
+    test("triggers only once — no second flying counter on a later turn") {
+        val driver = newDriver()
+        val cheerleader = driver.putCreatureOnBattlefield(driver.player1, "Acrobatic Cheerleader")
+        driver.tapPermanent(cheerleader)
+
+        // First controller second main: the ability fires once.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.bothPass()
+        flyingCounters(driver, cheerleader) shouldBe 1
+
+        // Advance to the controller's next turn (turn 3) precombat main, then re-tap so the
+        // intervening-if would again be satisfied at the second main.
+        driver.passPriorityUntil(Step.CLEANUP)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN) // opponent's turn 2
+        driver.passPriorityUntil(Step.CLEANUP)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN) // controller's turn 3
+        driver.tapPermanent(cheerleader)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.bothPass()
+
+        // Still exactly one — "This ability triggers only once" capped the lifetime.
+        flyingCounters(driver, cheerleader) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeastieBeatdownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeastieBeatdownScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Beastie Beatdown (DSK #210) — {R}{G} Sorcery.
+ *
+ * "Choose target creature you control and target creature an opponent controls.
+ *  Delirium — If there are four or more card types among cards in your graveyard, put two +1/+1
+ *  counters on the creature you control.
+ *  The creature you control deals damage equal to its power to the creature an opponent controls."
+ *
+ * A one-sided "fight": only the controlled creature deals damage. The Delirium counters are placed
+ * before the damage step, so the buffed power decides the result. Composes ConditionalEffect
+ * (Delirium-gated AddCounters) + DealDamage(targetPower(0), source = controlled creature); no new SDK.
+ */
+class BeastieBeatdownScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("no delirium: 2-power creature deals 2 damage, the 2/3 target survives") {
+        val driver = newDriver()
+        val yours = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // 2/2
+        val theirs = driver.putCreatureOnBattlefield(driver.player2, "Minotaur Warrior") // 2/3
+
+        val beatdown = driver.putCardInHand(driver.player1, "Beastie Beatdown")
+        driver.giveMana(driver.player1, Color.RED, 1)
+        driver.giveMana(driver.player1, Color.GREEN, 1)
+        driver.castSpell(driver.player1, beatdown, listOf(yours, theirs)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No delirium -> no counters; 2 damage to a toughness-3 creature is non-lethal.
+        plusCounters(driver, yours) shouldBe 0
+        driver.findPermanent(driver.player2, "Minotaur Warrior") shouldBe theirs
+    }
+
+    test("delirium active: two +1/+1 counters land first, so 4 damage destroys the 2/3 target") {
+        val driver = newDriver()
+        val yours = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // 2/2 -> 4/4
+        val theirs = driver.putCreatureOnBattlefield(driver.player2, "Minotaur Warrior") // 2/3
+
+        // Four card types in your graveyard: creature, instant, sorcery, enchantment.
+        driver.putCardInGraveyard(driver.player1, "Grizzly Bears")
+        driver.putCardInGraveyard(driver.player1, "Lightning Bolt")
+        driver.putCardInGraveyard(driver.player1, "Careful Study")
+        driver.putCardInGraveyard(driver.player1, "Test Enchantment")
+
+        val beatdown = driver.putCardInHand(driver.player1, "Beastie Beatdown")
+        driver.giveMana(driver.player1, Color.RED, 1)
+        driver.giveMana(driver.player1, Color.GREEN, 1)
+        driver.castSpell(driver.player1, beatdown, listOf(yours, theirs)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Delirium -> two +1/+1 counters; the now-4-power creature deals 4 to the 2/3, killing it.
+        plusCounters(driver, yours) shouldBe 2
+        driver.findPermanent(driver.player2, "Minotaur Warrior") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrackedSkullScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrackedSkullScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cracked Skull (DSK #88) — {2}{B} Enchantment — Aura. Enchant creature.
+ *
+ * "When this Aura enters, look at target player's hand. You may choose a nonland card from it.
+ *  That player discards that card."
+ * "When enchanted creature is dealt damage, destroy it."
+ *
+ * Both abilities compose existing primitives (LookAtTargetHand → Gather → SelectFromCollection →
+ * MoveCollection discard; and a `takesDamage(binding = ATTACHED)` → Destroy EnchantedCreature).
+ */
+class CrackedSkullScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun inGraveyard(driver: GameTestDriver, owner: EntityId, id: EntityId): Boolean =
+        driver.state.getZone(ZoneKey(owner, Zone.GRAVEYARD)).contains(id)
+
+    /**
+     * Drive the Cracked Skull ETB decisions: target the given player's hand, then optionally pick a
+     * card to discard (or none). Then pass priority until the stack is empty.
+     */
+    fun resolveEtb(driver: GameTestDriver, controller: EntityId, targetPlayer: EntityId, discard: EntityId?) {
+        var guard = 0
+        while (guard++ < 12) {
+            when (val decision = driver.state.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(controller, listOf(targetPlayer))
+                is SelectCardsDecision ->
+                    driver.submitCardSelection(controller, if (discard != null) listOf(discard) else emptyList())
+                null -> {
+                    if (driver.state.stack.isEmpty()) return
+                    driver.bothPass()
+                }
+                else -> error("Unexpected decision: $decision")
+            }
+        }
+    }
+
+    test("enchanted creature is destroyed when it is dealt damage") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        // Opponent's 1/4 Horned Turtle — 2 damage from Shock is NOT lethal on its own.
+        val turtle = driver.putCreatureOnBattlefield(p2, "Horned Turtle")
+
+        // Cast Cracked Skull ({2}{B}) on the turtle, then resolve the ETB (opponent has an empty hand).
+        driver.giveMana(p1, Color.BLACK, 3)
+        val skull = driver.putCardInHand(p1, "Cracked Skull")
+        driver.castSpellWithTargets(p1, skull, listOf(ChosenTarget.Permanent(turtle))).error shouldBe null
+        driver.bothPass()
+        resolveEtb(driver, p1, p2, discard = null)
+
+        // Shock the turtle for 2 (non-lethal vs toughness 4) — Cracked Skull destroys it.
+        driver.giveMana(p1, Color.RED, 1)
+        val shock = driver.putCardInHand(p1, "Shock")
+        driver.castSpellWithTargets(p1, shock, listOf(ChosenTarget.Permanent(turtle))).error shouldBe null
+        var guard = 0
+        while (guard++ < 8 && !(driver.state.stack.isEmpty() && driver.state.pendingDecision == null)) {
+            driver.bothPass()
+        }
+
+        inGraveyard(driver, p2, turtle) shouldBe true
+    }
+
+    test("ETB makes target player discard a chosen nonland card") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        val ownCreature = driver.putCreatureOnBattlefield(p1, "Horned Turtle")
+        driver.giveMana(p1, Color.BLACK, 3)
+
+        // Give the opponent exactly one nonland card to discard.
+        val victimCard = driver.putCardInHand(p2, "Horned Turtle")
+
+        val skull = driver.putCardInHand(p1, "Cracked Skull")
+        driver.castSpellWithTargets(p1, skull, listOf(ChosenTarget.Permanent(ownCreature))).error shouldBe null
+        driver.bothPass()
+        resolveEtb(driver, p1, p2, discard = victimCard)
+
+        inGraveyard(driver, p2, victimCard) shouldBe true
+    }
+})


### PR DESCRIPTION
## Cards implemented (3)

All auto-register via `CardDiscovery` in `DuskmournSet`; each has a passing scenario test.

- **Acrobatic Cheerleader** `{1}{W}` 2/2 Human Survivor — *Survival — At the beginning of your second main phase, if this creature is tapped, put a flying counter on it. This ability triggers only once.* Exercises the new `triggersOnce` lifetime cap.
- **Cracked Skull** `{2}{B}` Enchantment — Aura — ETB look-at-target-hand → choose-nonland → discard pipeline (Gather → SelectFromCollection → MoveCollection), plus *when enchanted creature is dealt damage, destroy it* (`takesDamage(binding = ATTACHED)` → Destroy). Composes existing primitives; no new SDK.
- **Beastie Beatdown** `{R}{G}` Sorcery — one-sided "fight". Delirium-gated two +1/+1 counters land **before** the controlled creature deals damage equal to its (buffed) power to an opponent's creature. `Effects.Composite(ConditionalEffect(Delirium, AddCounters), DealDamage(targetPower(0), source = controlled))`. No new SDK.

## Cards skipped (1)

- **Innocuous Rat** `{1}{B}` 1/1 Rat — *When this creature dies, manifest dread.* **Skipped:** Manifest Dread is unimplemented in the engine (look at top two of library, put one face-down as a 2/2 manifest creature that can be turned face up for its mana cost if it's a creature card, the other to graveyard). That is a whole new keyword mechanic with face-down manifest semantics and a turn-up special action — `add-feature` territory, too large for this card batch. The mtgish emit correctly declines to SCAFFOLD (`unrecovered: ['ManifestDread']`).

## SDK change: `TriggeredAbility.triggersOnce`

Lifetime firing cap for "This ability triggers only once" (distinct from the existing per-turn `oncePerTurn`). Backed by a new `TriggeredAbilityFiredEverComponent` that, unlike the per-turn tracker, is **never** cleared at end of turn — it lives on the entity, so a permanent that re-enters the battlefield (a new game object) triggers afresh. The detection-time filter and the `TriggerProcessor` mark reuse the `oncePerTurn` path. Documented in `docs/card-sdk-language-reference.md` §8. (This SDK work was already in the worktree from a prior session; this PR completes the cards, tests, and tooling around it.)

## mtgish tooling

- New `TriggerIOnce` capability envelope (`bridge/Envelopes.kt`) + emitter branch (`Emitter.kt`, `CardStructure.kt#triggerIOnceBlock`) that threads `triggersOnce = true` through the shared trigger renderer. **Acrobatic Cheerleader now emits AUTO** (was SCAFFOLD on `TriggerIOnce`); also unlocks Pearl Collector / Jet Collector etc.
- `just coverage-verify POR` stays **158/158, 0-mismatch**. `:mtgish-tooling:test` green (EmitterGoldenTest + POR gate).
- DSK's `coverage-verify` GATE FAIL is **pre-existing and unrelated**: the 3 mismatches (Glimmer Seeker `TriggerI`, Razorkin Needlehead `If`/`TriggerA`, Skullsnap Nuisance `Flying`/`TriggerA`) use rule kinds this change does not touch.
- Data note: Beastie Beatdown's mtgish IR mislabels **both** targets as "you control" (the second should be "an opponent controls"). The hand-authored card is correct — a source-data bug, not an emitter one — so I did not widen the emitter.

## Tests

- `AcrobaticCheerleaderScenarioTest`, `CrackedSkullScenarioTest`, `BeastieBeatdownScenarioTest` — all pass.
- `just test-rules` green; `:mtg-sets:test` (snapshot + lint + discovery) green.
- DSK card-snapshot golden re-blessed — diff is **+233 lines, only the 3 new cards**, no existing card moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)