### PR TITLE
Add SOS Prismari/Quandrix batch (Berta, Tam, Mica, Petrified Hamlet)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1583,6 +1583,14 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `chosenValues[variableName]` (case-insensitive). Set the name with `Effects.ChooseCardName` (player names it)
   or `Effects.StoreCardName` (captured from a chosen card). Fails closed in static/projection contexts. Used by
   the "name a card … cards with that name" family (Desperate Research, Lobotomy).
+- `.namedFromChosenComponent(slot = ChoiceSlot.CARD_NAME)` — `CardPredicate.NameEqualsChosenComponent`: matches
+  the card name **durably chosen by the source permanent as it entered** — read from that permanent's
+  `CastChoicesComponent` under `slot` (case-insensitive). Unlike `.namedFromVariable` (transient pipeline variable,
+  fails closed in projection), this is **static-projection / activation-legality safe**: it keys off the granting
+  permanent's id, which the predicate context supplies as the source wherever a static ability's filter is
+  evaluated. Pair with `replacementEffect(EntersWithChoice(ChoiceType.CARD_NAME))`. Fails closed (no match) before
+  a name is chosen. Used by name-keyed static abilities (Petrified Hamlet — "sources with the chosen name … /
+  Lands with the chosen name …").
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
@@ -4231,7 +4239,14 @@ EntersWithChoice(
 `SetEnchantedLandTypeFromChosen` and `GrantLandwalkOfChosenType`), and
 `ChoiceType.OPPONENT` writes an entity-id choice into the `CastChoicesComponent` under
 `ChoiceSlot.OPPONENT` — read back via the `Player.ChosenOpponent` reference (e.g. Jihad's
-anthem + state-trigger condition: `Exists(Player.ChosenOpponent, Zone.BATTLEFIELD, …)`). Example — Phantasmal Terrain
+anthem + state-trigger condition: `Exists(Player.ChosenOpponent, Zone.BATTLEFIELD, …)`), and
+`ChoiceType.CARD_NAME` writes a chosen **land card name** (every registered land name, presented as
+a searchable option list) into the `CastChoicesComponent` under `ChoiceSlot.CARD_NAME` as a
+`ChoiceValue.TextChoice` — read back via `chosenCardName()` or, for name-keyed static-ability
+filters, `GameObjectFilter.namedFromChosenComponent()` (→ `CardPredicate.NameEqualsChosenComponent`,
+see §7). Used by Petrified Hamlet ("When this land enters, choose a land card name", then two
+statics — `PreventActivatedAbilities(nonManaAbilitiesOnly = true)` and `GrantActivatedAbility` of a
+`{T}: Add {C}` mana ability — both filtered by `namedFromChosenComponent()`). Example — Phantasmal Terrain
 ("As this Aura enters, choose a basic land type. Enchanted land is the chosen type."):
 
 ```kotlin

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
@@ -31,6 +31,17 @@ enum class ChoiceSlot {
     /** A named card-defined mode chosen as the object entered (e.g. the Khans Sieges). */
     MODE,
 
+    /**
+     * A card name chosen as the object entered (e.g. Petrified Hamlet "choose a land card name").
+     * Stored as a [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice].
+     * Read back at static-projection / activation-legality time by
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosenComponent], which
+     * keys name-matching off the *source permanent's* durable choice — unlike
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosen], which reads a
+     * transient pipeline variable and fails closed in projection.
+     */
+    CARD_NAME,
+
     /** Another creature chosen as the object entered (e.g. Dauntless Bodyguard). */
     CREATURE,
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -981,7 +981,17 @@ enum class ChoiceType {
      * holding the chosen player's entity id, and read back through
      * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent].
      */
-    OPPONENT
+    OPPONENT,
+    /**
+     * Choose a land card name (e.g., Petrified Hamlet: "When this land enters, choose a land
+     * card name"). Stored on the permanent in a
+     * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_NAME] as a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice], and read
+     * back at static-projection / activation-legality time by
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosenComponent].
+     */
+    CARD_NAME
 }
 
 /**
@@ -1071,6 +1081,11 @@ data class EntersWithChoice(
             "As this permanent enters, an opponent chooses an opponent"
         } else {
             "As this permanent enters, choose an opponent"
+        }
+        ChoiceType.CARD_NAME -> if (chooser == Player.AnOpponent) {
+            "As this permanent enters, an opponent chooses a land card name"
+        } else {
+            "As this permanent enters, choose a land card name"
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -257,6 +257,16 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.NameEqualsChosen(variableName)
     )
 
+    /**
+     * Match cards whose name equals the name durably chosen by the *source permanent* as it
+     * entered (its [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under
+     * [slot]). Static-projection / activation-legality safe — use this in static-ability filters
+     * (Petrified Hamlet), where [namedFromVariable] would fail closed.
+     */
+    fun namedFromChosenComponent(slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_NAME) = copy(
+        cardPredicates = cardPredicates + CardPredicate.NameEqualsChosenComponent(slot)
+    )
+
     /** Mana value equals */
     fun manaValue(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting.predicates
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
@@ -259,6 +260,25 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     @SerialName("NameEqualsChosen")
     @Serializable
     data class NameEqualsChosen(val variableName: String) : CardPredicate {
+        override val description: String = "with the chosen name"
+    }
+
+    /**
+     * Matches cards whose name equals a name **durably chosen by the source permanent** as it
+     * entered — read from that permanent's [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent]
+     * under [slot]. Matching is case-insensitive.
+     *
+     * Unlike [NameEqualsChosen] (which reads a transient pipeline variable and fails closed in
+     * projection), this predicate is **static-projection / activation-legality safe**: the source
+     * permanent's id is in scope wherever a static ability's filter is evaluated (the granter
+     * supplies it as the predicate-context source). Used by name-keyed static abilities such as
+     * Petrified Hamlet ("sources with the chosen name … / Lands with the chosen name …").
+     *
+     * Fails closed (no match) when the source has made no such choice.
+     */
+    @SerialName("NameEqualsChosenComponent")
+    @Serializable
+    data class NameEqualsChosenComponent(val slot: ChoiceSlot = ChoiceSlot.CARD_NAME) : CardPredicate {
         override val description: String = "with the chosen name"
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BertaWiseExtrapolator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/BertaWiseExtrapolator.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.increment
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Berta, Wise Extrapolator
+ * {2}{G}{U}
+ * Legendary Creature — Frog Druid
+ * 1/4
+ *
+ * Increment (Whenever you cast a spell, if the amount of mana you spent is greater than
+ * this creature's power or toughness, put a +1/+1 counter on this creature.)
+ * Whenever one or more +1/+1 counters are put on Berta, add one mana of any color.
+ * {X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it.
+ */
+val BertaWiseExtrapolator = card("Berta, Wise Extrapolator") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Legendary Creature — Frog Druid"
+    power = 1
+    toughness = 4
+    oracleText = "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than " +
+        "this creature's power or toughness, put a +1/+1 counter on this creature.)\n" +
+        "Whenever one or more +1/+1 counters are put on Berta, add one mana of any color.\n" +
+        "{X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it."
+
+    increment()
+
+    // Whenever one or more +1/+1 counters are put on Berta, add one mana of any color.
+    triggeredAbility {
+        trigger = TriggerSpec(
+            EventPattern.CountersPlacedEvent(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                filter = GameObjectFilter.Any,
+            ),
+            TriggerBinding.SELF,
+        )
+        effect = Effects.AddManaOfChoice()
+        description = "Whenever one or more +1/+1 counters are put on Berta, add one mana of any color."
+    }
+
+    // {X}, {T}: Create a 0/0 Fractal and put X +1/+1 counters on it.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 0,
+                toughness = 0,
+                colors = setOf(Color.GREEN, Color.BLUE),
+                creatureTypes = setOf("Fractal"),
+                imageUri = "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279",
+            ),
+            Effects.AddDynamicCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmount.XValue,
+                target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+            ),
+        )
+        description = "{X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "175"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75f89c36-c81d-4580-9a5c-218fed0c5c9a.jpg?1775938201"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MicaReaderOfRuins.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/MicaReaderOfRuins.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mica, Reader of Ruins
+ * {3}{R}
+ * Legendary Creature — Human Artificer
+ * 4/4
+ *
+ * Ward—Pay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent
+ *   controls, counter it unless that player pays 3 life.)
+ * Whenever you cast an instant or sorcery spell, you may sacrifice an artifact. If you do, copy
+ *   that spell and you may choose new targets for the copy.
+ *
+ * Modeling notes:
+ * - "you may sacrifice an artifact. If you do, …" → [OptionalCostEffect]: the optional
+ *   [SacrificeEffect] cost gates the copy. Declining (or having no artifact) skips the copy.
+ * - The copy targets the triggering spell ([EffectTarget.TriggeringEntity]); [Effects.CopyTargetSpell]
+ *   lets the controller choose new targets for the copy. The copy is created on the stack, so it's
+ *   not "cast" and doesn't re-trigger Mica.
+ */
+val MicaReaderOfRuins = card("Mica, Reader of Ruins") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Artificer"
+    power = 4
+    toughness = 4
+    oracleText = "Ward—Pay 3 life. (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player pays 3 life.)\n" +
+        "Whenever you cast an instant or sorcery spell, you may sacrifice an artifact. If you do, " +
+        "copy that spell and you may choose new targets for the copy."
+
+    keywordAbility(KeywordAbility.wardLife(3))
+
+    // Whenever you cast an instant or sorcery spell, you may sacrifice an artifact to copy it.
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = OptionalCostEffect(
+            cost = SacrificeEffect(filter = GameObjectFilter.Artifact),
+            ifPaid = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity),
+        )
+        description = "Whenever you cast an instant or sorcery spell, you may sacrifice an " +
+            "artifact. If you do, copy that spell and you may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/949ad3ff-9e80-493c-a3ae-146b919bfcd7.jpg?1775937824"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PetrifiedHamlet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PetrifiedHamlet.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Petrified Hamlet
+ * Land
+ *
+ * When this land enters, choose a land card name.
+ * Activated abilities of sources with the chosen name can't be activated unless they're mana abilities.
+ * Lands with the chosen name have "{T}: Add {C}."
+ * {T}: Add {C}.
+ *
+ * Modeling notes:
+ * - "choose a land card name" is a name chosen *as the permanent enters* (worded "When this land
+ *   enters" but mechanically an as-enters choice, like Sanctum Prelate / Pithing Needle naming).
+ *   Modeled via [EntersWithChoice]`(ChoiceType.CARD_NAME)` — the engine presents every registered
+ *   land card name and stores the pick durably on the permanent's `CastChoicesComponent` under
+ *   `ChoiceSlot.CARD_NAME`.
+ * - Both name-keyed static abilities read that durable choice through
+ *   [GameObjectFilter.namedFromChosenComponent] (→ `CardPredicate.NameEqualsChosenComponent`),
+ *   which is static-projection / activation-legality safe (it keys off the *source permanent's*
+ *   choice rather than a transient pipeline variable). It fails closed before a name is chosen.
+ * - "Activated abilities of sources with the chosen name can't be activated unless they're mana
+ *   abilities" → [PreventActivatedAbilities]`(filter, nonManaAbilitiesOnly = true)`. "Sources" is
+ *   any object, so the filter is the bare chosen-name predicate (not restricted to lands).
+ * - "Lands with the chosen name have \"{T}: Add {C}.\"" → [GrantActivatedAbility] of a tap-for-{C}
+ *   mana ability to the battlefield-scoped set of lands whose name matches the choice.
+ * - "{T}: Add {C}." is the land's own intrinsic mana ability.
+ */
+val PetrifiedHamlet = card("Petrified Hamlet") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "When this land enters, choose a land card name.\n" +
+        "Activated abilities of sources with the chosen name can't be activated unless they're mana abilities.\n" +
+        "Lands with the chosen name have \"{T}: Add {C}.\"\n" +
+        "{T}: Add {C}."
+
+    // As this land enters, choose a land card name. Stored under ChoiceSlot.CARD_NAME.
+    replacementEffect(EntersWithChoice(ChoiceType.CARD_NAME))
+
+    // Activated abilities of sources with the chosen name can't be activated unless mana abilities.
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Any.namedFromChosenComponent(),
+            nonManaAbilitiesOnly = true,
+        )
+    }
+
+    // Lands with the chosen name have "{T}: Add {C}."
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddColorlessMana(1),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            ),
+            filter = GroupFilter(GameObjectFilter.Land.namedFromChosenComponent()),
+        )
+    }
+
+    // {T}: Add {C}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Richard Wright"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/355dd460-b0e9-41f2-a058-b7f7e39ac387.jpg?1777065626"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TamObservantSequencer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/TamObservantSequencer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tam, Observant Sequencer // Deep Sight — Secrets of Strixhaven #237
+ * {2}{G}{U} · Legendary Creature — Gorgon Wizard · 4/3
+ *
+ * Landfall — Whenever a land you control enters, Tam becomes prepared. (While it's prepared, you
+ * may cast a copy of its spell. Doing so unprepares it.)
+ * //
+ * Deep Sight — {G}{U}, Sorcery: You draw a card and gain 1 life.
+ *
+ * Prepare (Secrets of Strixhaven): like Encouraging Aviator, Tam does NOT enter prepared (no
+ * PREPARED keyword). It only becomes prepared via its landfall trigger through
+ * [Effects.BecomePrepared]. Becoming prepared creates a copy of its prepare spell ("Deep Sight")
+ * in exile that its controller may cast for {G}{U}; casting that copy unprepares Tam. Modeled via
+ * [com.wingedsheep.sdk.model.CardLayout.PREPARE] + the `prepare(name) { }` DSL.
+ */
+val TamObservantSequencer = card("Tam, Observant Sequencer") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Legendary Creature — Gorgon Wizard"
+    power = 4
+    toughness = 3
+    oracleText = "Landfall — Whenever a land you control enters, Tam becomes prepared. (While " +
+        "it's prepared, you may cast a copy of its spell. Doing so unprepares it.)"
+
+    // Landfall — whenever a land you control enters, Tam becomes prepared.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.BecomePrepared(EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, Tam becomes prepared."
+    }
+
+    // Deep Sight — the prepare spell. You draw a card and gain 1 life.
+    prepare("Deep Sight") {
+        manaCost = "{G}{U}"
+        typeLine = "Sorcery"
+        oracleText = "You draw a card and gain 1 life."
+        spell {
+            effect = Effects.Composite(
+                Effects.DrawCards(1),
+                Effects.GainLife(1),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Jodie Muir"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/7120e71b-2976-451b-89a7-a1665dc6fb6b.jpg?1778165018"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -970,6 +970,138 @@
     ]
 }
 
+// Berta, Wise Extrapolator
+{
+    "name": "Berta, Wise Extrapolator",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Legendary Creature — Frog Druid",
+    "oracleText": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on Berta, add one mana of any color.\n{X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "INCREMENT"
+    ],
+    "keywordAbilities": [
+        "Increment"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaSpent"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "+1/+1"
+                },
+                "effect": "AddManaOfChoice",
+                "descriptionOverride": "Whenever one or more +1/+1 counters are put on Berta, add one mana of any color."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "GREEN",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Fractal"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/e/de564776-9d88-4533-8717-842eecdd0594.jpg?1775828279"
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": "XValue",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "RARE",
+        "artist": "Tuan Duong Chu",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75f89c36-c81d-4580-9a5c-218fed0c5c9a.jpg?1775938201"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Biblioplex Tomekeeper
 {
     "name": "Biblioplex Tomekeeper",
@@ -8388,6 +8520,76 @@
     ]
 }
 
+// Mica, Reader of Ruins
+{
+    "name": "Mica, Reader of Ruins",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Human Artificer",
+    "oracleText": "Ward—Pay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)\nWhenever you cast an instant or sorcery spell, you may sacrifice an artifact. If you do, copy that spell and you may choose new targets for the copy.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 3
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity"
+                    }
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, you may sacrifice an artifact. If you do, copy that spell and you may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/949ad3ff-9e80-493c-a3ae-146b919bfcd7.jpg?1775937824"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mind Roots
 {
     "name": "Mind Roots",
@@ -9831,6 +10033,79 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Petrified Hamlet
+{
+    "name": "Petrified Hamlet",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "When this land enters, choose a land card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.\nLands with the chosen name have \"{T}: Add {C}.\"\n{T}: Add {C}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": {
+                    "cardPredicates": [
+                        "NameEqualsChosenComponent"
+                    ]
+                },
+                "nonManaAbilitiesOnly": true
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddColorlessMana",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsLand",
+                            "NameEqualsChosenComponent"
+                        ]
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CARD_NAME"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Richard Wright",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/355dd460-b0e9-41f2-a058-b7f7e39ac387.jpg?1777065626"
+    },
+    "colorIdentityOverride": []
 }
 
 // Pigment Wrangler
@@ -14527,6 +14802,73 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Tam, Observant Sequencer
+{
+    "name": "Tam, Observant Sequencer",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Legendary Creature — Gorgon Wizard",
+    "oracleText": "Landfall — Whenever a land you control enters, Tam becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": "BecomePrepared",
+                "descriptionOverride": "Landfall — Whenever a land you control enters, Tam becomes prepared."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Jodie Muir",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/7120e71b-2976-451b-89a7-a1665dc6fb6b.jpg?1778165018"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ],
+    "layout": "PREPARE",
+    "cardFaces": [
+        {
+            "name": "Deep Sight",
+            "manaCost": "{G}{U}",
+            "typeLine": "Sorcery",
+            "oracleText": "You draw a card and gain 1 life.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -215,7 +215,14 @@ data class EntersWithChoiceSpellContinuation(
      * stored on the resulting `CastChoicesComponent` under
      * [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT].
      */
-    val opponentIds: List<EntityId> = emptyList()
+    val opponentIds: List<EntityId> = emptyList(),
+    /**
+     * For [com.wingedsheep.sdk.scripting.ChoiceType.CARD_NAME] choices, the positionally
+     * aligned list of land card names presented. The response's chosen index indexes into
+     * this list to recover the name stored under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_NAME].
+     */
+    val cardNames: List<String> = emptyList()
 ) : ContinuationFrame
 
 /**
@@ -253,6 +260,9 @@ data class EntersWithChoiceOnBattlefieldContinuation(
     /** For [com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT] choices, see
      *  [EntersWithChoiceSpellContinuation.opponentIds]. */
     val opponentIds: List<EntityId> = emptyList(),
+    /** For [com.wingedsheep.sdk.scripting.ChoiceType.CARD_NAME] choices, the land card names
+     *  presented (the resumer stores the chosen name by index). */
+    val cardNames: List<String> = emptyList(),
     val fromZone: Zone? = null
 ) : ContinuationFrame
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -2,6 +2,8 @@ package com.wingedsheep.engine.handlers
 
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
 import com.wingedsheep.engine.state.components.battlefield.chosenColor
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -551,6 +553,18 @@ class PredicateEvaluator {
             // Context-relative predicates (pipeline variable references)
             is CardPredicate.NameEqualsChosen -> {
                 val chosenName = context?.chosenValues?.get(predicate.variableName) ?: return false
+                card.name.equals(chosenName, ignoreCase = true)
+            }
+
+            // Source-component name reference: the name durably chosen by the source permanent as it
+            // entered (Petrified Hamlet). Read from the source's CastChoicesComponent[slot] — works
+            // in static/projection contexts where there is no pipeline, as long as the predicate
+            // context supplies the granting permanent as the source.
+            is CardPredicate.NameEqualsChosenComponent -> {
+                val sourceId = context?.sourceId ?: return false
+                val chosenName = (state.getEntity(sourceId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
                 card.name.equals(chosenName, ignoreCase = true)
             }
 
@@ -1109,6 +1123,9 @@ class PredicateEvaluator {
             is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,
             is CardPredicate.HasSubtypeInEachStoredGroup -> false
+            // Source-component name reference is a permanent-static predicate, not meaningful for a
+            // cast-spell record.
+            is CardPredicate.NameEqualsChosenComponent -> false
 
             // Stack ability check — cast spells are not abilities
             CardPredicate.IsActivatedOrTriggeredAbility -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersWithChoice
 import com.wingedsheep.sdk.scripting.OnEnterRunEffect
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
@@ -358,7 +359,10 @@ class PlayLandHandler(
                         cardComponent = cardComponent,
                         choice = firstChoice,
                         fromZone = fromZone,
-                        carryEvents = events
+                        carryEvents = events,
+                        cardNameOptions = if (firstChoice.choiceType == ChoiceType.CARD_NAME) {
+                            cardRegistry.landCardNames().toList()
+                        } else emptyList(),
                     )
                 if (result != null) return result
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -594,6 +594,16 @@ class ModalAndCloneContinuationResumer(
                     c.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosenOpponent))
                 }
             }
+            com.wingedsheep.sdk.scripting.ChoiceType.CARD_NAME -> {
+                if (response !is OptionChosenResponse) {
+                    return ExecutionResult.error(state, "Expected option chosen response for card name choice")
+                }
+                val chosenName = continuation.cardNames.getOrNull(response.optionIndex)
+                    ?: return ExecutionResult.error(state, "Invalid card name index: ${response.optionIndex}")
+                state.updateEntity(spellId) { c ->
+                    c.withCastChoice(ChoiceSlot.CARD_NAME, ChoiceValue.TextChoice(chosenName))
+                }
+            }
         }
 
         // Check if the card has remaining choices to chain to
@@ -709,6 +719,16 @@ class ModalAndCloneContinuationResumer(
                     ?: return ExecutionResult.error(state, "Invalid opponent index: ${response.optionIndex}")
                 state.updateEntity(entityId) { c ->
                     c.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosenOpponent))
+                }
+            }
+            com.wingedsheep.sdk.scripting.ChoiceType.CARD_NAME -> {
+                if (response !is OptionChosenResponse) {
+                    return ExecutionResult.error(state, "Expected option chosen response for card name choice")
+                }
+                val chosenName = continuation.cardNames.getOrNull(response.optionIndex)
+                    ?: return ExecutionResult.error(state, "Invalid card name index: ${response.optionIndex}")
+                state.updateEntity(entityId) { c ->
+                    c.withCastChoice(ChoiceSlot.CARD_NAME, ChoiceValue.TextChoice(chosenName))
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -69,6 +69,7 @@ object PermanentEntryReplacements {
         choice: EntersWithChoice,
         fromZone: Zone?,
         carryEvents: List<GameEvent> = emptyList(),
+        cardNameOptions: List<String> = emptyList(),
     ): ExecutionResult? {
         val chooserId = when (choice.chooser) {
             Player.AnOpponent -> state.getOpponents(controllerId).firstOrNull() ?: controllerId
@@ -224,6 +225,32 @@ object PermanentEntryReplacements {
                         controllerId = controllerId,
                         choiceType = ChoiceType.OPPONENT,
                         opponentIds = opponentIds,
+                        fromZone = fromZone
+                    )
+                )
+            }
+
+            ChoiceType.CARD_NAME -> {
+                // The option list (land card names from the registry) is supplied by the caller,
+                // which has the registry in scope. If empty, there is nothing to name — complete
+                // entry normally.
+                val options = cardNameOptions.sorted()
+                if (options.isEmpty()) return null
+                val id = "choose-card-name-enters-${entityId.value}"
+                pause(
+                    ChooseOptionDecision(
+                        id = id,
+                        playerId = chooserId,
+                        prompt = "Choose a land card name",
+                        context = context(id),
+                        options = options
+                    ),
+                    EntersWithChoiceOnBattlefieldContinuation(
+                        decisionId = id,
+                        entityId = entityId,
+                        controllerId = controllerId,
+                        choiceType = ChoiceType.CARD_NAME,
+                        cardNames = options,
                         fromZone = fromZone
                     )
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.mechanics.layers
 
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
@@ -265,6 +267,18 @@ internal class AffectsFilterResolver {
                 ?: return emptySet()
         } else null
 
+        // If the base filter keys off the source's durably-chosen card name (Petrified Hamlet),
+        // resolve it once from the source's CastChoicesComponent. Fail closed (match nothing) when
+        // the source has made no such choice yet.
+        val nameComponentPredicate = baseFilter.cardPredicates
+            .filterIsInstance<CardPredicate.NameEqualsChosenComponent>()
+            .firstOrNull()
+        val sourceChosenName = if (nameComponentPredicate != null) {
+            (state.getEntity(sourceId)?.get<CastChoicesComponent>()
+                ?.chosen?.get(nameComponentPredicate.slot) as? ChoiceValue.TextChoice)?.text
+                ?: return emptySet()
+        } else null
+
         return state.getBattlefield().filter { entityId ->
             if (groupFilter.excludeSelf && entityId == sourceId) return@filter false
 
@@ -302,9 +316,18 @@ internal class AffectsFilterResolver {
             val isFaceDown = projected?.isFaceDown ?: container.has<FaceDownComponent>()
 
             for (predicate in baseFilter.cardPredicates) {
+                // The source-chosen-name predicate is resolved once above (sourceChosenName) and
+                // applied as a separate constraint below — skip it in the generic projection loop,
+                // which has no source in scope and would fail it closed.
+                if (predicate is CardPredicate.NameEqualsChosenComponent) continue
                 if (!matchesCardPredicateForProjection(predicate, card, container, projected, types, subtypes, colors, keywords, isFaceDown)) {
                     return@filter false
                 }
+            }
+
+            // Source-chosen card name constraint (from source's CastChoicesComponent).
+            if (sourceChosenName != null && !card.name.equals(sourceChosenName, ignoreCase = true)) {
+                return@filter false
             }
 
             // Check state predicates
@@ -605,6 +628,9 @@ internal class AffectsFilterResolver {
         is CardPredicate.HasSubtypeFromVariable,
         is CardPredicate.HasSubtypeInStoredList,
         is CardPredicate.NameEqualsChosen,
+        // Resolved separately in resolveGenericFilter against the source's CastChoicesComponent
+        // (no source in scope here) — fail closed if it ever reaches this generic path.
+        is CardPredicate.NameEqualsChosenComponent,
         is CardPredicate.HasSubtypeInEachStoredGroup -> false
         // Stack-only predicates — never match a battlefield entity being projected.
         CardPredicate.IsActivatedOrTriggeredAbility,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.mechanics.mana
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
 import com.wingedsheep.engine.state.components.battlefield.chosenColor
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -1005,6 +1007,13 @@ class CostCalculator(
             is CardPredicate.HasSubtypeInStoredList -> true
             is CardPredicate.HasSubtypeInEachStoredGroup -> true
             is CardPredicate.NameEqualsChosen -> true
+            is CardPredicate.NameEqualsChosenComponent -> {
+                if (sourceEntityId == null || state == null) return false
+                val chosenName = (state.getEntity(sourceEntityId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
+                cardDef.name.equals(chosenName, ignoreCase = true)
+            }
 
             is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }
             is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3006,6 +3006,40 @@ class StackResolver(
                     .withPendingDecision(decision)
                 ExecutionResult.paused(pausedState, decision)
             }
+
+            ChoiceType.CARD_NAME -> {
+                // "Choose a land card name" (Petrified Hamlet). For a permanent that enters from
+                // the stack the registry's land card names are the option set; the chosen name is
+                // stored durably under [ChoiceSlot.CARD_NAME] by the resumer. (Lands themselves
+                // route through PlayLandHandler / PermanentEntryReplacements, but this completes the
+                // spell-cast path for any permanent spell that names a land as it enters.)
+                val cardNames = cardRegistry.landCardNames().sorted()
+                if (cardNames.isEmpty()) return null
+                val decisionId = "choose-card-name-enters-${spellId.value}"
+                val decision = ChooseOptionDecision(
+                    id = decisionId,
+                    playerId = chooserId,
+                    prompt = "Choose a land card name",
+                    context = DecisionContext(
+                        sourceId = spellId,
+                        sourceName = cardComponent.name,
+                        phase = DecisionPhase.RESOLUTION
+                    ),
+                    options = cardNames
+                )
+                val continuation = EntersWithChoiceSpellContinuation(
+                    decisionId = decisionId,
+                    spellId = spellId,
+                    controllerId = controllerId,
+                    ownerId = ownerId,
+                    choiceType = ChoiceType.CARD_NAME,
+                    cardNames = cardNames
+                )
+                val pausedState = state
+                    .pushContinuation(continuation)
+                    .withPendingDecision(decision)
+                ExecutionResult.paused(pausedState, decision)
+            }
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
@@ -103,6 +103,13 @@ class CardRegistry {
     fun allCardNames(): Set<String> = cardsByName.keys.toSet()
 
     /**
+     * Get the names of every registered card whose type line includes Land (e.g. for
+     * Petrified Hamlet's "choose a land card name"). Unique names only.
+     */
+    fun landCardNames(): Set<String> =
+        cardsByName.values.filter { it.isLand }.map { it.name }.toSet()
+
+    /**
      * Get all cards with a given name (useful for basic lands with multiple variants).
      *
      * @param name The card name (e.g., "Plains")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
@@ -102,6 +102,10 @@ fun ComponentContainer.chosenLandType(): String? =
 fun ComponentContainer.chosenModeId(): String? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.MODE) as? ChoiceValue.TextChoice)?.text
 
+/** The card name chosen as this object entered (e.g. Petrified Hamlet), or null. */
+fun ComponentContainer.chosenCardName(): String? =
+    (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_NAME) as? ChoiceValue.TextChoice)?.text
+
 /** The creature chosen as this object entered, or null. */
 fun ComponentContainer.chosenCreatureRef(): EntityId? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CREATURE) as? ChoiceValue.EntityChoice)?.entityId

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BertaWiseExtrapolatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BertaWiseExtrapolatorScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Berta, Wise Extrapolator (Secrets of Strixhaven #175).
+ *
+ * Berta, Wise Extrapolator ({2}{G}{U}, 1/4, Legendary Frog Druid):
+ *   Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this
+ *     creature's power or toughness, put a +1/+1 counter on this creature.)
+ *   Whenever one or more +1/+1 counters are put on Berta, add one mana of any color.
+ *   {X}, {T}: Create a 0/0 green and blue Fractal creature token and put X +1/+1 counters on it.
+ *
+ * Exercises the Increment keyword combined with the CountersPlaced self-trigger that adds mana,
+ * plus the {X},{T} Fractal-token activated ability that distributes X +1/+1 counters.
+ */
+class BertaWiseExtrapolatorScenarioTest : ScenarioTestBase() {
+
+    private val fractalAbilityId =
+        cardRegistry.getCard("Berta, Wise Extrapolator")!!.activatedAbilities.first().id
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Berta, Wise Extrapolator — Increment feeds the counters-placed mana trigger") {
+
+            test("casting a spell with mana spent > P/T increments Berta and triggers mana") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Berta, Wise Extrapolator")
+                    .withCardInHand(1, "Stoke the Flames") // {2}{R}{R} = 4 mana spent > toughness 4? no, > power 1 yes
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val berta = game.findPermanent("Berta, Wise Extrapolator")!!
+
+                // Cast Stoke the Flames paying 4 mana (> Berta's power 1) targeting the opponent.
+                val cast = game.castSpellTargetingPlayer(1, "Stoke the Flames", 2)
+                withClue("Casting Stoke the Flames should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                // Increment trigger: 4 mana > power 1 -> +1/+1 counter. That counter placement
+                // in turn triggers Berta's "add one mana of any color".
+                game.resolveStack()
+
+                withClue("Increment should have placed one +1/+1 counter (4 mana > power 1)") {
+                    plusOneCounters(game, berta) shouldBe 1
+                }
+            }
+        }
+
+        context("Berta, Wise Extrapolator — {X},{T} Fractal token") {
+
+            test("activating with X=2 makes a 0/0 Fractal with two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Berta, Wise Extrapolator")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val berta = game.findPermanent("Berta, Wise Extrapolator")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = berta,
+                        abilityId = fractalAbilityId,
+                        xValue = 2,
+                    )
+                )
+                withClue("Activating Berta's {X},{T} ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val fractal = game.findPermanent("Fractal Token")
+                withClue("A Fractal token should have been created") {
+                    (fractal != null) shouldBe true
+                }
+                withClue("The Fractal token has X=2 +1/+1 counters (0/0 base)") {
+                    plusOneCounters(game, fractal!!) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MicaReaderOfRuinsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MicaReaderOfRuinsTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.MicaReaderOfRuins
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mica, Reader of Ruins {3}{R} — Human Artificer 4/4.
+ * "Ward—Pay 3 life.
+ *  Whenever you cast an instant or sorcery spell, you may sacrifice an artifact. If you do,
+ *  copy that spell and you may choose new targets for the copy."
+ *
+ * These tests pin the load-bearing composition: the instant/sorcery cast trigger and the optional
+ * sacrifice gate (no sacrifice → no copy; sacrifice → a copy of the triggering spell resolves).
+ */
+class MicaReaderOfRuinsTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MicaReaderOfRuins))
+        return driver
+    }
+
+    /** Put Mica on the battlefield for the active player; give an artifact to sacrifice. */
+    fun GameTestDriver.setup(): Triple<EntityId, EntityId, EntityId> {
+        initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = activePlayer!!
+        val opponent = getOpponent(you)
+        putCreatureOnBattlefield(you, "Mica, Reader of Ruins")
+        val artifact = putPermanentOnBattlefield(you, "Artifact Creature")
+        return Triple(you, opponent, artifact)
+    }
+
+    /**
+     * Resolve the whole stack after the instant/sorcery is cast, optionally accepting Mica's
+     * sacrifice gate. Handles three decision shapes: the may-pay yes/no gate, the artifact
+     * selection, and the copy's "choose new targets" (keep the same target — the opponent).
+     */
+    fun GameTestDriver.resolveMicaTrigger(
+        you: EntityId,
+        opponent: EntityId,
+        artifact: EntityId,
+        acceptSacrifice: Boolean
+    ) {
+        var answeredGate = false
+        var guard = 0
+        while (stackSize > 0 && guard++ < 40) {
+            val decision = pendingDecision
+            when {
+                decision == null -> bothPass()
+                decision is YesNoDecision && !answeredGate -> {
+                    answeredGate = true
+                    submitYesNo(you, acceptSacrifice)
+                }
+                decision is SelectCardsDecision -> submitCardSelection(you, listOf(artifact))
+                decision is ChooseTargetsDecision -> submitTargetSelection(you, listOf(opponent))
+                else -> autoResolveDecision()
+            }
+        }
+    }
+
+    test("declining the sacrifice makes no copy — opponent takes only the original bolt") {
+        val driver = createDriver()
+        val (you, opponent, artifact) = driver.setup()
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+
+        driver.resolveMicaTrigger(you, opponent, artifact, acceptSacrifice = false)
+
+        // Only the original Lightning Bolt (3) resolves.
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 3)
+        // Artifact survives (still on the battlefield).
+        (driver.state.getEntity(artifact) != null).shouldBeTrue()
+    }
+
+    test("sacrificing an artifact copies the spell — opponent takes the bolt plus its copy") {
+        val driver = createDriver()
+        val (you, opponent, artifact) = driver.setup()
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+
+        driver.resolveMicaTrigger(you, opponent, artifact, acceptSacrifice = true)
+
+        // Original Lightning Bolt (3) + the copy (3) = 6 damage.
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 6)
+        // The sacrificed artifact is gone.
+        (driver.state.getEntity(artifact) == null ||
+            driver.state.getBattlefield().none { it == artifact }).shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PetrifiedHamletScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PetrifiedHamletScenarioTest.kt
@@ -1,0 +1,188 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.chosenCardName
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Petrified Hamlet (Secrets of Strixhaven #259).
+ *
+ * Petrified Hamlet (Land):
+ *   When this land enters, choose a land card name.
+ *   Activated abilities of sources with the chosen name can't be activated unless they're
+ *     mana abilities.
+ *   Lands with the chosen name have "{T}: Add {C}."
+ *   {T}: Add {C}.
+ *
+ * "Choose a land card name" is an as-enters choice (ChoiceType.CARD_NAME) stored durably on the
+ * permanent's CastChoicesComponent under ChoiceSlot.CARD_NAME. Both name-keyed static abilities
+ * read that choice through CardPredicate.NameEqualsChosenComponent (filter
+ * .namedFromChosenComponent()), which is static-projection / activation-legality safe.
+ */
+class PetrifiedHamletScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.chooseCardNameOnEnter(name: String) {
+        val decision = getPendingDecision()
+        withClue("Petrified Hamlet must present an as-enters card-name choice") {
+            (decision is ChooseOptionDecision) shouldBe true
+        }
+        decision as ChooseOptionDecision
+        withClue("The chosen land name must be offered") {
+            decision.options shouldContain name
+        }
+        submitDecision(OptionChosenResponse(decision.id, decision.options.indexOf(name)))
+    }
+
+    private fun TestGame.activatableAbilityCount(sourceId: com.wingedsheep.sdk.model.EntityId): Int =
+        getLegalActions(1)
+            .filter { (it.action as? ActivateAbility)?.sourceId == sourceId }
+            .count()
+
+    private fun TestGame.activatableNonManaAbilityCount(sourceId: com.wingedsheep.sdk.model.EntityId): Int =
+        getLegalActions(1)
+            .filter { (it.action as? ActivateAbility)?.sourceId == sourceId }
+            .count { !it.isManaAbility }
+
+    private fun TestGame.activatableManaAbilityCount(sourceId: com.wingedsheep.sdk.model.EntityId): Int =
+        getLegalActions(1)
+            .filter { (it.action as? ActivateAbility)?.sourceId == sourceId }
+            .count { it.isManaAbility }
+
+    init {
+        context("Petrified Hamlet — choose a land card name on enter") {
+
+            test("entering presents land card names and stores the pick durably") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Petrified Hamlet")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hamletInHand = game.findCardsInHand(1, "Petrified Hamlet").first()
+                game.execute(PlayLand(game.player1Id, hamletInHand))
+
+                game.chooseCardNameOnEnter("Keldon Necropolis")
+
+                val hamlet = game.findPermanent("Petrified Hamlet")!!
+                withClue("The chosen name is stored under ChoiceSlot.CARD_NAME") {
+                    game.state.getEntity(hamlet)?.chosenCardName() shouldBe "Keldon Necropolis"
+                }
+            }
+        }
+
+        context("Petrified Hamlet — PreventActivatedAbilities (non-mana only) on the named source") {
+
+            test("naming a land shuts off its non-mana ability but leaves its mana ability legal") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Petrified Hamlet")
+                    .withCardOnBattlefield(1, "Keldon Necropolis", tapped = false)
+                    // Sacrifice fodder + a creature on the opponent so the damage ability could
+                    // otherwise be enumerable.
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val necropolis = game.findPermanent("Keldon Necropolis")!!
+
+                withClue("Before Hamlet names it, Keldon Necropolis's non-mana damage ability is legal") {
+                    game.activatableNonManaAbilityCount(necropolis) shouldBe 1
+                }
+
+                val hamletInHand = game.findCardsInHand(1, "Petrified Hamlet").first()
+                game.execute(PlayLand(game.player1Id, hamletInHand))
+                game.chooseCardNameOnEnter("Keldon Necropolis")
+
+                withClue("After Hamlet names it, the non-mana damage ability can't be activated") {
+                    game.activatableNonManaAbilityCount(necropolis) shouldBe 0
+                }
+                withClue("…but Keldon Necropolis's mana ability still works") {
+                    game.activatableManaAbilityCount(necropolis) shouldNotBe 0
+                }
+            }
+
+            test("naming an unrelated card leaves Keldon Necropolis's non-mana ability legal") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Petrified Hamlet")
+                    .withCardOnBattlefield(1, "Keldon Necropolis", tapped = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val necropolis = game.findPermanent("Keldon Necropolis")!!
+
+                val hamletInHand = game.findCardsInHand(1, "Petrified Hamlet").first()
+                game.execute(PlayLand(game.player1Id, hamletInHand))
+                game.chooseCardNameOnEnter("Plains")
+
+                withClue("Naming Plains does not affect Keldon Necropolis — its damage ability stays legal") {
+                    game.activatableNonManaAbilityCount(necropolis) shouldBe 1
+                }
+            }
+        }
+
+        context("Petrified Hamlet — GrantActivatedAbility ({T}: Add {C}) to lands with the chosen name") {
+
+            test("naming a basic land grants every copy an extra {T}: Add {C} mana ability") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Petrified Hamlet")
+                    .withCardOnBattlefield(1, "Plains", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val plains = game.findPermanent("Plains")!!
+
+                withClue("A vanilla Plains has exactly one mana ability before the grant") {
+                    game.activatableManaAbilityCount(plains) shouldBe 1
+                }
+
+                val hamletInHand = game.findCardsInHand(1, "Petrified Hamlet").first()
+                game.execute(PlayLand(game.player1Id, hamletInHand))
+                game.chooseCardNameOnEnter("Plains")
+
+                withClue("The named Plains gains the granted {T}: Add {C} ability (now two mana abilities)") {
+                    game.activatableManaAbilityCount(plains) shouldBe 2
+                }
+            }
+        }
+
+        context("Petrified Hamlet — its own intrinsic mana ability") {
+
+            test("Petrified Hamlet itself can tap for {C}") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Petrified Hamlet", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hamlet = game.findPermanent("Petrified Hamlet")!!
+                withClue("Petrified Hamlet has its own {T}: Add {C} mana ability") {
+                    game.getLegalActions(1)
+                        .mapNotNull { it.action as? ActivateAbility }
+                        .any { it.sourceId == hamlet } shouldBe true
+                }
+                // (It made no name choice in this fixture, so the name-keyed statics are inert —
+                // fail-closed — which is the intended behaviour.)
+                hamlet shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TamObservantSequencerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TamObservantSequencerScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
+import com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Tam, Observant Sequencer // Deep Sight (Secrets of Strixhaven #237).
+ *
+ * Tam, Observant Sequencer ({2}{G}{U}, 4/3, Legendary Gorgon Wizard):
+ *   Landfall — Whenever a land you control enters, Tam becomes prepared. (While it's prepared,
+ *     you may cast a copy of its spell. Doing so unprepares it.)
+ *   //
+ *   Deep Sight — {G}{U}, Sorcery: You draw a card and gain 1 life.
+ *
+ * Tam does NOT enter prepared (no PREPARED keyword) — it only becomes prepared via its landfall
+ * trigger (Effects.BecomePrepared). Casting the Deep Sight prepare-spell copy draws a card, gains
+ * 1 life, and unprepares Tam.
+ */
+class TamObservantSequencerScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.findExileCopy(playerNumber: Int, name: String): EntityId? {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).firstOrNull { id ->
+            val e = state.getEntity(id)
+            e?.get<CardComponent>()?.name == name && e.get<PreparedSpellCopyComponent>() != null
+        }
+    }
+
+    init {
+        context("Tam, Observant Sequencer — landfall makes it prepared") {
+
+            test("playing a land makes Tam prepared and exposes a Deep Sight copy in exile") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tam, Observant Sequencer", summoningSickness = false)
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tam = game.findPermanent("Tam, Observant Sequencer")!!
+                withClue("Tam must NOT be prepared before a land enters") {
+                    game.state.getEntity(tam)?.get<PreparedComponent>() shouldBe null
+                }
+
+                val forest = game.findCardsInHand(1, "Forest").first()
+                game.execute(PlayLand(game.player1Id, forest))
+                game.resolveStack() // landfall -> BecomePrepared
+
+                withClue("Landfall should make Tam prepared") {
+                    game.state.getEntity(tam)?.get<PreparedComponent>() shouldNotBe null
+                }
+                withClue("A Deep Sight prepare-spell copy should now exist in exile") {
+                    game.findExileCopy(1, "Tam, Observant Sequencer") shouldNotBe null
+                }
+            }
+
+            test("casting the Deep Sight copy draws a card, gains 1 life, and unprepares Tam") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tam, Observant Sequencer", summoningSickness = false)
+                    .withCardInHand(1, "Forest")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Plains") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Plains") }
+                val game = builder.build()
+
+                val tam = game.findPermanent("Tam, Observant Sequencer")!!
+
+                val forest = game.findCardsInHand(1, "Forest").first()
+                game.execute(PlayLand(game.player1Id, forest))
+                game.resolveStack()
+
+                withClue("Tam should be prepared after the landfall trigger") {
+                    game.state.getEntity(tam)?.get<PreparedComponent>() shouldNotBe null
+                }
+
+                val copyId = game.findExileCopy(1, "Tam, Observant Sequencer")!!
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                // Deep Sight is a sorcery — we're in our own precombat main with an empty stack.
+                game.execute(CastSpell(game.player1Id, copyId, faceIndex = 0))
+                game.resolveStack()
+
+                withClue("Deep Sight draws one card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("Deep Sight gains 1 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 1
+                }
+                withClue("Tam is no longer prepared after casting the copy") {
+                    game.state.getEntity(tam)?.get<PreparedComponent>() shouldBe null
+                }
+                withClue("The Deep Sight copy should be gone from exile") {
+                    game.findExileCopy(1, "Tam, Observant Sequencer") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Four Secrets of Strixhaven (SOS) cards from the Prismari/Quandrix slice, each with a passing scenario test:
- **Berta, Wise Extrapolator**
- **Tam, Observant Sequencer**
- **Mica, Reader of Ruins**
- **Petrified Hamlet**

## SDK / engine support
In-flight feature work backing these cards (preserved and verified):
- `CardPredicate` / `ObjectFilter` additions
- `ReplacementEffect` + `PermanentEntryReplacements`
- ModalAndClone continuation + `CastChoicesComponent` wiring
- `PlayLandHandler` / `CostCalculator` / `StackResolver` adjustments

`docs/card-sdk-language-reference.md` updated in lockstep.

## mtgish-tooling
- **Berta** and **Tam** auto-generate as full **AUTO**.
- **Mica** (`MayCost` optional sacrifice) and **Petrified Hamlet** (`ChooseACardName`) correctly **decline to SCAFFOLD** — rendering them would be lossy, so per the render-faithfully-or-decline policy they are left as scaffold rather than approximated.
- No emitter change in this batch; **POR coverage-verify stays 0-mismatch**.

## Tests
- 4 scenario tests pass (Berta, Tam, Mica, Petrified Hamlet)
- Full `:rules-engine:test` green
- `:mtg-sets` `CardDefinitionSnapshotTest` (SOS golden re-blessed, additions-only) + `CardLintTest` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)