### PR TITLE
Add 5 SOS cards: Prismari, Quandrix, Ral Zarek, Zimone's Experiment, Orysa

### DIFF
--- a/backlog/sos-engine-gaps.md
+++ b/backlog/sos-engine-gaps.md
@@ -197,9 +197,10 @@ for consistency, but it composes existing primitives.
 10. **`Subtype.LESSON`.** ❌ The 5 Paradigm cards are `Sorcery — Lesson`. No `LESSON` subtype constant exists. Trivial
     add (no Learn mechanic in this set, so it's a plain, non-functional subtype — but the type line must parse).
 
-11. **Multi-turn skip ("skips their next X turns").** ❌ `SkipNextTurnEffect` exists but is a singleton boolean
-    component — no count, no `DynamicAmount`. Needs `SkipNextTurnComponent.turnsToSkip: Int` + a `turns: DynamicAmount`
-    parameter so Ral Zarek's ultimate ("skips their next X turns, X = heads") works. (One card, but no other path.)
+11. **Multi-turn skip ("skips their next X turns").** ✅ DONE. `SkipNextTurnEffect` now takes a `count: DynamicAmount`
+    (default `Fixed(1)`) and `SkipNextTurnComponent(turns: Int)` accumulates/decrements one per the player's turn-start.
+    Plus a new `FlipCoinsEffect(count, storeHeadsAs)` that tallies heads into the pipeline, so Ral Zarek's ultimate
+    composes `FlipCoins(5) → SkipNextTurn(count = VariableReference("heads"))`.
 
 ---
 
@@ -210,9 +211,9 @@ for consistency, but it composes existing primitives.
     cost. `AdditionalCost.DiscardCards` discards by *filter*, but there's no "same-name-as-source" card filter.
     Needs a `CardFilter.SameNameAsSource` (or `NamedLike(self)`) + the keyword's sorcery-timing activated-ability shape.
 
-13. **Ral Zarek, Guest Lecturer** ❌ (depends on §11) + ✅ coin-flip exists. *"Flip five coins. Target opponent skips
-    their next X turns, X = heads."* Coin flip and "count heads" compose today; the blocker is the multi-turn skip (§11).
-    His other abilities (Surveil, discard, reanimate MV≤3) are standard.
+13. **Ral Zarek, Guest Lecturer** ✅ DONE. Built on §11's multi-turn skip + the new `FlipCoinsEffect`. The ultimate is
+    `FlipCoins(5) then SkipNextTurn(target opponent, count = heads)`. The other abilities (Surveil 2, any-number-of-target-
+    players each discard, reanimate MV≤3) compose existing primitives.
 
 14. **Professor Dellian Fel** ✅ buildable. +2 gain life / 0 draw-and-lose-1 / −3 destroy / −6 emblem
     ("Whenever you gain life, target opponent loses that much life" — `CreatePermanentEmblemEffect` + life-gain trigger

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -771,7 +771,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   card (listing goader names) — there is no separate game-log event. Used by **Glóin, Dwarf
   Emissary**: `Costs.Composite(Costs.Tap, Costs.Sacrifice(Artifact.withSubtype("Treasure"))):
   Goad(target creature)`.
-- `SkipNextTurnEffect(target)` — target skips their next turn.
+- `Effects.SkipNextTurn(target = Controller, count = Fixed(1))` (`SkipNextTurnEffect`) — target skips their next `count` turns. `count` is a `DynamicAmount`, so it can read a pipeline value (e.g. a coin-flip tally via `DynamicAmount.VariableReference`). Skips accumulate on a `SkipNextTurnComponent(turns)`, decremented one turn per the player's turn-start; a resolved count of 0 is a no-op. Used by Lethal Vapors (one turn) and **Ral Zarek, Guest Lecturer** (skip N turns where N = heads).
+- `Effects.FlipCoins(count, storeHeadsAs = "heads")` (`FlipCoinsEffect`) — flip `count` coins and store the number of heads under `storeHeadsAs` in the pipeline (`storedNumbers`) so a later sub-effect in the same composite can scale off it via `DynamicAmount.VariableReference`. The general "flip N coins, count heads" primitive (CR 705); unlike `FlipCoinEffect` (branch on win/lose) and `FlipTwoCoinsEffect` (branch on combined outcome) it only tallies. Each flip emits a `CoinFlipEvent`. **Ral Zarek, Guest Lecturer**'s ultimate composes `FlipCoins(5, "heads")` then `SkipNextTurn(target, count = VariableReference("heads"))`.
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
 - `HijackNextTurnEffect(target)` — you control target's next turn.
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
@@ -2887,6 +2888,19 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   alternative cost (e.g. a red evoke creature), both casts are offered and disambiguated by
   `CastSpell.alternativeCostType` (see `engine-server-interface.md`) — picking "Evoke" charges the
   evoke cost, not warp, even though warp would win a naive priority order.
+- `GrantKeywordToOwnSpells(keyword, spellFilter = Creature)` — while this permanent is on the battlefield,
+  spells its controller casts matching `spellFilter` effectively have `keyword` ("you cast" semantics). Read by
+  the cast machinery via `GrantedKeywordResolver`:
+  - **Cost-modifying keywords** (CONVOKE, DELVE) surface in the cast enumerator / alternative-payment handler —
+    e.g. **Eirdu, Carrier of Dawn** (`GrantKeywordToOwnSpells(CONVOKE, Creature)`), **Teval, Arbiter of Virtue**
+    (`DELVE`).
+  - **STORM** (and other "each instance triggers separately" cast keywords) are counted by
+    `GrantedKeywordResolver.countGrants` when `CastSpellHandler` builds the spell's storm triggers — one storm
+    instance per matching grant (CR 702.40b), added to the printed-keyword count. **Prismari, the Inspiration** =
+    `GrantKeywordToOwnSpells(STORM, InstantOrSorcery)`. Removing the granter before the spell is cast revokes the
+    grant. (Cascade-style granted keywords are instead modelled as a `youCastSpell(...)`-triggered `Effects.Cascade`
+    on the granter — see **Quandrix, the Proof** / Wildsear, Scouring Maw — since cascade is a cast trigger, not a
+    cost keyword.)
 - `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2727,11 +2727,23 @@ object Effects {
         CantActivateLoyaltyAbilitiesEffect(target, duration)
 
     /**
-     * Target player skips their next turn.
-     * Used for cards like Lethal Vapors.
+     * Target player skips their next [count] turns (default one).
+     * Used for cards like Lethal Vapors (one turn) and Ral Zarek, Guest Lecturer (a coin-flip
+     * tally of turns, via [DynamicAmount.VariableReference]).
      */
-    fun SkipNextTurn(target: EffectTarget = EffectTarget.Controller): Effect =
-        SkipNextTurnEffect(target)
+    fun SkipNextTurn(
+        target: EffectTarget = EffectTarget.Controller,
+        count: DynamicAmount = DynamicAmount.Fixed(1)
+    ): Effect = SkipNextTurnEffect(target, count)
+
+    /**
+     * Flip [count] coins and store the number that came up heads under [storeHeadsAs] in the
+     * pipeline, so a later sub-effect in the same composite can scale off it via
+     * [DynamicAmount.VariableReference]. The general "flip N coins, count heads" primitive
+     * (Ral Zarek, Guest Lecturer's ultimate).
+     */
+    fun FlipCoins(count: Int, storeHeadsAs: String = "heads"): Effect =
+        com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect(count, storeHeadsAs)
 
     /**
      * Target player skips their next draw step.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -845,6 +845,32 @@ data class FlipTwoCoinsEffect(
     }
 }
 
+/**
+ * Flip [count] coins, then store the number that came up heads under [storeHeadsAs] in pipeline
+ * `storedNumbers` so a later sub-effect in the same composite can scale off it via
+ * [com.wingedsheep.sdk.scripting.values.DynamicAmount.VariableReference].
+ *
+ * The general "flip N coins and count the heads" primitive (CR 705). Unlike [FlipCoinEffect]
+ * (one coin, branch on win/lose) and [FlipTwoCoinsEffect] (two coins, branch on the combined
+ * outcome), this neither branches nor wins/loses — it just tallies heads — so it composes with
+ * any count-consuming effect. Each flip emits its own coin-flip event.
+ *
+ * Used by Ral Zarek, Guest Lecturer's ultimate ("Flip five coins. Target opponent skips their
+ * next X turns, where X is the number of coins that came up heads."):
+ * `FlipCoinsEffect(5, "heads")` then `SkipNextTurnEffect(target, count = VariableReference("heads"))`.
+ *
+ * @property count How many coins to flip.
+ * @property storeHeadsAs Pipeline `storedNumbers` key the heads tally is written to.
+ */
+@SerialName("FlipCoins")
+@Serializable
+data class FlipCoinsEffect(
+    val count: Int,
+    val storeHeadsAs: String = "heads"
+) : Effect {
+    override val description: String = "Flip $count coins"
+}
+
 // =============================================================================
 // Budget Modal (Pawprint / Season Cycle)
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -193,17 +193,28 @@ data class CreateGlobalTriggeredAbilityEffect(
 }
 
 /**
- * Target player skips their next turn.
- * Used for cards like Lethal Vapors: "You skip your next turn."
+ * Target player skips their next [count] turns.
+ * Used for cards like Lethal Vapors ("You skip your next turn." → `count = Fixed(1)`) and Ral
+ * Zarek, Guest Lecturer ("Target opponent skips their next X turns." → `count` is a
+ * [DynamicAmount.VariableReference] reading a previously-stored coin-flip tally).
  *
- * @param target The player who skips their next turn (default: the controller/activating player)
+ * The count accumulates: applying this twice to the same player stacks the skipped turns
+ * (CR 720.4 — each skip is tracked independently). Resolving with `count == 0` is a no-op.
+ *
+ * @param target The player who skips turns (default: the controller/activating player)
+ * @param count How many of their upcoming turns to skip (default: one)
  */
 @SerialName("SkipNextTurn")
 @Serializable
 data class SkipNextTurnEffect(
-    val target: EffectTarget = EffectTarget.Controller
+    val target: EffectTarget = EffectTarget.Controller,
+    val count: DynamicAmount = DynamicAmount.Fixed(1)
 ) : Effect {
-    override val description: String = "${target.description.replaceFirstChar { it.uppercase() }} skips their next turn"
+    override val description: String = buildString {
+        append(target.description.replaceFirstChar { it.uppercase() })
+        append(" skips their next ")
+        append(if (count == DynamicAmount.Fixed(1)) "turn" else "${count.description} turns")
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -177,6 +177,7 @@ object CardLinter {
         put("BeholdOrPay" to "storeAs", write(Space.COLLECTION))
         put("ChooseEntity" to "storeAs", write(Space.COLLECTION))
         put("StoreNumber" to "name", write(Space.NUMBER))
+        put("FlipCoins" to "storeHeadsAs", write(Space.NUMBER))
         put("ForEachCapturedController" to "countVariable", write(Space.NUMBER))
         put("DrawUpTo" to "storeNotDrawnAs", write(Space.NUMBER))
         put("ChooseOption" to "storeAs", write(Space.CHOSEN))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/OrysaTideChoreographer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/OrysaTideChoreographer.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Orysa, Tide Choreographer
+ * {4}{U}
+ * Legendary Creature — Merfolk Bard
+ * 2/2
+ *
+ * This spell costs {3} less to cast if creatures you control have total toughness 10 or greater.
+ * When Orysa enters, draw two cards.
+ *
+ * The cost reduction is a fixed {3} gated on an intervening condition (CR 601.2f, the
+ * cost-determination step reads the battlefield), modelled with [ModifySpellCost] +
+ * [CostGating.OnlyIf]. The condition sums the projected toughness of creatures you control via
+ * [DynamicAmount.AggregateBattlefield] (SUM over TOUGHNESS), so layer/counter modifications are
+ * respected.
+ */
+val OrysaTideChoreographer = card("Orysa, Tide Choreographer") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Merfolk Bard"
+    power = 2
+    toughness = 2
+    oracleText = "This spell costs {3} less to cast if creatures you control have total toughness " +
+        "10 or greater.\nWhen Orysa enters, draw two cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(CostReductionSource.Fixed(3)),
+            gating = CostGating.OnlyIf(
+                Conditions.CompareAmounts(
+                    DynamicAmount.AggregateBattlefield(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature,
+                        aggregation = Aggregation.SUM,
+                        property = CardNumericProperty.TOUGHNESS,
+                    ),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(10),
+                ),
+            ),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(2)
+        description = "When Orysa enters, draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Anna Pavleeva"
+        flavorText = "Orysa and her troupe of turtles are a staple of Summitfest's daytime celebrations."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/010ed379-63f5-452c-9cd4-00d51647c0e3.jpg?1775937343"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PrismariTheInspiration.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/PrismariTheInspiration.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeywordToOwnSpells
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Prismari, the Inspiration
+ * {5}{U}{R}
+ * Legendary Creature — Elder Dragon
+ * 7/7
+ *
+ * Flying
+ * Ward—Pay 5 life.
+ * Instant and sorcery spells you cast have storm.
+ *
+ * The storm grant is a continuous static ability ([GrantKeywordToOwnSpells]) scoped to the
+ * controller — while Prismari is on the battlefield, instant and sorcery spells its controller
+ * casts effectively have storm (CR 702.40). The cast handler reads battlefield
+ * `GrantKeywordToOwnSpells` grants alongside printed storm when building each spell's storm
+ * trigger, so removing Prismari before the spell is cast revokes the grant. Like the printed
+ * keyword, the granted storm copies zero times when no other spells have been cast this turn.
+ */
+val PrismariTheInspiration = card("Prismari, the Inspiration") {
+    manaCost = "{5}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Elder Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying\n" +
+        "Ward—Pay 5 life.\n" +
+        "Instant and sorcery spells you cast have storm. (Whenever you cast an instant or sorcery " +
+        "spell, copy it for each spell cast before it this turn. You may choose new targets for " +
+        "the copies.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.wardLife(5))
+
+    staticAbility {
+        ability = GrantKeywordToOwnSpells(
+            keyword = Keyword.STORM,
+            spellFilter = GameObjectFilter.InstantOrSorcery,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "212"
+        artist = "Justin Gerard"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/767ff9fa-4e7f-421a-b911-45186b520ae1.jpg?1775938472"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuandrixTheProof.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/QuandrixTheProof.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+
+/**
+ * Quandrix, the Proof
+ * {4}{G}{U}
+ * Legendary Creature — Elder Dragon
+ * 6/6
+ *
+ * Flying, trample
+ * Cascade
+ * Instant and sorcery spells you cast from your hand have cascade.
+ *
+ * Cascade is itself a "when you cast this spell" triggered ability (CR 702.85a), so both halves
+ * are modelled as cast triggers feeding the shared [com.wingedsheep.sdk.scripting.effects.CascadeEffect]
+ * executor (which reads the triggering spell's mana value to set the threshold):
+ *  - Quandrix's own cascade fires on [Triggers.WhenYouCastThisSpell] (SELF), reading Quandrix's
+ *    mana value.
+ *  - The granted cascade fires whenever the controller casts an instant or sorcery spell from
+ *    their hand, mirroring Wildsear, Scouring Maw. Granting the trigger rather than literally
+ *    stamping the CASCADE keyword onto the stacked spell produces identical game behavior, and
+ *    the from-hand restriction is expressed with [SpellCastPredicate.CastFromZone].
+ */
+val QuandrixTheProof = card("Quandrix, the Proof") {
+    manaCost = "{4}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elder Dragon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying, trample\n" +
+        "Cascade (When you cast this spell, exile cards from the top of your library until you " +
+        "exile a nonland card that costs less. You may cast it without paying its mana cost. Put " +
+        "the exiled cards on the bottom in a random order.)\n" +
+        "Instant and sorcery spells you cast from your hand have cascade."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE, Keyword.CASCADE)
+
+    // Cascade — Quandrix's own cast trigger.
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Cascade
+        description = "Cascade"
+    }
+
+    // Instant and sorcery spells you cast from your hand have cascade.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery,
+            requires = setOf(SpellCastPredicate.CastFromZone(Zone.HAND)),
+        )
+        effect = Effects.Cascade
+        description = "Instant and sorcery spells you cast from your hand have cascade."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "218"
+        artist = "Lucas Graciano"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/015afe31-af3c-4c9b-9997-d7c33b915a33.jpg?1775938517"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RalZarekGuestLecturer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/RalZarekGuestLecturer.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ral Zarek, Guest Lecturer
+ * {1}{B}{B}
+ * Legendary Planeswalker — Ral
+ * Starting loyalty: 3
+ *
+ * +1: Surveil 2.
+ * −1: Any number of target players each discard a card.
+ * −2: Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ * −7: Flip five coins. Target opponent skips their next X turns, where X is the number of coins
+ *     that came up heads.
+ *
+ * The ultimate composes two general primitives: [Effects.FlipCoins] tallies the heads into the
+ * pipeline, and [Effects.SkipNextTurn] reads that tally as its turn count — so a result of zero
+ * heads is a clean no-op.
+ */
+val RalZarekGuestLecturer = card("Ral Zarek, Guest Lecturer") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Planeswalker — Ral"
+    startingLoyalty = 3
+    oracleText = "+1: Surveil 2.\n" +
+        "−1: Any number of target players each discard a card.\n" +
+        "−2: Return target creature card with mana value 3 or less from your graveyard to " +
+        "the battlefield.\n" +
+        "−7: Flip five coins. Target opponent skips their next X turns, where X is the number " +
+        "of coins that came up heads."
+
+    // +1: Surveil 2.
+    loyaltyAbility(+1) {
+        effect = Patterns.Library.surveil(2)
+    }
+
+    // −1: Any number of target players each discard a card.
+    loyaltyAbility(-1) {
+        target = TargetPlayer(unlimited = true)
+        effect = ForEachTargetEffect(
+            listOf(Effects.Discard(1, EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    // −2: Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+    loyaltyAbility(-2) {
+        val creature = target(
+            "creature",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3)),
+        )
+        effect = Effects.Move(creature, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    // −7: Flip five coins. Target opponent skips their next X turns, where X is heads.
+    loyaltyAbility(-7) {
+        target = Targets.Opponent
+        effect = Effects.Composite(
+            listOf(
+                Effects.FlipCoins(5, storeHeadsAs = "heads"),
+                Effects.SkipNextTurn(
+                    target = EffectTarget.ContextTarget(0),
+                    count = DynamicAmount.VariableReference("heads"),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "97"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fbad757-4081-42f7-a460-68ac03e77510.jpg?1775937587"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ZimonesExperiment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/ZimonesExperiment.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.sos.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zimone's Experiment
+ * {3}{G}
+ * Sorcery
+ *
+ * Look at the top five cards of your library. You may reveal up to two creature and/or land
+ * cards from among them, then put the rest on the bottom of your library in a random order.
+ * Put all land cards revealed this way onto the battlefield tapped and put all creature cards
+ * revealed this way into your hand.
+ *
+ * Atomic Gather → Select → split-by-type → Move pipeline:
+ *  1. Gather the top five cards into a private "looked" pile.
+ *  2. Choose up to two creature/land cards (the remainder is everything not chosen).
+ *  3. Split the chosen pile by type, routing lands → battlefield tapped, creatures → hand.
+ *  4. Bottom the rest in a random order.
+ *
+ * A chosen pile entry can only be a creature or a land (the selection filter is
+ * [GameObjectFilter.CreatureOrLand]); a card that is both a creature and a land would be put
+ * onto the battlefield by the land split, matching the printed routing order.
+ */
+val ZimonesExperiment = card("Zimone's Experiment") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top five cards of your library. You may reveal up to two creature " +
+        "and/or land cards from among them, then put the rest on the bottom of your library in a " +
+        "random order. Put all land cards revealed this way onto the battlefield tapped and put " +
+        "all creature cards revealed this way into your hand."
+
+    spell {
+        effect = Effects.Pipeline {
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(5)), name = "looked")
+            val (kept, rest) = chooseUpToSplit(
+                count = 2,
+                from = looked,
+                filter = GameObjectFilter.CreatureOrLand,
+                prompt = "Reveal up to two creature and/or land cards",
+                showAllCards = true,
+                name = "kept",
+                remainderName = "rest",
+            )
+            val (lands, creatures) = filterSplit(
+                from = kept,
+                filter = GameObjectFilter.Land,
+                name = "keptLands",
+                restName = "keptCreatures",
+            )
+            move(
+                from = lands,
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                revealed = true,
+            )
+            move(
+                from = creatures,
+                destination = CardDestination.ToZone(Zone.HAND),
+                revealed = true,
+            )
+            move(
+                from = rest,
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "169"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6597852-4267-4ea6-a391-f927e4833be2.jpg?1775938156"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -9931,6 +9931,78 @@
     ]
 }
 
+// Orysa, Tide Choreographer
+{
+    "name": "Orysa, Tide Choreographer",
+    "manaCost": "{4}{U}",
+    "typeLine": "Legendary Creature — Merfolk Bard",
+    "oracleText": "This spell costs {3} less to cast if creatures you control have total toughness 10 or greater.\nWhen Orysa enters, draw two cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When Orysa enters, draw two cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature",
+                            "aggregation": "SUM",
+                            "property": "TOUGHNESS"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 10
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Pavleeva",
+        "flavorText": "Orysa and her troupe of turtles are a staple of Summitfest's daytime celebrations.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/010ed379-63f5-452c-9cd4-00d51647c0e3.jpg?1775937343"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Owlin Historian
 {
     "name": "Owlin Historian",
@@ -11343,6 +11415,60 @@
     ]
 }
 
+// Prismari, the Inspiration
+{
+    "name": "Prismari, the Inspiration",
+    "manaCost": "{5}{U}{R}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying\nWard—Pay 5 life.\nInstant and sorcery spells you cast have storm. (Whenever you cast an instant or sorcery spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 5
+            }
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeywordToOwnSpells",
+                "keyword": "STORM",
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Or",
+                            "predicates": [
+                                "IsInstant",
+                                "IsSorcery"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "MYTHIC",
+        "artist": "Justin Gerard",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/767ff9fa-4e7f-421a-b911-45186b520ae1.jpg?1775938472"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Procrastinate
 {
     "name": "Procrastinate",
@@ -11759,6 +11885,69 @@
     ]
 }
 
+// Quandrix, the Proof
+{
+    "name": "Quandrix, the Proof",
+    "manaCost": "{4}{G}{U}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)\nInstant and sorcery spells you cast from your hand have cascade.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE",
+        "CASCADE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": "Cascade",
+                "descriptionOverride": "Cascade"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    },
+                    "requires": [
+                        {
+                            "type": "SpellCastFromZone",
+                            "zone": "Hand"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": "Cascade",
+                "descriptionOverride": "Instant and sorcery spells you cast from your hand have cascade."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "MYTHIC",
+        "artist": "Lucas Graciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/015afe31-af3c-4c9b-9997-d7c33b915a33.jpg?1775938517"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Quill-Blade Laureate
 {
     "name": "Quill-Blade Laureate",
@@ -11902,6 +12091,209 @@
         "flavorText": "\"Let me guess, the scurrids got to you lot?\"\n—Witherbloom infirmary attendant",
         "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5e67560-3135-4b27-a344-5859edf8bcd9.jpg?1775937579"
     },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Ral Zarek, Guest Lecturer
+{
+    "name": "Ral Zarek, Guest Lecturer",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Legendary Planeswalker — Ral",
+    "oracleText": "+1: Surveil 2.\n−1: Any number of target players each discard a card.\n−2: Return target creature card with mana value 3 or less from your graveyard to the battlefield.\n−7: Flip five coins. Target opponent skips their next X turns, where X is the number of coins that came up heads.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -1
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "unlimited": true
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature mv<=3 own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -7
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "FlipCoins",
+                            "count": 5
+                        },
+                        {
+                            "type": "SkipNextTurn",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "count": {
+                                "type": "VariableReference",
+                                "variableName": "heads"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    "TargetOpponent"
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "MYTHIC",
+        "artist": "Billy Christian",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fbad757-4081-42f7-a460-68ac03e77510.jpg?1775937587"
+    },
+    "startingLoyalty": 3,
     "colorIdentityOverride": [
         "BLACK"
     ]
@@ -17556,5 +17948,95 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Zimone's Experiment
+{
+    "name": "Zimone's Experiment",
+    "manaCost": "{3}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top five cards of your library. You may reveal up to two creature and/or land cards from among them, then put the rest on the bottom of your library in a random order. Put all land cards revealed this way onto the battlefield tapped and put all creature cards revealed this way into your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "filter": "creature|land",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "Reveal up to two creature and/or land cards",
+                    "showAllCards": true
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "kept",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "land"
+                    },
+                    "storeMatching": "keptLands",
+                    "storeNonMatching": "keptCreatures"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "keptLands",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "keptCreatures",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6597852-4267-4ea6-a391-f927e4833be2.jpg?1775938156"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -532,8 +532,15 @@ class TurnManager(
         // individual.
         val nextTeam = cleanedState.sharedTurnTeam(nextPlayer)
         if (nextTeam.any { cleanedState.getEntity(it)?.has<SkipNextTurnComponent>() == true }) {
+            // Consume one skipped turn per affected member: decrement the remaining count and
+            // remove the component once it reaches zero (Ral Zarek can stack several). One turn
+            // is skipped per endTurn call; multi-turn skips persist across successive turns.
             for (member in nextTeam) {
-                cleanedState = cleanedState.updateEntity(member) { it.without<SkipNextTurnComponent>() }
+                cleanedState = cleanedState.updateEntity(member) { container ->
+                    val remaining = container.get<SkipNextTurnComponent>()?.turns ?: 0
+                    if (remaining > 1) container.with(SkipNextTurnComponent(remaining - 1))
+                    else container.without<SkipNextTurnComponent>()
+                }
             }
             nextPlayer = cleanedState.getNextTeam(nextPlayer)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2584,13 +2584,21 @@ class CastSpellHandler(
         // but the trigger must still land on the stack so "whenever an ability triggers /
         // is put onto the stack" effects see it.
         val stormGrantCount = run {
+            // Source 2a: GrantedSpellKeywordsComponent — emblem-style player grants (Ral, Crackling Wit).
             val playerContainer = currentCastState.getEntity(action.playerId)
             val grants = playerContainer?.get<GrantedSpellKeywordsComponent>()?.grants ?: emptyList()
             val evalContext = PredicateContext(controllerId = action.playerId)
-            grants.count { grant ->
+            val componentGrants = grants.count { grant ->
                 grant.keyword == Keyword.STORM &&
                     predicateEvaluator.matches(currentCastState, currentCastState.projectedState, action.cardId, grant.spellFilter, evalContext)
             }
+            // Source 2b: GrantKeywordToOwnSpells static abilities on battlefield permanents the
+            // caster controls (Prismari, the Inspiration). Each matching permanent is a separate
+            // instance of storm (CR 702.40b), so count them all rather than short-circuiting.
+            val staticGrants = if (cardDef != null) {
+                grantedKeywordResolver.countGrants(currentCastState, action.playerId, cardDef, Keyword.STORM)
+            } else 0
+            componentGrants + staticGrants
         }
         val printedStormCount = if (cardDef != null && cardDef.hasKeyword(Keyword.STORM)) 1 else 0
         val stormInstanceCount = printedStormCount + stormGrantCount

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -575,7 +575,8 @@ object ZoneMovementUtils {
             val cid = controllerId ?: return state
             return state.getOpponents(cid).fold(state) { acc, opponentId ->
                 acc.updateEntity(opponentId) { container ->
-                    container.with(SkipNextTurnComponent)
+                    val existing = container.get<SkipNextTurnComponent>()?.turns ?: 0
+                    container.with(SkipNextTurnComponent(existing + 1))
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -39,6 +39,7 @@ class CompositeExecutors(
     private val repeatWhileExecutor by lazy { RepeatWhileExecutor(effectExecutor) }
     private val conditionalOnCollectionExecutor by lazy { ConditionalOnCollectionExecutor(effectExecutor) }
     private val flipTwoCoinsExecutor by lazy { FlipTwoCoinsExecutor(effectExecutor) }
+    private val flipCoinsExecutor by lazy { FlipCoinsExecutor() }
     private val chooseActionEffectExecutor by lazy { ChooseActionEffectExecutor(effectExecutor) }
     private val repeatDynamicTimesExecutor by lazy { RepeatDynamicTimesExecutor(effectExecutor) }
     private val chooseNumberThenExecutor by lazy { ChooseNumberThenExecutor(decisionHandler) }
@@ -67,6 +68,7 @@ class CompositeExecutors(
         reflexiveTriggerEffectExecutor,
         flipCoinExecutor,
         flipTwoCoinsExecutor,
+        flipCoinsExecutor,
         repeatWhileExecutor,
         repeatDynamicTimesExecutor,
         conditionalOnCollectionExecutor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsExecutor.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [FlipCoinsEffect].
+ *
+ * Flips [FlipCoinsEffect.count] coins, emitting one [CoinFlipEvent] per flip, and publishes the
+ * number that came up heads into the pipeline (`storedNumbers[storeHeadsAs]`) via
+ * [EffectResult.updatedStoredNumbers] so a later sub-effect in the same composite can scale off it
+ * with [com.wingedsheep.sdk.scripting.values.DynamicAmount.VariableReference] — exactly how
+ * [StoreNumberExecutor][com.wingedsheep.engine.handlers.effects.library.StoreNumberExecutor]
+ * surfaces a value.
+ *
+ * "Heads" is modelled as a won flip, matching the rest of the coin-flip plumbing
+ * ([FlipCoinExecutor]).
+ */
+class FlipCoinsExecutor : EffectExecutor<FlipCoinsEffect> {
+
+    override val effectType: KClass<FlipCoinsEffect> = FlipCoinsEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: FlipCoinsEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId
+        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
+
+        var currentState = state
+        val events = mutableListOf<GameEvent>()
+        var heads = 0
+        repeat(effect.count.coerceAtLeast(0)) {
+            val (won, advanced) = currentState.nextRandom { nextBoolean() }
+            currentState = advanced
+            if (won) heads++
+            events.add(CoinFlipEvent(context.controllerId, won, sourceId ?: context.controllerId, sourceName))
+        }
+
+        return EffectResult(
+            state = currentState,
+            events = events,
+            updatedStoredNumbers = mapOf(effect.storeHeadsAs to heads)
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextTurnExecutor.kt
@@ -1,20 +1,26 @@
 package com.wingedsheep.engine.handlers.effects.player
 
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
 import com.wingedsheep.sdk.scripting.effects.SkipNextTurnEffect
-import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
 
 /**
- * Executor for SkipNextTurnEffect.
- * Adds SkipNextTurnComponent to the target player so their next turn is skipped.
+ * Executor for [SkipNextTurnEffect].
+ *
+ * Evaluates the effect's [count][SkipNextTurnEffect.count] and accumulates a
+ * [SkipNextTurnComponent] on the target player so that many of their upcoming turns are skipped.
+ * A resolved count of 0 (e.g. zero coins came up heads on Ral Zarek's ultimate) is a no-op.
  */
-class SkipNextTurnExecutor : EffectExecutor<SkipNextTurnEffect> {
+class SkipNextTurnExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<SkipNextTurnEffect> {
 
     override val effectType: KClass<SkipNextTurnEffect> = SkipNextTurnEffect::class
 
@@ -23,19 +29,18 @@ class SkipNextTurnExecutor : EffectExecutor<SkipNextTurnEffect> {
         effect: SkipNextTurnEffect,
         context: EffectContext
     ): EffectResult {
-        val target = effect.target
-        val targetPlayerId = when (target) {
-            is EffectTarget.Controller -> context.controllerId
-            is EffectTarget.PlayerRef -> {
-                com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
-                    .resolvePlayerRef(target.player, context, state)
-                    ?: return EffectResult.error(state, "Cannot resolve player for SkipNextTurnEffect")
-            }
-            else -> return EffectResult.error(state, "Unsupported target for SkipNextTurnEffect")
-        }
+        val targetPlayerId = when (val target = effect.target) {
+            is EffectTarget.PlayerRef ->
+                TargetResolutionUtils.resolvePlayerRef(target.player, context, state)
+            else -> TargetResolutionUtils.resolveTarget(target, context, state)
+        } ?: return EffectResult.error(state, "Cannot resolve player for SkipNextTurnEffect")
+
+        val turns = amountEvaluator.evaluate(state, effect.count, context)
+        if (turns <= 0) return EffectResult.success(state)
 
         val newState = state.updateEntity(targetPlayerId) { container ->
-            container.with(SkipNextTurnComponent)
+            val existing = container.get<SkipNextTurnComponent>()?.turns ?: 0
+            container.with(SkipNextTurnComponent(existing + turns))
         }
 
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TakeExtraTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TakeExtraTurnExecutor.kt
@@ -48,7 +48,8 @@ class TakeExtraTurnExecutor : EffectExecutor<TakeExtraTurnEffect> {
         }
         var newState = otherPlayerIds.fold(state) { acc, otherPlayerId ->
             acc.updateEntity(otherPlayerId) { container ->
-                container.with(SkipNextTurnComponent)
+                val existing = container.get<SkipNextTurnComponent>()?.turns ?: 0
+                container.with(SkipNextTurnComponent(existing + 1))
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/GrantedKeywordResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/GrantedKeywordResolver.kt
@@ -68,6 +68,37 @@ class GrantedKeywordResolver(
     }
 
     /**
+     * Count how many battlefield permanents controlled by [playerId] grant [keyword] to [cardDef]
+     * via [GrantKeywordToOwnSpells]. Unlike [findGrant], this does not short-circuit — each grant
+     * counts as a separate instance, which matters for "each instance triggers separately"
+     * keywords like STORM (CR 702.40b: e.g. two Prismaris grant two storm triggers).
+     */
+    fun countGrants(
+        state: GameState,
+        playerId: EntityId,
+        cardDef: CardDefinition,
+        keyword: Keyword
+    ): Int {
+        var count = 0
+        for (permanentId in state.getBattlefield()) {
+            val container = state.getEntity(permanentId) ?: continue
+            val controllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            if (controllerId != playerId) continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+            val sourceDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            for (ability in sourceDef.script.staticAbilities) {
+                if (ability is GrantKeywordToOwnSpells &&
+                    ability.keyword == keyword &&
+                    matchesSpellFilter(ability.spellFilter, cardDef)
+                ) {
+                    count++
+                }
+            }
+        }
+        return count
+    }
+
+    /**
      * Match a spell's [cardDef] against a [GameObjectFilter] using the card's printed
      * characteristics. Only a narrow set of predicates is supported because spells being cast
      * don't yet have battlefield state — the caller knows the card, not an entity.
@@ -75,34 +106,42 @@ class GrantedKeywordResolver(
     private fun matchesSpellFilter(filter: GameObjectFilter, cardDef: CardDefinition): Boolean {
         // GameObjectFilter.Any / empty predicates match everything.
         if (filter.cardPredicates.isEmpty() && filter.controllerPredicate == null) return true
-        for (predicate in filter.cardPredicates) {
-            val matches = when (predicate) {
-                CardPredicate.IsCreature -> cardDef.typeLine.isCreature
-                CardPredicate.IsNoncreature -> !cardDef.typeLine.isCreature
-                CardPredicate.IsArtifact -> cardDef.typeLine.isArtifact
-                CardPredicate.IsEnchantment -> cardDef.typeLine.isEnchantment
-                CardPredicate.IsInstant -> cardDef.typeLine.isInstant
-                CardPredicate.IsSorcery -> cardDef.typeLine.isSorcery
-                CardPredicate.IsLand -> cardDef.typeLine.isLand
-                CardPredicate.IsNonland -> !cardDef.typeLine.isLand
-                CardPredicate.IsLegendary -> cardDef.typeLine.isLegendary
-                CardPredicate.IsNonlegendary -> !cardDef.typeLine.isLegendary
-                CardPredicate.IsPermanent -> cardDef.typeLine.isPermanent
-                CardPredicate.IsNonenchantment -> !cardDef.typeLine.isEnchantment
-                CardPredicate.IsNonartifact -> !cardDef.typeLine.isArtifact
-                CardPredicate.IsToken, CardPredicate.IsNontoken -> true
-                is CardPredicate.HasSubtype -> cardDef.typeLine.subtypes.any { it == predicate.subtype }
-                is CardPredicate.HasAnyOfSubtypes -> cardDef.typeLine.subtypes.any { predicate.subtypes.contains(it) }
-                is CardPredicate.HasColor -> cardDef.colors.contains(predicate.color)
-                CardPredicate.IsColorless -> cardDef.colors.isEmpty()
-                // Fail closed: an unhandled predicate cannot be evaluated against a
-                // CardDefinition alone, so we conservatively refuse to grant the keyword
-                // rather than silently match every spell. Add explicit handling here when
-                // a new spell-filter predicate is needed (e.g. ManaValue, NameEquals).
-                else -> false
-            }
-            if (!matches) return false
-        }
-        return true
+        return filter.cardPredicates.all { matchesPredicate(it, cardDef) }
     }
+
+    /**
+     * Evaluate a single [CardPredicate] against a [CardDefinition]. Recurses through the
+     * boolean combinators ([CardPredicate.And]/[Or]/[Not]) so combined-type filters such as
+     * [GameObjectFilter.InstantOrSorcery] (an `Or` of `IsInstant`/`IsSorcery`) resolve, which
+     * is what "instant and sorcery spells you cast have storm" needs.
+     */
+    private fun matchesPredicate(predicate: CardPredicate, cardDef: CardDefinition): Boolean =
+        when (predicate) {
+            is CardPredicate.And -> predicate.predicates.all { matchesPredicate(it, cardDef) }
+            is CardPredicate.Or -> predicate.predicates.any { matchesPredicate(it, cardDef) }
+            is CardPredicate.Not -> !matchesPredicate(predicate.predicate, cardDef)
+            CardPredicate.IsCreature -> cardDef.typeLine.isCreature
+            CardPredicate.IsNoncreature -> !cardDef.typeLine.isCreature
+            CardPredicate.IsArtifact -> cardDef.typeLine.isArtifact
+            CardPredicate.IsEnchantment -> cardDef.typeLine.isEnchantment
+            CardPredicate.IsInstant -> cardDef.typeLine.isInstant
+            CardPredicate.IsSorcery -> cardDef.typeLine.isSorcery
+            CardPredicate.IsLand -> cardDef.typeLine.isLand
+            CardPredicate.IsNonland -> !cardDef.typeLine.isLand
+            CardPredicate.IsLegendary -> cardDef.typeLine.isLegendary
+            CardPredicate.IsNonlegendary -> !cardDef.typeLine.isLegendary
+            CardPredicate.IsPermanent -> cardDef.typeLine.isPermanent
+            CardPredicate.IsNonenchantment -> !cardDef.typeLine.isEnchantment
+            CardPredicate.IsNonartifact -> !cardDef.typeLine.isArtifact
+            CardPredicate.IsToken, CardPredicate.IsNontoken -> true
+            is CardPredicate.HasSubtype -> cardDef.typeLine.subtypes.any { it == predicate.subtype }
+            is CardPredicate.HasAnyOfSubtypes -> cardDef.typeLine.subtypes.any { predicate.subtypes.contains(it) }
+            is CardPredicate.HasColor -> cardDef.colors.contains(predicate.color)
+            CardPredicate.IsColorless -> cardDef.colors.isEmpty()
+            // Fail closed: an unhandled predicate cannot be evaluated against a
+            // CardDefinition alone, so we conservatively refuse to grant the keyword
+            // rather than silently match every spell. Add explicit handling here when
+            // a new spell-filter predicate is needed (e.g. ManaValue, NameEquals).
+            else -> false
+        }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -869,15 +869,19 @@ data object PutCounterOnCreatureThisTurnComponent : Component
 data object WasDealtCombatDamageThisTurnComponent : Component
 
 /**
- * Marker component indicating that a player should skip their entire next turn.
- * Applied by effects like Last Chance (which gives the opponent an "extra turn"
- * by skipping the other player's turn in a 2-player game).
+ * Component indicating that a player should skip their entire next [turns] turns.
+ * Applied by effects like Last Chance (which gives the opponent an "extra turn" by skipping the
+ * other player's turn in a 2-player game) and Ral Zarek, Guest Lecturer's ultimate (skip several
+ * turns).
  *
- * This component is consumed (removed) when the turn would start, and the turn
- * is skipped instead.
+ * One skipped turn is consumed each time the affected player's turn would start: [turns] is
+ * decremented, the turn is skipped, and the component is removed once the count reaches zero.
+ * Re-applying it adds to the remaining count rather than overwriting (multiple skip effects stack).
+ *
+ * @property turns How many of the player's upcoming turns remain to be skipped (≥ 1 while present).
  */
 @Serializable
-data object SkipNextTurnComponent : Component
+data class SkipNextTurnComponent(val turns: Int = 1) : Component
 
 /**
  * Tracks a Mindslaver-style "you control target opponent during their next turn" effect.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlipCoinsEffectTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlipCoinsEffectTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.composite.FlipCoinsExecutor
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [FlipCoinsExecutor] — the "flip N coins, count the heads" primitive behind Ral Zarek's ultimate.
+ * Verifies it emits one [CoinFlipEvent] per flip and publishes the heads tally into the pipeline
+ * under the requested key. Seeded so the count assertion is deterministic.
+ */
+class FlipCoinsEffectTest : FunSpec({
+
+    test("flips exactly N coins and stores the number of heads (= won flips)") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+
+        // Seed the RNG so the run is reproducible.
+        driver.replaceState(driver.state.copy(rng = GameRng.seeded(12345L)))
+
+        val executor = FlipCoinsExecutor()
+        val context = EffectContext(sourceId = null, controllerId = player)
+        val result = executor.execute(driver.state, FlipCoinsEffect(5, "heads"), context)
+
+        result.error shouldBe null
+        // One coin-flip event per flip.
+        result.events.filterIsInstance<CoinFlipEvent>().size shouldBe 5
+        // Stored heads equals the number of won flips actually emitted.
+        val wonCount = result.events.filterIsInstance<CoinFlipEvent>().count { it.won }
+        result.updatedStoredNumbers["heads"] shouldBe wonCount
+    }
+
+    test("flipping zero coins stores zero heads and emits no events") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+
+        val executor = FlipCoinsExecutor()
+        val context = EffectContext(sourceId = null, controllerId = player)
+        val result = executor.execute(driver.state, FlipCoinsEffect(0, "heads"), context)
+
+        result.error shouldBe null
+        result.events.filterIsInstance<CoinFlipEvent>().size shouldBe 0
+        result.updatedStoredNumbers["heads"] shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrysaTideChoreographerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrysaTideChoreographerScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.OrysaTideChoreographer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Orysa, Tide Choreographer {4}{U}: "This spell costs {3} less to cast if creatures you control
+ * have total toughness 10 or greater." Modelled as a self [ModifySpellCost] gated on an
+ * [CostGating.OnlyIf] condition summing projected creature toughness.
+ */
+class OrysaTideChoreographerScenarioTest : FunSpec({
+
+    fun registry(): CardRegistry {
+        val r = CardRegistry()
+        r.register(TestCards.all)
+        r.register(OrysaTideChoreographer)
+        return r
+    }
+
+    test("costs {3} less when creatures you control have total toughness >= 10") {
+        val reg = registry()
+        val calculator = CostCalculator(reg)
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OrysaTideChoreographer))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two Force of Nature (toughness 5 each) → total toughness 10.
+        driver.putCreatureOnBattlefield(me, "Force of Nature")
+        driver.putCreatureOnBattlefield(me, "Force of Nature")
+
+        // {4}{U} → {1}{U}: generic 4 - 3 = 1.
+        val orysa = reg.requireCard("Orysa, Tide Choreographer")
+        val cost = calculator.calculateEffectiveCost(driver.state, orysa, me)
+        cost.genericAmount shouldBe 1
+    }
+
+    test("not reduced when total toughness is below 10") {
+        val reg = registry()
+        val calculator = CostCalculator(reg)
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OrysaTideChoreographer))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // One Force of Nature (toughness 5) → total toughness 5, below the threshold.
+        driver.putCreatureOnBattlefield(me, "Force of Nature")
+
+        val orysa = reg.requireCard("Orysa, Tide Choreographer")
+        val cost = calculator.calculateEffectiveCost(driver.state, orysa, me)
+        cost.genericAmount shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerTurnHijackedComponentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerTurnHijackedComponentTest.kt
@@ -97,7 +97,7 @@ class PlayerTurnHijackedComponentTest : FunSpec({
         driver.replaceState(
             driver.state.updateEntity(opponent) { container ->
                 container
-                    .with(SkipNextTurnComponent)
+                    .with(SkipNextTurnComponent())
                     .with(
                         PlayerTurnHijackedComponent(
                             controllerId = active,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrismariTheInspirationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrismariTheInspirationScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.PrismariTheInspiration
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.StormCopyEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Prismari, the Inspiration: "Instant and sorcery spells you cast have storm." The grant is a
+ * [com.wingedsheep.sdk.scripting.GrantKeywordToOwnSpells] static ability read by the cast handler
+ * via [com.wingedsheep.engine.mechanics.mana.GrantedKeywordResolver]. A non-storm instant cast
+ * while Prismari is in play should produce a storm trigger; two Prismaris should produce two.
+ */
+class PrismariTheInspirationScenarioTest : FunSpec({
+
+    fun stormTriggers(driver: GameTestDriver): List<StormCopyEffect> =
+        driver.state.stack.mapNotNull {
+            driver.state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>()
+        }.mapNotNull { it.effect as? StormCopyEffect }
+
+    test("instant cast with Prismari in play gets a storm trigger with copyCount = spells cast before it") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PrismariTheInspiration))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        driver.putCreatureOnBattlefield(caster, "Prismari, the Inspiration")
+        driver.replaceState(driver.state.copy(spellsCastThisTurn = 2))
+        driver.putLandOnBattlefield(caster, "Mountain")
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+
+        driver.castSpell(caster, bolt, listOf(opponent)).isSuccess shouldBe true
+
+        val triggers = stormTriggers(driver)
+        triggers.size shouldBe 1
+        triggers.single().copyCount shouldBe 2
+    }
+
+    test("two Prismaris produce two separate storm triggers (CR 702.40b)") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PrismariTheInspiration))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        driver.putCreatureOnBattlefield(caster, "Prismari, the Inspiration")
+        driver.putCreatureOnBattlefield(caster, "Prismari, the Inspiration")
+        driver.replaceState(driver.state.copy(spellsCastThisTurn = 1))
+        driver.putLandOnBattlefield(caster, "Mountain")
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+
+        driver.castSpell(caster, bolt, listOf(opponent)).isSuccess shouldBe true
+
+        stormTriggers(driver).size shouldBe 2
+    }
+
+    test("without Prismari, an instant produces no storm trigger") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PrismariTheInspiration))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        driver.replaceState(driver.state.copy(spellsCastThisTurn = 2))
+        driver.putLandOnBattlefield(caster, "Mountain")
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+
+        driver.castSpell(caster, bolt, listOf(opponent)).isSuccess shouldBe true
+
+        stormTriggers(driver).size shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuandrixTheProofScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuandrixTheProofScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.QuandrixTheProof
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Quandrix, the Proof {4}{G}{U} — Flying, trample, Cascade, and "Instant and sorcery spells you
+ * cast from your hand have cascade." Both halves are cast-trigger cascade abilities (CR 702.85a)
+ * feeding the shared cascade executor; a cascade hit pauses with a "cast for free?" decision.
+ */
+class QuandrixTheProofScenarioTest : FunSpec({
+
+    // A {4} instant (MV 4) so Lightning Bolt (MV 1) is a legal cascade hit.
+    val BigBlast = card("Big Blast") {
+        manaCost = "{4}"
+        typeLine = "Instant"
+        spell { effect = Effects.GainLife(1) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(QuandrixTheProof)
+        driver.registerCard(BigBlast)
+        return driver
+    }
+
+    test("Quandrix's own cascade fires when cast and finds a cheaper nonland card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        // Cascade walks from the top: a land, then Lightning Bolt (MV 1 < Quandrix's MV 6) as the hit.
+        driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        val quandrix = driver.putCardInHand(me, "Quandrix, the Proof")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 4)
+        driver.submit(
+            CastSpell(playerId = me, cardId = quandrix, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass() // cascade trigger resolves -> finds Lightning Bolt -> may-cast pause
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+    }
+
+    test("an instant cast from hand gets cascade while Quandrix is in play") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Quandrix, the Proof")
+
+        // Cascade walks from the top: a land, then Lightning Bolt (MV 1 < Big Blast's MV 4).
+        driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        val blast = driver.putCardInHand(me, "Big Blast")
+        driver.giveColorlessMana(me, 4)
+        driver.submit(
+            CastSpell(playerId = me, cardId = blast, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass() // granted cascade trigger resolves -> may-cast pause
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+    }
+
+    test("a creature spell from hand does NOT get cascade (filter is instant/sorcery)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Quandrix, the Proof")
+        driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        // Centaur Courser ({2}{G}) is a creature spell — not instant/sorcery, so no cascade.
+        val courser = driver.putCardInHand(me, "Centaur Courser")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(playerId = me, cardId = courser, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No cascade decision — the creature simply resolves.
+        driver.isPaused shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RalZarekGuestLecturerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RalZarekGuestLecturerScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.RalZarekGuestLecturer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContain
+
+/**
+ * Ral Zarek, Guest Lecturer.
+ *
+ * Covers the −2 reanimate (existing primitives) and the [SkipNextTurnComponent] turn-count
+ * mechanic that backs the −7 ultimate. The coin-flip half of the ultimate is exercised by
+ * [FlipCoinsEffectTest]; here we drive the deterministic skip-count directly so the assertion
+ * isn't probabilistic.
+ */
+class RalZarekGuestLecturerScenarioTest : FunSpec({
+
+    test("−2 returns a creature card with mana value 3 or less from your graveyard to the battlefield") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RalZarekGuestLecturer))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val ral = driver.putPermanentOnBattlefield(me, "Ral Zarek, Guest Lecturer")
+        // The battlefield helper doesn't seed loyalty counters; give Ral its starting loyalty.
+        driver.replaceState(
+            driver.state.updateEntity(ral) {
+                it.with(
+                    com.wingedsheep.engine.state.components.battlefield.CountersComponent(
+                        mapOf(com.wingedsheep.sdk.core.CounterType.LOYALTY to 3)
+                    )
+                )
+            }
+        )
+        // Savannah Lions ({W}, MV 1) is a legal target; put it in the graveyard.
+        val bears = driver.putCardInGraveyard(me, "Savannah Lions")
+
+        val minus2 = driver.cardRegistry.requireCard("Ral Zarek, Guest Lecturer")
+            .activatedAbilities.first {
+                (it.cost as? com.wingedsheep.sdk.scripting.AbilityCost.Loyalty)?.change == -2
+            }
+
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = ral,
+                abilityId = minus2.id,
+                targets = listOf(
+                    com.wingedsheep.engine.state.components.stack.ChosenTarget.Card(
+                        cardId = bears, ownerId = me, zone = Zone.GRAVEYARD,
+                    )
+                ),
+            )
+        ).error shouldBe null
+
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        // Bears is now a permanent on the battlefield under my control.
+        driver.state.getBattlefield() shouldContain bears
+        driver.state.getEntity(bears)?.get<ControllerComponent>()?.playerId shouldBe me
+    }
+
+    test("SkipNextTurnComponent with turns = 2 skips that player's next two turns") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+
+        val first = driver.activePlayer!!
+        val second = driver.getOpponent(first)
+
+        // The second player will skip their next two turns.
+        driver.replaceState(
+            driver.state.updateEntity(second) { it.with(SkipNextTurnComponent(2)) }
+        )
+
+        // End turns until the second player finally takes a turn, counting how many turn
+        // transitions it took and how the skip count drains.
+        val skipCountsObserved = mutableListOf<Int?>()
+        var transitions = 0
+        while (driver.activePlayer != second && transitions < 10) {
+            driver.passPriorityUntil(Step.END)
+            driver.bothPass()
+            transitions++
+            skipCountsObserved.add(driver.state.getEntity(second)?.get<SkipNextTurnComponent>()?.turns)
+        }
+
+        // The second player only becomes active once both skipped turns have been consumed.
+        driver.activePlayer shouldBe second
+        // The skip count drained 2 -> 1 -> 0(removed) across the first player's intervening turns.
+        skipCountsObserved.shouldContain(1)
+        driver.state.getEntity(second)?.get<SkipNextTurnComponent>() shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZimonesExperimentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZimonesExperimentScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.sos.cards.ZimonesExperiment
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Zimone's Experiment {3}{G} Sorcery — look at the top five, reveal up to two creature and/or
+ * land cards, lands enter tapped, creatures go to hand, the rest are bottomed at random.
+ */
+class ZimonesExperimentScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ZimonesExperiment)
+        return driver
+    }
+
+    test("revealed land enters tapped, revealed creature goes to hand, rest are bottomed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        // Top five (top-down): a creature, a land, then three filler cards.
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        val land = driver.putCardOnTopOfLibrary(me, "Forest")
+        val creature = driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Zimone's Experiment")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.submit(
+            CastSpell(playerId = me, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve -> look at five -> pause for the up-to-two selection
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        // Among the five, only creature + land cards are eligible (the instant is excluded).
+        // Top five = Centaur Courser, Forest, Lightning Bolt, Forest, Forest → 4 eligible.
+        select.options.size shouldBe 4
+
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(creature, land))
+        )
+        driver.isPaused shouldBe false
+
+        // Creature went to hand.
+        driver.getHand(me).contains(creature) shouldBe true
+        // Land entered the battlefield tapped.
+        driver.getLands(me).contains(land) shouldBe true
+        driver.isTapped(land) shouldBe true
+    }
+
+    test("may reveal nothing — all five go to the bottom") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val handBefore = driver.getHand(me).size
+        val landsBefore = driver.getLands(me).size
+
+        val spell = driver.putCardInHand(me, "Zimone's Experiment")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 3)
+        driver.submit(
+            CastSpell(playerId = me, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        // Decline: reveal nothing.
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = emptyList())
+        )
+        driver.isPaused shouldBe false
+
+        // Nothing added to hand (besides the spell leaving) or to the battlefield.
+        driver.getHand(me).size shouldBe handBefore
+        driver.getLands(me).size shouldBe landsBefore
+    }
+})


### PR DESCRIPTION
Implements five **Secrets of Strixhaven** (SOS) cards via the `add-card` flow, composing existing primitives where possible and adding two small, general engine primitives only where genuinely needed (Ral Zarek's ultimate).

## Cards (all SOS-canonical)

| Card | Notes |
|------|-------|
| **Prismari, the Inspiration** | 7/7 Flying, Ward—Pay 5 life, "instant and sorcery spells you cast have storm" via the existing `GrantKeywordToOwnSpells` static. |
| **Quandrix, the Proof** | 6/6 Flying trample, printed Cascade (self cast trigger) + "instant and sorcery spells you cast from your hand have cascade" (granted cast trigger feeding `Effects.Cascade`, mirroring Wildsear, Scouring Maw). |
| **Ral Zarek, Guest Lecturer** | Planeswalker. +1 Surveil 2; −1 any number of target players each discard; −2 reanimate creature MV≤3 from your graveyard; −7 flip five coins, target opponent skips their next X turns (X = heads). |
| **Zimone's Experiment** | Look at top 5, reveal up to two creature/land cards; lands enter tapped, creatures to hand, rest bottomed at random (atomic Gather→Select→split-by-type→Move pipeline). |
| **Orysa, Tide Choreographer** | Costs {3} less if creatures you control have total toughness ≥ 10 (`ModifySpellCost` + `CostGating.OnlyIf` over `AggregateBattlefield` SUM toughness); ETB draw two. |

## Engine additions (general-purpose)

- **`FlipCoinsEffect(count, storeHeadsAs)`** — flip N coins, tally heads into the pipeline; composes with any count-consuming effect.
- **`SkipNextTurnEffect`** now takes `count: DynamicAmount`; **`SkipNextTurnComponent`** carries a `turns` count that accumulates and decrements one per turn-start. Backward compatible — Last Chance / Time Warp / Ugin's Nexus / hijack tests unchanged.
- **`GrantedKeywordResolver.countGrants`** + boolean-combinator-aware spell-filter matching, so STORM (CR 702.40b) granted by a battlefield permanent is counted **per instance** by `CastSpellHandler` (Prismari). Also fixes `InstantOrSorcery` (an `Or` filter) not matching in the grant resolver.

Ral Zarek's ultimate composes these: `FlipCoins(5) then SkipNextTurn(target opponent, count = VariableReference("heads"))`.

## mtgish-tooling

All 5 cards correctly **DECLINE to SCAFFOLD** (no lossy emission) — `StackSpellsEffect` / `PlayerEffect` / `activated-cost` / `LookAtTheTopNumberCardsOfLibrary` / cost-reduction-if are genuine generator gaps left as SCAFFOLD per the "fix the generator, not the cards" rule. `FlipCoins.storeHeadsAs` classified as a NUMBER write in `CardLinter.dataflowFields`. `EmitterGoldenTest` (incl. SOS) and `CardLintTest` pass.

## Tests

- 6 new scenario/effect test classes (14 tests) — all pass.
- Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets` (snapshot re-blessed: only the 5 new cards added; lint), and `:mtgish-tooling` suites green.

## Docs / backlog

- `docs/card-sdk-language-reference.md`: `SkipNextTurn` count, `FlipCoins`, and `GrantKeywordToOwnSpells` (incl. the storm/cascade grant paths).
- `backlog/sos-engine-gaps.md`: items 11 (multi-turn skip) & 13 (Ral Zarek) marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)