### PR TITLE
Expose Room door-unlock state to the SDK (DSK Tier 1)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2742,6 +2742,31 @@ staticAbility {
   mana cost; generic is floored at {0} and colored pips are never reduced. Doc Aurlock, Grizzled
   Genius: "Plotting cards from your hand costs {2} less" = `ReduceGeneric(2)`.
 
+**Door-unlock cost statics — `ModifyUnlockCost`**
+
+Unlocking a Room door (CR 709.5e) is a *special action*, so neither `ModifySpellCost` nor
+`ModifyPlotCost` touches it. `ModifyUnlockCost(target, modification)` is its dedicated cost modifier,
+evaluated by the engine's `UnlockCostReducer` (consulted by both the unlock legal-action enumerator
+and `UnlockRoomDoorHandler` so affordability and payment stay in lockstep — the same lockstep pattern
+as `ModifyPlotCost`).
+
+```kotlin
+staticAbility {
+    ability = ModifyUnlockCost(
+        target = UnlockCostTarget.YouUnlock,
+        modification = CostModification.ReduceGeneric(1),
+    )
+}
+```
+
+- `target: UnlockCostTarget` — currently `YouUnlock` (unlock actions performed by the source's
+  controller; a future "opponents' unlock costs" tax slots in as a new variant without changing call
+  sites).
+- `modification: CostModification` — like plot, only the flat generic shapes are meaningful (printed
+  unlock cost is a flat mana cost); generic is floored at {0}, colored pips untouched. Inquisitive
+  Glimmer: "Unlock costs you pay cost {1} less" = `ReduceGeneric(1)` (its "Enchantment spells you cast
+  cost {1} less" half is a plain `ModifySpellCost(YouCast(GameObjectFilter.Enchantment), ...)`).
+
 **Global denial statics** (no `filter`/`duration` block — they're singleton-style)
 
 - `PreventCycling` — "Players can't cycle cards." (Stabilizer)
@@ -3753,6 +3778,15 @@ Numbers computed at resolution time.
   `CastRecordComponent` afterward), so it reads correctly both at resolution and as the permanent enters
   (the common use: feeding `EntersWithDynamicCounters`). Facade: `DynamicAmounts.colorsOfManaSpent()`.
   A permanent put onto the battlefield without being cast spent no mana, so this is 0 for it.
+- `UnlockedDoors(player = You, distinctNames = false)` — the number of unlocked doors among Rooms
+  `player` controls (CR 709.5). Reads per-face door state, so a single Room with **both** doors
+  unlocked counts as **two** — an entity-level `AggregateBattlefield`/`Count` cannot see this. With
+  `distinctNames = true`, counts the distinct printed names among those unlocked door faces instead
+  (two Rooms sharing an unlocked face name count once). Controller read via projected state.
+  Facades: `DynamicAmounts.unlockedDoors(player)` and `DynamicAmounts.distinctUnlockedDoorNames(player)`;
+  condition facade `Conditions.UnlockedDoorsAtLeast(count, player)`. Feeds the standard `Compare`
+  machinery — Rampaging Soulrager ("+3/+0 while two or more unlocked doors"), Misty Salon's X/X token,
+  Promising Stairs' "eight or more different names among unlocked doors" alt-win.
 - `Add(a, b)` — `a + b`.
 - `Subtract(a, b)` — `a − b`.
 - `Multiply(a, b)` — `a × b`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -229,6 +229,19 @@ object Conditions {
         )
 
     /**
+     * If [count] or more unlocked doors are among Rooms [player] controls (CR 709.5).
+     * A Room with both doors unlocked counts as two. Evaluates under both resolution and
+     * projection, so it gates "as long as" static buffs (Rampaging Soulrager: +3/+0 while two
+     * or more unlocked doors).
+     */
+    fun UnlockedDoorsAtLeast(count: Int, player: Player = Player.You): ConditionInterface =
+        Compare(
+            DynamicAmount.UnlockedDoors(player),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(count)
+        )
+
+    /**
      * Domain threshold: if [count] or more basic land types are among lands you control.
      * Reads via projected state, so type-changed lands and dual lands count.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -179,6 +179,22 @@ object DynamicAmounts {
     fun differentlyNamedLandsYouControl(player: Player = Player.You): DynamicAmount =
         DynamicAmount.AggregateBattlefield(player, GameObjectFilter.Land, Aggregation.DISTINCT_NAMES)
 
+    /**
+     * The number of unlocked doors among Rooms [player] controls (CR 709.5). A Room with both
+     * doors unlocked counts as two. Used for Misty Salon's X/X token and Rampaging Soulrager's
+     * "two or more unlocked doors" gate (via [Conditions]).
+     */
+    fun unlockedDoors(player: Player = Player.You): DynamicAmount =
+        DynamicAmount.UnlockedDoors(player)
+
+    /**
+     * The number of distinct printed names among unlocked door faces of Rooms [player] controls.
+     * The per-face analogue of [differentlyNamedLandsYouControl] — distinct over door faces, not
+     * whole Room entities. Feeds Promising Stairs' "eight or more different names" alt-win.
+     */
+    fun distinctUnlockedDoorNames(player: Player = Player.You): DynamicAmount =
+        DynamicAmount.UnlockedDoors(player, distinctNames = true)
+
     fun attackingCreaturesYouControl(): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Creature.attacking()).count()
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -699,3 +699,61 @@ sealed interface PlotCostTarget {
     @Serializable
     data object YouPlotFromHand : PlotCostTarget
 }
+
+/**
+ * Static ability that modifies the cost of the **door-unlock** special action (CR 709.5e).
+ *
+ * Unlocking a door is not a spell or the Plot action, so neither [ModifySpellCost] nor
+ * [ModifyPlotCost] touches it; this is its dedicated cost modifier. The engine's
+ * `UnlockCostReducer` scans the battlefield for these and reduces the unlock cost paid by
+ * `UnlockRoomDoorEnumerator` (affordability) and `UnlockRoomDoorHandler` (validate + pay),
+ * keeping the two in lockstep — mirroring the [ModifyPlotCost]/`PlotCostReducer` pair.
+ *
+ * Used for Inquisitive Glimmer ("Unlock costs you pay cost {1} less") via
+ * `ModifyUnlockCost(UnlockCostTarget.YouUnlock, CostModification.ReduceGeneric(1))`. Only
+ * generic [CostModification] reductions/increases are meaningful — the printed unlock cost is
+ * a flat mana cost.
+ *
+ * @property target Whose unlock actions the modifier applies to.
+ * @property modification How the cost is changed (reuses the spell-cost [CostModification]
+ *           vocabulary; only generic adjustments apply to unlocking).
+ */
+@SerialName("ModifyUnlockCost")
+@Serializable
+data class ModifyUnlockCost(
+    val target: UnlockCostTarget,
+    val modification: CostModification,
+) : StaticAbility {
+    override val description: String = buildString {
+        append(
+            when (target) {
+                UnlockCostTarget.YouUnlock -> "Unlock costs you pay"
+            }
+        )
+        append(
+            when (val m = modification) {
+                is CostModification.ReduceGeneric -> " cost {${m.amount}} less"
+                is CostModification.IncreaseGeneric -> " cost {${m.amount}} more"
+                else -> " have a modified cost"
+            }
+        )
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newModification = modification.applyTextReplacement(replacer)
+        return if (newModification !== modification) copy(modification = newModification) else this
+    }
+}
+
+/**
+ * Whose door-unlock actions a [ModifyUnlockCost] applies to. Modeled as a sealed interface so a
+ * future "opponents' unlock costs" tax slots in as a new variant without changing the
+ * static-ability shape.
+ */
+@Serializable
+sealed interface UnlockCostTarget {
+    /** Door-unlock special actions performed by the source's controller ("unlock costs you pay"). */
+    @SerialName("YouUnlock")
+    @Serializable
+    data object YouUnlock : UnlockCostTarget
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -691,6 +691,34 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The number of unlocked doors among Rooms controlled by [player] (CR 709.5). A Room
+     * permanent contributes one per unlocked door face, so a Room with both doors unlocked
+     * counts as two.
+     *
+     * With [distinctNames] = true, counts the distinct printed names among those unlocked
+     * door faces instead of the raw total — the "different names among unlocked doors" shape
+     * (Promising Stairs). This reads per-face door state, which no entity-level aggregate
+     * ([AggregateBattlefield]/[Count]) can see, since a single Room entity carries two faces.
+     *
+     * Feeds the standard [Compare] machinery: pair with `ComparisonOperator.GTE` for
+     * "two or more unlocked doors" gating (Rampaging Soulrager) or a [WinGameEffect]-gated
+     * "eight or more different names" (Promising Stairs), and use it directly as a count
+     * (Misty Salon's X/X token).
+     */
+    @SerialName("UnlockedDoors")
+    @Serializable
+    data class UnlockedDoors(
+        val player: Player = Player.You,
+        val distinctNames: Boolean = false,
+    ) : DynamicAmount {
+        override val description: String = buildString {
+            append("the number of ")
+            append(if (distinctNames) "different names among unlocked doors of Rooms " else "unlocked doors among Rooms ")
+            append(if (player == Player.You) "you control" else "${player.description} controls")
+        }
+    }
+
+    /**
      * Generic battlefield aggregation primitive.
      * Queries permanents on the battlefield, filters them, optionally maps to a numeric
      * property, and applies an aggregation function.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InquisitiveGlimmer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InquisitiveGlimmer.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.ModifyUnlockCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.UnlockCostTarget
+
+/**
+ * Inquisitive Glimmer
+ * {W}{U}
+ * Enchantment Creature — Fox Glimmer
+ * 2/3
+ *
+ * Enchantment spells you cast cost {1} less to cast.
+ * Unlock costs you pay cost {1} less.
+ *
+ * The enchantment-spell discount is a standard [ModifySpellCost]; the unlock discount is the
+ * dedicated [ModifyUnlockCost] (CR 709.5e), routed through the same `UnlockCostReducer` the
+ * unlock special action pays through.
+ */
+val InquisitiveGlimmer = card("Inquisitive Glimmer") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Enchantment Creature — Fox Glimmer"
+    power = 2
+    toughness = 3
+    oracleText = "Enchantment spells you cast cost {1} less to cast.\n" +
+        "Unlock costs you pay cost {1} less."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Enchantment),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    staticAbility {
+        ability = ModifyUnlockCost(
+            target = UnlockCostTarget.YouUnlock,
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Julie Dillon"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg?1726286675"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RampagingSoulrager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RampagingSoulrager.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Rampaging Soulrager
+ * {2}{R}
+ * Creature — Spirit
+ * 1/4
+ *
+ * This creature gets +3/+0 as long as there are two or more unlocked doors among Rooms you control.
+ *
+ * A "Rooms-matter" payoff: the +3/+0 is a [ConditionalStaticAbility] gated on
+ * [Conditions.UnlockedDoorsAtLeast] (CR 709.5), which counts each unlocked door face among Rooms
+ * the controller has — a Room with both doors unlocked counts as two.
+ */
+val RampagingSoulrager = card("Rampaging Soulrager") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 4
+    oracleText = "This creature gets +3/+0 as long as there are two or more unlocked doors among Rooms you control."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 3, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.UnlockedDoorsAtLeast(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Slawomir Maniak"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg?1726286414"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3225,6 +3225,51 @@
     ]
 }
 
+// Inquisitive Glimmer
+{
+    "name": "Inquisitive Glimmer",
+    "manaCost": "{W}{U}",
+    "typeLine": "Enchantment Creature — Fox Glimmer",
+    "oracleText": "Enchantment spells you cast cost {1} less to cast.\nUnlock costs you pay cost {1} less.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "enchantment"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            },
+            {
+                "type": "ModifyUnlockCost",
+                "target": "YouUnlock",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Julie Dillon",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg?1726286675"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Insidious Fungus
 {
     "name": "Insidious Fungus",
@@ -4412,6 +4457,51 @@
         "artist": "Kaitlyn McCulley",
         "flavorText": "\"You tried to throw me away, Henry. I don't like that at all.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/0/0/000499a4-3f39-4d25-a2a2-b2f014e30754.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rampaging Soulrager
+{
+    "name": "Rampaging Soulrager",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "This creature gets +3/+0 as long as there are two or more unlocked doors among Rooms you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 3,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "UnlockedDoors",
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Slawomir Maniak",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg?1726286414"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Subtype
@@ -156,6 +157,26 @@ class DynamicAmountEvaluator(
                 val playerIds = resolveUnifiedPlayerIds(state, amount.player, context)
                 val playerId = playerIds.firstOrNull() ?: return 0
                 state.getEntity(playerId)?.get<PlayerComponent>()?.startingLifeTotal ?: 20
+            }
+
+            // Unlocked doors among Rooms the player controls (CR 709.5). Reads per-face door
+            // state off each Room's RoomComponent — a single Room entity can contribute two
+            // doors, so this can't go through the entity-level AggregateBattlefield. Controller
+            // is read from projection so control-changing effects move a Room's doors with it.
+            is DynamicAmount.UnlockedDoors -> {
+                val playerIds = resolveUnifiedPlayerIds(state, amount.player, context).toSet()
+                val projection = resolveProjection(state, projectedState)
+                val rooms = state.getBattlefield().mapNotNull { entityId ->
+                    val room = state.getEntity(entityId)?.get<RoomComponent>() ?: return@mapNotNull null
+                    if (controllerOf(state, projection, entityId) in playerIds) room else null
+                }
+                if (amount.distinctNames) {
+                    rooms.flatMapTo(mutableSetOf()) { room ->
+                        room.faces.filter { it.id in room.unlocked }.map { it.name }
+                    }.size
+                } else {
+                    rooms.sumOf { it.unlocked.size }
+                }
             }
 
             is DynamicAmount.VariableReference -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.UnlockCostReducer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -43,8 +44,13 @@ class UnlockRoomDoorHandler(
     private val triggerDetector: TriggerDetector,
     private val triggerProcessor: TriggerProcessor,
     private val manaAbilitySideEffectExecutor: ManaAbilitySideEffectExecutor,
+    cardRegistry: com.wingedsheep.engine.registry.CardRegistry,
 ) : ActionHandler<UnlockRoomDoor> {
     override val actionType: KClass<UnlockRoomDoor> = UnlockRoomDoor::class
+
+    // Inquisitive-Glimmer-style "Unlock costs you pay cost {N} less" reductions. The enumerator
+    // applies the same reducer so affordability and payment agree (CR 709.5e).
+    private val unlockCostReducer = UnlockCostReducer(cardRegistry)
 
     override fun validate(state: GameState, action: UnlockRoomDoor): String? {
         if (state.priorityPlayerId != action.playerId) {
@@ -82,7 +88,7 @@ class UnlockRoomDoorHandler(
             return "This door is already unlocked"
         }
 
-        val cost = face.manaCost
+        val cost = unlockCostReducer.effectiveUnlockCost(state, action.playerId, face.manaCost)
         when (action.paymentStrategy) {
             is PaymentStrategy.AutoPay -> {
                 if (!manaSolver.canPay(state, action.playerId, cost, 0)) {
@@ -137,7 +143,9 @@ class UnlockRoomDoorHandler(
         val face = room.faces.find { it.id == action.faceId }
             ?: return ExecutionResult.error(state, "Unknown face")
 
-        // Pay the face's mana cost (the unlock cost, per CR 709.5e).
+        // Pay the face's mana cost (the unlock cost, per CR 709.5e), after any
+        // "Unlock costs you pay cost {N} less" reductions (Inquisitive Glimmer).
+        val cost = unlockCostReducer.effectiveUnlockCost(currentState, action.playerId, face.manaCost)
         when (action.paymentStrategy) {
             is PaymentStrategy.FromPool -> {
                 val poolComponent = currentState.getEntity(action.playerId)?.get<ManaPoolComponent>()
@@ -150,7 +158,7 @@ class UnlockRoomDoorHandler(
                     green = poolComponent.green,
                     colorless = poolComponent.colorless
                 )
-                val newPool = costHandler.payManaCost(pool, face.manaCost)
+                val newPool = costHandler.payManaCost(pool, cost)
                     ?: return ExecutionResult.error(currentState, "Insufficient mana in pool")
                 currentState = currentState.updateEntity(action.playerId) { c ->
                     c.with(
@@ -188,7 +196,7 @@ class UnlockRoomDoorHandler(
                     green = poolComponent.green,
                     colorless = poolComponent.colorless
                 )
-                val partialResult = pool.payPartial(face.manaCost)
+                val partialResult = pool.payPartial(cost)
                 val poolAfterPayment = partialResult.newPool
                 val remainingCost = partialResult.remainingCost
                 val manaSpentFromPool = partialResult.manaSpent
@@ -318,6 +326,7 @@ class UnlockRoomDoorHandler(
                 triggerDetector = services.triggerDetector,
                 triggerProcessor = services.triggerProcessor,
                 manaAbilitySideEffectExecutor = services.manaAbilitySideEffectExecutor,
+                cardRegistry = services.cardRegistry,
             )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -59,6 +59,10 @@ class EnumerationContext(
     // Plot (CR 718) cost reduction — Doc Aurlock-style "plotting cards costs {N} less".
     val plotCostReducer by lazy { com.wingedsheep.engine.mechanics.mana.PlotCostReducer(cardRegistry) }
 
+    // Door-unlock (CR 709.5e) cost reduction — Inquisitive-Glimmer-style "Unlock costs you pay
+    // cost {N} less". Kept in lockstep with UnlockRoomDoorHandler's own reducer.
+    val unlockCostReducer by lazy { com.wingedsheep.engine.mechanics.mana.UnlockCostReducer(cardRegistry) }
+
     // Projected state
     val projected: ProjectedState by lazy { state.projectedState }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/UnlockRoomDoorEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/UnlockRoomDoorEnumerator.kt
@@ -26,7 +26,7 @@ class UnlockRoomDoorEnumerator : ActionEnumerator {
             val room = container.get<RoomComponent>() ?: continue
 
             for (face in room.lockedFaces) {
-                val cost = face.manaCost
+                val cost = context.unlockCostReducer.effectiveUnlockCost(state, playerId, face.manaCost)
                 if (!context.manaSolver.canPay(state, playerId, cost, precomputedSources = context.availableManaSources)) {
                     continue
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -114,6 +114,7 @@ import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.ModifyPlotCost
 import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.ModifyUnlockCost
 import com.wingedsheep.sdk.scripting.NoMaximumHandSize
 import com.wingedsheep.sdk.scripting.NoncombatDamageBonus
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
@@ -738,6 +739,10 @@ class StaticAbilityHandler(
 
             // Plot special-action cost (PlotCostReducer / PlotEnumerator / PlotCardHandler):
             is ModifyPlotCost,
+
+            // Door-unlock special-action cost (UnlockCostReducer / UnlockRoomDoorEnumerator /
+            // UnlockRoomDoorHandler):
+            is ModifyUnlockCost,
 
             // Spells on the stack (StackResolver / GrantedKeywordResolver):
             is GrantCantBeCountered,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/UnlockCostReducer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/UnlockCostReducer.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.mechanics.mana
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.ManaSymbol
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifyUnlockCost
+import com.wingedsheep.sdk.scripting.UnlockCostTarget
+
+/**
+ * Computes the effective cost of the **door-unlock** special action (CR 709.5e) after applying
+ * battlefield [ModifyUnlockCost] static abilities.
+ *
+ * Unlocking is neither a spell nor the Plot action, so neither [CostCalculator] (which works on
+ * `ModifySpellCost`) nor [PlotCostReducer] touches it; this is unlocking's dedicated, parallel
+ * cost-reduction path. Both
+ * [com.wingedsheep.engine.legalactions.enumerators.UnlockRoomDoorEnumerator] (affordability) and
+ * [com.wingedsheep.engine.handlers.actions.room.UnlockRoomDoorHandler] (validate + pay) route the
+ * unlock cost through here so the two stay in lockstep.
+ *
+ * Only [UnlockCostTarget.YouUnlock] is matched today (Inquisitive Glimmer: "Unlock costs you pay
+ * cost {1} less"); a future "opponents' unlock costs" tax adds an [UnlockCostTarget] variant
+ * without changing call sites. Only generic [CostModification] reductions/increases are meaningful
+ * — the printed unlock cost is a flat mana cost.
+ */
+class UnlockCostReducer(
+    private val cardRegistry: CardRegistry,
+) {
+    /**
+     * The unlock cost [unlockerId] actually pays, after reductions. Floored at {0} generic;
+     * colored pips are never reduced below the printed requirement.
+     */
+    fun effectiveUnlockCost(state: GameState, unlockerId: EntityId, baseCost: ManaCost): ManaCost {
+        var totalReduction = 0
+        var totalIncrease = 0
+        for ((sourceId, ability) in scanBattlefield(state)) {
+            if (ability.target != UnlockCostTarget.YouUnlock) continue
+            if (state.projectedState.getController(sourceId) != unlockerId) continue
+            when (val mod = ability.modification) {
+                is CostModification.ReduceGeneric -> totalReduction += mod.amount
+                is CostModification.IncreaseGeneric -> totalIncrease += mod.amount
+                else -> { /* unlocking only supports flat generic adjustments */ }
+            }
+        }
+        var cost = baseCost
+        if (totalIncrease > 0) cost = increaseGeneric(cost, totalIncrease)
+        if (totalReduction > 0) cost = cost.reduceGeneric(totalReduction)
+        return cost
+    }
+
+    private fun increaseGeneric(cost: ManaCost, increase: Int): ManaCost {
+        if (increase <= 0) return cost
+        val colored = cost.symbols.filter { it !is ManaSymbol.Generic }
+        val newGeneric = cost.genericAmount + increase
+        val symbols = if (newGeneric > 0) {
+            listOf(ManaSymbol.Generic(newGeneric)) + colored
+        } else colored
+        return ManaCost(symbols)
+    }
+
+    private fun scanBattlefield(state: GameState): List<Pair<EntityId, ModifyUnlockCost>> {
+        val results = mutableListOf<Pair<EntityId, ModifyUnlockCost>>()
+        for (playerId in state.turnOrder) {
+            for (entityId in state.getBattlefield(playerId)) {
+                val container = state.getEntity(entityId) ?: continue
+                val card = container.get<CardComponent>() ?: continue
+                val def = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+                val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+                for (ability in def.script.effectiveStaticAbilities(classLevel)) {
+                    if (ability is ModifyUnlockCost) results += entityId to ability
+                }
+            }
+        }
+        return results
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InquisitiveGlimmerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InquisitiveGlimmerScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.InquisitiveGlimmer
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Inquisitive Glimmer (DSK 217): "Enchantment spells you cast cost {1} less to cast. Unlock costs
+ * you pay cost {1} less." Proves the new [com.wingedsheep.sdk.scripting.ModifyUnlockCost] reduces
+ * the door-unlock special action through `UnlockCostReducer`, and confirms the enchantment-spell
+ * half rides the existing `ModifySpellCost` machinery.
+ */
+class InquisitiveGlimmerScenarioTest : FunSpec({
+
+    // A vanilla {2} enchantment used only to observe the enchantment-spell discount.
+    val testEnchantment = card("Glimmer Test Sigil") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(InquisitiveGlimmer)
+        d.registerCard(UnholyAnnexRitualChamber)
+        d.registerCard(testEnchantment)
+        d.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("with Inquisitive Glimmer out, the {3}{B}{B} unlock costs only {2}{B}{B} — four mana is enough") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(p1, InquisitiveGlimmer.name)
+
+        // Cast Unholy Annex (face 0).
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+
+        // Ritual Chamber's printed unlock is {3}{B}{B} (5 mana). With Glimmer it is {2}{B}{B}
+        // (4 mana). Give exactly four black — only enough if the reduction applied.
+        d.giveMana(p1, Color.BLACK, 4)
+        d.submitSuccess(UnlockRoomDoor(p1, roomId, RoomFaceId("Ritual Chamber")))
+        d.bothPass()
+
+        d.state.getEntity(roomId)?.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+    }
+
+    test("without Inquisitive Glimmer, four mana cannot pay the {3}{B}{B} unlock") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+
+        // No Glimmer in play: the unlock still costs the full {3}{B}{B}, so four mana is short.
+        d.giveMana(p1, Color.BLACK, 4)
+        d.submitExpectFailure(UnlockRoomDoor(p1, roomId, RoomFaceId("Ritual Chamber")))
+        d.state.getEntity(roomId)?.get<RoomComponent>()!!.isFullyUnlocked shouldBe false
+    }
+
+    test("with Inquisitive Glimmer out, a {2} enchantment spell costs only {1}") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(p1, InquisitiveGlimmer.name)
+
+        val sigil = d.putCardInHand(p1, testEnchantment.name)
+        d.giveMana(p1, Color.BLACK, 1)
+        d.submitSuccess(CastSpell(p1, sigil))
+        d.bothPass()
+
+        (sigil in d.state.getBattlefield()) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RampagingSoulragerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RampagingSoulragerScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.RampagingSoulrager
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rampaging Soulrager (DSK 151): "+3/+0 as long as there are two or more unlocked doors among
+ * Rooms you control." Proves the [com.wingedsheep.sdk.scripting.values.DynamicAmount.UnlockedDoors]
+ * door count drives a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] under projection,
+ * counting *door faces* — so a single Room with both doors unlocked supplies the two needed.
+ */
+class RampagingSoulragerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(RampagingSoulrager)
+        d.registerCard(UnholyAnnexRitualChamber)
+        d.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("Soulrager is a 1/4 with zero or one unlocked door, and a 4/4 once a second door is unlocked") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val soulrager = d.putCreatureOnBattlefield(p1, RampagingSoulrager.name)
+
+        // No Rooms yet → 0 unlocked doors → base 1/4.
+        d.state.projectedState.getPower(soulrager) shouldBe 1
+        d.state.projectedState.getToughness(soulrager) shouldBe 4
+
+        // Cast Unholy Annex (face 0). One unlocked door — still below the threshold.
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+        d.state.projectedState.getPower(soulrager) shouldBe 1
+        d.state.projectedState.getToughness(soulrager) shouldBe 4
+
+        // Unlock the other door ({3}{B}{B}). Now both doors of the one Room are unlocked = two
+        // unlocked doors → the +3/+0 turns on.
+        d.giveMana(p1, Color.BLACK, 5)
+        d.submitSuccess(UnlockRoomDoor(p1, roomId, RoomFaceId("Ritual Chamber")))
+        d.bothPass()
+        d.state.projectedState.getPower(soulrager) shouldBe 4
+        d.state.projectedState.getToughness(soulrager) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnlockedDoorCountScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnlockedDoorCountScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exercises [DynamicAmount.UnlockedDoors] with `distinctNames = true` — the Promising-Stairs shape
+ * ("different names among unlocked doors"). This is genuinely separate evaluator logic from the raw
+ * door total (proven by Rampaging Soulrager): it deduplicates by printed door-face name, so two
+ * Rooms that share an unlocked face name count once.
+ *
+ * The probe is a 1/1 whose +10/+0 turns on at two or more *distinct* unlocked door names, read
+ * under projection.
+ */
+class UnlockedDoorCountScenarioTest : FunSpec({
+
+    val watcher = card("Distinct Door Watcher") {
+        manaCost = "{1}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        staticAbility {
+            ability = ConditionalStaticAbility(
+                ability = ModifyStats(powerBonus = 10, toughnessBonus = 0, filter = GroupFilter.source()),
+                condition = Compare(
+                    DynamicAmount.UnlockedDoors(distinctNames = true),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(2),
+                ),
+            )
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(watcher)
+        d.registerCard(UnholyAnnexRitualChamber)
+        d.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("one Room with both doors unlocked = two distinct door names → the probe is buffed") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val probe = d.putCreatureOnBattlefield(p1, watcher.name)
+
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+        // Only "Unholy Annex" unlocked so far — one distinct name, no buff.
+        d.state.projectedState.getPower(probe) shouldBe 1
+
+        d.giveMana(p1, Color.BLACK, 5)
+        d.submitSuccess(UnlockRoomDoor(p1, roomId, RoomFaceId("Ritual Chamber")))
+        d.bothPass()
+        // "Unholy Annex" + "Ritual Chamber" = two distinct names → +10/+0.
+        d.state.projectedState.getPower(probe) shouldBe 11
+    }
+
+    test("two Rooms sharing one unlocked face name = two doors but one distinct name → no buff") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val probe = d.putCreatureOnBattlefield(p1, watcher.name)
+
+        // Two copies of Unholy Annex // Ritual Chamber, each cast on its "Unholy Annex" face.
+        val roomA = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomA, faceIndex = 0))
+        d.bothPass()
+
+        val roomB = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        d.giveMana(p1, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(p1, roomB, faceIndex = 0))
+        d.bothPass()
+
+        // Two unlocked doors total, but both are named "Unholy Annex": distinct names = 1, so the
+        // distinct-name gate (≥ 2) stays off even though the raw total is 2.
+        d.state.projectedState.getPower(probe) shouldBe 1
+    }
+})


### PR DESCRIPTION
Implements **Tier 1** from `backlog/dsk-engine-gaps.md` — *Rooms door-state exposure*. The engine
tracked door-unlock state in `RoomComponent` but never exposed it to the SDK. This one cohesive
feature adds that surface (CR 709.5), the highest-leverage gap among the DSK remainders.

## What's added

**Door counting / gating**
- `DynamicAmount.UnlockedDoors(player, distinctNames)` — sums unlocked door *faces* among Rooms a
  player controls (a single Room with both doors unlocked counts as **two** — per-face state that no
  entity-level `AggregateBattlefield`/`Count` can see). With `distinctNames = true` it counts
  distinct printed door-face names instead. Controller read via projected state.
- Facades: `DynamicAmounts.unlockedDoors()` / `.distinctUnlockedDoorNames()`,
  `Conditions.UnlockedDoorsAtLeast(n)`. Threshold gating reuses the existing `Compare` machinery —
  no new `Condition` type.

**Unlock-action cost reduction**
- `ModifyUnlockCost(target, modification)` static ability + `UnlockCostTarget`, mirroring the
  `ModifyPlotCost`/`PlotCostReducer` pair. The new `UnlockCostReducer` is consulted by both
  `UnlockRoomDoorEnumerator` (affordability + displayed cost) and `UnlockRoomDoorHandler`
  (validate + pay) so they stay in lockstep. "unlock cost" is the literal CR 709.5e term.

## Proof cards (fully buildable on Tier 1 alone)
- **Rampaging Soulrager** — +3/+0 while two or more unlocked doors.
- **Inquisitive Glimmer** — `ModifySpellCost(Enchantment)` + `ModifyUnlockCost`.

## Tests
- `RampagingSoulragerScenarioTest` — buff off at 0/1 doors, on once a second door is unlocked.
- `UnlockedDoorCountScenarioTest` — distinct-name path: on at two distinct names; **off** when two
  Rooms share an unlocked face name (total 2, distinct 1), proving distinct ≠ total.
- `InquisitiveGlimmerScenarioTest` — four mana pays the `{3}{B}{B}` unlock with Glimmer out, and
  fails without it; plus the enchantment-spell discount.
- Full `:rules-engine` + `:mtg-sets` suites green; DSK card snapshot golden re-blessed.

## Scope notes
- **Smoky Lounge // Misty Salon** and **Central Elevator // Promising Stairs** carry *non-Tier-1*
  dependencies (restricted "Room spells and unlock doors" mana; a Room-name library search), so
  their door-state halves (`unlockedDoors` token count, `distinctUnlockedDoorNames` alt-win) are
  proven at the primitive level rather than shipped as whole cards.
- mtgish generator (add-feature Step 8b) deferred: these primitives are narrow/DSK-specific and the
  motivating cards are isolated rares — no obvious corpus-wide tag to bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)