### PR TITLE
Rename MorphDataComponent → FaceDownTurnUpComponent

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -228,7 +228,7 @@ sealed interface StatePredicate {
         override val description: String = "face-up"
     }
 
-    /** Has a morph ability (has MorphDataComponent) */
+    /** Has a morph ability (has HasMorphAbilityComponent) */
     @SerialName("HasMorphAbility")
     @Serializable
     data object HasMorphAbility : Entity {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -321,7 +321,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TokenComponent::class)
         subclass(FaceDownComponent::class)
         subclass(RevealedToComponent::class)
-        subclass(MorphDataComponent::class)
+        subclass(FaceDownTurnUpComponent::class)
         subclass(ManifestedComponent::class)
         subclass(TextReplacementComponent::class)
         subclass(ProtectionComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -24,7 +24,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.sdk.core.Color
@@ -895,7 +895,7 @@ class PredicateEvaluator {
             // Morph ability — check both the runtime component (face-down permanents)
             // and the card definition tag (cards in hand/library/graveyard)
             StatePredicate.HasMorphAbility ->
-                container.has<MorphDataComponent>() ||
+                container.has<FaceDownTurnUpComponent>() ||
                 container.has<HasMorphAbilityComponent>()
 
             // Ring-bearer designation (CR 701.54e): only while it has the component AND is controlled

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -26,7 +26,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.ManifestedComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Effects
@@ -79,13 +79,13 @@ class TurnFaceUpHandler(
             return "This creature is not face-down"
         }
 
-        val morphData = container.get<MorphDataComponent>()
+        val turnUpData = container.get<FaceDownTurnUpComponent>()
             ?: return "This creature cannot be turned face up (no morph cost)"
 
         // Validate cost payment based on morph cost type.
         // Apply morph cost increases from permanents like Exiled Doomsayer.
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(state)
-        val morphCost = morphData.morphCost
+        val morphCost = turnUpData.turnUpCost
         val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
         when {
             manaMorph != null -> {
@@ -158,17 +158,17 @@ class TurnFaceUpHandler(
         val container = state.getEntity(action.sourceId)
             ?: return ExecutionResult.error(state, "Permanent not found")
 
-        val morphData = container.get<MorphDataComponent>()
+        val turnUpData = container.get<FaceDownTurnUpComponent>()
             ?: return ExecutionResult.error(state, "No morph data found")
 
         val cardComponent = container.get<CardComponent>()
-        val cardDef = cardRegistry.getCard(morphData.originalCardDefinitionId)
+        val cardDef = cardRegistry.getCard(turnUpData.originalCardDefinitionId)
         val cardName = cardDef?.name ?: cardComponent?.name ?: "Unknown"
 
         // Pay the morph cost (including any morph cost increases)
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(currentState)
         val xValue = action.xValue ?: 0
-        val morphCost = morphData.morphCost
+        val morphCost = turnUpData.turnUpCost
         val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
         when {
             manaMorph != null -> {
@@ -342,7 +342,7 @@ class TurnFaceUpHandler(
             // face down — equivalent to never having taken the action.
             else -> {
                 val flip: com.wingedsheep.sdk.scripting.effects.Effect =
-                    morphData.faceUpEffect
+                    turnUpData.faceUpEffect
                         ?.let { Effects.Composite(TurnFaceUpEffect(EffectTarget.Self), it) }
                         ?: TurnFaceUpEffect(EffectTarget.Self)
                 return when (
@@ -375,12 +375,12 @@ class TurnFaceUpHandler(
         }
 
         // Execute face-up replacement effect (e.g., "put five +1/+1 counters on it")
-        if (morphData.faceUpEffect != null) {
+        if (turnUpData.faceUpEffect != null) {
             val effectContext = com.wingedsheep.engine.handlers.EffectContext(
                 sourceId = action.sourceId,
                 controllerId = action.playerId,
             )
-            val effectResult = effectExecutorRegistry.execute(currentState, morphData.faceUpEffect, effectContext)
+            val effectResult = effectExecutorRegistry.execute(currentState, turnUpData.faceUpEffect, effectContext)
             if (effectResult.error == null) {
                 currentState = effectResult.state
                 events.addAll(effectResult.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
@@ -1,6 +1,6 @@
 package com.wingedsheep.engine.handlers.effects
 
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.costs.CostAtom
@@ -8,11 +8,11 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 
 /**
- * Derives the [MorphDataComponent] that lets a face-down permanent be turned face up, given the
+ * Derives the [FaceDownTurnUpComponent] that lets a face-down permanent be turned face up, given the
  * card it represents and the [FaceDownMode] under which it entered the battlefield.
  *
  * This is the one place that knows the turn-up rule of each face-down mechanic. The turn-up itself
- * (special action, payment, flip) is mechanic-agnostic — it reads only [MorphDataComponent] — so a
+ * (special action, payment, flip) is mechanic-agnostic — it reads only [FaceDownTurnUpComponent] — so a
  * manifested creature reuses the entire morph turn-up machinery for free.
  *
  * Returns `null` when the permanent has no way to be turned face up (a non-morph card entered as
@@ -24,11 +24,11 @@ object FaceDownTurnUp {
         cardDef: CardDefinition?,
         cardDefinitionId: String,
         mode: FaceDownMode
-    ): MorphDataComponent? = when (mode) {
+    ): FaceDownTurnUpComponent? = when (mode) {
         // Morph / Megamorph (CR 702.37): turn face up by paying the card's morph cost.
         FaceDownMode.MORPH -> {
             val morph = cardDef?.keywordAbilities?.filterIsInstance<KeywordAbility.Morph>()?.firstOrNull()
-            morph?.let { MorphDataComponent(it.morphCost, cardDefinitionId, it.faceUpEffect) }
+            morph?.let { FaceDownTurnUpComponent(it.morphCost, cardDefinitionId, it.faceUpEffect) }
         }
 
         // Manifest / Cloak (CR 701.40b): turn face up by paying the card's mana cost, but only if
@@ -36,8 +36,8 @@ object FaceDownTurnUp {
         // can never be turned face up this way.
         FaceDownMode.MANIFEST ->
             if (cardDef != null && cardDef.typeLine.isCreature) {
-                MorphDataComponent(
-                    morphCost = PayCost.Atom(CostAtom.Mana(cardDef.manaCost)),
+                FaceDownTurnUpComponent(
+                    turnUpCost = PayCost.Atom(CostAtom.Mana(cardDef.manaCost)),
                     originalCardDefinitionId = cardDefinitionId,
                     faceUpEffect = null
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -44,7 +44,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.CommanderComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
@@ -267,7 +267,7 @@ object ZoneMovementUtils {
             // Identity
             .without<ControllerComponent>()
             .without<FaceDownComponent>()
-            .without<MorphDataComponent>()
+            .without<FaceDownTurnUpComponent>()
             .without<RevealedToComponent>()
             // Copy effects on permanents end when the object leaves the battlefield
             // (CR 400.7 / 707.2). ZoneTransitionService restores the printed

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.ManifestedComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
@@ -46,7 +46,7 @@ data class ZoneEntryOptions(
     val tapped: Boolean = false,
     val tappedAndAttacking: Boolean = false,
     val faceDown: Boolean = false,
-    val morphData: MorphDataComponent? = null,
+    val turnUpData: FaceDownTurnUpComponent? = null,
     /** True when the face-down battlefield entry is a manifest (CR 701.40), not a morph. */
     val manifested: Boolean = false,
     val skipZoneChangeRedirect: Boolean = false,
@@ -714,8 +714,8 @@ object ZoneTransitionService {
             // Face-down entry (morph / manifest)
             if (options.faceDown) {
                 updated = updated.with(FaceDownComponent)
-                if (options.morphData != null) {
-                    updated = updated.with(options.morphData)
+                if (options.turnUpData != null) {
+                    updated = updated.with(options.turnUpData)
                 }
                 if (options.manifested) {
                     updated = updated.with(ManifestedComponent)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -653,7 +653,7 @@ class MoveCollectionExecutor(
             // its identity and the mode. Per-card because manifested cards turn up for their own
             // (differing) mana costs. Exile face-down (Hideaway) is just hidden — no turn-up data.
             val isBattlefieldFaceDown = faceDown != null && destZone == Zone.BATTLEFIELD
-            val morphData = if (isBattlefieldFaceDown) {
+            val turnUpData = if (isBattlefieldFaceDown) {
                 val cardDefinitionId = newState.getEntity(cardId)?.get<CardComponent>()?.cardDefinitionId
                 if (cardDefinitionId != null) {
                     com.wingedsheep.engine.handlers.effects.FaceDownTurnUp.dataFor(
@@ -668,7 +668,7 @@ class MoveCollectionExecutor(
                 tapped = destination.placement == ZonePlacement.Tapped || destination.placement == ZonePlacement.TappedAndAttacking,
                 tappedAndAttacking = destination.placement == ZonePlacement.TappedAndAttacking,
                 faceDown = isBattlefieldFaceDown,
-                morphData = morphData,
+                turnUpData = turnUpData,
                 manifested = isBattlefieldFaceDown && faceDown == FaceDownMode.MANIFEST,
                 faceDownExile = faceDown != null && destZone == Zone.EXILE
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceDownExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceDownExecutor.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
  *
  * Adds FaceDownComponent to the target creature. The creature becomes
  * a 2/2 colorless creature with no name, types, or abilities (Rule 708.2).
- * MorphDataComponent should already be present on the creature.
+ * FaceDownTurnUpComponent should already be present on the creature.
  */
 class TurnFaceDownExecutor : EffectExecutor<TurnFaceDownEffect> {
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -261,7 +261,7 @@ class MoveToZoneEffectExecutor(
         // Derive turn-up data for a face-down battlefield entry (morph cost vs. manifest mana cost).
         val faceDownMode = effect.faceDown
         val isBattlefieldFaceDown = faceDownMode != null && effect.destination == Zone.BATTLEFIELD
-        val morphData = if (isBattlefieldFaceDown) {
+        val turnUpData = if (isBattlefieldFaceDown) {
             com.wingedsheep.engine.handlers.effects.FaceDownTurnUp.dataFor(
                 cardRegistry.getCard(cardComponent.cardDefinitionId),
                 cardComponent.cardDefinitionId,
@@ -275,7 +275,7 @@ class MoveToZoneEffectExecutor(
             tapped = effect.placement == ZonePlacement.Tapped,
             tappedAndAttacking = effect.placement == ZonePlacement.TappedAndAttacking,
             faceDown = isBattlefieldFaceDown,
-            morphData = morphData,
+            turnUpData = turnUpData,
             manifested = isBattlefieldFaceDown && faceDownMode == FaceDownMode.MANIFEST
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 
@@ -36,12 +36,12 @@ class TurnFaceUpEnumerator : ActionEnumerator {
             if (!container.has<FaceDownComponent>()) continue
 
             // Must have morph data (to get the morph cost)
-            val morphData = container.get<MorphDataComponent>() ?: continue
+            val turnUpData = container.get<FaceDownTurnUpComponent>() ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
 
             // Check if player can afford the morph cost (including any morph cost increases)
             val morphCostIncrease = context.costCalculator.calculateMorphCostIncrease(state)
-            val cost = morphData.morphCost
+            val cost = turnUpData.turnUpCost
             val manaMorph = (cost as? PayCost.Atom)?.atom as? CostAtom.Mana
             when {
                 manaMorph != null -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
@@ -407,7 +407,7 @@ internal class AffectsFilterResolver {
         StatePredicate.IsFaceDown -> isFaceDown
         StatePredicate.IsFaceUp -> !isFaceDown
         StatePredicate.HasMorphAbility ->
-            container.has<MorphDataComponent>() || container.has<HasMorphAbilityComponent>()
+            container.has<FaceDownTurnUpComponent>() || container.has<HasMorphAbilityComponent>()
         StatePredicate.IsRingBearer -> {
             val bearer = container.get<com.wingedsheep.engine.state.components.identity.RingBearerComponent>()
             bearer != null && projectedController(state, entityId, projectedValues) == bearer.ownerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -28,7 +28,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.CopyOfComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.identity.ExileAfterResolveComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.components.identity.PlottedComponent
@@ -98,7 +98,7 @@ class StackResolver(
      *
      * @param castFaceDown If true, cast as a face-down 2/2 creature (morph). The spell
      *                     will resolve as a face-down creature with FaceDownComponent
-     *                     and MorphDataComponent.
+     *                     and FaceDownTurnUpComponent.
      * @param damageDistribution Pre-chosen damage distribution for DividedDamageEffect spells
      */
     fun castSpell(
@@ -213,8 +213,8 @@ class StackResolver(
             val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
             val morphAbility = cardDef?.keywordAbilities?.filterIsInstance<KeywordAbility.Morph>()?.firstOrNull()
             if (morphAbility != null) {
-                updated = updated.with(MorphDataComponent(
-                    morphCost = morphAbility.morphCost,
+                updated = updated.with(FaceDownTurnUpComponent(
+                    turnUpCost = morphAbility.morphCost,
                     originalCardDefinitionId = cardComponent.cardDefinitionId,
                     faceUpEffect = morphAbility.faceUpEffect
                 ))
@@ -1085,7 +1085,7 @@ class StackResolver(
 
             // If cast face-down (morph), add FaceDownComponent and strip any
             // RevealedToComponent from hand-peek effects (zone change = new object)
-            // MorphDataComponent was already added when the spell was cast
+            // FaceDownTurnUpComponent was already added when the spell was cast
             if (spellComponent.castFaceDown) {
                 updated = updated.with(FaceDownComponent)
                     .without<RevealedToComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
@@ -12,12 +12,16 @@ import kotlinx.serialization.Serializable
 data object FaceDownComponent : Component
 
 /**
- * Stores the morph cost and original card identity for face-down creatures.
- * This allows the creature to be turned face up by paying the morph cost.
+ * The "turn face up" record for a face-down permanent — shared by every face-down mechanic
+ * (morph, manifest, …). [turnUpCost] is the cost to turn it face up (the morph cost for a morph,
+ * the card's mana cost for a manifested creature card — see
+ * [com.wingedsheep.engine.handlers.effects.FaceDownTurnUp], which derives it at entry), and
+ * [originalCardDefinitionId] records what the permanent really is. Absent when the permanent has no
+ * way to be turned face up (e.g. a manifested non-creature card, CR 701.40b).
  */
 @Serializable
-data class MorphDataComponent(
-    val morphCost: PayCost,
+data class FaceDownTurnUpComponent(
+    val turnUpCost: PayCost,
     val originalCardDefinitionId: String,
     /** Effect to execute as a replacement effect when turned face up (e.g., put 5 +1/+1 counters on it) */
     val faceUpEffect: Effect? = null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -746,7 +746,7 @@ class ClientStateTransformer(
             projectedState.isCreature(entityId)
 
         // Get morph data for face-down creatures
-        val morphData = container.get<MorphDataComponent>()
+        val turnUpData = container.get<FaceDownTurnUpComponent>()
 
         // Handle face-down card masking
         // Opponents and spectators see modified stats but no card information
@@ -1134,7 +1134,7 @@ class ClientStateTransformer(
             isPlotted = isPlotted,
             isPrepared = isPrepared,
             isWarped = isWarped,
-            morphCost = if (isFaceDown && morphData != null) morphData.morphCost.description else null,
+            morphCost = if (isFaceDown && turnUpData != null) turnUpData.turnUpCost.description else null,
             targets = targets,
             imageUri = cardComponent.imageUri ?: cardDef?.metadata?.imageUri,
             activeEffects = activeEffects,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerieBowmastersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerieBowmastersTest.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.dtk.cards.AerieBowmasters
@@ -48,7 +48,7 @@ class AerieBowmastersTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             container
                 .with(FaceDownComponent)
-                .with(MorphDataComponent(morphAbility.morphCost, cardDef.name, morphAbility.faceUpEffect))
+                .with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name, morphAbility.faceUpEffect))
         })
         return creatureId
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DermoplasmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DermoplasmTest.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.lgn.cards.Dermoplasm
@@ -52,7 +52,7 @@ class DermoplasmTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExplicitManaPaymentColorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExplicitManaPaymentColorTest.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.ons.cards.BirchloreRangers
@@ -42,7 +42,7 @@ class ExplicitManaPaymentColorTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeeringInstigatorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeeringInstigatorTest.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.ktk.cards.JeeringInstigator
@@ -47,7 +47,7 @@ class JeeringInstigatorTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManifestDreadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManifestDreadScenarioTest.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.ManifestedComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -98,8 +98,8 @@ class ManifestDreadScenarioTest : FunSpec({
         d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
 
         // Its turn-up cost is its real mana cost {2}{G} (CR 701.40b), not a morph cost.
-        val morphData = d.state.getEntity(creature)?.get<MorphDataComponent>()
-        morphData.shouldNotBeNull()
+        val turnUpData = d.state.getEntity(creature)?.get<FaceDownTurnUpComponent>()
+        turnUpData.shouldNotBeNull()
 
         // Pay {2}{G} to turn it face up — it becomes the real 3/3 Centaur Courser.
         d.giveMana(you, Color.GREEN, 3)
@@ -131,7 +131,7 @@ class ManifestDreadScenarioTest : FunSpec({
         entity?.get<FaceDownComponent>() shouldBe FaceDownComponent
         entity?.get<ManifestedComponent>() shouldBe ManifestedComponent
         // No morph/turn-up data — a manifested non-creature can never be turned face up (CR 701.40b).
-        entity?.get<MorphDataComponent>() shouldBe null
+        entity?.get<FaceDownTurnUpComponent>() shouldBe null
 
         d.giveMana(you, Color.GREEN, 5)
         d.submit(TurnFaceUp(playerId = you, sourceId = land, paymentStrategy = PaymentStrategy.FromPool))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.scg.cards.PutridRaptor
@@ -69,7 +69,7 @@ class MorphCostPaymentTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RattleclawMysticTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RattleclawMysticTest.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -51,7 +51,7 @@ class RattleclawMysticTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessRipperTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessRipperTest.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.ktk.cards.RuthlessRipper
@@ -43,7 +43,7 @@ class RuthlessRipperTest : FunSpec({
         replaceState(state.updateEntity(creatureId) { container ->
             var c = container.with(FaceDownComponent)
             if (morphAbility != null) {
-                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                c = c.with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
             }
             c
         })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaguMaulerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaguMaulerTest.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownTurnUpComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.ktk.cards.SaguMauler
@@ -42,7 +42,7 @@ class SaguMaulerTest : FunSpec({
             .filterIsInstance<KeywordAbility.Morph>()
             .first()
         replaceState(state.updateEntity(creatureId) { container ->
-            container.with(FaceDownComponent).with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+            container.with(FaceDownComponent).with(FaceDownTurnUpComponent(morphAbility.morphCost, cardDef.name))
         })
         return creatureId
     }


### PR DESCRIPTION
Follow-up to #888.

The engine component that stores how a face-down permanent can be turned face up now serves **two** mechanics — morph and manifest — so its morph-specific name was misleading. This is a pure rename, no behaviour change:

- `MorphDataComponent` → **`FaceDownTurnUpComponent`** (the shared "turn face up" record)
- its `morphCost` field → **`turnUpCost`** (morph cost for a morph; mana cost for a manifested creature)
- `morphData` locals + `ZoneEntryOptions.morphData` → **`turnUpData`**

Genuinely morph-specific names are left alone: `HasMorphAbilityComponent` and `KeywordAbility.Morph.morphCost`.

24 files (15 main + 9 test). Full `rules-engine` + `game-server` suites green. No card-snapshot changes (this is a runtime component, not part of card JSON).

**Stacked on `worktree-feat+manifest-dread` (#888)** — review/merge that first, or retarget this to `main` once #888 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)