### PR TITLE
Fire becomes-tapped triggers when paying a tap-creatures cost (Station)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.LifeChangedEvent
 import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
+import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.mechanics.mana.ManaPool
@@ -780,10 +781,17 @@ class CostHandler(
         }
 
         var newState = state
+        val events = mutableListOf<GameEvent>()
         for (permanentId in toTap) {
             newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
+            // Emit TappedEvent so "whenever this becomes tapped" triggers fire when a creature
+            // is tapped to pay a cost (Station, Cryptic Gateway). Without this, paying the cost
+            // adds TappedComponent silently and the trigger never sees the tap (cf. the analogous
+            // declare-attackers fix in AttackPhaseManager.commitAttackDeclaration).
+            val name = state.getEntity(permanentId)?.get<CardComponent>()?.name ?: "Permanent"
+            events.add(TappedEvent(permanentId, name))
         }
-        return CostPaymentResult.success(newState, manaPool)
+        return CostPaymentResult.success(newState, manaPool, events)
     }
 
     /** Pay a [CostAtom.ReturnToHand] atom from the chosen bounce targets, validating each. */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HemosymbicMiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HemosymbicMiteTest.kt
@@ -1,12 +1,18 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.eoe.cards.HemosymbicMite
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.WedgelightRammer
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
@@ -31,6 +37,7 @@ class HemosymbicMiteTest : FunSpec({
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all)
         driver.registerCard(HemosymbicMite)
+        driver.registerCard(WedgelightRammer)
         return driver
     }
 
@@ -82,6 +89,56 @@ class HemosymbicMiteTest : FunSpec({
         driver.submitTargetSelection(activePlayer, listOf(bears)).isSuccess shouldBe true
         driver.bothPass() // resolve the trigger
 
+        projector.getProjectedPower(driver.state, bears) shouldBe 3
+        projector.getProjectedToughness(driver.state, bears) shouldBe 3
+    }
+
+    // Regression: tapping the Mite to pay a cost (here, the Station ability on Wedgelight Rammer)
+    // must fire its "becomes tapped" trigger. Cost-payment taps used to add TappedComponent
+    // silently without emitting a TappedEvent, so the trigger never saw the tap.
+    test("Hemosymbic Mite's becomes-tapped trigger fires when tapped to pay a Station cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+
+        val mite = driver.putCreatureOnBattlefield(activePlayer, "Hemosymbic Mite")
+        driver.removeSummoningSickness(mite)
+        val bears = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        val rammer = driver.putPermanentOnBattlefield(activePlayer, "Wedgelight Rammer")
+
+        // Station is sorcery-speed — advance to the active player's main phase with an empty stack.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Station ability: "Tap another untapped creature you control: ...". Tap the Mite to pay.
+        val stationAbilityId = driver.cardRegistry.requireCard("Wedgelight Rammer")
+            .activatedAbilities.first { (it.cost as? AbilityCost.Atom)?.atom is CostAtom.TapPermanents }.id
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = rammer,
+                abilityId = stationAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(mite))
+            )
+        )
+        withClue("station activation should not error: ${result.error}") {
+            (result.isSuccess || result.isPaused) shouldBe true
+        }
+
+        // The Mite was tapped to pay the cost, so its "becomes tapped" trigger should be on the
+        // stack and pausing for a target.
+        val decision = driver.pendingDecision as? ChooseTargetsDecision
+            ?: error("Expected a ChooseTargetsDecision from the becomes-tapped trigger after stationing")
+        (decision.legalTargets[0] ?: emptyList()) shouldContain bears
+
+        driver.submitTargetSelection(activePlayer, listOf(bears)).isSuccess shouldBe true
+        driver.bothPass() // resolve the trigger (and the station ability)
+
+        // X = Mite's power (1), so Grizzly Bears (2/2) -> 3/3.
         projector.getProjectedPower(driver.state, bears) shouldBe 3
         projector.getProjectedToughness(driver.state, bears) shouldBe 3
     }


### PR DESCRIPTION
## Problem

[`HemosymbicMite`](mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HemosymbicMite.kt) — *"Whenever this creature becomes tapped, another target creature you control gets +X/+X…"* — did **not** trigger when the Mite was tapped to pay a **Station** cost (CR 702.184: *"Tap another untapped creature you control: …"*).

## Root cause

`CostHandler.payTapPermanents` (the executor for `CostAtom.TapPermanents` — Station, Cryptic Gateway, "tap N creatures" costs) tapped each chosen permanent by adding `TappedComponent` **silently**, without emitting a `TappedEvent`. The `BecomesTapped` trigger listens for `TappedEvent`, so paying the cost never fired it.

This is the same class of bug previously fixed for combat in `AttackPhaseManager.commitAttackDeclaration`, which emits a `TappedEvent` per tapped attacker.

## Fix

`payTapPermanents` now emits a `TappedEvent` for each tapped permanent and returns them in the `CostPaymentResult`. These cost-payment events already flow into trigger detection in `ActivateAbilityHandler`, so the becomes-tapped trigger now fires correctly.

## Tests

- New regression test in `HemosymbicMiteTest`: stationing a Wedgelight Rammer by tapping the Mite fires its becomes-tapped trigger and buffs another creature (+1/+1). Fails before the fix, passes after.
- Full `:rules-engine` suite green, including `StationMechanicTest`, convoke, and existing Mite tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)