### PR TITLE
Add DSK Tier 2 player-scoped effects (enchant player, life-gain lock, dynamic max hand size)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -40,7 +40,11 @@ section; do not let SDK additions land without a corresponding doc update.
 - `dynamicStats(source, powerOffset?, toughnessOffset?)` — sets both with optional `±` deltas.
 - `startingLoyalty: Int?` — starting loyalty for planeswalkers.
 - `colorIdentity: String?` — override (normally auto-detected). Treated as authoritative in this repo.
-- `auraTarget: TargetRequirement?` — what this Aura enchants.
+- `auraTarget: TargetRequirement?` — what this Aura enchants. Usually a permanent (`Targets.Creature`),
+  but `Targets.Player` makes it an **"enchant player"** Aura: it attaches to a player via
+  `AttachedToComponent` (players are entities too), survives state-based actions while that player is in
+  the game, and exposes the player through `Player.EnchantedPlayer` / `EventPattern.LifeGainEvent(EnchantedPlayer)`
+  and a `takesDamage(binding = ATTACHED)` "whenever enchanted player is dealt damage" trigger. (Grievous Wound.)
 - `morph: String?` — morph mana cost (cast face-down).
 - `morphCost: PayCost?` — non-mana morph cost.
 - `morphFaceUpEffect: Effect?` — effect that fires when this morph turns face up.
@@ -337,6 +341,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `SetLifeTotal(amount, target)` — set target's life total to N.
 - `ExchangeLifeAndPower(target)` — swap target's power with controller's life total.
 - `LoseHalfLife(roundUp, target, lifePlayer?)` — lose half of life total (round up/down).
+- `LockLifeGain(target?, duration?)` — "target player can't gain life" for `duration` (default
+  `Duration.Permanent` = rest of the game; `EndOfTurn` / `UntilYourNextTurn` also honored). A one-shot
+  effect that tags the player with `CantGainLifeComponent`, so the lock is independent of any source —
+  unlike the `PreventLifeGain` *replacement* (§11), which ends when its permanent leaves play.
+  Non-player targets are a no-op, so it composes after a "deal damage to any target" rider (Screaming
+  Nemesis). Checked by `DamageUtils.isLifeGainPrevented`.
 - `LoseGame(target, message?)` — target loses the game.
 - `RemoveMaximumHandSize(target?)` — "target has no maximum hand size for the rest of the game"
   (default target: controller). One-shot resolution effect that confers a permanent, player-scoped
@@ -1349,6 +1359,11 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   choice flow is tracked in `backlog/multiplayer.md`. Do **not** use it where the text means
   `TargetOpponent`, `EachOpponent`, `DefendingPlayer`, or `TriggeringPlayer`.
 - `Player.ChosenOpponent` — the opponent locked into the source's `ChoiceSlot.OPPONENT` slot.
+- `Player.EnchantedPlayer` — the player the source Aura is attached to ("enchant player", CR 303),
+  read from the source's `AttachedToComponent` when its target is a player. Use it both for the payoff
+  (`DynamicAmount.LifeTotal(EnchantedPlayer)`, `EffectTarget.PlayerRef(EnchantedPlayer)`) and to scope a
+  `PreventLifeGain` (`LifeGainEvent(player = EnchantedPlayer)`). Resolves to nothing if the source isn't
+  an Aura attached to a player. (Grievous Wound.)
 - `Player.ControllerOf(desc)` / `Player.OwnerOf(desc)` — controller/owner of the first chosen target.
 - `Player.ContextPlayer(i)` / `Player.Candidate` / `Player.Any` — positional target, CR 115
   candidate during target-restriction evaluation, and "a player" matching.
@@ -2784,6 +2799,13 @@ staticAbility {
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source
   leaving play), use the effect `Effects.RemoveMaximumHandSize(target)` instead — see §4. (Wisdom of Ages)
+- `SetMaximumHandSize(player, amount)` — sets the maximum hand size of a `player` scope (`You` /
+  `EachOpponent` / `Each`, resolved relative to the source's controller) to a `DynamicAmount`, read at
+  cleanup. Most restrictive (smallest) value wins when several apply; a `NoMaximumHandSize` controlled
+  by that player still removes the cap entirely. Gate it behind a `ConditionalStaticAbility` for an "as
+  long as …" form — the cleanup read unwraps the conditional and evaluates its condition against the
+  source's controller. (Winter, Misanthropic Guide — `ConditionalStaticAbility(SetMaximumHandSize(
+  EachOpponent, Subtract(Fixed(7), AggregateZone(You, GRAVEYARD, Any, DISTINCT_TYPES))), Delirium())`.)
 - `DampLandManaProduction` — a land tapped for 2+ mana produces `{C}` instead. (Damping Sphere)
 - `RestrictSpellsCastPerTurn(maxPerTurn, eachPlayer = false)` — a per-turn cap on spells cast.
   `eachPlayer = false` (default) limits only the source's controller (Yawgmoth's Agenda: "You can't
@@ -4469,6 +4491,10 @@ replacementEffect {
   Ali from Cairo (`LifeLossFloor(floor = 1, appliesTo = LifeLossEvent(Player.You))`); Worship adds a
   `restrictions = listOf(YouControlACreature)` gate.
 - `PreventLifeGain(appliesTo)` — life gain matching the event is fully prevented (Sulfuric Vortex, Erebos).
+  The `LifeGainEvent.player` scope can be `You` / `EachOpponent` / `Each` (resolved relative to the
+  source's controller) or `EnchantedPlayer` for an "enchant player" Aura whose locked player is its
+  attachment target (Grievous Wound). For a *source-independent, rest-of-game* lock on a specific player
+  instead, use the one-shot effect `Effects.LockLifeGain` (§4).
 - Custom — implement the `ReplacementEffect` interface directly.
 
 Amount-modifying replacements expose **both** `multiplier` (×) and `modifier` (±) on the same type — do not split into

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -691,6 +691,17 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.RemoveMaximumHandSizeEffect(target)
 
     /**
+     * "[target] can't gain life for [duration]." A one-shot effect that tags the player directly,
+     * so the lock is independent of the source (unlike the
+     * [com.wingedsheep.sdk.scripting.PreventLifeGain] static replacement). Defaults to the rest of
+     * the game (Screaming Nemesis). Non-player targets are a no-op.
+     */
+    fun LockLifeGain(
+        target: EffectTarget = EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.TargetPlayer),
+        duration: com.wingedsheep.sdk.scripting.Duration = com.wingedsheep.sdk.scripting.Duration.Permanent
+    ): Effect = com.wingedsheep.sdk.scripting.effects.LockLifeGainEffect(target, duration)
+
+    /**
      * "The Ring tempts you" (CR 701.54). The target player gets the Ring emblem (if they don't have
      * one), then chooses a creature they control to become their Ring-bearer. Defaults to the
      * controller. Tempting still happens even if the player controls no creatures.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.SerialName
@@ -584,6 +585,56 @@ data object PreventManaPoolEmptying : StaticAbility {
 @Serializable
 data object NoMaximumHandSize : StaticAbility {
     override val description: String = "You have no maximum hand size"
+}
+
+/**
+ * Set the maximum hand size of a scoped set of players to a dynamic value.
+ *
+ * Like [NoMaximumHandSize], this is a turn-based read rather than a continuous-projection
+ * effect: the cleanup step ([com.wingedsheep.engine.core.CleanupPhaseManager]) scans the
+ * battlefield for this ability and, for each one whose [player] scope (resolved relative to
+ * the source's controller) includes the discarding player, evaluates [amount] and discards
+ * down to it. When several set-maximum abilities apply to the same player, the engine uses
+ * the most restrictive (smallest) value — a deterministic stand-in for timestamp ordering,
+ * since maximum hand size is a player value with no Rule 613 layer. A [NoMaximumHandSize]
+ * controlled by that player still wins outright (no discard at all).
+ *
+ * Gate it behind a [ConditionalStaticAbility] for "as long as …" forms — the cleanup read
+ * unwraps the conditional and evaluates its [Condition] against the source's controller.
+ *
+ * Example — Winter, Misanthropic Guide ("Delirium — As long as there are four or more card
+ * types among cards in your graveyard, each opponent's maximum hand size is equal to seven
+ * minus the number of those card types"):
+ * ```kotlin
+ * ConditionalStaticAbility(
+ *     ability = SetMaximumHandSize(
+ *         player = Player.EachOpponent,
+ *         amount = DynamicAmount.Subtract(
+ *             DynamicAmount.Fixed(7),
+ *             DynamicAmount.AggregateZone(Player.You, Zone.GRAVEYARD, GameObjectFilter.Any, Aggregation.DISTINCT_TYPES)
+ *         )
+ *     ),
+ *     condition = Conditions.Delirium()
+ * )
+ * ```
+ *
+ * @property player Whose maximum hand size is set, resolved relative to the source's
+ *   controller (`You` / `EachOpponent` / `Each` / `Any`).
+ * @property amount The dynamic maximum hand size (clamped to ≥ 0 by the engine).
+ */
+@SerialName("SetMaximumHandSize")
+@Serializable
+data class SetMaximumHandSize(
+    val player: Player = Player.You,
+    val amount: DynamicAmount
+) : StaticAbility {
+    override val description: String =
+        "${player.possessive.replaceFirstChar { it.uppercase() }} maximum hand size is ${amount.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newAmount !== amount) copy(amount = newAmount) else this
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -591,6 +591,40 @@ data class RemoveMaximumHandSizeEffect(
 }
 
 /**
+ * Lock [target] player's life gain — they can't gain life for [duration].
+ *
+ * Unlike the [com.wingedsheep.sdk.scripting.PreventLifeGain] replacement effect (a static that
+ * ends when its source permanent leaves the battlefield), this is a one-shot effect that tags the
+ * player directly, so the lock is independent of the source. With the default [Duration.Permanent]
+ * it lasts for the rest of the game (Screaming Nemesis: "If a player is dealt damage this way,
+ * they can't gain life for the rest of the game"); [Duration.EndOfTurn] / [Duration.UntilYourNextTurn]
+ * are also honored for turn-scoped variants.
+ *
+ * Non-player targets are a no-op — only players have a life total to lock — so this composes
+ * safely with a "deal damage to any target" rider that may hit a creature or planeswalker.
+ *
+ * @param target The player whose life gain is locked.
+ * @param duration How long the lock lasts (default: rest of game).
+ */
+@SerialName("LockLifeGain")
+@Serializable
+data class LockLifeGainEffect(
+    val target: EffectTarget = EffectTarget.PlayerRef(Player.TargetPlayer),
+    val duration: Duration = Duration.Permanent
+) : Effect {
+    override val description: String = buildString {
+        append(target.description.replaceFirstChar { it.uppercase() })
+        append(" can't gain life")
+        when (duration) {
+            Duration.Permanent -> append(" for the rest of the game")
+            Duration.EndOfTurn -> append(" this turn")
+            Duration.UntilYourNextTurn -> append(" until your next turn")
+            else -> {}
+        }
+    }
+}
+
+/**
  * "The Ring tempts you" (CR 701.54). The target player gets an emblem named The Ring (if they
  * don't have one) and chooses a creature they control to become their Ring-bearer. The emblem's
  * four cumulative abilities are gated by how many times that player has been tempted.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -156,6 +156,20 @@ sealed interface Player {
         override val description: String = "the chosen player"
     }
 
+    /**
+     * The player enchanted by the source Aura — read from the source's
+     * [com.wingedsheep.engine.state.components.battlefield.AttachedToComponent] target id when it
+     * is a player. Used by "enchant player" Auras (Grievous Wound) for both the payoff target
+     * ("they lose half their life") and the [com.wingedsheep.sdk.scripting.PreventLifeGain] scope
+     * ("enchanted player can't gain life"). Resolves to nothing when the source isn't an Aura
+     * attached to a player.
+     */
+    @SerialName("EnchantedPlayer")
+    @Serializable
+    data object EnchantedPlayer : Player {
+        override val description: String = "enchanted player"
+    }
+
     /** Controller of a permanent (used with EffectTarget) */
     @SerialName("ControllerOf")
     @Serializable
@@ -190,6 +204,7 @@ sealed interface Player {
             Candidate -> "that player's"
             TriggeringPlayer -> "that player's"
             ChosenOpponent -> "the chosen player's"
+            EnchantedPlayer -> "enchanted player's"
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrievousWound.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrievousWound.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventLifeGain
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grievous Wound
+ * {3}{B}{B}
+ * Enchantment — Aura
+ * Enchant player
+ * Enchanted player can't gain life.
+ * Whenever enchanted player is dealt damage, they lose half their life, rounded up.
+ */
+val GrievousWound = card("Grievous Wound") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant player\n" +
+        "Enchanted player can't gain life.\n" +
+        "Whenever enchanted player is dealt damage, they lose half their life, rounded up."
+
+    auraTarget = Targets.Player
+
+    // Enchanted player can't gain life.
+    replacementEffect(PreventLifeGain(appliesTo = EventPattern.LifeGainEvent(player = Player.EnchantedPlayer)))
+
+    // Whenever enchanted player is dealt damage, they lose half their life, rounded up.
+    triggeredAbility {
+        trigger = Triggers.takesDamage(binding = TriggerBinding.ATTACHED)
+        effect = Effects.LoseHalfLife(
+            roundUp = true,
+            target = EffectTarget.PlayerRef(Player.EnchantedPlayer),
+            lifePlayer = Player.EnchantedPlayer,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "102"
+        artist = "Martina Fačková"
+        flavorText = "Vicky was so tired. The pain began to fade. \"You were so brave,\" said her " +
+            "grandmother's voice from somewhere far away. \"But it's time to rest now.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg?1726286230"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ScreamingNemesis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ScreamingNemesis.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Screaming Nemesis
+ * {2}{R}
+ * Creature — Spirit
+ * 3/3
+ * Haste
+ * Whenever this creature is dealt damage, it deals that much damage to any other target.
+ * If a player is dealt damage this way, they can't gain life for the rest of the game.
+ */
+val ScreamingNemesis = card("Screaming Nemesis") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Haste\n" +
+        "Whenever this creature is dealt damage, it deals that much damage to any other target. " +
+        "If a player is dealt damage this way, they can't gain life for the rest of the game."
+
+    keywords(Keyword.HASTE)
+
+    // Whenever this creature is dealt damage, it deals that much damage to any other target.
+    // If a player is dealt damage this way, they can't gain life for the rest of the game.
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        val victim = target("any other target", TargetOther(AnyTarget()))
+        effect = Effects.Composite(
+            listOf(
+                Effects.DealDamage(
+                    amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+                    target = victim,
+                ),
+                // No-op when the target isn't a player; locks a struck player for the rest of the game.
+                Effects.LockLifeGain(target = victim),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "157"
+        artist = "Liiga Smilshkalne"
+        flavorText = "She sees the faces of those who wronged her in everyone she encounters."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg?1762773071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WinterMisanthropicGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WinterMisanthropicGuide.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.SetMaximumHandSize
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Winter, Misanthropic Guide
+ * {1}{B}{R}{G}
+ * Legendary Creature — Human Warlock
+ * 3/4
+ * Ward {2}
+ * At the beginning of your upkeep, each player draws two cards.
+ * Delirium — As long as there are four or more card types among cards in your graveyard, each
+ * opponent's maximum hand size is equal to seven minus the number of those card types.
+ */
+val WinterMisanthropicGuide = card("Winter, Misanthropic Guide") {
+    manaCost = "{1}{B}{R}{G}"
+    colorIdentity = "BRG"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 4
+    oracleText = "Ward {2} (Whenever this creature becomes the target of a spell or ability an " +
+        "opponent controls, counter it unless that player pays {2}.)\n" +
+        "At the beginning of your upkeep, each player draws two cards.\n" +
+        "Delirium — As long as there are four or more card types among cards in your graveyard, " +
+        "each opponent's maximum hand size is equal to seven minus the number of those card types."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    // At the beginning of your upkeep, each player draws two cards.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.DrawCards(2, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    // Delirium — As long as there are four or more card types among cards in your graveyard, each
+    // opponent's maximum hand size is equal to seven minus the number of those card types.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = SetMaximumHandSize(
+                player = Player.EachOpponent,
+                amount = DynamicAmount.Subtract(
+                    DynamicAmount.Fixed(7),
+                    DynamicAmount.AggregateZone(
+                        player = Player.You,
+                        zone = Zone.GRAVEYARD,
+                        filter = GameObjectFilter.Any,
+                        aggregation = Aggregation.DISTINCT_TYPES,
+                    ),
+                ),
+            ),
+            condition = Conditions.Delirium(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Jodie Muir"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg?1726286766"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2868,6 +2868,61 @@
     ]
 }
 
+// Grievous Wound
+{
+    "name": "Grievous Wound",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Divide",
+                        "numerator": {
+                            "type": "LifeTotal",
+                            "player": "EnchantedPlayer"
+                        },
+                        "denominator": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EnchantedPlayer"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "PreventLifeGain",
+                "appliesTo": {
+                    "type": "LifeGainEvent",
+                    "player": "EnchantedPlayer"
+                }
+            }
+        ],
+        "auraTarget": "TargetPlayer"
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "RARE",
+        "artist": "Martina Fačková",
+        "flavorText": "Vicky was so tired. The pain began to fade. \"You were so brave,\" said her grandmother's voice from somewhere far away. \"But it's time to rest now.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg?1726286230"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hardened Escort
 {
     "name": "Hardened Escort",
@@ -4930,6 +4985,67 @@
     ]
 }
 
+// Screaming Nemesis
+{
+    "name": "Screaming Nemesis",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Haste\nWhenever this creature is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "ContextProperty",
+                                "key": "TRIGGER_DAMAGE_AMOUNT"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any other target"
+                            }
+                        },
+                        {
+                            "type": "LockLifeGain",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any other target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOther",
+                    "baseRequirement": "AnyTarget",
+                    "id": "any other target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "MYTHIC",
+        "artist": "Liiga Smilshkalne",
+        "flavorText": "She sees the faces of those who wronged her in everyone she encounters.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg?1762773071"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Seized from Slumber
 {
     "name": "Seized from Slumber",
@@ -6939,6 +7055,100 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Winter, Misanthropic Guide
+{
+    "name": "Winter, Misanthropic Guide",
+    "manaCost": "{1}{B}{R}{G}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your upkeep, each player draws two cards.\nDelirium — As long as there are four or more card types among cards in your graveyard, each opponent's maximum hand size is equal to seven minus the number of those card types.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "SetMaximumHandSize",
+                    "player": "EachOpponent",
+                    "amount": {
+                        "type": "Subtract",
+                        "left": {
+                            "type": "Fixed",
+                            "amount": 7
+                        },
+                        "right": {
+                            "type": "AggregateZone",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "aggregation": "DISTINCT_TYPES"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Jodie Muir",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg?1726286766"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
 import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
 import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
+import com.wingedsheep.engine.state.components.player.CantGainLifeComponent
 import com.wingedsheep.engine.state.components.player.DamageBonusComponent
 import com.wingedsheep.engine.state.components.player.DamageReceivedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
@@ -62,11 +63,17 @@ import com.wingedsheep.engine.state.components.player.PlayerNoMaximumHandSizeCom
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.player.SpellsCantBeCounteredComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.NoMaximumHandSize
 import com.wingedsheep.sdk.scripting.PreventManaPoolEmptying
+import com.wingedsheep.sdk.scripting.SetMaximumHandSize
+import com.wingedsheep.sdk.scripting.references.Player
 
 /**
  * Handles all end-of-turn cleanup: discard to hand size, damage removal,
@@ -76,6 +83,14 @@ class CleanupPhaseManager(
     private val cardRegistry: com.wingedsheep.engine.registry.CardRegistry,
     private val decisionHandler: DecisionHandler
 ) {
+
+    /** Default maximum hand size (CR 402.2), absent any effect that sets or removes it. */
+    private val defaultMaxHandSize = 7
+
+    // Stateless evaluators (default projection) used to read SetMaximumHandSize abilities and
+    // their ConditionalStaticAbility gates at cleanup time.
+    private val conditionEvaluator = ConditionEvaluator()
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator(conditionEvaluator)
 
     /**
      * Perform cleanup step actions.
@@ -93,10 +108,10 @@ class CleanupPhaseManager(
         // Check if player needs to discard
         val handKey = ZoneKey(activePlayer, Zone.HAND)
         val hand = newState.getZone(handKey)
-        val maxHandSize = 7
-        val cardsToDiscard = hand.size - maxHandSize
+        val maxHandSize = maximumHandSize(newState, activePlayer)
+        val cardsToDiscard = if (maxHandSize == null) 0 else hand.size - maxHandSize
 
-        if (cardsToDiscard > 0 && !hasNoMaximumHandSize(newState, activePlayer)) {
+        if (cardsToDiscard > 0) {
             // Player needs to discard - create a decision
             events.add(DiscardRequiredEvent(activePlayer, cardsToDiscard))
 
@@ -193,6 +208,10 @@ class CleanupPhaseManager(
         val protection = result.getEntity(activePlayer)?.get<PlayerProtectionComponent>()
         if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
             result = result.updateEntity(activePlayer) { it.without<PlayerProtectionComponent>() }
+        }
+        val cantGainLife = result.getEntity(activePlayer)?.get<CantGainLifeComponent>()
+        if (cantGainLife?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
+            result = result.updateEntity(activePlayer) { it.without<CantGainLifeComponent>() }
         }
         // Memory Vessel's "they can't play cards from their hand until your next turn" expires on
         // the same post-untap hook. The window keys off the *activating* player (every affected
@@ -291,6 +310,68 @@ class CleanupPhaseManager(
             state
         }
     }
+
+    /**
+     * The effective maximum hand size for [playerId] at cleanup, or `null` when they have no
+     * maximum (Reliquary Tower / Wisdom of Ages — [hasNoMaximumHandSize]).
+     *
+     * Starts from [defaultMaxHandSize] (CR 402.2) and applies every [SetMaximumHandSize] static
+     * ability on the battlefield whose [SetMaximumHandSize.player] scope (resolved relative to the
+     * source's controller) includes [playerId], taking the most restrictive (smallest) value. A
+     * [ConditionalStaticAbility] wrapper is unwrapped and its condition evaluated against the
+     * source's controller, so "as long as …" gates (Winter's Delirium) are honored.
+     */
+    private fun maximumHandSize(state: GameState, playerId: EntityId): Int? {
+        if (hasNoMaximumHandSize(state, playerId)) return null
+        var max = defaultMaxHandSize
+        val registry = cardRegistry
+        val projected = state.projectedState
+        for (permanentId in state.getBattlefield()) {
+            val card = state.getEntity(permanentId)?.get<CardComponent>() ?: continue
+            val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.isEmpty()) continue
+            val controllerId = projected.getController(permanentId) ?: continue
+            val context = EffectContext(sourceId = permanentId, controllerId = controllerId)
+            for (raw in cardDef.script.staticAbilities) {
+                val setAbility = activeSetMaximumHandSize(state, raw, context) ?: continue
+                if (!playerScopeIncludes(setAbility.player, playerId, controllerId)) continue
+                val value = dynamicAmountEvaluator.evaluate(state, setAbility.amount, context)
+                    .coerceAtLeast(0)
+                max = minOf(max, value)
+            }
+        }
+        return max
+    }
+
+    /**
+     * Unwrap [raw] to a live [SetMaximumHandSize] if it is one (directly or behind a
+     * [ConditionalStaticAbility] whose condition holds), else `null`.
+     */
+    private fun activeSetMaximumHandSize(
+        state: GameState,
+        raw: com.wingedsheep.sdk.scripting.StaticAbility,
+        context: EffectContext
+    ): SetMaximumHandSize? = when (raw) {
+        is SetMaximumHandSize -> raw
+        is ConditionalStaticAbility -> {
+            val inner = raw.ability as? SetMaximumHandSize
+            if (inner != null && conditionEvaluator.evaluate(state, raw.condition, context)) inner else null
+        }
+        else -> null
+    }
+
+    /**
+     * Whether a [SetMaximumHandSize.player] scope, resolved relative to [controllerId] (the
+     * source's controller), includes [playerId]. Mirrors the player-scope switch in
+     * [com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented].
+     */
+    private fun playerScopeIncludes(scope: Player, playerId: EntityId, controllerId: EntityId): Boolean =
+        when (scope) {
+            Player.You -> playerId == controllerId
+            Player.EachOpponent -> playerId != controllerId
+            Player.Each, Player.Any, Player.ActivePlayerFirst -> true
+            else -> false
+        }
 
     /**
      * Check if [playerId] has no maximum hand size — either from a permanent they control with the
@@ -463,6 +544,10 @@ class CleanupPhaseManager(
                 val cantCast = result.get<CantCastSpellsComponent>()
                 if (cantCast?.removeOn == PlayerEffectRemoval.EndOfTurn) {
                     result = result.without<CantCastSpellsComponent>()
+                }
+                val cantGainLife = result.get<CantGainLifeComponent>()
+                if (cantGainLife?.removeOn == PlayerEffectRemoval.EndOfTurn) {
+                    result = result.without<CantGainLifeComponent>()
                 }
                 val cantLoyalty = result.get<CantActivateLoyaltyAbilitiesComponent>()
                 if (cantLoyalty?.removeOn == PlayerEffectRemoval.EndOfTurn) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -449,6 +449,7 @@ val engineSerializersModule = SerializersModule {
         subclass(AdditionalUpkeepStepsComponent::class)
         subclass(InAdditionalUpkeepStepComponent::class)
         subclass(CantCastSpellsComponent::class)
+        subclass(CantGainLifeComponent::class)
         subclass(CantActivateLoyaltyAbilitiesComponent::class)
         subclass(CardsLeftGraveyardThisTurnComponent::class)
         subclass(CreaturesDiedThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -68,10 +68,13 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
     private fun getRelevantEntityIds(event: EngineGameEvent): List<com.wingedsheep.sdk.model.EntityId> {
         return when (event) {
             is DamageDealtEvent -> {
-                // Check both target (for "enchanted creature takes damage") and
-                // source (for "enchanted creature deals damage")
+                // Check both target (for "enchanted creature/player takes damage") and
+                // source (for "enchanted creature deals damage"). The target id is included
+                // even when it's a player so "whenever enchanted player is dealt damage"
+                // auras (Grievous Wound) fire — aurasByTarget only resolves to player-attached
+                // auras for that id, so non-enchant-player damage stays a no-op lookup.
                 buildList {
-                    if (!event.targetIsPlayer) add(event.targetId)
+                    add(event.targetId)
                     event.sourceId?.let { add(it) }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -830,7 +830,7 @@ class DynamicAmountEvaluator(
             is Player.ChosenOpponent -> listOfNotNull(
                 context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
             )
-            is Player.AnOpponent, is Player.DefendingPlayer -> listOfNotNull(
+            is Player.AnOpponent, is Player.DefendingPlayer, is Player.EnchantedPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -648,6 +648,13 @@ object DamageUtils {
      * on the battlefield (e.g., Sulfuric Vortex, Erebos).
      */
     fun isLifeGainPrevented(state: GameState, playerId: EntityId): Boolean {
+        // Durable, source-independent lock conferred directly on the player
+        // (LockLifeGainEffect — Screaming Nemesis).
+        if (state.getEntity(playerId)
+                ?.has<com.wingedsheep.engine.state.components.player.CantGainLifeComponent>() == true
+        ) {
+            return true
+        }
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
@@ -665,6 +672,14 @@ object DamageUtils {
                     // "Your opponents can't gain life." — Gríma Wormtongue (LTR).
                     Player.EachOpponent ->
                         if (playerId != sourceControllerId) return true
+                    // "Enchanted player can't gain life." — Grievous Wound. The host is an Aura
+                    // attached to the locked player; compare against its attachment target.
+                    Player.EnchantedPlayer -> {
+                        val enchanted = container
+                            .get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                            ?.targetId
+                        if (enchanted == playerId) return true
+                    }
                     else -> {}
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -132,6 +132,7 @@ object TargetResolutionUtils {
             Player.AnOpponent -> state.getOpponents(context.controllerId).firstOrNull()
             Player.DefendingPlayer -> resolveDefendingPlayer(context, state)
             Player.ChosenOpponent -> context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+            Player.EnchantedPlayer -> enchantedPlayer(context, state)
             is Player.OwnerOf -> context.targets.firstOrNull()?.toEntityId()
                 ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
             is Player.ControllerOf -> context.targets.firstOrNull()?.toEntityId()
@@ -167,6 +168,17 @@ object TargetResolutionUtils {
      * card they don't own (e.g. casting a spell from an opponent's graveyard). Falls back to the
      * [ControllerComponent] (battlefield permanents) and finally the owner.
      */
+    /**
+     * The player the source Aura is attached to (CR 303 enchant player), or `null` when the source
+     * isn't attached to a player. Reads the source's [AttachedToComponent] target and confirms it
+     * is a player (in [GameState.turnOrder]). Used to resolve [Player.EnchantedPlayer].
+     */
+    fun enchantedPlayer(context: EffectContext, state: GameState): EntityId? {
+        val sourceId = context.sourceId ?: return null
+        val targetId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId ?: return null
+        return targetId.takeIf { it in state.turnOrder }
+    }
+
     private fun controllerOf(state: GameState, entityId: EntityId): EntityId? {
         val entity = state.getEntity(entityId) ?: return null
         return entity.get<SpellOnStackComponent>()?.casterId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LockLifeGainExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LockLifeGainExecutor.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.CantGainLifeComponent
+import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.LockLifeGainEffect
+import kotlin.reflect.KClass
+
+/**
+ * Resolves [LockLifeGainEffect] — tags each resolved player target with a
+ * [CantGainLifeComponent] so their life gain is locked for the effect's duration.
+ *
+ * Only players (entities with a [LifeTotalComponent]) are affected; a non-player target — e.g. a
+ * creature or planeswalker hit by a "deal damage to any target" rider — is silently skipped, so
+ * the effect composes safely after such damage. The lock is idempotent at the most-durable level:
+ * a Permanent lock is never downgraded by a later turn-scoped lock.
+ */
+class LockLifeGainExecutor : EffectExecutor<LockLifeGainEffect> {
+
+    override val effectType: KClass<LockLifeGainEffect> = LockLifeGainEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: LockLifeGainEffect,
+        context: EffectContext
+    ): EffectResult {
+        val removeOn = when (effect.duration) {
+            Duration.EndOfTurn -> PlayerEffectRemoval.EndOfTurn
+            Duration.UntilYourNextTurn -> PlayerEffectRemoval.UntilYourNextTurn
+            else -> PlayerEffectRemoval.Permanent
+        }
+
+        val targetIds = context.resolvePlayerTargets(effect.target, state)
+            .filter { state.turnOrder.contains(it) }
+
+        var newState = state
+        for (playerId in targetIds) {
+            val container = newState.getEntity(playerId) ?: continue
+            // Only players have a life total to lock.
+            if (container.get<LifeTotalComponent>() == null) continue
+            val existing = container.get<CantGainLifeComponent>()
+            // Never downgrade a Permanent lock to a shorter duration.
+            if (existing?.removeOn == PlayerEffectRemoval.Permanent) continue
+            newState = newState.updateEntity(playerId) { c ->
+                c.with(CantGainLifeComponent(removeOn = removeOn))
+            }
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -60,6 +60,7 @@ class PlayerExecutors(
         GrantPlayerProtectionExecutor(),
         GrantShroudExecutor(),
         HijackNextTurnExecutor(),
+        LockLifeGainExecutor(),
         openLifeBidExecutor,
         LoseGameExecutor(),
         WinGameExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -115,6 +115,7 @@ import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.ModifyPlotCost
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.SetMaximumHandSize
 import com.wingedsheep.sdk.scripting.NoncombatDamageBonus
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.OverrideEnchantedLandManaColor
@@ -759,6 +760,7 @@ class StaticAbilityHandler(
 
             // Turn-based actions (BeginningPhaseManager / CleanupPhaseManager):
             is NoMaximumHandSize,
+            is SetMaximumHandSize,
             is PreventManaPoolEmptying,
             is UntapDuringOtherUntapSteps,
             is UntapFilteredDuringOtherUntapSteps,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -52,6 +52,12 @@ class UnattachedAurasCheck : StateBasedActionCheck {
                     events.addAll(result.events)
                 }
                 // Equipment not attached to anything is fine - stays on battlefield
+            } else if (isAura && attachedTo.targetId in state.turnOrder) {
+                // 704.5m — an "enchant player" Aura (Grievous Wound) is attached to a player, not
+                // a battlefield permanent. It stays as long as that player is still in the game;
+                // once the player leaves, PlayerLeavesGameProcessor removes them from turnOrder and
+                // the next check sends the now-unattached Aura to the graveyard.
+                continue
             } else {
                 // Check if attached target still exists on battlefield
                 if (attachedTo.targetId !in state.getBattlefield()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1056,11 +1056,14 @@ class StackResolver(
     ): Pair<GameState, List<GameEvent>> {
         val controllerId = spellComponent.casterId
 
-        // For Auras: get the target before removing TargetsComponent
+        // For Auras: get the target before removing TargetsComponent. The target is usually a
+        // permanent, but "enchant player" Auras (Grievous Wound) attach to a player — both are
+        // entities, so AttachedToComponent holds either id (CR 303.4).
         val auraTargetId = if (cardComponent?.isAura == true) {
             state.getEntity(spellId)?.get<TargetsComponent>()?.targets?.firstOrNull()?.let { target ->
                 when (target) {
                     is ChosenTarget.Permanent -> target.entityId
+                    is ChosenTarget.Player -> target.playerId
                     else -> null
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -587,6 +587,25 @@ data class CantCastSpellsComponent(
 ) : Component
 
 /**
+ * Component indicating that a player can't gain life. Conferred directly on the player by
+ * [com.wingedsheep.sdk.scripting.effects.LockLifeGainEffect] (Screaming Nemesis), so the lock is
+ * independent of any source permanent — distinct from the
+ * [com.wingedsheep.sdk.scripting.PreventLifeGain] static replacement, which ends when its
+ * permanent leaves play.
+ *
+ * Consulted by [com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented].
+ *
+ * @param removeOn When this component should be removed:
+ *   - [PlayerEffectRemoval.Permanent] — rest of the game (default; Screaming Nemesis)
+ *   - [PlayerEffectRemoval.EndOfTurn] — removed during end-of-turn cleanup
+ *   - [PlayerEffectRemoval.UntilYourNextTurn] — removed after that player's next untap step
+ */
+@Serializable
+data class CantGainLifeComponent(
+    val removeOn: PlayerEffectRemoval = PlayerEffectRemoval.Permanent
+) : Component
+
+/**
  * Component indicating that a player cannot activate planeswalkers' loyalty abilities for the
  * rest of this turn. Applied by effects like Revel in Silence. Sibling of [CantCastSpellsComponent].
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrievousWoundTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrievousWoundTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Grievous Wound (DSK #102) — proves the "enchant player" aura subsystem.
+ *
+ * "Enchant player
+ *  Enchanted player can't gain life.
+ *  Whenever enchanted player is dealt damage, they lose half their life, rounded up."
+ *
+ * Exercises: an Aura attaching to a player (not a permanent) and surviving state-based actions; a
+ * PreventLifeGain scoped to Player.EnchantedPlayer; and a `takesDamage(binding = ATTACHED)` trigger
+ * firing when the enchanted *player* is dealt damage.
+ */
+class GrievousWoundTest : FunSpec({
+
+    // "Target player gains 5 life." — probes whether the enchanted player's life gain is locked.
+    val TargetGainsFiveLife = CardDefinition.instant(
+        name = "Bestow Five Life",
+        manaCost = ManaCost.parse("{W}"),
+        oracleText = "Target player gains 5 life.",
+        script = CardScript.spell(
+            GainLifeEffect(5, EffectTarget.PlayerRef(Player.TargetPlayer)),
+            com.wingedsheep.sdk.dsl.Targets.Player,
+        ),
+    )
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TargetGainsFiveLife))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun findOnBattlefield(driver: GameTestDriver, name: String): EntityId? =
+        driver.state.getBattlefield().firstOrNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+
+    fun castGrievousWoundOn(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        driver.giveMana(caster, Color.BLACK, 5)
+        val gw = driver.putCardInHand(caster, "Grievous Wound")
+        driver.castSpellWithTargets(caster, gw, listOf(ChosenTarget.Player(victim))).error shouldBe null
+        driver.bothPass()
+    }
+
+    test("the Aura attaches to the enchanted player and survives state-based actions") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        castGrievousWoundOn(driver, caster = p1, victim = p2)
+
+        val aura = findOnBattlefield(driver, "Grievous Wound")
+        aura.shouldNotBeNull()
+        driver.state.getEntity(aura)?.get<AttachedToComponent>()?.targetId shouldBe p2
+    }
+
+    test("enchanted player can't gain life") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        castGrievousWoundOn(driver, caster = p1, victim = p2)
+
+        // p1 tries to make p2 gain 5 life — prevented.
+        val gain = driver.putCardInHand(p1, "Bestow Five Life")
+        driver.giveMana(p1, Color.WHITE, 1)
+        driver.castSpellWithTargets(p1, gain, listOf(ChosenTarget.Player(p2))).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(p2) shouldBe 20
+    }
+
+    test("when the enchanted player is dealt damage they lose half their life, rounded up") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        castGrievousWoundOn(driver, caster = p1, victim = p2)
+
+        // Lightning Bolt deals 3 to p2 (20 -> 17); the trigger then halves 17 rounded up = 9 (17 -> 8).
+        val bolt = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.giveMana(p1, Color.RED, 1)
+        driver.castSpellWithTargets(p1, bolt, listOf(ChosenTarget.Player(p2))).error shouldBe null
+        var guard = 0
+        while (guard++ < 10 && !(driver.state.stack.isEmpty() && driver.state.pendingDecision == null)) {
+            driver.bothPass()
+        }
+
+        driver.getLifeTotal(p2) shouldBe 8
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreamingNemesisTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreamingNemesisTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Screaming Nemesis (DSK #157) — proves the durable, source-independent life-gain lock
+ * ([com.wingedsheep.sdk.scripting.effects.LockLifeGainEffect]).
+ *
+ * "Whenever this creature is dealt damage, it deals that much damage to any other target. If a
+ * player is dealt damage this way, they can't gain life for the rest of the game."
+ *
+ * The reflected damage is the existing Tephraderm/any-target composition; the new engine surface is
+ * the rest-of-game can't-gain-life lock applied to a struck player.
+ */
+class ScreamingNemesisTest : FunSpec({
+
+    // "You gain 5 life." — used to probe whether a player's life gain is locked.
+    val GainFiveLife = CardDefinition.instant(
+        name = "Gain Five Life",
+        manaCost = ManaCost.parse("{W}"),
+        oracleText = "You gain 5 life.",
+        script = CardScript.spell(effect = GainLifeEffect(5)),
+    )
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GainFiveLife))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Resolve the stack, answering the reflected-damage trigger's target choice with [reflectTarget]. */
+    fun resolveStack(driver: GameTestDriver, controller: EntityId, reflectTarget: EntityId) {
+        var guard = 0
+        while (guard++ < 16) {
+            when (driver.state.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(controller, listOf(reflectTarget))
+                null -> {
+                    if (driver.state.stack.isEmpty()) return
+                    driver.bothPass()
+                }
+                else -> driver.autoResolveDecision()
+            }
+        }
+    }
+
+    test("a player struck by the reflected damage can't gain life for the rest of the game") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        val nemesis = driver.putCreatureOnBattlefield(p1, "Screaming Nemesis")
+
+        // Shock the Nemesis for 2 (survives, 3/3); it reflects 2 to a chosen target — pick p2.
+        driver.giveMana(p1, Color.RED, 1)
+        val shock = driver.putCardInHand(p1, "Shock")
+        driver.castSpellWithTargets(p1, shock, listOf(ChosenTarget.Permanent(nemesis))).error shouldBe null
+        resolveStack(driver, controller = p1, reflectTarget = p2)
+
+        driver.getLifeTotal(p2) shouldBe 18 // 20 - 2 reflected
+
+        // On p2's own turn, a gain-life spell does nothing — the lock persists across turns.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val gain = driver.putCardInHand(p2, "Gain Five Life")
+        driver.giveMana(p2, Color.WHITE, 1)
+        driver.castSpell(p2, gain).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(p2) shouldBe 18 // no life gained
+    }
+
+    test("reflecting onto a creature locks no one — the targeted creature simply takes the damage") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        val nemesis = driver.putCreatureOnBattlefield(p1, "Screaming Nemesis")
+        val turtle = driver.putCreatureOnBattlefield(p2, "Horned Turtle") // 1/4, survives 2
+
+        driver.giveMana(p1, Color.RED, 1)
+        val shock = driver.putCardInHand(p1, "Shock")
+        driver.castSpellWithTargets(p1, shock, listOf(ChosenTarget.Permanent(nemesis))).error shouldBe null
+        resolveStack(driver, controller = p1, reflectTarget = turtle)
+
+        // p2 was not the damage recipient, so they can still gain life normally.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val gain = driver.putCardInHand(p2, "Gain Five Life")
+        driver.giveMana(p2, Color.WHITE, 1)
+        driver.castSpell(p2, gain).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(p2) shouldBe 25 // 20 + 5
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinterMisanthropicGuideTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinterMisanthropicGuideTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Winter, Misanthropic Guide (DSK #240) — proves the SetMaximumHandSize static ability.
+ *
+ * "Delirium — As long as there are four or more card types among cards in your graveyard, each
+ * opponent's maximum hand size is equal to seven minus the number of those card types."
+ *
+ * The cleanup step reads the (Delirium-gated) SetMaximumHandSize(EachOpponent, 7 - distinctTypes)
+ * static off Winter and discards the opponent down to that value; below delirium the gate is off and
+ * the default maximum of seven applies.
+ */
+class WinterMisanthropicGuideTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    /** Active player (whose cleanup runs) is the opponent of Winter's controller. */
+    fun setup(driver: GameTestDriver, distinctTypesInGraveyard: Int): Pair<EntityId, EntityId> {
+        val active = driver.activePlayer!!
+        val winterController = driver.getOpponent(active)
+        driver.putPermanentOnBattlefield(winterController, "Winter, Misanthropic Guide")
+
+        // Fill Winter's controller's graveyard with the requested number of distinct card types.
+        val fodder = listOf(
+            "Grizzly Bears", // Creature
+            "Lightning Bolt", // Instant
+            "Doom Blade",     // Sorcery
+            "Swamp",          // Land
+        )
+        repeat(distinctTypesInGraveyard) { driver.putCardInGraveyard(winterController, fodder[it]) }
+        return active to winterController
+    }
+
+    test("with delirium (4 types) each opponent's maximum hand size is 7 minus the type count") {
+        val driver = newDriver()
+        val (active, _) = setup(driver, distinctTypesInGraveyard = 4)
+
+        // Reach the active player's end step, then pad their hand well above any cap.
+        driver.passPriorityUntil(Step.END)
+        repeat(6) { driver.putCardInHand(active, "Swamp") }
+
+        // Enter cleanup and resolve the discard-to-hand-size decision.
+        driver.passPriorityUntil(Step.CLEANUP)
+        if (driver.state.pendingDecision != null) driver.autoResolveDecision()
+
+        // 7 - 4 distinct card types = maximum hand size of 3.
+        driver.getHandSize(active) shouldBe 3
+    }
+
+    test("below delirium (3 types) the opponent keeps the default maximum hand size of 7") {
+        val driver = newDriver()
+        val (active, _) = setup(driver, distinctTypesInGraveyard = 3)
+
+        driver.passPriorityUntil(Step.END)
+        repeat(6) { driver.putCardInHand(active, "Swamp") }
+
+        driver.passPriorityUntil(Step.CLEANUP)
+        if (driver.state.pendingDecision != null) driver.autoResolveDecision()
+
+        // Delirium is not met, so the SetMaximumHandSize static doesn't apply: default 7.
+        driver.getHandSize(active) shouldBe 7
+    }
+
+    test("Winter's controller is unaffected — their own maximum hand size stays 7") {
+        val driver = newDriver()
+        // Make Winter's controller the active (discarding) player this time.
+        val discarder = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(discarder, "Winter, Misanthropic Guide")
+        repeat(4) { i ->
+            driver.putCardInGraveyard(discarder, listOf("Grizzly Bears", "Lightning Bolt", "Doom Blade", "Swamp")[i])
+        }
+
+        driver.passPriorityUntil(Step.END)
+        repeat(6) { driver.putCardInHand(discarder, "Swamp") }
+
+        driver.passPriorityUntil(Step.CLEANUP)
+        if (driver.state.pendingDecision != null) driver.autoResolveDecision()
+
+        // "each opponent's" excludes Winter's own controller.
+        driver.getHandSize(discarder) shouldBe 7
+    }
+})

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -562,7 +562,12 @@ export function useBattlefieldCards(opponentId?: EntityId | null): BattlefieldCa
       .map((id) => gameState.cards[id])
       .filter((card): card is ClientCard => card !== null && card !== undefined)
 
-    const isNotAttached = (c: ClientCard) => !c.attachedTo
+    // A card counts as "attached" only when its host is itself a battlefield card. An
+    // "enchant player" Aura (Grievous Wound) has attachedTo pointing at a player entity, which
+    // is not a battlefield card — render it standalone in its controller's row rather than
+    // dropping it (it is only ever rendered nested under a host card otherwise).
+    const cardIdSet = new Set(cards.map((c) => c.id))
+    const isNotAttached = (c: ClientCard) => !c.attachedTo || !cardIdSet.has(c.attachedTo)
     const playerCards = cards.filter((c) => c.controllerId === playerId)
     const opponentCards = opponentId
       ? cards.filter((c) => c.controllerId === opponentId)


### PR DESCRIPTION
Implements **Tier 2** of `backlog/dsk-engine-gaps.md` — the player-scoped effects the engine couldn't express — plus the three cards that motivate them. Each gap is built as a reusable, parameterized primitive (not a one-off for the card in front of it).

## Gap 4 — Enchant player (Grievous Wound, #102)
`{3}{B}{B}` Aura · *Enchant player. Enchanted player can't gain life. Whenever enchanted player is dealt damage, they lose half their life, rounded up.*

- **`Player.EnchantedPlayer`** reference — resolves from the source Aura's `AttachedToComponent` target; wired through `resolvePlayerRef` / `resolveUnifiedPlayerIds`.
- **Auras attach to a player:** `StackResolver` handles a `ChosenTarget.Player` aura target; `UnattachedAurasCheck` keeps a player-attached Aura while that player is in the game (704.5m); `AttachmentTriggerDetector` now fires `takesDamage(binding = ATTACHED)` when the enchanted *player* is dealt damage.
- **`PreventLifeGain`** gains a `Player.EnchantedPlayer` scope in `isLifeGainPrevented`.
- **Client:** a player-attached Aura renders standalone in its controller's row instead of being dropped (it was previously only ever rendered nested under a host battlefield card).

## Gap 5 — Durable life-gain lock (Screaming Nemesis, #157)
`{2}{R}` 3/3 · *…If a player is dealt damage this way, they can't gain life for the rest of the game.*

- **`Effects.LockLifeGain(target, duration?)`** (+ executor) tags a player with `CantGainLifeComponent` for a `Duration` (default rest-of-game), **independent of any source** — unlike the `PreventLifeGain` static replacement. Checked by `isLifeGainPrevented`; turn-scoped durations expire in cleanup. No-op on non-player targets, so it composes after the existing "deal damage to any other target" rider.

## Gap 6 — Dynamic max hand size (Winter, Misanthropic Guide, #240)
`{1}{B}{R}{G}` 3/4 · *Delirium — …each opponent's maximum hand size is equal to seven minus the number of those card types.*

- **`SetMaximumHandSize(player, DynamicAmount)`** static ability, read at cleanup by `CleanupPhaseManager` (most-restrictive value wins; `NoMaximumHandSize` still removes the cap). The cleanup read unwraps a `ConditionalStaticAbility` gate (Delirium) and evaluates its condition/amount against the source's controller.

## Tests
Scenario tests in `rules-engine` for all three cards (8 cases): aura stays attached to a player & survives SBAs, enchanted-player can't-gain-life, lose-half-life-on-damage; reflected lock persists across turns & no-ops on creatures; max hand size = 7−types under Delirium, default 7 below it, controller unaffected.

Full `:rules-engine` (4910), `:mtg-sdk`, and `:mtg-sets` (snapshot re-blessed + lint) suites pass; web-client typecheck clean. SDK reference updated.

## Notes / out of scope
- **mtgish generator (Step 8b):** not extended — these three mechanics are card-specific enough that the emitter would decline to render them; left for a follow-up.
- The enchant-player client treatment renders the Aura standalone on its controller's battlefield (correct & visible); a dedicated arrow/link to the enchanted player's life orb could be a future UX polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)