### PR TITLE
Add 13 The Lord of the Rings cards (ltr-pr-5)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AragornCompanyLeader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AragornCompanyLeader.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Aragorn, Company Leader
+ * {1}{G}{W}
+ * Legendary Creature — Human Ranger
+ * 3/3
+ *
+ * Whenever the Ring tempts you, if you chose a creature other than Aragorn as your Ring-bearer,
+ * put your choice of a counter from among first strike, vigilance, deathtouch, and lifelink on
+ * Aragorn.
+ * Whenever you put one or more counters on Aragorn, put one of each of those kinds of counters on
+ * up to one other target creature.
+ *
+ * The first ability is the Ring-tempt payoff (`Triggers.RingTemptsYou` +
+ * `Conditions.YouChoseOtherCreatureAsRingBearer`); "put your choice of a counter from among …" is a
+ * resolution-time `Effects.ChooseAction` over the four keyword-counter kinds, each branch adding one
+ * counter of that kind to Aragorn (`EffectTarget.Self`). The four counters are keyword counters
+ * (CR 122.1d): a first strike / vigilance / deathtouch / lifelink counter grants the matching
+ * keyword via the state projection's keyword-counter map.
+ *
+ * The second ability fires on `Triggers.CountersPlacedOnThis` (SELF-bound `CountersPlacedEvent`, any
+ * kind), so any counter landing on Aragorn — including the one from his own first ability — puts one
+ * of EACH of the four named kinds onto up to one OTHER target creature
+ * (`TargetOther(TargetCreature(optional))`).
+ */
+val AragornCompanyLeader = card("Aragorn, Company Leader") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever the Ring tempts you, if you chose a creature other than Aragorn as your " +
+        "Ring-bearer, put your choice of a counter from among first strike, vigilance, deathtouch, " +
+        "and lifelink on Aragorn.\n" +
+        "Whenever you put one or more counters on Aragorn, put one of each of those kinds of " +
+        "counters on up to one other target creature."
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        triggerCondition = Conditions.YouChoseOtherCreatureAsRingBearer
+        effect = Effects.ChooseAction(
+            listOf(
+                EffectChoice(
+                    label = "First strike counter",
+                    effect = Effects.AddCounters(Counters.FIRST_STRIKE, 1, EffectTarget.Self),
+                ),
+                EffectChoice(
+                    label = "Vigilance counter",
+                    effect = Effects.AddCounters(Counters.VIGILANCE, 1, EffectTarget.Self),
+                ),
+                EffectChoice(
+                    label = "Deathtouch counter",
+                    effect = Effects.AddCounters(Counters.DEATHTOUCH, 1, EffectTarget.Self),
+                ),
+                EffectChoice(
+                    label = "Lifelink counter",
+                    effect = Effects.AddCounters(Counters.LIFELINK, 1, EffectTarget.Self),
+                ),
+            )
+        )
+        description = "Whenever the Ring tempts you, if you chose a creature other than Aragorn as " +
+            "your Ring-bearer, put your choice of a counter from among first strike, vigilance, " +
+            "deathtouch, and lifelink on Aragorn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CountersPlacedOnThis
+        target("up to one other target creature", TargetOther(TargetCreature(count = 1, minCount = 0, optional = true)))
+        effect = Effects.Composite(
+            listOf(
+                Effects.AddCounters(Counters.FIRST_STRIKE, 1, EffectTarget.ContextTarget(0)),
+                Effects.AddCounters(Counters.VIGILANCE, 1, EffectTarget.ContextTarget(0)),
+                Effects.AddCounters(Counters.DEATHTOUCH, 1, EffectTarget.ContextTarget(0)),
+                Effects.AddCounters(Counters.LIFELINK, 1, EffectTarget.ContextTarget(0)),
+            )
+        )
+        description = "Whenever you put one or more counters on Aragorn, put one of each of those " +
+            "kinds of counters on up to one other target creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "191"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg?1686969633"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AragornCompanyLeader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AragornCompanyLeader.kt
@@ -27,7 +27,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetOther
  * `Conditions.YouChoseOtherCreatureAsRingBearer`); "put your choice of a counter from among …" is a
  * resolution-time `Effects.ChooseAction` over the four keyword-counter kinds, each branch adding one
  * counter of that kind to Aragorn (`EffectTarget.Self`). The four counters are keyword counters
- * (CR 122.1d): a first strike / vigilance / deathtouch / lifelink counter grants the matching
+ * (CR 122.1b): a first strike / vigilance / deathtouch / lifelink counter grants the matching
  * keyword via the state projection's keyword-counter map.
  *
  * The second ability fires on `Triggers.CountersPlacedOnThis` (SELF-bound `CountersPlacedEvent`, any

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FlameOfAnor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FlameOfAnor.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Flame of Anor
+ * {1}{U}{R}
+ * Instant
+ *
+ * Choose one. If you control a Wizard as you cast this spell, you may choose two instead.
+ * • Target player draws two cards.
+ * • Destroy target artifact.
+ * • Flame of Anor deals 5 damage to target creature.
+ *
+ * The conditional modal count is a cast-time `dynamicChooseCount`: the floor stays
+ * `minChooseCount = 1` ("choose one" is mandatory), and the cap is 2 when you control a
+ * Wizard as you cast the spell, otherwise 1 — evaluated against the battlefield at cast
+ * time by [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler].
+ */
+val FlameOfAnor = card("Flame of Anor") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Instant"
+    oracleText = "Choose one. If you control a Wizard as you cast this spell, you may choose two instead.\n" +
+        "• Target player draws two cards.\n" +
+        "• Destroy target artifact.\n" +
+        "• Flame of Anor deals 5 damage to target creature."
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.YouControlAtLeast(1, GameObjectFilter.Creature.withSubtype("Wizard")),
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1)
+            )
+        ) {
+            mode("Target player draws two cards") {
+                val player = target("target player", Targets.Player)
+                effect = Effects.DrawCards(2, player)
+            }
+            mode("Destroy target artifact") {
+                val artifact = target("target artifact", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+            mode("Flame of Anor deals 5 damage to target creature") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.DealDamage(5, creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "203"
+        artist = "Yigit Koroglu"
+        flavorText = "There was a ringing clash and a stab of white fire, and the Balrog fell back."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg?1686969766"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoSauronsBane.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FrodoSauronsBane.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frodo, Sauron's Bane
+ * {W}
+ * Legendary Creature — Halfling Citizen
+ * 1/2
+ *
+ * {W/B}{W/B}: If Frodo is a Citizen, it becomes a Halfling Scout with base power and
+ * toughness 2/3 and lifelink.
+ * {B}{B}{B}: If Frodo is a Scout, it becomes a Halfling Rogue with "Whenever this creature
+ * deals combat damage to a player, that player loses the game if the Ring has tempted you
+ * four or more times this game. Otherwise, the Ring tempts you."
+ *
+ * Like Figure of Fable, each ability checks Frodo's creature types on resolution: the
+ * conditional gate lives inside the effect, not as an activation restriction, so the ability
+ * is always legal to activate but does nothing if Frodo isn't currently the prerequisite form.
+ * None of these abilities has a duration — they last until the game ends, Frodo leaves the
+ * battlefield, or a later effect changes his characteristics. The Scout step sets base P/T 2/3;
+ * the Rogue step keeps that base P/T (it only swaps the class subtype and grants the ability),
+ * because "becomes a Halfling Rogue" states no new power/toughness.
+ */
+/**
+ * Granted to Frodo when he becomes a Rogue: "Whenever this creature deals combat damage to a
+ * player, that player loses the game if the Ring has tempted you four or more times this game.
+ * Otherwise, the Ring tempts you."
+ */
+private val rogueCombatDamageAbility = TriggeredAbility.create(
+    trigger = Triggers.DealsCombatDamageToPlayer.event,
+    binding = Triggers.DealsCombatDamageToPlayer.binding,
+    effect = ConditionalEffect(
+        condition = Conditions.RingHasTemptedYouAtLeast(4),
+        effect = Effects.LoseGame(
+            target = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+            message = "Frodo, Sauron's Bane dealt combat damage (Ring tempted you 4+ times)"
+        ),
+        elseEffect = Effects.TheRingTemptsYou()
+    ),
+    descriptionOverride = "Whenever this creature deals combat damage to a player, that player loses the game if the Ring has tempted you four or more times this game. Otherwise, the Ring tempts you."
+)
+
+val FrodoSauronsBane = card("Frodo, Sauron's Bane") {
+    manaCost = "{W}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Halfling Citizen"
+    power = 1
+    toughness = 2
+    oracleText = "{W/B}{W/B}: If Frodo is a Citizen, it becomes a Halfling Scout with base power and toughness 2/3 and lifelink.\n" +
+        "{B}{B}{B}: If Frodo is a Scout, it becomes a Halfling Rogue with \"Whenever this creature deals combat damage to a player, that player loses the game if the Ring has tempted you four or more times this game. Otherwise, the Ring tempts you.\""
+
+    // {W/B}{W/B}: If Frodo is a Citizen, becomes a 2/3 Halfling Scout with lifelink.
+    activatedAbility {
+        cost = Costs.Mana("{W/B}{W/B}")
+        effect = ConditionalEffect(
+            condition = Conditions.SourceHasSubtype(Subtype.CITIZEN),
+            effect = Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 2,
+                toughness = 3,
+                keywords = setOf(Keyword.LIFELINK),
+                creatureTypes = setOf("Halfling", "Scout"),
+                duration = Duration.Permanent
+            )
+        )
+    }
+
+    // {B}{B}{B}: If Frodo is a Scout, becomes a Halfling Rogue with the combat-damage trigger.
+    // Keeps his current base P/T (2/3 from the Scout step); only the class subtype changes and
+    // the triggered ability is granted permanently.
+    activatedAbility {
+        cost = Costs.Mana("{B}{B}{B}")
+        effect = ConditionalEffect(
+            condition = Conditions.SourceHasSubtype(Subtype.SCOUT),
+            effect = Effects.SetCreatureSubtypes(
+                subtypes = setOf("Halfling", "Rogue"),
+                target = EffectTarget.Self,
+                duration = Duration.Permanent
+            ) then GrantTriggeredAbilityEffect(
+                ability = rogueCombatDamageAbility,
+                target = EffectTarget.Self,
+                duration = Duration.Permanent
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg?1686967812"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheGrey.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheGrey.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gandalf the Grey
+ * {3}{U}{R}
+ * Legendary Creature — Avatar Wizard
+ * 3/4
+ *
+ * Whenever you cast an instant or sorcery spell, choose one that hasn't been chosen —
+ * • You may tap or untap target permanent.
+ * • Gandalf deals 3 damage to each opponent.
+ * • Copy target instant or sorcery spell you control. You may choose new targets for the copy.
+ * • Put Gandalf on top of its owner's library.
+ *
+ * "Choose one that hasn't been chosen" is modeled with [ModalEffect.chooseOneNotYetChosen]:
+ * the engine remembers which modes this Gandalf has already chosen (in a per-source
+ * memory component) and never offers them again. Once all four have been chosen, the
+ * ability has no legal mode and does nothing. The memory persists while this Gandalf
+ * remains the same object; the fourth mode (return Gandalf to the library) resets it by
+ * making Gandalf a new object on a later cast.
+ */
+val GandalfTheGrey = card("Gandalf the Grey") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever you cast an instant or sorcery spell, choose one that hasn't been chosen —\n" +
+        "• You may tap or untap target permanent.\n" +
+        "• Gandalf deals 3 damage to each opponent.\n" +
+        "• Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n" +
+        "• Put Gandalf on top of its owner's library."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = ModalEffect.chooseOneNotYetChosen(
+            // • You may tap or untap target permanent.
+            Mode.withTarget(
+                MayEffect(
+                    Effects.ChooseAction(
+                        listOf(
+                            EffectChoice("Tap it", Effects.Tap(EffectTarget.ContextTarget(0))),
+                            EffectChoice("Untap it", Effects.Untap(EffectTarget.ContextTarget(0)))
+                        )
+                    ),
+                    descriptionOverride = "You may tap or untap that permanent"
+                ),
+                Targets.Permanent,
+                "You may tap or untap target permanent"
+            ),
+            // • Gandalf deals 3 damage to each opponent.
+            Mode.noTarget(
+                Effects.DealDamage(
+                    3,
+                    EffectTarget.PlayerRef(Player.EachOpponent),
+                    damageSource = EffectTarget.Self
+                ),
+                "Gandalf deals 3 damage to each opponent"
+            ),
+            // • Copy target instant or sorcery spell you control. You may choose new targets for the copy.
+            Mode.withTarget(
+                Effects.CopyTargetSpell(),
+                Targets.InstantOrSorcerySpellYouControl,
+                "Copy target instant or sorcery spell you control. You may choose new targets for the copy"
+            ),
+            // • Put Gandalf on top of its owner's library.
+            Mode.noTarget(
+                Effects.PutOnTopOfLibrary(EffectTarget.Self),
+                "Put Gandalf on top of its owner's library"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "207"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg?1686969808"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Glamdring.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Glamdring.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Glamdring — The Lord of the Rings: Tales of Middle-earth #239
+ * {2} · Legendary Artifact — Equipment · Mythic
+ *
+ * Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your
+ * graveyard.
+ * Whenever equipped creature deals combat damage to a player, you may cast an instant or sorcery
+ * spell from your hand with mana value less than or equal to that damage without paying its mana
+ * cost.
+ * Equip {3}
+ *
+ * Composed entirely from existing primitives:
+ *   1. [GrantKeyword] first strike + [GrantDynamicStatsEffect] +X/+0 on [Filters.EquippedCreature],
+ *      where X is a graveyard-count [DynamicAmount] over instant/sorcery cards in your graveyard.
+ *   2. A [Triggers.DealsCombatDamageToPlayer]-shaped trigger bound to the equipped creature
+ *      ([TriggerBinding.ATTACHED]). "That damage" is read from the triggering damage event via
+ *      [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] and stored as the free-cast mana-value cap, then
+ *      the same Press-the-Enemy free-cast pipeline (gather hand instants/sorceries → keep MV ≤ cap
+ *      → optional [Effects.CastFromCollectionWithoutPayingCost]) offers the optional free cast.
+ */
+val Glamdring = card("Glamdring") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature has first strike and gets +1/+0 for each instant and sorcery " +
+        "card in your graveyard.\n" +
+        "Whenever equipped creature deals combat damage to a player, you may cast an instant or " +
+        "sorcery spell from your hand with mana value less than or equal to that damage without " +
+        "paying its mana cost.\n" +
+        "Equip {3}"
+
+    // Equipped creature has first strike...
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.EquippedCreature)
+    }
+
+    // ...and gets +1/+0 for each instant and sorcery card in your graveyard.
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = Filters.EquippedCreature,
+            powerBonus = DynamicAmounts.zone(
+                Player.You,
+                Zone.GRAVEYARD,
+                GameObjectFilter.InstantOrSorcery
+            ).count(),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    // Whenever equipped creature deals combat damage to a player, you may cast an instant or
+    // sorcery spell from your hand with MV ≤ that damage without paying its mana cost.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.Composite(
+            // Capture "that damage" — the combat damage just dealt to the player.
+            Effects.StoreNumber(
+                "combatDamage",
+                DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+            ),
+            // Gather instant/sorcery cards from your hand with MV ≤ that damage.
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.HAND,
+                    player = Player.You,
+                    filter = GameObjectFilter.InstantOrSorcery
+                ),
+                storeAs = "handSpells"
+            ),
+            FilterCollectionEffect(
+                from = "handSpells",
+                filter = CollectionFilter.ManaValueAtMost(DynamicAmount.VariableReference("combatDamage")),
+                storeMatching = "castable"
+            ),
+            // You may cast one of them without paying its mana cost.
+            ConditionalOnCollectionEffect(
+                collection = "castable",
+                ifNotEmpty = MayEffect(Effects.CastFromCollectionWithoutPayingCost("castable"))
+            )
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "239"
+        artist = "Andrea Piparo"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg?1686970159"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/KingOfTheOathbreakers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/KingOfTheOathbreakers.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * King of the Oathbreakers
+ * {2}{W}{B}
+ * Legendary Creature — Spirit Noble
+ * 3/3
+ *
+ * Flying
+ * Whenever King of the Oathbreakers or another Spirit you control becomes the target
+ * of a spell, it phases out.
+ * Whenever King of the Oathbreakers or another Spirit you control phases in, create a
+ * tapped 1/1 white Spirit creature token with flying.
+ *
+ * Engine notes (Gap 32 — phasing, CR 702.26):
+ * - Phasing already exists in the engine: `Effects.PhaseOut` adds a `PhasedOutComponent`,
+ *   `GameState.getBattlefield` hides phased-out permanents from projection/combat/targeting,
+ *   and `BeginningPhaseManager.performUntapStep` phases them back in (emitting `PhasedInEvent`)
+ *   during their controller's untap step.
+ * - The "becomes the target of a spell" wording (not abilities) is modeled by the new
+ *   `Triggers.BecomesTargetOfSpell(filter)` — a `BecomesTargetEvent(spellsOnly = true)` that
+ *   only matches when the targeting source is a spell on the stack (`sourceIsSpell`). The ANY
+ *   binding with filter "a Spirit you control" covers both "King … or another Spirit you control"
+ *   halves, because King itself is a Spirit you control. `EffectTarget.TriggeringEntity` resolves
+ *   to the targeted Spirit, so "it phases out" affects exactly the targeted permanent.
+ * - The "phases in" trigger is the new `Triggers.PhasesIn(filter)` over `PhasedInEvent`. King
+ *   itself phasing back in (on its controller's untap step) is the common case and is covered by
+ *   the same Spirit-you-control filter.
+ */
+val KingOfTheOathbreakers = card("King of the Oathbreakers") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Spirit Noble"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever King of the Oathbreakers or another Spirit you control becomes the target of a " +
+        "spell, it phases out. (Treat it and anything attached to it as though they don't exist " +
+        "until your next turn.)\n" +
+        "Whenever King of the Oathbreakers or another Spirit you control phases in, create a " +
+        "tapped 1/1 white Spirit creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever King of the Oathbreakers or another Spirit you control becomes the target
+    // of a spell, it phases out.
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetOfSpell(
+            GameObjectFilter.Creature.withSubtype(Subtype.SPIRIT).youControl()
+        )
+        effect = Effects.PhaseOut(EffectTarget.TriggeringEntity)
+    }
+
+    // Whenever King of the Oathbreakers or another Spirit you control phases in, create a
+    // tapped 1/1 white Spirit creature token with flying.
+    triggeredAbility {
+        trigger = Triggers.PhasesIn(
+            GameObjectFilter.Creature.withSubtype(Subtype.SPIRIT).youControl()
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            tapped = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "211"
+        artist = "Tatiana Veryayskaya"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg?1686969851"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PippinGuardOfTheCitadel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PippinGuardOfTheCitadel.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Pippin, Guard of the Citadel
+ * {W}{U}
+ * Legendary Creature — Halfling Soldier
+ * 2/2
+ *
+ * Vigilance, ward {1}
+ * {T}: Another target creature you control gains protection from the card type of your choice
+ * until end of turn.
+ *
+ * The activated ability uses [Effects.GrantProtectionFromChosenCardType], the card-type analogue
+ * of the chosen-color protection effect: at resolution the controller picks a card type and the
+ * target gains a floating `PROTECTION_FROM_CARDTYPE_<TYPE>` keyword.
+ */
+val PippinGuardOfTheCitadel = card("Pippin, Guard of the Citadel") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Halfling Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance, ward {1}\n" +
+        "{T}: Another target creature you control gains protection from the card type of your " +
+        "choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or " +
+        "equipped by anything of that type.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.ward("{1}"))
+
+    activatedAbility {
+        cost = Costs.Tap
+        target = Targets.OtherCreatureYouControl
+        effect = Effects.GrantProtectionFromChosenCardType()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "218"
+        flavorText = "\"Here do I swear fealty to Gondor, until my lord release me, or death take me.\""
+        artist = "Bartłomiej Gaweł"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg?1686969929"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PressTheEnemy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PressTheEnemy.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetSpellOrPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Press the Enemy — The Lord of the Rings: Tales of Middle-earth #65
+ * {2}{U}{U} · Instant · Rare
+ *
+ * Return target spell or nonland permanent an opponent controls to its owner's hand. You may
+ * cast an instant or sorcery spell with equal or lesser mana value from your hand without
+ * paying its mana cost.
+ *
+ * Composed from existing pipeline primitives:
+ *   1. Capture the target's mana value *before* the bounce — once a spell leaves the stack (or
+ *      a permanent leaves the battlefield) the engine no longer tracks it as the same object,
+ *      so the MV cap must be stored up front (`StoreNumber`).
+ *   2. `ReturnSpellOrPermanentToOwnersHand` — one bounce that dispatches on the resolved target:
+ *      a spell on the stack is removed from the stack to its owner's hand (it does not resolve,
+ *      and this is not a counter), a permanent is bounced normally.
+ *   3. Gather instant/sorcery cards in your hand, keep only those with MV ≤ the stored cap.
+ *   4. `MayEffect(CastFromCollectionWithoutPayingCost)` — optional free cast; only prompted when
+ *      a legal castable card exists, so a too-expensive spell is never offered.
+ */
+val PressTheEnemy = card("Press the Enemy") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target spell or nonland permanent an opponent controls to its owner's hand. " +
+        "You may cast an instant or sorcery spell with equal or lesser mana value from your hand " +
+        "without paying its mana cost."
+
+    spell {
+        val t = target(
+            "target spell or nonland permanent an opponent controls",
+            TargetSpellOrPermanent(
+                permanentFilter = GameObjectFilter.NonlandPermanent.opponentControls()
+            )
+        )
+        effect = Effects.Composite(
+            listOf(
+                // Capture the bounced object's mana value as the free-cast cap.
+                Effects.StoreNumber(
+                    "bouncedMv",
+                    DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue)
+                ),
+                // Return the spell or nonland permanent to its owner's hand.
+                Effects.ReturnSpellOrPermanentToOwnersHand(t),
+                // Gather instant/sorcery cards from your hand with MV ≤ the captured cap.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.HAND,
+                        player = Player.You,
+                        filter = GameObjectFilter.InstantOrSorcery
+                    ),
+                    storeAs = "handSpells"
+                ),
+                FilterCollectionEffect(
+                    from = "handSpells",
+                    filter = CollectionFilter.ManaValueAtMost(DynamicAmount.VariableReference("bouncedMv")),
+                    storeMatching = "castable"
+                ),
+                // You may cast one of them without paying its mana cost.
+                ConditionalOnCollectionEffect(
+                    collection = "castable",
+                    ifNotEmpty = MayEffect(Effects.CastFromCollectionWithoutPayingCost("castable"))
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "65"
+        artist = "Valera Lutfullina"
+        flavorText = "\"I showed the blade reforged to him. He is not so mighty yet that he is above fear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg?1686968246"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheNecromancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheNecromancer.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sauron, the Necromancer — The Lord of the Rings: Tales of Middle-earth #106
+ * {3}{B}{B} · Legendary Creature — Avatar Horror · Rare
+ * 4/4
+ *
+ * Menace
+ * Whenever Sauron attacks, exile target creature card from your graveyard. Create a tapped and
+ * attacking token that's a copy of that card, except it's a 3/3 black Wraith with menace. At the
+ * beginning of the next end step, exile that token unless Sauron is your Ring-bearer.
+ *
+ * Modeling:
+ * - The attack trigger targets a creature card in your graveyard, exiles it, then creates a token
+ *   copy of "that card" via [Effects.CreateTokenCopyOfTarget]. The token copies the exiled card's
+ *   copiable values (read from its CardComponent, which survives the move to exile), then applies
+ *   the printed overrides: 3/3 (`overridePower`/`overrideToughness`), black (`overrideColors`),
+ *   Wraith (`overrideSubtypes`, replacing the copied creature types), and menace (`addedKeywords`).
+ *   It enters tapped and attacking (`tapped`/`attacking`).
+ * - "At the beginning of the next end step, exile that token unless Sauron is your Ring-bearer"
+ *   is the copy effect's `exileAtStep = Step.END` with `exileUnlessSourceIsRingBearer = true`. The
+ *   firing step is the next end step of any player's turn ("the next end step"); the Ring-bearer
+ *   gate (CR 701.54e) is re-evaluated against Sauron when the delayed trigger fires.
+ */
+val SauronTheNecromancer = card("Sauron, the Necromancer") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Avatar Horror"
+    power = 4
+    toughness = 4
+    oracleText = "Menace\n" +
+        "Whenever Sauron attacks, exile target creature card from your graveyard. Create a tapped " +
+        "and attacking token that's a copy of that card, except it's a 3/3 black Wraith with " +
+        "menace. At the beginning of the next end step, exile that token unless Sauron is your " +
+        "Ring-bearer."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val card = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard
+        )
+        effect = Effects.Composite(listOf(
+            Effects.Exile(card),
+            Effects.CreateTokenCopyOfTarget(
+                target = EffectTarget.ContextTarget(0),
+                overridePower = 3,
+                overrideToughness = 3,
+                overrideColors = setOf(Color.BLACK),
+                overrideSubtypes = setOf(Subtype("Wraith")),
+                addedKeywords = setOf(Keyword.MENACE),
+                tapped = true,
+                attacking = true,
+                exileAtStep = Step.END,
+                exileUnlessSourceIsRingBearer = true
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "106"
+        artist = "Yongjae Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg?1686968699"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShelobChildOfUngoliant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShelobChildOfUngoliant.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantWard
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shelob, Child of Ungoliant — The Lord of the Rings: Tales of Middle-earth #230
+ * {4}{B}{G} · Legendary Creature — Spider Demon · Rare
+ * 8/8
+ *
+ * Deathtouch, ward {2}
+ * Other Spiders you control have deathtouch and ward {2}.
+ * Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token
+ * that's a copy of that creature, except it's a Food artifact with "{2}, {T}, Sacrifice this token:
+ * You gain 3 life," and it loses all other card types.
+ *
+ * Modeling:
+ * - Deathtouch is an intrinsic keyword; "ward {2}" is the parameterized ward keyword ability
+ *   ([KeywordAbility.ward]).
+ * - The Spider anthem is two `other Spiders you control` static grants: [GrantKeyword] (deathtouch)
+ *   and [GrantWard] (`{2}`), filtered by [GroupFilter.AllCreaturesYouControl] `.withSubtype("Spider").other()`.
+ * - The death-tracking ability uses the observer form of the dealt-damage-by-source-dies trigger
+ *   ([Triggers.creatureDealtDamageBySourceDies] with a "Spider you control" source filter). The
+ *   damaging source is matched against the filter using last-known info from when it dealt the
+ *   damage, so a Spider that died in the same combat still qualifies (CR 608.2h). The token copy of
+ *   the dying creature is built with [Effects.CreateTokenCopyOfTarget]: `overrideCardTypes = {ARTIFACT}`
+ *   makes it "a Food artifact … and it loses all other card types", `addedSubtypes = {Food}` adds the
+ *   Food type, and `activatedAbilities` grants the Food sacrifice ability.
+ */
+val ShelobChildOfUngoliant = card("Shelob, Child of Ungoliant") {
+    manaCost = "{4}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Spider Demon"
+    power = 8
+    toughness = 8
+    oracleText = "Deathtouch, ward {2}\n" +
+        "Other Spiders you control have deathtouch and ward {2}.\n" +
+        "Whenever another creature dealt damage this turn by a Spider you controlled dies, create a " +
+        "token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, " +
+        "Sacrifice this token: You gain 3 life,\" and it loses all other card types."
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    // "Other Spiders you control have deathtouch and ward {2}."
+    val otherSpiders = GroupFilter.AllCreaturesYouControl.withSubtype("Spider").other()
+    staticAbility { ability = GrantKeyword(Keyword.DEATHTOUCH, otherSpiders) }
+    staticAbility { ability = GrantWard(cost = WardCost.Mana("{2}"), filter = otherSpiders) }
+
+    // "Whenever another creature dealt damage this turn by a Spider you controlled dies, ..."
+    triggeredAbility {
+        trigger = Triggers.creatureDealtDamageBySourceDies(
+            GameObjectFilter.Creature.youControl().withSubtype("Spider")
+        )
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = EffectTarget.TriggeringEntity,
+            overrideCardTypes = setOf(CardType.ARTIFACT),
+            addedSubtypes = setOf(Subtype("Food")),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf),
+                    effect = Effects.GainLife(3)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Lorenzo Mastroianni"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg?1686970060"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/StingTheGlintingDagger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/StingTheGlintingDagger.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sting, the Glinting Dagger
+ * {2}
+ * Legendary Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 and has haste.
+ * At the beginning of each combat, untap equipped creature.
+ * Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.
+ * Equip {2}
+ *
+ * The conditional first strike is a [ConditionalStaticAbility] granting first strike to the
+ * equipped creature, gated on [Conditions.SourceIsBlockingOrBlockedBySubtype]. The condition reads
+ * the equipped creature (through the Equipment's attachment) and checks both combat directions —
+ * the attackers it blocks and the creatures blocking it — against the Goblin/Orc subtypes via
+ * projected state, so the keyword is honored when first-strike combat damage is assigned.
+ */
+val StingTheGlintingDagger = card("Sting, the Glinting Dagger") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has haste.\n" +
+        "At the beginning of each combat, untap equipped creature.\n" +
+        "Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.\n" +
+        "Equip {2}"
+
+    // Equipped creature gets +1/+1...
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // ...and has haste.
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, Filters.EquippedCreature)
+    }
+
+    // At the beginning of each combat, untap equipped creature.
+    triggeredAbility {
+        trigger = Triggers.EachCombat
+        effect = Effects.Untap(EffectTarget.EquippedCreature)
+    }
+
+    // Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.EquippedCreature),
+            condition = Conditions.SourceIsBlockingOrBlockedBySubtype(listOf(Subtype.GOBLIN, Subtype.ORC))
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "250"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg?1686970284"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBalrogDurinsBane.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBalrogDurinsBane.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * The Balrog, Durin's Bane
+ * {5}{B}{R}
+ * Legendary Creature — Avatar Demon
+ * 7/5
+ *
+ * This spell costs {1} less to cast for each permanent sacrificed this turn.
+ * Haste
+ * The Balrog can't be blocked except by legendary creatures.
+ * When The Balrog dies, destroy target artifact or creature an opponent controls.
+ *
+ * Engine notes (Gap 30 — cost reduction by per-turn game history):
+ * - "Costs {1} less for each permanent sacrificed this turn" is the per-turn-history analogue of
+ *   the existing zone-count cost reductions. It reads the new turn-scoped GameState counter
+ *   `permanentsSacrificedThisTurn` via `CostReductionSource.PermanentsSacrificedThisTurn`. The
+ *   wording is NOT controller-scoped — every permanent sacrificed by any player this turn counts.
+ *   The counter is incremented by the central sacrifice hook
+ *   `ZoneTransitionService.trackPermanentSacrifice` (called at every sacrifice site) and reset to
+ *   0 in `TurnManager.startTurn`. The reduction floors the mana component at the colored
+ *   requirement {B}{R} (CR 601.2f), so the cheapest possible cast is {B}{R}.
+ * - "Can't be blocked except by legendary creatures" — the evasion static
+ *   `CantBeBlockedExceptBy` with a legendary-creature blocker filter.
+ * - The dies trigger destroys "target artifact or creature an opponent controls"
+ *   (`GameObjectFilter.CreatureOrArtifact.opponentControls()`).
+ */
+val TheBalrogDurinsBane = card("The Balrog, Durin's Bane") {
+    manaCost = "{5}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Avatar Demon"
+    oracleText = "This spell costs {1} less to cast for each permanent sacrificed this turn.\n" +
+        "Haste\n" +
+        "The Balrog can't be blocked except by legendary creatures.\n" +
+        "When The Balrog dies, destroy target artifact or creature an opponent controls."
+    power = 7
+    toughness = 5
+
+    keywords(Keyword.HASTE)
+
+    // This spell costs {1} less to cast for each permanent sacrificed this turn.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.PermanentsSacrificedThisTurn(),
+            ),
+        )
+    }
+
+    // The Balrog can't be blocked except by legendary creatures.
+    staticAbility {
+        ability = CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.legendary())
+    }
+
+    // When The Balrog dies, destroy target artifact or creature an opponent controls.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target(
+            "target artifact or creature an opponent controls",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.opponentControls())),
+        )
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "195"
+        artist = "Kekai Kotaki"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg?1686969678"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WitchKingOfAngmar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WitchKingOfAngmar.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Witch-king of Angmar
+ * {3}{B}{B}
+ * Legendary Creature — Wraith Noble
+ * 5/3
+ *
+ * Flying
+ * Whenever one or more creatures deal combat damage to you, each opponent sacrifices a creature of
+ * their choice that dealt combat damage to you this turn. The Ring tempts you.
+ * Discard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it.
+ *
+ * The triggered ability uses the defensive combat-damage batch trigger
+ * `Triggers.OneOrMoreCreaturesDealCombatDamageToYou()` (fires once per combat regardless of how
+ * many creatures connected). The edict restricts each opponent's sacrifice to creatures matching
+ * the new source-relative filter `dealtCombatDamageToSourceControllerThisTurn()` — i.e. creatures
+ * that dealt combat damage to the Witch-king's controller this turn.
+ */
+val WitchKingOfAngmar = card("Witch-king of Angmar") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Wraith Noble"
+    power = 5
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever one or more creatures deal combat damage to you, each opponent sacrifices a " +
+        "creature of their choice that dealt combat damage to you this turn. The Ring tempts you.\n" +
+        "Discard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesDealCombatDamageToYou()
+        effect = Effects.Sacrifice(
+            filter = GameObjectFilter.Creature.dealtCombatDamageToSourceControllerThisTurn(),
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    activatedAbility {
+        cost = Costs.DiscardCard
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self, Duration.EndOfTurn)
+            .then(Effects.Tap(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "114"
+        artist = "Anato Finnstark"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg?1686968786"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -366,6 +366,141 @@
     ]
 }
 
+// Aragorn, Company Leader
+{
+    "name": "Aragorn, Company Leader",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Legendary Creature — Human Ranger",
+    "oracleText": "Whenever the Ring tempts you, if you chose a creature other than Aragorn as your Ring-bearer, put your choice of a counter from among first strike, vigilance, deathtouch, and lifelink on Aragorn.\nWhenever you put one or more counters on Aragorn, put one of each of those kinds of counters on up to one other target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "RingTemptedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ChooseAction",
+                    "choices": [
+                        {
+                            "label": "First strike counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "first strike",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "label": "Vigilance counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "vigilance",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "label": "Deathtouch counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "deathtouch",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "label": "Lifelink counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "lifelink",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": "YouChoseOtherCreatureAsRingBearer",
+                "descriptionOverride": "Whenever the Ring tempts you, if you chose a creature other than Aragorn as your Ring-bearer, put your choice of a counter from among first strike, vigilance, deathtouch, and lifelink on Aragorn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "any"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "first strike",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "vigilance",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "deathtouch",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "lifelink",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOther",
+                    "baseRequirement": {
+                        "type": "TargetObject",
+                        "minCount": 0,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "id": "up to one other target creature"
+                },
+                "descriptionOverride": "Whenever you put one or more counters on Aragorn, put one of each of those kinds of counters on up to one other target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg?1686969633"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Aragorn, the Uniter
 {
     "name": "Aragorn, the Uniter",
@@ -5253,6 +5388,122 @@
     ]
 }
 
+// Flame of Anor
+{
+    "name": "Flame of Anor",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one. If you control a Wizard as you cast this spell, you may choose two instead.\n• Target player draws two cards.\n• Destroy target artifact.\n• Flame of Anor deals 5 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Target player draws two cards"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target artifact"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Flame of Anor deals 5 damage to target creature"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Wizard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "RARE",
+        "artist": "Yigit Koroglu",
+        "flavorText": "There was a ringing clash and a stab of white fire, and the Balrog fell back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg?1686969766"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Flowering of the White Tree
 {
     "name": "Flowering of the White Tree",
@@ -5701,6 +5952,138 @@
     ]
 }
 
+// Frodo, Sauron's Bane
+{
+    "name": "Frodo, Sauron's Bane",
+    "manaCost": "{W}",
+    "typeLine": "Legendary Creature — Halfling Citizen",
+    "oracleText": "{W/B}{W/B}: If Frodo is a Citizen, it becomes a Halfling Scout with base power and toughness 2/3 and lifelink.\n{B}{B}{B}: If Frodo is a Scout, it becomes a Halfling Rogue with \"Whenever this creature deals combat damage to a player, that player loses the game if the Ring has tempted you four or more times this game. Otherwise, the Ring tempts you.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W/B}{W/B}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": "Citizen"
+                        }
+                    },
+                    "then": {
+                        "type": "BecomeCreature",
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "keywords": [
+                            "LIFELINK"
+                        ],
+                        "creatureTypes": [
+                            "Halfling",
+                            "Scout"
+                        ],
+                        "duration": "Permanent"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{B}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": "Scout"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetCreatureSubtypes",
+                                "subtypes": [
+                                    "Halfling",
+                                    "Rogue"
+                                ]
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_3",
+                                    "trigger": {
+                                        "type": "DealsDamageEvent",
+                                        "damageType": "DamageCombat",
+                                        "recipient": "AnyPlayer"
+                                    },
+                                    "effect": {
+                                        "type": "Gated",
+                                        "gate": {
+                                            "type": "Gate.WhenCondition",
+                                            "condition": {
+                                                "type": "RingHasTemptedPlayerAtLeast",
+                                                "times": 4
+                                            }
+                                        },
+                                        "then": {
+                                            "type": "LoseGame",
+                                            "target": {
+                                                "type": "PlayerRef",
+                                                "player": "TriggeringPlayer"
+                                            },
+                                            "message": "Frodo, Sauron's Bane dealt combat damage (Ring tempted you 4+ times)"
+                                        },
+                                        "otherwise": "TheRingTemptsYou"
+                                    },
+                                    "descriptionOverride": "Whenever this creature deals combat damage to a player, that player loses the game if the Ring has tempted you four or more times this game. Otherwise, the Ring tempts you."
+                                },
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "RARE",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg?1686967812"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Galadhrim Bow
 {
     "name": "Galadhrim Bow",
@@ -6115,6 +6498,136 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Gandalf the Grey
+{
+    "name": "Gandalf the Grey",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Whenever you cast an instant or sorcery spell, choose one that hasn't been chosen —\n• You may tap or untap target permanent.\n• Gandalf deals 3 damage to each opponent.\n• Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n• Put Gandalf on top of its owner's library.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "ChooseAction",
+                                    "choices": [
+                                        {
+                                            "label": "Tap it",
+                                            "effect": {
+                                                "type": "TapUntap",
+                                                "target": {
+                                                    "type": "ContextTarget",
+                                                    "index": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "label": "Untap it",
+                                            "effect": {
+                                                "type": "TapUntap",
+                                                "target": {
+                                                    "type": "ContextTarget",
+                                                    "index": 0
+                                                },
+                                                "tap": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "descriptionOverride": "You may tap or untap that permanent"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "permanent"
+                                    }
+                                }
+                            ],
+                            "description": "You may tap or untap target permanent"
+                        },
+                        {
+                            "effect": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                },
+                                "damageSource": "Self"
+                            },
+                            "description": "Gandalf deals 3 damage to each opponent"
+                        },
+                        {
+                            "effect": "CopyTargetSpell",
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "instant|sorcery ctrl:you",
+                                        "zone": "Stack"
+                                    }
+                                }
+                            ],
+                            "description": "Copy target instant or sorcery spell you control. You may choose new targets for the copy"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": "Self",
+                                "destination": "Library",
+                                "placement": "Top"
+                            },
+                            "description": "Put Gandalf on top of its owner's library"
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "RARE",
+        "artist": "Aaron Miller",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg?1686969808"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -6844,6 +7357,134 @@
         "GREEN",
         "RED"
     ]
+}
+
+// Glamdring
+{
+    "name": "Glamdring",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard.\nWhenever equipped creature deals combat damage to a player, you may cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "StoreNumber",
+                            "name": "combatDamage",
+                            "amount": {
+                                "type": "ContextProperty",
+                                "key": "TRIGGER_DAMAGE_AMOUNT"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "instant|sorcery"
+                            },
+                            "storeAs": "handSpells"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "handSpells",
+                            "filter": {
+                                "type": "ManaValueAtMost",
+                                "max": {
+                                    "type": "VariableReference",
+                                    "variableName": "combatDamage"
+                                }
+                            },
+                            "storeMatching": "castable"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "castable",
+                            "ifNotEmpty": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "CastFromCollectionWithoutPayingCost",
+                                    "from": "castable"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            },
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "AggregateZone",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "instant|sorcery"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "MYTHIC",
+        "artist": "Andrea Piparo",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg?1686970159"
+    },
+    "colorIdentityOverride": []
 }
 
 // Glorfindel, Dauntless Rescuer
@@ -8648,6 +9289,71 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// King of the Oathbreakers
+{
+    "name": "King of the Oathbreakers",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Legendary Creature — Spirit Noble",
+    "oracleText": "Flying\nWhenever King of the Oathbreakers or another Spirit you control becomes the target of a spell, it phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)\nWhenever King of the Oathbreakers or another Spirit you control phases in, create a tapped 1/1 white Spirit creature token with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "targetFilter": "creature Spirit ctrl:you",
+                    "spellsOnly": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PhaseOut",
+                    "target": "TriggeringEntity"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PhasesInEvent",
+                    "filter": "creature Spirit ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "tapped": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "RARE",
+        "artist": "Tatiana Veryayskaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg?1686969851"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 
@@ -12081,6 +12787,147 @@
     ]
 }
 
+// Pippin, Guard of the Citadel
+{
+    "name": "Pippin, Guard of the Citadel",
+    "manaCost": "{W}{U}",
+    "typeLine": "Legendary Creature — Halfling Soldier",
+    "oracleText": "Vigilance, ward {1}\n{T}: Another target creature you control gains protection from the card type of your choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything of that type.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "GrantProtectionFromChosenCardType",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you",
+                            "excludeSelf": true
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "RARE",
+        "artist": "Bartłomiej Gaweł",
+        "flavorText": "\"Here do I swear fealty to Gondor, until my lord release me, or death take me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg?1686969929"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Press the Enemy
+{
+    "name": "Press the Enemy",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target spell or nonland permanent an opponent controls to its owner's hand. You may cast an instant or sorcery spell with equal or lesser mana value from your hand without paying its mana cost.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "StoreNumber",
+                    "name": "bouncedMv",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "ManaValue"
+                    }
+                },
+                {
+                    "type": "ReturnSpellOrPermanentToOwnersHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target spell or nonland permanent an opponent controls"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "filter": "instant|sorcery"
+                    },
+                    "storeAs": "handSpells"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "handSpells",
+                    "filter": {
+                        "type": "ManaValueAtMost",
+                        "max": {
+                            "type": "VariableReference",
+                            "variableName": "bouncedMv"
+                        }
+                    },
+                    "storeMatching": "castable"
+                },
+                {
+                    "type": "ConditionalOnCollection",
+                    "collection": "castable",
+                    "ifNotEmpty": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "castable"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetSpellOrPermanent",
+                "id": "target spell or nonland permanent an opponent controls",
+                "permanentFilter": {
+                    "cardPredicates": [
+                        "IsNonland",
+                        "IsPermanent"
+                    ],
+                    "controllerPredicate": "ControlledByOpponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "RARE",
+        "artist": "Valera Lutfullina",
+        "flavorText": "\"I showed the blade reforged to him. He is not so mighty yet that he is above fear.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg?1686968246"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Prince Imrahil the Fair
 {
     "name": "Prince Imrahil the Fair",
@@ -13759,6 +14606,81 @@
     ]
 }
 
+// Sauron, the Necromancer
+{
+    "name": "Sauron, the Necromancer",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Avatar Horror",
+    "oracleText": "Menace\nWhenever Sauron attacks, exile target creature card from your graveyard. Create a tapped and attacking token that's a copy of that card, except it's a 3/3 black Wraith with menace. At the beginning of the next end step, exile that token unless Sauron is your Ring-bearer.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "overridePower": 3,
+                            "overrideToughness": 3,
+                            "tapped": true,
+                            "attacking": true,
+                            "addedKeywords": [
+                                "MENACE"
+                            ],
+                            "overrideColors": [
+                                "BLACK"
+                            ],
+                            "overrideSubtypes": [
+                                "Wraith"
+                            ],
+                            "exileAtStep": "END",
+                            "exileUnlessSourceIsRingBearer": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "RARE",
+        "artist": "Yongjae Choi",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg?1686968699"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Scroll of Isildur
 {
     "name": "Scroll of Isildur",
@@ -14153,6 +15075,110 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Shelob, Child of Ungoliant
+{
+    "name": "Shelob, Child of Ungoliant",
+    "manaCost": "{4}{B}{G}",
+    "typeLine": "Legendary Creature — Spider Demon",
+    "oracleText": "Deathtouch, ward {2}\nOther Spiders you control have deathtouch and ward {2}.\nWhenever another creature dealt damage this turn by a Spider you controlled dies, create a token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life,\" and it loses all other card types.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CreatureDealtDamageBySourceDiesEvent",
+                    "sourceFilter": "creature Spider ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": "TriggeringEntity",
+                    "addedSubtypes": [
+                        "Food"
+                    ],
+                    "overrideCardTypes": [
+                        "ARTIFACT"
+                    ],
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_2",
+                            "cost": {
+                                "type": "CostComposite",
+                                "costs": [
+                                    {
+                                        "type": "CostAtomWrapper",
+                                        "atom": {
+                                            "type": "AtomMana",
+                                            "cost": "{2}"
+                                        }
+                                    },
+                                    "CostTap",
+                                    "CostSacrificeSelf"
+                                ]
+                            },
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH",
+                "filter": {
+                    "baseFilter": "creature Spider ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantWard",
+                "cost": {
+                    "type": "WardCost.Mana",
+                    "manaCost": "{2}"
+                },
+                "filter": {
+                    "baseFilter": "creature Spider ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Lorenzo Mastroianni",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg?1686970060"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -15076,6 +16102,95 @@
     ]
 }
 
+// Sting, the Glinting Dagger
+{
+    "name": "Sting, the Glinting Dagger",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has haste.\nAt the beginning of each combat, untap equipped creature.\nEquipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EquippedCreature",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE"
+                },
+                "condition": {
+                    "type": "SourceIsBlockingOrBlockedBySubtype",
+                    "subtypes": [
+                        "Goblin",
+                        "Orc"
+                    ]
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "RARE",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg?1686970284"
+    },
+    "colorIdentityOverride": []
+}
+
 // Stone of Erech
 {
     "name": "Stone of Erech",
@@ -15498,6 +16613,78 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// The Balrog, Durin's Bane
+{
+    "name": "The Balrog, Durin's Bane",
+    "manaCost": "{5}{B}{R}",
+    "typeLine": "Legendary Creature — Avatar Demon",
+    "oracleText": "This spell costs {1} less to cast for each permanent sacrificed this turn.\nHaste\nThe Balrog can't be blocked except by legendary creatures.\nWhen The Balrog dies, destroy target artifact or creature an opponent controls.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|artifact ctrl:opponent"
+                    },
+                    "id": "target artifact or creature an opponent controls"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "PermanentsSacrificedThisTurn"
+                }
+            },
+            {
+                "type": "CantBeBlockedExceptBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        "IsLegendary"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "RARE",
+        "artist": "Kekai Kotaki",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg?1686969678"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -17300,6 +18487,83 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Witch-king of Angmar
+{
+    "name": "Witch-king of Angmar",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Wraith Noble",
+    "oracleText": "Flying\nWhenever one or more creatures deal combat damage to you, each opponent sacrifices a creature of their choice that dealt combat damage to you this turn. The Ring tempts you.\nDiscard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "OneOrMoreDealCombatDamageToYouEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForceSacrifice",
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "DealtCombatDamageToSourceControllerThisTurn"
+                                ]
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        "TheRingTemptsYou"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "MYTHIC",
+        "artist": "Anato Finnstark",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg?1686968786"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AragornCompanyLeaderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AragornCompanyLeaderScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.AragornCompanyLeader
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aragorn, Company Leader — Gap 7 (keyword counters + "choose a kind of counter").
+ *
+ * (a) A Ring tempt with a Ring-bearer other than Aragorn lets you choose a counter kind and put it
+ *     on Aragorn, granting the matching keyword via the projection's keyword-counter map.
+ * (b) Putting a counter on Aragorn fires his second ability, putting one of each of the four named
+ *     kinds (first strike, vigilance, deathtouch, lifelink) on up to one other target creature.
+ *
+ * The Ring tempt is driven by a local "Ring Tempter" sorcery (the Faramir test pattern); the
+ * Ring-bearer is designated by answering the temptation's SelectCardsDecision with a creature other
+ * than Aragorn.
+ */
+class AragornCompanyLeaderScenarioTest : FunSpec({
+
+    val RingTempter = card("Ring Tempter") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "The Ring tempts you."
+        spell { effect = Effects.TheRingTemptsYou() }
+    }
+
+    val Bear = CardDefinition.creature("Ring Bear", ManaCost.parse("{2}"), emptySet(), 2, 2)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RingTempter, Bear, AragornCompanyLeader))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.tempt(player: EntityId, bearerId: EntityId) {
+        val cardId = putCardInHand(player, "Ring Tempter")
+        castSpell(player, cardId)
+        bothPass()
+        val decision = pendingDecision
+        if (decision is SelectCardsDecision) {
+            submitDecision(player, CardsSelectedResponse(decision.id, listOf(bearerId)))
+        }
+    }
+
+    fun GameTestDriver.countersOf(entity: EntityId, type: CounterType): Int =
+        state.getEntity(entity)?.get<CountersComponent>()?.counters?.get(type) ?: 0
+
+    test("Ring tempt with another Ring-bearer lets you choose a counter kind for Aragorn") {
+        val driver = createDriver()
+        val active = driver.activePlayer!!
+
+        val aragorn = driver.putCreatureOnBattlefield(active, "Aragorn, Company Leader")
+        val bear = driver.putCreatureOnBattlefield(active, "Ring Bear")
+
+        driver.tempt(active, bear)
+
+        // First trigger resolves → ChooseOptionDecision over the four counter kinds. Pick first strike (index 0).
+        driver.bothPass()
+        val choose = driver.pendingDecision
+        (choose is ChooseOptionDecision) shouldBe true
+        choose as ChooseOptionDecision
+        driver.submitDecision(active, OptionChosenResponse(choose.id, 0))
+
+        // The first strike counter triggers the second ability; decline its optional target.
+        var guard = 0
+        while (guard++ < 8) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(active, emptyList())
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        driver.countersOf(aragorn, CounterType.FIRST_STRIKE) shouldBe 1
+        driver.state.projectedState.hasKeyword(aragorn, Keyword.FIRST_STRIKE) shouldBe true
+    }
+
+    test("putting a counter on Aragorn puts one of each kind on another target creature") {
+        val driver = createDriver()
+        val active = driver.activePlayer!!
+
+        val aragorn = driver.putCreatureOnBattlefield(active, "Aragorn, Company Leader")
+        val bear = driver.putCreatureOnBattlefield(active, "Ring Bear")
+
+        driver.tempt(active, bear)
+
+        // First trigger → choose a counter for Aragorn (deathtouch, index 2).
+        driver.bothPass()
+        val choose = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(active, OptionChosenResponse(choose.id, 2))
+
+        // Second ability triggers off that counter; target the Bear with all four kinds.
+        var guard = 0
+        while (guard++ < 8) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(active, listOf(bear))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // Aragorn got his deathtouch counter.
+        driver.countersOf(aragorn, CounterType.DEATHTOUCH) shouldBe 1
+        // The Bear got one of each of the four named kinds.
+        driver.countersOf(bear, CounterType.FIRST_STRIKE) shouldBe 1
+        driver.countersOf(bear, CounterType.VIGILANCE) shouldBe 1
+        driver.countersOf(bear, CounterType.DEATHTOUCH) shouldBe 1
+        driver.countersOf(bear, CounterType.LIFELINK) shouldBe 1
+        // …granting the matching keywords via the keyword-counter projection.
+        driver.state.projectedState.hasKeyword(bear, Keyword.FIRST_STRIKE) shouldBe true
+        driver.state.projectedState.hasKeyword(bear, Keyword.DEATHTOUCH) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameOfAnorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameOfAnorScenarioTest.kt
@@ -1,0 +1,182 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.FlameOfAnor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Flame of Anor — "Choose one. If you control a Wizard as you cast this spell, you may
+ * choose two instead." Pins the conditional modal count: the dynamic cap is 2 when you
+ * control a Wizard at cast time, otherwise 1, with a mandatory floor of one mode.
+ *
+ * Modes: 0 = target player draws two cards, 1 = destroy target artifact,
+ *        2 = Flame of Anor deals 5 damage to target creature.
+ */
+class FlameOfAnorScenarioTest : FunSpec({
+
+    val WizardCreature: CardDefinition = CardDefinition.creature(
+        name = "Test Wizard",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Wizard")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(FlameOfAnor)
+        d.registerCard(WizardCreature)
+        return d
+    }
+
+    fun castSetup(d: GameTestDriver): Pair<com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        d.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 1)
+        d.giveMana(p1, Color.BLUE, 1)
+        d.giveMana(p1, Color.RED, 1)
+        val opponent = d.getOpponent(p1)
+        return p1 to opponent
+    }
+
+    test("no Wizard — choosing two modes is illegal (effective max is one)") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        // Opponent has a creature so the damage mode has a legal target.
+        d.putCreatureOnBattlefield(p2, "Goblin Guide")
+        val goblin = d.getCreatures(p2).first()
+
+        val spell = d.putCardInHand(p1, "Flame of Anor")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Player(p1), ChosenTarget.Permanent(goblin)),
+            chosenModes = listOf(0, 2),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Player(p1)),
+                listOf(ChosenTarget.Permanent(goblin))
+            )
+        ))
+
+        result.isSuccess shouldBe false
+    }
+
+    test("no Wizard — choosing exactly one mode resolves (deal 5 to a creature)") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        d.putCreatureOnBattlefield(p2, "Centaur Courser") // 3/3
+        val centaur = d.getCreatures(p2).first()
+
+        val spell = d.putCardInHand(p1, "Flame of Anor")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(centaur)),
+            chosenModes = listOf(2),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(centaur)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        // Centaur (3/3) took 5 damage → destroyed.
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+    }
+
+    test("control a Wizard — may choose two: draw two AND deal 5 to a creature") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        d.putCreatureOnBattlefield(p1, "Test Wizard")
+        d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val centaur = d.getCreatures(p2).first { d.state.getEntity(it)?.get<CardComponent>()?.name == "Centaur Courser" }
+
+        val handBefore = d.getHand(p1).size
+
+        val spell = d.putCardInHand(p1, "Flame of Anor")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Player(p1), ChosenTarget.Permanent(centaur)),
+            chosenModes = listOf(0, 2),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Player(p1)),
+                listOf(ChosenTarget.Permanent(centaur))
+            )
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+
+        // Mode 0: P1 drew two cards. Hand delta from handBefore (captured before adding
+        // Flame): +1 (put Flame in hand) - 1 (cast Flame) + 2 (draw) = +2.
+        d.getHand(p1).size shouldBe (handBefore + 2)
+        // Mode 2: Centaur (3/3) took 5 damage → destroyed.
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+    }
+
+    test("control a Wizard — cast-time picker offers a second mode pick") {
+        val d = driver()
+        val (p1, _) = castSetup(d)
+        d.putCreatureOnBattlefield(p1, "Test Wizard")
+
+        val spell = d.putCardInHand(p1, "Flame of Anor")
+        d.submit(CastSpell(playerId = p1, cardId = spell))
+
+        // First mode pick — minChooseCount = 1, so "Done" must NOT be offered yet.
+        val first = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        first.options shouldNotContain "Done"
+        first.options shouldContain "Target player draws two cards"
+
+        // Pick mode 0; with a Wizard the effective chooseCount is 2, so a second pick
+        // (with "Done" now available) must be presented rather than going straight to targets.
+        d.submitDecision(p1, OptionChosenResponse(first.id, 0))
+        val second = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        second.options shouldContain "Done"
+    }
+
+    test("no Wizard — cast-time picker resolves after a single mandatory pick") {
+        val d = driver()
+        val (p1, _) = castSetup(d)
+
+        val spell = d.putCardInHand(p1, "Flame of Anor")
+        d.submit(CastSpell(playerId = p1, cardId = spell))
+
+        // With no Wizard the effective chooseCount is 1; the first decision is the only
+        // mode pick and must not offer "Done".
+        val first = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        first.options shouldNotContain "Done"
+
+        // Picking the draw mode (mode 0) transitions straight to target selection — no
+        // second mode pick is offered.
+        d.submitDecision(p1, OptionChosenResponse(first.id, 0))
+        val next = d.pendingDecision
+        next.shouldNotBeNull()
+        // The next decision is not another mode-selection ChooseOptionDecision with a
+        // "Done" option (it is the player-target selection for the draw mode).
+        if (next is ChooseOptionDecision) {
+            next.options shouldNotContain "Done"
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrodoSauronsBaneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrodoSauronsBaneScenarioTest.kt
@@ -1,0 +1,166 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.FrodoSauronsBane
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Frodo, Sauron's Bane (LTR #18) — the level-up Halfling who climbs Citizen → Scout → Rogue.
+ *
+ * Exercises:
+ *  - The {W/B}{W/B} ability gating on `Conditions.SourceHasSubtype(CITIZEN)`: it turns Frodo into a
+ *    2/3 Halfling Scout with lifelink, and does nothing if he isn't currently a Citizen.
+ *  - The {B}{B}{B} ability gating on Scout: it makes the Scout a Halfling Rogue (keeping the 2/3 base
+ *    P/T from the Scout step) and permanently grants the combat-damage triggered ability.
+ *  - The granted Rogue trigger via the new `Conditions.RingHasTemptedYouAtLeast`: combat damage to a
+ *    player makes that player lose the game when the Ring has tempted you 4+ times this game,
+ *    otherwise the Ring tempts you.
+ */
+class FrodoSauronsBaneScenarioTest : FunSpec({
+
+    // Auto-generated ids — read them off the registered definition in declaration order.
+    val scoutAbilityId = FrodoSauronsBane.activatedAbilities[0].id
+    val rogueAbilityId = FrodoSauronsBane.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.makeScout(player: EntityId, frodo: EntityId) {
+        giveMana(player, Color.BLACK, 2) // {W/B}{W/B} payable with black
+        submitSuccess(ActivateAbility(playerId = player, sourceId = frodo, abilityId = scoutAbilityId))
+        bothPass()
+    }
+
+    fun GameTestDriver.makeRogue(player: EntityId, frodo: EntityId) {
+        giveMana(player, Color.BLACK, 3) // {B}{B}{B}
+        submitSuccess(ActivateAbility(playerId = player, sourceId = frodo, abilityId = rogueAbilityId))
+        bothPass()
+    }
+
+    test("{W/B}{W/B} turns the Citizen Frodo into a 2/3 Halfling Scout with lifelink") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val frodo = driver.putCreatureOnBattlefield(player, "Frodo, Sauron's Bane")
+
+        // Starts as a 1/2 Halfling Citizen.
+        driver.state.projectedState.hasSubtype(frodo, "Citizen") shouldBe true
+        driver.state.projectedState.getPower(frodo) shouldBe 1
+        driver.state.projectedState.getToughness(frodo) shouldBe 2
+
+        driver.makeScout(player, frodo)
+
+        val projected = driver.state.projectedState
+        projected.hasSubtype(frodo, "Halfling") shouldBe true
+        projected.hasSubtype(frodo, "Scout") shouldBe true
+        projected.hasSubtype(frodo, "Citizen") shouldBe false
+        projected.getPower(frodo) shouldBe 2
+        projected.getToughness(frodo) shouldBe 3
+        projected.hasKeyword(frodo, Keyword.LIFELINK) shouldBe true
+    }
+
+    test("{W/B}{W/B} does nothing once Frodo is no longer a Citizen") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val frodo = driver.putCreatureOnBattlefield(player, "Frodo, Sauron's Bane")
+
+        driver.makeScout(player, frodo) // now a Scout
+        driver.makeScout(player, frodo) // gate is false — no change
+
+        val projected = driver.state.projectedState
+        projected.hasSubtype(frodo, "Scout") shouldBe true
+        projected.getPower(frodo) shouldBe 2
+        projected.getToughness(frodo) shouldBe 3
+    }
+
+    test("{B}{B}{B} turns the Scout into a Halfling Rogue, keeping its 2/3 base P/T") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val frodo = driver.putCreatureOnBattlefield(player, "Frodo, Sauron's Bane")
+
+        // {B}{B}{B} before being a Scout does nothing — still a Citizen.
+        driver.makeRogue(player, frodo)
+        driver.state.projectedState.hasSubtype(frodo, "Citizen") shouldBe true
+        driver.state.projectedState.hasSubtype(frodo, "Rogue") shouldBe false
+
+        driver.makeScout(player, frodo)
+        driver.makeRogue(player, frodo)
+
+        val projected = driver.state.projectedState
+        projected.hasSubtype(frodo, "Halfling") shouldBe true
+        projected.hasSubtype(frodo, "Rogue") shouldBe true
+        projected.hasSubtype(frodo, "Scout") shouldBe false
+        // Base P/T unchanged by the Rogue step (no new P/T printed).
+        projected.getPower(frodo) shouldBe 2
+        projected.getToughness(frodo) shouldBe 3
+    }
+
+    test("Rogue's combat damage makes the player lose when the Ring tempted you 4+ times") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        val frodo = driver.putCreatureOnBattlefield(attacker, "Frodo, Sauron's Bane")
+
+        driver.makeScout(attacker, frodo)
+        driver.makeRogue(attacker, frodo)
+        driver.removeSummoningSickness(frodo)
+
+        // The Ring has tempted you four times this game.
+        driver.addComponent(attacker, TheRingComponent(temptCount = 4))
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(frodo), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(defender)
+        // Resolve combat damage and the resulting "loses the game" trigger. The game ends mid-combat
+        // once the defender loses, so step through priority/decisions until that happens rather than
+        // advancing to a later step (which would never be reached).
+        var guard = 0
+        while (!driver.state.gameOver && guard++ < 50) {
+            if (driver.state.pendingDecision != null) driver.autoResolveDecision()
+            else driver.bothPass()
+        }
+
+        driver.state.gameOver shouldBe true
+    }
+
+    test("Rogue's combat damage tempts you when the Ring has tempted you fewer than 4 times") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        val frodo = driver.putCreatureOnBattlefield(attacker, "Frodo, Sauron's Bane")
+
+        driver.makeScout(attacker, frodo)
+        driver.makeRogue(attacker, frodo)
+        driver.removeSummoningSickness(frodo)
+
+        // Tempted only three times — below the threshold, so combat damage tempts again.
+        driver.addComponent(attacker, TheRingComponent(temptCount = 3))
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(frodo), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(defender)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        while (driver.state.stack.isNotEmpty() || driver.state.pendingDecision != null) {
+            driver.bothPass()
+        }
+
+        // Defender still in the game; attacker has been tempted a fourth time.
+        driver.state.gameOver shouldBe false
+        driver.state.getEntity(attacker)?.get<TheRingComponent>()?.temptCount shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheGreyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheGreyScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf the Grey — "Whenever you cast an instant or sorcery spell, choose one that hasn't
+ * been chosen —" with the four-mode modal-with-memory ability.
+ *
+ * Covers:
+ *  - casting an instant triggers the modal choice;
+ *  - the "deal 3 damage to each opponent" mode hits the opponent;
+ *  - the chosen mode is no longer offered on a later trigger ("hasn't been chosen");
+ *  - the copy mode copies a controlled instant on the stack.
+ */
+class GandalfTheGreyScenarioTest : ScenarioTestBase() {
+
+    private val damageMode = "Gandalf deals 3 damage to each opponent"
+    private val copyMode = "Copy target instant or sorcery spell you control. You may choose new targets for the copy"
+
+    /** Resolve the stack until the modal ChooseOptionDecision appears. */
+    private fun TestGame.resolveToModeChoice(): ChooseOptionDecision {
+        resolveStack()
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        return decision as ChooseOptionDecision
+    }
+
+    private fun TestGame.chooseMode(decision: ChooseOptionDecision, description: String) {
+        val index = decision.options.indexOf(description)
+        check(index >= 0) { "Mode '$description' not offered; options=${decision.options}" }
+        submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    init {
+        test("casting an instant triggers the choice; damage mode hits each opponent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Gandalf the Grey")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Cast Lightning Bolt at the opponent's face — Gandalf triggers on the cast.
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+
+            // The trigger resolves first → modal choice with all four modes offered.
+            val choice = game.resolveToModeChoice()
+            choice.options.size shouldBe 4
+            choice.options shouldContain damageMode
+
+            game.chooseMode(choice, damageMode)
+
+            // Resolve the rest (the Bolt then deals its 3). 3 (Gandalf) + 3 (Bolt) = 6.
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 14
+        }
+
+        test("a chosen mode is no longer offered on a later trigger") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Gandalf the Grey")
+                .withCardsInHand(1, "Lightning Bolt", 2)
+                .withLandsOnBattlefield(1, "Mountain", 8)
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // First instant: choose the damage mode.
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+            val first = game.resolveToModeChoice()
+            first.options.size shouldBe 4
+            game.chooseMode(first, damageMode)
+            game.resolveStack()
+
+            // Second instant: the damage mode must NOT be offered again.
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+            val second = game.resolveToModeChoice()
+            second.options.size shouldBe 3
+            second.options shouldNotContain damageMode
+        }
+
+        test("copy mode copies a controlled instant on the stack") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Gandalf the Grey")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Cast Lightning Bolt at the opponent. The Bolt sits on the stack below the
+            // Gandalf trigger, so it's a legal "instant you control" to copy.
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+
+            val choice = game.resolveToModeChoice()
+            game.chooseMode(choice, copyMode)
+
+            // The copy mode needs a target spell — pick the Bolt on the stack.
+            val boltSpell = game.state.stack.first { id ->
+                game.state.getEntity(id)
+                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Lightning Bolt"
+            }
+            game.selectTargets(listOf(boltSpell)).error shouldBe null
+
+            // The copy may be retargeted — keep it on the opponent's face.
+            var guard = 0
+            while (game.state.stack.isNotEmpty() && guard++ < 12) {
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(game.player2Id))
+                }
+            }
+
+            // Original Bolt (3) + copy (3) = 6 damage.
+            game.getLifeTotal(2) shouldBe 14
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlamdringScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlamdringScenarioTest.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Glamdring — {2} Legendary Artifact — Equipment:
+ *   "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your
+ *    graveyard.
+ *    Whenever equipped creature deals combat damage to a player, you may cast an instant or sorcery
+ *    spell from your hand with mana value less than or equal to that damage without paying its mana
+ *    cost.
+ *    Equip {3}"
+ *
+ * Covers (a) the static grant: first strike + a dynamic +X/+0 that scales with the count of instant
+ * and sorcery cards in your graveyard, and (b) the combat-damage free cast: dealing N combat damage
+ * to a player lets you free-cast a hand instant/sorcery with MV ≤ N (and a higher-MV one is not
+ * offered).
+ */
+class GlamdringScenarioTest : ScenarioTestBase() {
+
+    private val equipAbilityId by lazy {
+        cardRegistry.requireCard("Glamdring").activatedAbilities[0].id
+    }
+
+    init {
+        // A cheap sorcery (MV 1) that draws a card — within a small combat-damage cap.
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Cheap Draw",
+                manaCost = ManaCost.parse("{U}"),
+                oracleText = "Draw a card.",
+                script = CardScript(spellEffect = Effects.DrawCards(1))
+            )
+        )
+        // An expensive sorcery (MV 5) — above a small combat-damage cap, must NOT be free-castable.
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Expensive Draw",
+                manaCost = ManaCost.parse("{4}{U}"),
+                oracleText = "Draw a card.",
+                script = CardScript(spellEffect = Effects.DrawCards(1))
+            )
+        )
+
+        test("equipped creature has first strike and gets +1/+0 per instant/sorcery in your graveyard") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")  // 2/2 base
+                .withCardOnBattlefield(1, "Glamdring")
+                .withLandsOnBattlefield(1, "Plains", 3)     // pay Equip {3}
+                .withCardInGraveyard(1, "Cheap Draw")       // instant/sorcery #1
+                .withCardInGraveyard(1, "Expensive Draw")   // instant/sorcery #2
+                .withCardInGraveyard(1, "Grizzly Bears")    // a creature — must NOT count
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val sword = game.findPermanent("Glamdring")!!
+
+            game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+
+            // Equip Glamdring onto the Bears.
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sword,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("Equipped creature has first strike") {
+                game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+            }
+            withClue("+1/+0 for each of the two instant/sorcery cards (the creature card does not count)") {
+                game.state.projectedState.getPower(bears) shouldBe 4   // 2 base + 2
+                game.state.projectedState.getToughness(bears) shouldBe 2 // unchanged
+            }
+        }
+
+        test("dealing N combat damage lets you free-cast a hand instant/sorcery with MV <= N") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hill Giant")     // 3/3 — deals 3 combat damage
+                .withCardOnBattlefield(1, "Glamdring")
+                .withLandsOnBattlefield(1, "Plains", 3)     // pay Equip {3}
+                .withCardInHand(1, "Cheap Draw")            // MV 1 <= 3 — free-castable
+                .withCardInLibrary(1, "Plains")             // something to draw, proving the cast resolved
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val giant = game.findPermanent("Hill Giant")!!
+            val sword = game.findPermanent("Glamdring")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sword,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(giant))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Attack the opponent; no blockers; combat damage fires the trigger.
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hill Giant" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers()
+            // The equipped creature has first strike (granted by Glamdring), so it deals its combat
+            // damage in the FIRST STRIKE combat damage step — that is where the trigger fires.
+            game.passUntilPhase(Phase.COMBAT, Step.FIRST_STRIKE_COMBAT_DAMAGE)
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("Opponent took 3 combat damage") {
+                game.getLifeTotal(2) shouldBe 17
+            }
+
+            // The free cast is optional — accept it, then resolve the targetless sorcery.
+            game.answerYesNo(true)
+            game.resolveStack()
+
+            withClue("Cheap Draw (MV 1 <= 3) was free-cast and resolved (moved to graveyard)") {
+                game.isInHand(1, "Cheap Draw") shouldBe false
+                game.isInGraveyard(1, "Cheap Draw") shouldBe true
+            }
+        }
+
+        test("a too-expensive instant/sorcery is NOT offered for the free cast") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hill Giant")     // 3/3 — deals 3 combat damage
+                .withCardOnBattlefield(1, "Glamdring")
+                .withLandsOnBattlefield(1, "Plains", 3)     // pay Equip {3}
+                .withCardInHand(1, "Expensive Draw")        // MV 5 > 3 — must not be offered
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val giant = game.findPermanent("Hill Giant")!!
+            val sword = game.findPermanent("Glamdring")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sword,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(giant))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hill Giant" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers()
+            // First strike: combat damage (and the Glamdring trigger) happen in the first strike step.
+            game.passUntilPhase(Phase.COMBAT, Step.FIRST_STRIKE_COMBAT_DAMAGE)
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("No free-cast decision was offered (MV 5 > 3)") {
+                game.state.pendingDecision shouldBe null
+            }
+            withClue("Expensive Draw stays in hand, uncast") {
+                game.isInHand(1, "Expensive Draw") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KingOfTheOathbreakersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KingOfTheOathbreakersScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.KingOfTheOathbreakers
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * King of the Oathbreakers (Gap 32 — phasing, CR 702.26).
+ *
+ * Flying
+ * Whenever King of the Oathbreakers or another Spirit you control becomes the target of a
+ * spell, it phases out.
+ * Whenever King of the Oathbreakers or another Spirit you control phases in, create a tapped
+ * 1/1 white Spirit creature token with flying.
+ *
+ * Verifies the actual oracle behaviour:
+ *  - targeting King with a spell phases it out (it leaves the battlefield view, can't be hit, the
+ *    targeting spell fizzles for lack of a legal target),
+ *  - King phases back in on its controller's next untap step,
+ *  - the phase-in fires the "create a tapped 1/1 white flying Spirit token" trigger.
+ */
+class KingOfTheOathbreakersScenarioTest : FunSpec({
+
+    /**
+     * Advance to [player]'s next upkeep. The untap step (where phasing-in happens) gives no
+     * priority and is not observable as a stopping point, so we stop at the upkeep that
+     * immediately follows it — by then phase-in has already run.
+     */
+    fun GameTestDriver.passUntilUpkeepOf(player: EntityId, maxTurns: Int = 8) {
+        repeat(maxTurns) {
+            passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+            if (activePlayer == player) return
+            // Move off this upkeep so the next passPriorityUntil(UPKEEP) lands on a new turn.
+            passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+        }
+        throw AssertionError("Never reached $player's upkeep")
+    }
+
+    test("targeting a Spirit you control phases it out, the spell fizzles, then it phases back in and makes a token") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KingOfTheOathbreakers))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val king = driver.putCreatureOnBattlefield(active, "King of the Oathbreakers")
+
+        // Cast Giant Growth (a spell) targeting our own King — "becomes the target of a spell".
+        val growth = driver.putCardInHand(active, "Giant Growth")
+        driver.giveMana(active, Color.GREEN, 1)
+        driver.castSpell(active, growth, targets = listOf(king))
+        // Resolve the phase-out trigger, then the (now-targetless) Giant Growth.
+        driver.bothPass()
+        driver.bothPass()
+
+        // King phased out: it's gone from the battlefield view but still physically present
+        // with a PhasedOutComponent recording its controller.
+        driver.state.getBattlefield().contains(king) shouldBe false
+        driver.state.getEntity(king)?.has<PhasedOutComponent>() shouldBe true
+        driver.state.getEntity(king)?.get<PhasedOutComponent>()?.phasedOutByController shouldBe active
+
+        // No token yet — nothing has phased in. A created Spirit token is a TokenComponent
+        // permanent with the Spirit subtype controlled by the active player (the printed token's
+        // name is "Spirit Token", so match on subtype rather than the raw name).
+        fun spiritTokens() = driver.state.getBattlefield().filter { id ->
+            val c = driver.state.getEntity(id) ?: return@filter false
+            c.has<TokenComponent>() &&
+                c.get<CardComponent>()?.typeLine?.hasSubtype(Subtype.SPIRIT) == true &&
+                c.get<ControllerComponent>()?.playerId == active
+        }
+        spiritTokens().size shouldBe 0
+
+        // Advance to the controller's next turn: King phases in during their untap step, then
+        // the phase-in trigger resolves during upkeep.
+        driver.passUntilUpkeepOf(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+
+        // King is back on the battlefield (same object) and no longer phased out.
+        driver.state.getBattlefield().contains(king) shouldBe true
+        driver.state.getEntity(king)?.has<PhasedOutComponent>() shouldBe false
+
+        // The phase-in trigger created a tapped 1/1 white Spirit token with flying.
+        val tokens = spiritTokens()
+        tokens.size shouldBe 1
+        val tokenId = tokens.first()
+        driver.state.getEntity(tokenId)?.has<TappedComponent>() shouldBe true
+        val projected = driver.state.projectedState
+        projected.getPower(tokenId) shouldBe 1
+        projected.getToughness(tokenId) shouldBe 1
+        driver.state.getEntity(tokenId)?.get<CardComponent>()?.colors shouldBe setOf(Color.WHITE)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PippinGuardOfTheCitadelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PippinGuardOfTheCitadelScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Pippin, Guard of the Citadel (LTR #218) — {W}{U} Halfling Soldier, 2/2.
+ *
+ * "{T}: Another target creature you control gains protection from the card type of your choice
+ *  until end of turn."
+ *
+ * Exercises the Gap-8 chosen-card-type protection flow: activating the {T} ability presents a
+ * ChooseOptionDecision over the protectable card types; choosing "Creature" grants the target a
+ * floating `PROTECTION_FROM_CARDTYPE_CREATURE` keyword that the targeting / combat-damage /
+ * block-evasion enforcement sites all honor.
+ */
+class PippinGuardOfTheCitadelScenarioTest : ScenarioTestBase() {
+
+    private val tapAbilityId =
+        cardRegistry.getCard("Pippin, Guard of the Citadel")!!.activatedAbilities.first().id
+
+    init {
+        context("Pippin, Guard of the Citadel — protection from the chosen card type") {
+
+            test("grants protection from creatures: target can't be dealt combat damage by a creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pippin, Guard of the Citadel")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 — the creature we protect
+                    .withCardOnBattlefield(2, "Hill Giant")     // 3/3 attacker
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pippin = game.findPermanent("Pippin, Guard of the Citadel")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Activate {T}: target our own Grizzly Bears.
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = pippin,
+                        abilityId = tapAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activating Pippin's ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Resolution pauses for the card-type choice.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseOptionDecision>()
+                val creatureIndex = decision.options.indexOf("Creature")
+                withClue("Creature must be an offered card type") { (creatureIndex >= 0) shouldBe true }
+                game.submitDecision(OptionChosenResponse(decision.id, creatureIndex))
+
+                withClue("Grizzly Bears gains protection from creatures") {
+                    game.state.projectedState.hasKeyword(bears, "PROTECTION_FROM_CARDTYPE_CREATURE") shouldBe true
+                }
+
+                // Player 2's Hill Giant (3/3) attacks; Grizzly Bears (2/2) blocks. Protection from
+                // creatures prevents the combat damage from the Giant, so the Bears survive.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Hill Giant" to 1))
+                withClue("Hill Giant attacks Player1: ${attack.error}") { attack.error shouldBe null }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val block = game.declareBlockers(mapOf("Grizzly Bears" to listOf("Hill Giant")))
+                withClue("Grizzly Bears may block Hill Giant: ${block.error}") { block.error shouldBe null }
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Grizzly Bears survives — combat damage from the creature is prevented") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("grants protection from creatures: target can't be blocked by a creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pippin, Guard of the Citadel")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 attacker we protect
+                    .withCardOnBattlefield(2, "Hill Giant")     // 3/3 would-be blocker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pippin = game.findPermanent("Pippin, Guard of the Citadel")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = pippin,
+                        abilityId = tapAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activating Pippin's ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as ChooseOptionDecision
+                val creatureIndex = decision.options.indexOf("Creature")
+                game.submitDecision(OptionChosenResponse(decision.id, creatureIndex))
+
+                withClue("Grizzly Bears gains protection from creatures") {
+                    game.state.projectedState.hasKeyword(bears, "PROTECTION_FROM_CARDTYPE_CREATURE") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                withClue("Grizzly Bears attacks: ${attack.error}") { attack.error shouldBe null }
+
+                // Hill Giant is a creature; the protected Grizzly Bears can't be blocked by it.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val block = game.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears")))
+                withClue("Blocking the creature-protected attacker with a creature is illegal: ${block.error}") {
+                    (block.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PressTheEnemyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PressTheEnemyScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Press the Enemy:
+ *   {2}{U}{U} Instant — "Return target spell or nonland permanent an opponent controls to its
+ *   owner's hand. You may cast an instant or sorcery spell with equal or lesser mana value from
+ *   your hand without paying its mana cost."
+ *
+ * Covers (a) bouncing a nonland permanent an opponent controls then free-casting an instant/sorcery
+ * whose mana value is within the cap (and a too-expensive one not being offered), and (b) bouncing
+ * a spell on the stack so it does not resolve.
+ */
+class PressTheEnemyScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A mana-value-3 creature for the opponent to control / cast (the MV cap source).
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Ogre",
+                manaCost = ManaCost.parse("{2}{R}"),
+                subtypes = setOf(Subtype("Ogre")),
+                power = 3,
+                toughness = 3
+            )
+        )
+        // A cheap sorcery (MV 1) that draws a card — within the MV-3 cap, observable via card draw.
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Cheap Draw",
+                manaCost = ManaCost.parse("{U}"),
+                oracleText = "Draw a card.",
+                script = CardScript(spellEffect = Effects.DrawCards(1))
+            )
+        )
+        // An expensive sorcery (MV 5) — above the MV-3 cap, must NOT be free-castable.
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Expensive Draw",
+                manaCost = ManaCost.parse("{4}{U}"),
+                oracleText = "Draw a card.",
+                script = CardScript(spellEffect = Effects.DrawCards(1))
+            )
+        )
+
+        context("Press the Enemy — bounce a nonland permanent an opponent controls") {
+
+            test("free-cast an instant/sorcery with MV <= the bounced permanent's MV") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Press the Enemy")
+                    .withCardInHand(1, "Cheap Draw")
+                    .withCardInLibrary(1, "Test Ogre") // something to draw, proving the free cast resolved
+                    .withCardOnBattlefield(2, "Test Ogre")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ogreId = game.findPermanent("Test Ogre") ?: error("Test Ogre not on battlefield")
+
+                game.castSpell(1, "Press the Enemy", ogreId).error shouldBe null
+                game.resolveStack()
+
+                withClue("Opponent's creature returned to its owner's hand") {
+                    game.isInHand(2, "Test Ogre") shouldBe true
+                    game.isOnBattlefield("Test Ogre") shouldBe false
+                }
+
+                // The free cast is optional — accept it.
+                game.answerYesNo(true)
+                // Cheap Draw is a targetless sorcery — resolve it.
+                game.resolveStack()
+
+                withClue("Cheap Draw (MV 1 <= 3) was cast for free and resolved (drew a card)") {
+                    game.isInHand(1, "Cheap Draw") shouldBe false
+                    game.isInGraveyard(1, "Cheap Draw") shouldBe true
+                }
+            }
+
+            test("a too-expensive instant/sorcery is NOT offered for the free cast") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Press the Enemy")
+                    .withCardInHand(1, "Expensive Draw")
+                    .withCardOnBattlefield(2, "Test Ogre")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ogreId = game.findPermanent("Test Ogre") ?: error("Test Ogre not on battlefield")
+
+                game.castSpell(1, "Press the Enemy", ogreId).error shouldBe null
+                game.resolveStack()
+
+                withClue("Opponent's creature still returned to hand") {
+                    game.isInHand(2, "Test Ogre") shouldBe true
+                }
+                withClue("No free-cast decision was offered (MV 5 > 3)") {
+                    game.state.pendingDecision shouldBe null
+                }
+                withClue("Expensive Draw stays in hand, uncast") {
+                    game.isInHand(1, "Expensive Draw") shouldBe true
+                    game.isOnBattlefield("Expensive Draw") shouldBe false
+                }
+            }
+        }
+
+        context("Press the Enemy — bounce a spell on the stack") {
+
+            test("returns the opponent's spell to its owner's hand; it does not resolve") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Press the Enemy")
+                    .withCardInHand(2, "Test Ogre")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Opponent casts a creature spell; it goes on the stack.
+                game.castSpell(2, "Test Ogre").error shouldBe null
+                game.state.stack.any {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+                } shouldBe true
+
+                // Active player passes priority with the spell on the stack; Player1 now responds.
+                game.passPriority()
+
+                // In response, Player1 bounces the spell with Press the Enemy.
+                game.castSpellTargetingStackSpell(1, "Press the Enemy", "Test Ogre").error shouldBe null
+                game.resolveStack()
+
+                withClue("The spell was removed from the stack to its owner's hand (did not resolve)") {
+                    game.isInHand(2, "Test Ogre") shouldBe true
+                    game.isOnBattlefield("Test Ogre") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronTheNecromancerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronTheNecromancerScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.RingBearerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sauron, the Necromancer (LTR #106) — {3}{B}{B} Legendary Avatar Horror, 4/4.
+ *
+ * Menace
+ * Whenever Sauron attacks, exile target creature card from your graveyard. Create a tapped and
+ * attacking token that's a copy of that card, except it's a 3/3 black Wraith with menace. At the
+ * beginning of the next end step, exile that token unless Sauron is your Ring-bearer.
+ *
+ * Exercises the `CreateTokenCopyOfTargetEffect.exileAtStep` / `exileUnlessSourceIsRingBearer`
+ * additions (the exile sibling of the existing `sacrificeAtStep`, gated on the source being the
+ * Ring-bearer), plus the token-copy overrides (P/T 3/3, black, Wraith, added menace), tapped, and
+ * attacking. The copied card carries flying to prove the token inherits the source's copiable
+ * keywords on top of the overrides.
+ */
+class SauronTheNecromancerScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Dead Goblin",
+                manaCost = ManaCost.parse("{1}{R}"),
+                subtypes = setOf(Subtype("Goblin")),
+                power = 5,
+                toughness = 1,
+                keywords = setOf(Keyword.FLYING)
+            )
+        )
+
+        context("Sauron, the Necromancer") {
+
+            test("has menace") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sauron, the Necromancer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sauron = game.findPermanent("Sauron, the Necromancer")!!
+                withClue("Sauron has menace") {
+                    game.state.projectedState.hasKeyword(sauron, Keyword.MENACE) shouldBe true
+                }
+            }
+
+            test("attack exiles a graveyard creature card and makes a tapped attacking 3/3 black Wraith with menace") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sauron, the Necromancer", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Dead Goblin")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Sauron, the Necromancer" to 2))
+                withClue("Declaring Sauron as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+
+                // The attack trigger targets a creature card in the graveyard. With one legal
+                // target the engine may auto-target; otherwise resolve the target decision.
+                resolveTriggerTargetingDeadGoblin(game)
+                game.resolveStack()
+
+                // The Dead Goblin card was exiled from the graveyard.
+                withClue("Dead Goblin is no longer in the graveyard") {
+                    game.state.getGraveyard(game.player1Id)
+                        .mapNotNull { game.cardName(it) }
+                        .contains("Dead Goblin") shouldBe false
+                }
+
+                val token = game.findPermanents("Dead Goblin").singleOrNull()
+                    ?: error("Expected exactly one token copy of Dead Goblin, found ${game.findPermanents("Dead Goblin").size}")
+
+                withClue("token enters tapped") {
+                    game.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("token enters attacking") {
+                    game.state.getEntity(token)?.has<AttackingComponent>() shouldBe true
+                }
+                withClue("token is 3/3 (overridden P/T, not the card's 5/1)") {
+                    game.state.projectedState.getPower(token) shouldBe 3
+                    game.state.projectedState.getToughness(token) shouldBe 3
+                }
+                withClue("token is black") {
+                    game.state.projectedState.getColors(token) shouldBe setOf("BLACK")
+                }
+                withClue("token is a Wraith (overridden subtype, not Goblin)") {
+                    game.state.projectedState.getSubtypes(token) shouldBe setOf("Wraith")
+                }
+                withClue("token has menace (added keyword)") {
+                    game.state.projectedState.hasKeyword(token, Keyword.MENACE) shouldBe true
+                }
+                withClue("token inherits the copied card's flying") {
+                    game.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("token is exiled at the next end step when Sauron is NOT the Ring-bearer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sauron, the Necromancer", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Dead Goblin")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Sauron, the Necromancer" to 2))
+                resolveTriggerTargetingDeadGoblin(game)
+                game.resolveStack()
+
+                game.findPermanents("Dead Goblin").size shouldBe 1
+
+                // Advance to the end step and drain the delayed "exile that token" trigger.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Sauron is not the Ring-bearer, so the token is exiled at the next end step") {
+                    game.findPermanents("Dead Goblin").size shouldBe 0
+                }
+            }
+
+            test("token survives the next end step when Sauron IS the Ring-bearer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sauron, the Necromancer", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Dead Goblin")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Designate Sauron as Player 1's Ring-bearer.
+                val sauron = game.findPermanent("Sauron, the Necromancer")!!
+                game.state = game.state.updateEntity(sauron) { container ->
+                    container.with(RingBearerComponent(game.player1Id))
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Sauron, the Necromancer" to 2))
+                resolveTriggerTargetingDeadGoblin(game)
+                game.resolveStack()
+
+                game.findPermanents("Dead Goblin").size shouldBe 1
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Sauron is the Ring-bearer, so the token is NOT exiled and survives") {
+                    game.findPermanents("Dead Goblin").size shouldBe 1
+                }
+            }
+        }
+    }
+
+    /**
+     * If the attack trigger paused for target selection, choose the Dead Goblin card in Player 1's
+     * graveyard; otherwise (single legal target auto-chosen) do nothing.
+     */
+    private fun resolveTriggerTargetingDeadGoblin(game: TestGame) {
+        if (game.hasPendingDecision()) {
+            val deadGoblin = game.state.getGraveyard(game.player1Id)
+                .first { game.cardName(it) == "Dead Goblin" }
+            game.selectTargets(listOf(deadGoblin))
+        }
+    }
+}
+
+private fun ScenarioTestBase.TestGame.cardName(id: EntityId): String? =
+    state.getEntity(id)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelobChildOfUngoliantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelobChildOfUngoliantScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shelob, Child of Ungoliant (LTR #230) — {4}{B}{G} Legendary Spider Demon, 8/8.
+ *
+ * Deathtouch, ward {2}
+ * Other Spiders you control have deathtouch and ward {2}.
+ * Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token
+ * that's a copy of that creature, except it's a Food artifact with "{2}, {T}, Sacrifice this token:
+ * You gain 3 life," and it loses all other card types.
+ *
+ * Exercises:
+ * - the intrinsic deathtouch + ward {2} keywords;
+ * - the "other Spiders you control" anthem granting deathtouch + ward {2} to another Spider;
+ * - the observer dealt-damage-by-source-dies trigger (filtered to "a Spider you controlled") plus
+ *   the new token-copy overrides (`overrideCardTypes` = ARTIFACT, `addedSubtypes` = Food,
+ *   granted Food sacrifice activated ability).
+ */
+class ShelobChildOfUngoliantScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A vanilla Spider the anthem can buff and that deals lethal (deathtouch) damage.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Pet Spider",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Spider")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        // An opposing creature the Spider can kill in combat.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Doomed Bear",
+                manaCost = ManaCost.parse("{2}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 3
+            )
+        )
+
+        context("Shelob, Child of Ungoliant") {
+
+            test("has deathtouch and ward {2}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shelob, Child of Ungoliant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shelob = game.findPermanent("Shelob, Child of Ungoliant")!!
+                withClue("Shelob has deathtouch") {
+                    game.state.projectedState.hasKeyword(shelob, Keyword.DEATHTOUCH) shouldBe true
+                }
+                withClue("Shelob has ward") {
+                    game.state.projectedState.hasKeyword(shelob, Keyword.WARD) shouldBe true
+                }
+            }
+
+            test("anthem grants deathtouch and ward {2} to another Spider you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shelob, Child of Ungoliant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Pet Spider", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spider = game.findPermanent("Pet Spider")!!
+                withClue("the other Spider gains deathtouch from the anthem") {
+                    game.state.projectedState.hasKeyword(spider, Keyword.DEATHTOUCH) shouldBe true
+                }
+                withClue("the other Spider gains ward from the anthem") {
+                    game.state.projectedState.hasKeyword(spider, Keyword.WARD) shouldBe true
+                }
+            }
+
+            test("a creature dealt damage by a Spider you control that dies becomes a Food-artifact token copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shelob, Child of Ungoliant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Pet Spider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Doomed Bear", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // The Spider (granted deathtouch by Shelob) attacks; the Bear blocks and is dealt
+                // lethal (deathtouch) damage, then dies during combat damage SBAs.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Pet Spider" to 2))
+                withClue("declaring the Spider as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val block = game.declareBlockers(mapOf("Doomed Bear" to listOf("Pet Spider")))
+                withClue("declaring the Bear as blocker should succeed: ${block.error}") {
+                    block.error shouldBe null
+                }
+
+                // Resolve combat damage (auto-resolved while passing to the postcombat main); the
+                // Bear dies (deathtouch) and Shelob's trigger fires, then resolve the trigger.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("the Doomed Bear died and is no longer the original creature on the battlefield") {
+                    game.state.getBattlefield()
+                        .any { game.state.getEntity(it)
+                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                            ?.name == "Doomed Bear" &&
+                            !game.state.getEntity(it)!!.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()
+                        } shouldBe false
+                }
+
+                val token = game.findPermanents("Doomed Bear")
+                    .singleOrNull { game.state.getEntity(it)!!.has<com.wingedsheep.engine.state.components.identity.TokenComponent>() }
+                    ?: error("Expected exactly one Food token copy of Doomed Bear")
+
+                withClue("token is controlled by Shelob's controller (Player 1)") {
+                    game.state.getEntity(token)
+                        ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                        ?.playerId shouldBe game.player1Id
+                }
+                withClue("token is an artifact") {
+                    game.state.projectedState.hasType(token, "ARTIFACT") shouldBe true
+                }
+                withClue("token has the Food subtype") {
+                    game.state.projectedState.getSubtypes(token).contains("Food") shouldBe true
+                }
+                withClue("token lost all other card types — it is no longer a creature") {
+                    game.state.projectedState.isCreature(token) shouldBe false
+                }
+                withClue("token has a granted activated ability (the Food sacrifice ability)") {
+                    game.state.grantedActivatedAbilities.any { it.entityId == token } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StingTheGlintingDaggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StingTheGlintingDaggerScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sting, the Glinting Dagger (LTR) —
+ *   "Equipped creature gets +1/+1 and has haste.
+ *    At the beginning of each combat, untap equipped creature.
+ *    Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.
+ *    Equip {2}"
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.conditions.SourceIsBlockingOrBlockedBySubtype]
+ * condition wrapping a conditional first-strike grant on the equipped creature, plus the composed
+ * +1/+1, haste, and begin-of-combat untap pieces.
+ */
+class StingTheGlintingDaggerScenarioTest : ScenarioTestBase() {
+
+    private val equipAbilityId by lazy {
+        cardRegistry.requireCard("Sting, the Glinting Dagger").activatedAbilities
+            .single { it.isEquipAbility }.id
+    }
+
+    init {
+        test("equip grants +1/+1 and haste") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Centaur Courser", summoningSickness = true) // 3/3
+                .withCardOnBattlefield(1, "Sting, the Glinting Dagger")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findPermanent("Centaur Courser")!!
+            val sting = game.findPermanent("Sting, the Glinting Dagger")!!
+
+            game.state.projectedState.hasKeyword(courser, Keyword.HASTE) shouldBe false
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sting,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(courser))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.state.projectedState.getPower(courser) shouldBe 4
+            game.state.projectedState.getToughness(courser) shouldBe 4
+            game.state.projectedState.hasKeyword(courser, Keyword.HASTE) shouldBe true
+        }
+
+        test("beginning of each combat untaps the equipped creature") {
+            val game = scenario()
+                .withPlayers()
+                // Equipped creature starts tapped; the begin-combat trigger should untap it.
+                .withCardOnBattlefield(1, "Centaur Courser", tapped = true)
+                .withCardOnBattlefield(1, "Sting, the Glinting Dagger")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findPermanent("Centaur Courser")!!
+            val sting = game.findPermanent("Sting, the Glinting Dagger")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sting,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(courser))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.state.getEntity(courser)?.has<TappedComponent>() shouldBe true
+
+            // Advance into combat; the begin-combat trigger fires and untaps the equipped creature.
+            game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+            game.resolveStack()
+
+            game.state.getEntity(courser)?.has<TappedComponent>() shouldBe false
+        }
+
+        test("equipped creature has first strike when blocked by a Goblin") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Centaur Courser") // 3/3 attacker (4/4 equipped)
+                .withCardOnBattlefield(1, "Sting, the Glinting Dagger")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardOnBattlefield(2, "Goblin Guide") // 2/1 Goblin blocker
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findPermanent("Centaur Courser")!!
+            val sting = game.findPermanent("Sting, the Glinting Dagger")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sting,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(courser))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            // No combat yet — no first strike.
+            game.state.projectedState.hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe false
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Centaur Courser" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Goblin Guide" to listOf("Centaur Courser"))).error shouldBe null
+
+            // Now blocked by a Goblin — the conditional grant turns on first strike.
+            game.state.projectedState.hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe true
+        }
+
+        test("equipped creature does NOT have first strike when blocked by a non-Goblin/Orc") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Centaur Courser") // 3/3 attacker (4/4 equipped)
+                .withCardOnBattlefield(1, "Sting, the Glinting Dagger")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardOnBattlefield(2, "Savannah Lions") // 1/1 Cat blocker
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findPermanent("Centaur Courser")!!
+            val sting = game.findPermanent("Sting, the Glinting Dagger")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = sting,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(courser))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Centaur Courser" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Savannah Lions" to listOf("Centaur Courser"))).error shouldBe null
+
+            // Blocked by a Cat — the condition is not met, so no first strike.
+            game.state.projectedState.hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBalrogDurinsBaneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBalrogDurinsBaneScenarioTest.kt
@@ -1,0 +1,182 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The Balrog, Durin's Bane (LTR #195) — {5}{B}{R} Legendary Creature — Avatar Demon, 7/5.
+ *
+ *   This spell costs {1} less to cast for each permanent sacrificed this turn.
+ *   Haste
+ *   The Balrog can't be blocked except by legendary creatures.
+ *   When The Balrog dies, destroy target artifact or creature an opponent controls.
+ *
+ * Exercises the new SDK primitive
+ * [com.wingedsheep.sdk.scripting.CostReductionSource.PermanentsSacrificedThisTurn] and its
+ * backing turn-scoped counter `GameState.permanentsSacrificedThisTurn` (incremented by the
+ * central sacrifice hook `ZoneTransitionService.trackPermanentSacrifice`, reset each turn).
+ */
+class TheBalrogDurinsBaneScenarioTest : ScenarioTestBase() {
+
+    private val calculator = CostCalculator(cardRegistry)
+    private val balrog get() = cardRegistry.requireCard("The Balrog, Durin's Bane")
+
+    init {
+        context("cost reduction by permanents sacrificed this turn") {
+
+            test("base cost is {5}{B}{R} = 7 mana with no sacrifices") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Balrog, Durin's Bane")
+                    .build()
+                val cost = calculator.calculateEffectiveCost(game.state, balrog, game.player1Id)
+                cost.cmc shouldBe 7
+                cost.genericAmount shouldBe 5
+            }
+
+            test("each permanent sacrificed this turn reduces the cost by {1}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Balrog, Durin's Bane")
+                    .build()
+
+                // Three permanents sacrificed this turn → {3} less → {2}{B}{R} = 4 mana.
+                game.state = game.state.copy(permanentsSacrificedThisTurn = 3)
+                val cost = calculator.calculateEffectiveCost(game.state, balrog, game.player1Id)
+                withClue("{5}{B}{R} reduced by {3} = {2}{B}{R}") {
+                    cost.cmc shouldBe 4
+                    cost.genericAmount shouldBe 2
+                }
+            }
+
+            test("the count never reduces the cost below the colored pips") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Balrog, Durin's Bane")
+                    .build()
+
+                // Far more sacrifices than generic mana — floored at the {B}{R} requirement.
+                game.state = game.state.copy(permanentsSacrificedThisTurn = 99)
+                val cost = calculator.calculateEffectiveCost(game.state, balrog, game.player1Id)
+                withClue("Cannot reduce below the colored {B}{R} requirement") {
+                    cost.cmc shouldBe 2
+                    cost.genericAmount shouldBe 0
+                }
+            }
+
+            test("a real in-engine sacrifice increments the per-turn counter and discounts the cast") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .withCardInHand(1, "Nasty End")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .build()
+
+                game.state.permanentsSacrificedThisTurn shouldBe 0
+
+                // Nasty End: sacrifice a creature as an additional cost, then draw.
+                val result = game.castSpellWithAdditionalSacrifice(1, "Nasty End", "Grizzly Bears")
+                result.error shouldBe null
+                game.resolveStack()
+
+                withClue("Sacrificing Grizzly Bears should bump permanentsSacrificedThisTurn to 1") {
+                    game.state.permanentsSacrificedThisTurn shouldBe 1
+                }
+                game.isInGraveyard(1, "Grizzly Bears").shouldBeTrue()
+
+                // The Balrog now costs {1} less → {4}{B}{R} = 6 mana.
+                val cost = calculator.calculateEffectiveCost(game.state, balrog, game.player1Id)
+                cost.cmc shouldBe 6
+            }
+        }
+
+        context("haste") {
+            test("The Balrog has haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Balrog, Durin's Bane")
+                    .build()
+                val balrogId = game.findPermanent("The Balrog, Durin's Bane")!!
+                game.state.projectedState.hasKeyword(balrogId, Keyword.HASTE).shouldBeTrue()
+            }
+        }
+
+        context("can't be blocked except by legendary creatures") {
+
+            test("a nonlegendary creature cannot block The Balrog, but a legendary can") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Balrog, Durin's Bane")
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // nonlegendary
+                    .withCardOnBattlefield(2, "Bill the Pony")    // legendary 1/4
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("The Balrog, Durin's Bane" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("Grizzly Bears is nonlegendary, so it cannot block The Balrog") {
+                    game.declareBlockers(
+                        mapOf("Grizzly Bears" to listOf("The Balrog, Durin's Bane")),
+                    ).error shouldNotBe null
+                }
+
+                withClue("Bill the Pony is legendary, so it may block The Balrog") {
+                    game.declareBlockers(
+                        mapOf("Bill the Pony" to listOf("The Balrog, Durin's Bane")),
+                    ).error shouldBe null
+                }
+            }
+        }
+
+        context("dies trigger") {
+            test("destroys a target artifact or creature an opponent controls") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .withCardOnBattlefield(1, "The Balrog, Durin's Bane")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(2, "Murder")
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Swamp")
+                    .build()
+
+                val balrogId = game.findPermanent("The Balrog, Durin's Bane")!!
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+
+                // Player 2 Murders The Balrog (player 1's) → it dies, its dies trigger goes on the stack.
+                game.castSpell(2, "Murder", balrogId).error shouldBe null
+                game.resolveStack()
+
+                // The Balrog's controller is player 1, so "an opponent controls" = player 2's Grizzly Bears.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bearsId))
+                }
+                game.resolveStack()
+
+                withClue("The dies trigger should destroy a creature an opponent controls") {
+                    game.isInGraveyard(1, "The Balrog, Durin's Bane").shouldBeTrue()
+                    game.isInGraveyard(2, "Grizzly Bears").shouldBeTrue()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchKingOfAngmarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchKingOfAngmarScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.WitchKingOfAngmar
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Witch-king of Angmar (LTR #114) — {3}{B}{B} Legendary Creature — Wraith Noble, 5/3.
+ *
+ *   Flying
+ *   Whenever one or more creatures deal combat damage to you, each opponent sacrifices a creature
+ *   of their choice that dealt combat damage to you this turn. The Ring tempts you.
+ *   Discard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it.
+ *
+ * Verifies the defensive combat-damage batch trigger + edict restricted to creatures that dealt
+ * combat damage to the Witch-king's controller this turn (a creature that did NOT deal you damage
+ * is not a legal sacrifice), the Ring temptation, and the discard-for-indestructible ability.
+ */
+class WitchKingOfAngmarScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(WitchKingOfAngmar))
+        return driver
+    }
+
+    test("opponent sacrifices the creature that dealt you combat damage, and the Ring tempts you") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!          // the opponent (each opponent sacrifices)
+        val defender = driver.getOpponent(attacker)   // controls Witch-king
+
+        // Defender controls the Witch-king (the trigger's controller).
+        driver.putCreatureOnBattlefield(defender, "Witch-king of Angmar")
+
+        // Attacker has two creatures: the Bears attack and connect; the Giant stays home and so
+        // never deals combat damage to the defender this turn.
+        val bears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        val giant = driver.putCreatureOnBattlefield(attacker, "Hill Giant")
+        driver.removeSummoningSickness(bears)
+        driver.removeSummoningSickness(giant)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(bears), defender).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(defender).isSuccess shouldBe true
+
+        // Advance through the combat-damage step: defender takes 2, the Witch-king trigger goes on
+        // the stack and resolves. passPriorityUntil auto-resolves the combat-damage assignment, the
+        // edict sacrifice (only the connecting Bears qualifies), and the Ring temptation.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.assertLifeTotal(defender, 18)
+
+        // The Bears dealt combat damage to the defender this turn -> sacrificed.
+        driver.getGraveyardCardNames(attacker) shouldContain "Grizzly Bears"
+        // The Hill Giant never dealt the defender combat damage -> not a legal sacrifice, survives.
+        driver.findPermanent(attacker, "Hill Giant") shouldNotBe null
+        driver.getGraveyardCardNames(attacker) shouldNotContain "Hill Giant"
+
+        // The Ring tempted the Witch-king's controller.
+        driver.state.getEntity(defender)?.get<TheRingComponent>()?.temptCount shouldBe 1
+    }
+
+    test("discard a card: Witch-king gains indestructible until end of turn and taps itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val witchKing = driver.putCreatureOnBattlefield(player, "Witch-king of Angmar")
+        val toDiscard = driver.putCardInHand(player, "Grizzly Bears")
+        val abilityId = WitchKingOfAngmar.activatedAbilities[0].id
+
+        driver.state.projectedState.hasKeyword(witchKing, Keyword.INDESTRUCTIBLE) shouldBe false
+        driver.isTapped(witchKing) shouldBe false
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = witchKing,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(discardedCards = listOf(toDiscard))
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Card was discarded as the cost.
+        driver.getHand(player).contains(toDiscard) shouldBe false
+        driver.getGraveyard(player).contains(toDiscard) shouldBe true
+
+        // Witch-king gained indestructible (projected) and tapped itself.
+        driver.state.projectedState.hasKeyword(witchKing, Keyword.INDESTRUCTIBLE) shouldBe true
+        driver.isTapped(witchKing) shouldBe true
+    }
+})


### PR DESCRIPTION
Adds 13 LTR cards, each with a full scenario test. All compose SDK primitives
already on `main` — no new SDK/engine types.

Cards:
- Pippin, Guard of the Citadel — {T}: grant protection from a chosen card type
- Aragorn, Company Leader — Ring-tempt keyword-counter payoff (CR 122.1b)
- Sting, the Glinting Dagger — first strike vs. Goblin/Orc blockers
- Frodo, Sauron's Bane — Citizen → Scout → Rogue level-up forms
- King of the Oathbreakers — phasing on targeted, token on phase-in (CR 702.26)
- Flame of Anor — conditional "choose two" with a Wizard
- Gandalf the Grey — "choose one that hasn't been chosen" modal-with-memory
- Press the Enemy — bounce a spell/permanent, then free-cast within MV
- Glamdring — graveyard-count +X/+0, combat-damage free cast
- Sauron, the Necromancer — attacking token copy from graveyard (CR 701.54e)
- Shelob, Child of Ungoliant — Food-artifact token copy on Spider kills
- The Balrog, Durin's Bane — cost reduction per permanent sacrificed this turn
- Witch-king of Angmar — defensive sacrifice edict + Ring tempt

Also: re-blessed the LTR snapshot golden (main migrated BecomeCreature P/T to
DynamicAmount serialization) and fixed a CR citation in the Aragorn comment
(keyword counters are 122.1b, not 122.1d).

Tests: CardDefinitionSnapshotTest, CardLintTest, and all 13 scenario classes
pass. No client/server changes.
