### PR TITLE
LTR pr-6: 13 more Lord of the Rings cards (composed from existing primitives)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EntDraughtBasin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EntDraughtBasin.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ent-Draught Basin
+ * {2}
+ * Artifact
+ *
+ * {X}, {T}: Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.
+ *
+ * The "{X}" lives in the activated-ability cost (cf. Barad-dûr) — the X-cost activation
+ * continuation threads the chosen X into [com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue]
+ * and onto the action. The target filter "creature with power X" references that same activation X:
+ * [TargetFilter.powerEqualsX] (the power analogue of `manaValueEqualsX`, Void/Repeal) compares each
+ * candidate's projected power against the chosen X. Legal-action enumeration runs before X is bound,
+ * so the predicate matches permissively then; activation-time validation re-checks with X bound and
+ * rejects any creature whose power isn't exactly X (a power-2 or power-4 creature can't be chosen for
+ * X=3, only a power-3 one). `Activate only as a sorcery` is [TimingRule.SorcerySpeed].
+ */
+val EntDraughtBasin = card("Ent-Draught Basin") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "{X}, {T}: Put a +1/+1 counter on target creature with power X. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        target = TargetCreature(
+            filter = TargetFilter.Creature.powerEqualsX(),
+            id = "creature with power X"
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Torgeir Fjereide"
+        flavorText = "The effect of the draught began at the toes, and rose steadily through every limb, " +
+            "bringing refreshment and vigor as it coursed upward, right to the tips of the hair."
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg?1686970148"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EowynLadyOfRohan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EowynLadyOfRohan.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReduceEquipCost
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Éowyn, Lady of Rohan
+ * {2}{W}
+ * Legendary Creature — Human Noble
+ * 2/4
+ *
+ * At the beginning of combat on your turn, target creature gains your choice of first strike or
+ * vigilance until end of turn. If that creature is equipped, it gains first strike and vigilance
+ * until end of turn instead.
+ * Equip abilities you activate cost {1} less to activate.
+ *
+ * The combat trigger composes existing primitives: a [ConditionalEffect] gated on
+ * [Conditions.TargetMatchesFilter] for `GameObjectFilter.Creature.equipped()` — when the target is
+ * equipped it grants both keywords; otherwise a [ModalEffect.chooseOne] lets the controller pick a
+ * single keyword. The cost clause uses the new controller-scoped [ReduceEquipCost] static, which
+ * the engine keys off `ActivatedAbility.isEquipAbility` to shave {1} off the generic equip cost.
+ */
+val EowynLadyOfRohan = card("Éowyn, Lady of Rohan") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 2
+    toughness = 4
+    oracleText = "At the beginning of combat on your turn, target creature gains your choice of first strike or vigilance until end of turn. If that creature is equipped, it gains first strike and vigilance until end of turn instead.\n" +
+        "Equip abilities you activate cost {1} less to activate."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("target creature", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.equipped(), targetIndex = 0),
+            // Target is equipped: it gains first strike AND vigilance.
+            effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature, Duration.EndOfTurn)
+                .then(Effects.GrantKeyword(Keyword.VIGILANCE, creature, Duration.EndOfTurn)),
+            // Otherwise: choose first strike OR vigilance.
+            elseEffect = ModalEffect.chooseOne(
+                Mode.noTarget(
+                    Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature, Duration.EndOfTurn),
+                    "First strike"
+                ),
+                Mode.noTarget(
+                    Effects.GrantKeyword(Keyword.VIGILANCE, creature, Duration.EndOfTurn),
+                    "Vigilance"
+                )
+            )
+        )
+    }
+
+    // "Equip abilities you activate cost {1} less to activate."
+    staticAbility {
+        ability = ReduceEquipCost(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Sean Vo"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg?1686967724"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirPrinceOfIthilien.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirPrinceOfIthilien.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Faramir, Prince of Ithilien
+ * {2}{W}{U}
+ * Legendary Creature — Human Noble
+ * 3/3
+ *
+ * At the beginning of your end step, choose an opponent. At the beginning of that
+ * player's next end step, you draw a card if they didn't attack you that turn.
+ * Otherwise, create three 1/1 white Human Soldier creature tokens.
+ *
+ * Modelled as: at the controller's end step, an opponent is chosen. The choice is
+ * expressed via [Targets.Opponent] (the engine's mechanism for "choose an opponent");
+ * functionally this is the controller picking one opponent. That chosen opponent is
+ * baked into [CreateDelayedTriggerEffect.fireOnPlayer] so the delayed trigger fires
+ * at the beginning of *that* player's next end step and re-exposes them as
+ * [Player.TriggeringPlayer] to the inner conditional.
+ *
+ * When the delayed trigger resolves, it checks whether the chosen opponent attacked
+ * Faramir's controller this turn (CR 508.6 — declared one or more attackers whose
+ * defending player was the controller, including attacking the controller's
+ * planeswalkers). If they did NOT, the controller draws a card; otherwise the
+ * controller creates three 1/1 white Human Soldier tokens.
+ */
+val FaramirPrinceOfIthilien = card("Faramir, Prince of Ithilien") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 3
+    toughness = 3
+    oracleText = "At the beginning of your end step, choose an opponent. At the beginning " +
+        "of that player's next end step, you draw a card if they didn't attack you that turn. " +
+        "Otherwise, create three 1/1 white Human Soldier creature tokens."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        target = Targets.Opponent
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END,
+            fireOnPlayer = EffectTarget.ContextTarget(0),
+            // The chosen opponent is never the active player at Faramir's controller's end step,
+            // so the next END step gated to that opponent (fireOnPlayer) is necessarily a later
+            // turn — CURRENT_TURN_OR_LATER avoids a turn-floor off-by-one while still firing only
+            // at "that player's next end step" (same axis as Nafs Asp).
+            timing = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+            effect = ConditionalEffect(
+                condition = Conditions.Not(
+                    Conditions.PlayerAttackedPlayerThisTurn(
+                        attacker = Player.TriggeringPlayer,
+                        defender = Player.You
+                    )
+                ),
+                effect = Effects.DrawCards(1),
+                elseEffect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Human", "Soldier"),
+                    count = 3,
+                    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6181330-7521-4ec6-be6c-b35487c2d2d4.jpg?1699974464"
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Tomas Duchek"
+        flavorText = "The City was made more fair than it had ever been, even in the days of its first glory."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg?1686969755"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirPrinceOfIthilien.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirPrinceOfIthilien.kt
@@ -32,9 +32,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * [Player.TriggeringPlayer] to the inner conditional.
  *
  * When the delayed trigger resolves, it checks whether the chosen opponent attacked
- * Faramir's controller this turn (CR 508.6 — declared one or more attackers whose
- * defending player was the controller, including attacking the controller's
- * planeswalkers). If they did NOT, the controller draws a card; otherwise the
+ * Faramir's controller this turn (CR 508.6 — a player "has attacked [a player]" if they
+ * declared one or more creatures as attackers attacking that player). Attacking a
+ * planeswalker or battle the controller owns is not attacking the controller, so it
+ * doesn't count here. If they did NOT, the controller draws a card; otherwise the
  * controller creates three 1/1 white Human Soldier tokens.
  */
 val FaramirPrinceOfIthilien = card("Faramir, Prince of Ithilien") {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FearFireFoes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FearFireFoes.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fear, Fire, Foes!
+ * {X}{R}
+ * Sorcery
+ *
+ * Damage can't be prevented this turn. Fear, Fire, Foes! deals X damage to target creature and
+ * 1 damage to each other creature with the same controller.
+ *
+ * - "Damage can't be prevented this turn." sets a turn-scoped flag (DamageCantBePreventedThisTurn)
+ *   so every damage event this turn ignores prevention shields / protection's prevention clause
+ *   (CR 615.6).
+ * - The group clause deals 1 to each OTHER creature controlled by the target creature's controller:
+ *   `targetPlayerControls(TargetController)` scopes to the target's controller and `otherThanTarget()`
+ *   excludes the target creature itself.
+ */
+val FearFireFoes = card("Fear, Fire, Foes!") {
+    manaCost = "{X}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Damage can't be prevented this turn. Fear, Fire, Foes! deals X damage to target creature and 1 damage to each other creature with the same controller."
+
+    spell {
+        target("target creature", Targets.Creature)
+        effect = Effects.DamageCantBePreventedThisTurn()
+            .then(Effects.DealDamage(DynamicAmount.XValue, EffectTarget.ContextTarget(0)))
+            .then(
+                Patterns.Group.dealDamageToAll(
+                    1,
+                    GroupFilter(
+                        GameObjectFilter.Creature.targetPlayerControls(EffectTarget.TargetController)
+                    ).otherThanTarget()
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Hristo D. Chukov"
+        flavorText = "\"Open, in the name of Mordor!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg?1686968914"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FearFireFoes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FearFireFoes.kt
@@ -20,7 +20,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *
  * - "Damage can't be prevented this turn." sets a turn-scoped flag (DamageCantBePreventedThisTurn)
  *   so every damage event this turn ignores prevention shields / protection's prevention clause
- *   (CR 615.6).
+ *   (CR 615.12: prevention effects still "apply" but prevent nothing, and existing shields aren't
+ *   reduced by damage that can't be prevented).
  * - The group clause deals 1 to each OTHER creature controlled by the target creature's controller:
  *   `targetPlayerControls(TargetController)` scopes to the target's controller and `otherThanTarget()`
  *   excludes the target creature itself.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FiresOfMountDoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FiresOfMountDoom.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fires of Mount Doom
+ * {2}{R}
+ * Legendary Enchantment
+ *
+ * When Fires of Mount Doom enters, it deals 2 damage to target creature an opponent
+ * controls. Destroy all Equipment attached to that creature.
+ * {2}{R}: Exile the top card of your library. You may play that card this turn. When you
+ * play a card this way, Fires of Mount Doom deals 2 damage to each player.
+ *
+ * The activated ability is the standard impulse pipeline (Gather → Exile → GrantMayPlay),
+ * with the rider expressed via [GrantMayPlayFromExile]'s `onPlayRider`: playing the exiled
+ * card fires "Fires of Mount Doom deals 2 damage to each player" on the stack.
+ */
+val FiresOfMountDoom = card("Fires of Mount Doom") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Enchantment"
+    oracleText = "When Fires of Mount Doom enters, it deals 2 damage to target creature an " +
+        "opponent controls. Destroy all Equipment attached to that creature.\n" +
+        "{2}{R}: Exile the top card of your library. You may play that card this turn. When " +
+        "you play a card this way, Fires of Mount Doom deals 2 damage to each player."
+
+    // ETB: 2 damage to target creature an opponent controls, then destroy all Equipment on it.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.Composite(
+            listOf(
+                Effects.DealDamage(2, creature, damageSource = EffectTarget.Self),
+                Effects.DestroyAllEquipmentOnTarget(creature),
+            )
+        )
+    }
+
+    // {2}{R}: impulse-exile the top card; play it this turn; when played, 2 damage to each player.
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "exiledCard"
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                Effects.GrantMayPlayFromExile(
+                    from = "exiledCard",
+                    onPlayRider = Effects.DealDamage(
+                        2,
+                        EffectTarget.PlayerRef(Player.Each),
+                        damageSource = EffectTarget.Self
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "294"
+        artist = "Shahab Alizadeh"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg?1687424796"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GollumSchemingGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GollumSchemingGuide.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gollum, Scheming Guide
+ * {1}{B}
+ * Legendary Creature — Halfling Horror
+ * 2/1
+ *
+ * Whenever Gollum attacks, look at the top two cards of your library, put them back in any order,
+ * then choose land or nonland. An opponent guesses whether the top card of your library is the
+ * chosen kind. Reveal that card. If they guessed right, remove Gollum from combat. Otherwise, you
+ * draw a card and Gollum can't be blocked this turn.
+ *
+ * The attack trigger composes a look-at-top-2-and-reorder ([Patterns.Library.lookAtTopAndReorder])
+ * with the reusable opponent-guess primitive ([Effects.OpponentGuessesTopCardKind]): the controller
+ * picks the framing land/nonland kind, an opponent guesses the top card's actual kind, that card is
+ * revealed and compared, and the matching branch resolves — remove Gollum from combat on a correct
+ * guess, or (on a wrong guess) draw a card and make Gollum unblockable this turn.
+ */
+val GollumSchemingGuide = card("Gollum, Scheming Guide") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Halfling Horror"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever Gollum attacks, look at the top two cards of your library, put them back " +
+        "in any order, then choose land or nonland. An opponent guesses whether the top card of " +
+        "your library is the chosen kind. Reveal that card. If they guessed right, remove Gollum " +
+        "from combat. Otherwise, you draw a card and Gollum can't be blocked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Library.lookAtTopAndReorder(count = 2) then
+            Effects.OpponentGuessesTopCardKind(
+                onGuessedRight = Effects.RemoveFromCombat(EffectTarget.Self),
+                onGuessedWrong = Effects.DrawCards(1) then
+                    Effects.GrantKeyword(
+                        AbilityFlag.CANT_BE_BLOCKED,
+                        target = EffectTarget.Self,
+                        duration = Duration.EndOfTurn
+                    )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "292"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg?1687424790"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GrishnakhBrashInstigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GrishnakhBrashInstigator.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Grishnákh, Brash Instigator
+ * {2}{R}
+ * Legendary Creature — Goblin Soldier
+ * 1/1
+ *
+ * When Grishnákh enters, amass Orcs 2. When you do, until end of turn, gain control of target
+ * nonlegendary creature an opponent controls with power less than or equal to the amassed Army's
+ * power. Untap that creature. It gains haste until end of turn.
+ *
+ * Modeled as a [ReflexiveTriggerEffect] — the "when you do" half is a second, reflexive triggered
+ * ability that fires after the amass resolves (Scryfall ruling 2023-06-16). Its target is chosen as
+ * the reflexive ability goes on the stack, and players may respond.
+ *
+ * The reflexive target filter — "creature with power <= the amassed Army's power" — references a
+ * resolution-time pipeline value: the amass step stashes the just-amassed Army under
+ * [EntityReference.AmassedArmy], and [TargetFilter.powerAtMostEntity] compares each candidate's
+ * projected power against it. The pipeline is threaded into the target search via
+ * `findLegalTargets(..., pipelineContext = ...)`, so a power-3 creature is excluded from the legal
+ * targets after "amass Orcs 2" produced a 2/2 Army while a power-2 creature is included.
+ */
+val GrishnakhBrashInstigator = card("Grishnákh, Brash Instigator") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Goblin Soldier"
+    oracleText = "When Grishnákh enters, amass Orcs 2. When you do, until end of turn, gain control " +
+        "of target nonlegendary creature an opponent controls with power less than or equal to the " +
+        "amassed Army's power. Untap that creature. It gains haste until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val controlled = EffectTarget.ContextTarget(0)
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Amass(2, "Orc"),
+            optional = false,
+            reflexiveEffect = Effects.Composite(
+                Effects.GainControl(controlled, Duration.EndOfTurn),
+                Effects.Untap(controlled),
+                Effects.GrantKeyword(Keyword.HASTE, controlled, Duration.EndOfTurn)
+            ),
+            reflexiveTargetRequirements = listOf(
+                TargetCreature(
+                    filter = TargetFilter.CreatureOpponentControls
+                        .nonlegendary()
+                        .powerAtMostEntity(EntityReference.AmassedArmy)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Victor Harmatiuk"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg?1686969015"
+        ruling("2023-06-16", "You don't choose a target for Grishnákh, Brash Instigator's ability at the time it triggers. Rather, a second \"reflexive\" ability triggers when you amass Orcs this way. You choose a target for that ability as it goes on the stack. Each player may respond to this triggered ability as normal.")
+        ruling("2023-06-16", "Some cards refer to the \"amassed Army.\" That means the Army creature you chose to receive counters, even if no counters were placed on it for some reason.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GrondTheGatebreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GrondTheGatebreaker.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Grond, the Gatebreaker
+ * {3}{B}
+ * Legendary Artifact — Vehicle
+ * 5/5
+ * Trample
+ * As long as it's your turn and you control an Army, Grond is an artifact creature.
+ * Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle
+ *   becomes an artifact creature until end of turn.)
+ *
+ * Vehicle = artifact subtype (CR 301.7); a Vehicle has printed power/toughness but isn't a
+ * creature unless an effect makes it one. Crew (CR 702.122) is a built-in keyword ability that
+ * taps creatures totalling power N to animate the Vehicle to its printed P/T (with its keywords,
+ * here Trample) until end of turn. The static is a conditional Layer-4 type change: while it's
+ * your turn AND you control an Army, Grond gains the CREATURE type and so uses its printed 5/5.
+ */
+val GrondTheGatebreaker = card("Grond, the Gatebreaker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Trample\n" +
+        "As long as it's your turn and you control an Army, Grond is an artifact creature.\n" +
+        "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    // As long as it's your turn and you control an Army, Grond is an artifact creature.
+    staticAbility {
+        condition = Conditions.All(
+            Conditions.IsYourTurn,
+            Conditions.YouControl(GameObjectFilter.Creature.youControl().withSubtype("Army"))
+        )
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    // Crew 3
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 3))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Ramazan Kazaliev"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg?1738052978"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LostIsleCalling.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LostIsleCalling.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lost Isle Calling
+ * {1}{U}
+ * Enchantment
+ *
+ * Whenever you scry, put a verse counter on this enchantment.
+ * {4}{U}{U}, Exile this enchantment: Draw a card for each verse counter on this enchantment.
+ * If it had seven or more verse counters on it, take an extra turn after this one.
+ * Activate only as a sorcery.
+ *
+ * The activated ability exiles its own source as part of the cost, so by the time the effect
+ * resolves the source — and its verse counters (CR 122.2) — are gone. The pre-cost count is
+ * snapshotted into the resolution context at cost-payment time and read back via
+ * [DynamicAmount.LastKnownSourceCounters] for both the draw amount and the seven-or-more test.
+ */
+val LostIsleCalling = card("Lost Isle Calling") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you scry, put a verse counter on this enchantment.\n" +
+        "{4}{U}{U}, Exile this enchantment: Draw a card for each verse counter on this " +
+        "enchantment. If it had seven or more verse counters on it, take an extra turn after " +
+        "this one. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        effect = Effects.AddCounters(Counters.VERSE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{U}{U}"), Costs.ExileSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            listOf(
+                Effects.DrawCards(
+                    DynamicAmounts.lastKnownSourceCounters(CounterTypeFilter.Named(Counters.VERSE))
+                ),
+                ConditionalEffect(
+                    condition = Compare(
+                        DynamicAmounts.lastKnownSourceCounters(CounterTypeFilter.Named(Counters.VERSE)),
+                        ComparisonOperator.GTE,
+                        DynamicAmount.Fixed(7)
+                    ),
+                    effect = Effects.TakeExtraTurn()
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "61"
+        artist = "Wangjie Li"
+        flavorText = "\"To the Sea, to the Sea!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg?1686968202"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PalantirOfOrthanc.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PalantirOfOrthanc.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Palantír of Orthanc
+ * {3}
+ * Legendary Artifact
+ *
+ * At the beginning of your end step, put an influence counter on Palantír of Orthanc and scry 2.
+ * Then target opponent may have you draw a card. If that player doesn't, you mill X cards, where X
+ * is the number of influence counters on Palantír of Orthanc, and that player loses life equal to
+ * the total mana value of those cards.
+ *
+ * The "target opponent may" is routed to the targeted opponent (not the controller) via
+ * [MayEffect]'s `decisionMaker`. On yes → the controller draws a card; on no → the else-branch
+ * mills X cards into the "milled" collection and the opponent loses life equal to their total
+ * mana value (DynamicAmount.ManaValueSumOfCollection / DynamicAmounts.manaValueSumOf).
+ */
+val PalantirOfOrthanc = card("Palantír of Orthanc") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "At the beginning of your end step, put an influence counter on Palantír of Orthanc and scry 2. " +
+        "Then target opponent may have you draw a card. If that player doesn't, you mill X cards, where X is " +
+        "the number of influence counters on Palantír of Orthanc, and that player loses life equal to the total " +
+        "mana value of those cards."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val opponent = target("target opponent", Targets.Opponent)
+
+        val influenceCount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.INFLUENCE))
+
+        effect = Effects.Composite(
+            listOf(
+                Effects.AddCounters(Counters.INFLUENCE, 1, EffectTarget.Self),
+                Patterns.Library.scry(2),
+                MayEffect(
+                    effect = Effects.DrawCards(1, EffectTarget.Controller),
+                    descriptionOverride = "Have Palantír of Orthanc's controller draw a card?",
+                    decisionMaker = opponent,
+                    otherwise = Effects.Composite(
+                        listOf(
+                            Patterns.Library.mill(influenceCount, EffectTarget.Controller),
+                            Effects.LoseLife(DynamicAmounts.manaValueSumOf("milled"), opponent)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "247"
+        artist = "Tatiana Veryayskaya"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg?1686970247"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PeregrinTook.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/PeregrinTook.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CreateAdditionalToken
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Peregrin Took
+ * {2}{G}
+ * Legendary Creature — Halfling Citizen
+ * 2/3
+ *
+ * If one or more tokens would be created under your control, those tokens plus an
+ * additional Food token are created instead.
+ * Sacrifice three Foods: Draw a card.
+ *
+ * The token-creation clause is a replacement effect (CR 614) that fires once per
+ * token-creation event under your control, regardless of how many or what kind of tokens
+ * the event makes (rulings 2023-06-16). It is self-limiting (CR 614.5): the added Food is
+ * created directly and does not itself trigger another Food.
+ */
+val PeregrinTook = card("Peregrin Took") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Halfling Citizen"
+    power = 2
+    toughness = 3
+    oracleText = "If one or more tokens would be created under your control, those tokens plus an additional Food token are created instead. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "Sacrifice three Foods: Draw a card."
+
+    // "those tokens plus an additional Food token are created instead." The engine creates
+    // the extra Food directly after the primary tokens, without re-entering the token-creation
+    // replacement pipeline, so it never recurses on its own added Food (CR 614.5).
+    replacementEffect(CreateAdditionalToken(additionalTokenType = "Food"))
+
+    // Sacrifice three Foods: Draw a card.
+    activatedAbility {
+        cost = Costs.SacrificeMultiple(3, GameObjectFilter.Artifact.withSubtype("Food"))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Campbell White"
+        flavorText = "\"Sam! Get breakfast ready for half-past nine!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg?1686969525"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RadagastTheBrown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/RadagastTheBrown.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Radagast the Brown
+ * {2}{G}{G}
+ * Legendary Creature — Avatar Wizard
+ * 2/5
+ *
+ * Whenever Radagast or another nontoken creature you control enters, look at the top X cards
+ * of your library, where X is that creature's mana value. You may reveal a creature card that
+ * doesn't share a creature type with a creature you control from among those cards and put it
+ * into your hand. Put the rest on the bottom of your library in a random order.
+ *
+ * The trigger fires for Radagast itself too — `TriggerBinding.ANY` over a "nontoken creature
+ * you control" filter. X is the *triggering* creature's mana value
+ * (`DynamicAmounts.triggeringManaValue()`), so it reads off whichever creature just entered.
+ * The reveal-to-hand uses the new `GameObjectFilter.notSharingCreatureTypeWithPermanentYouControl`
+ * predicate composed into `Patterns.Library.lookAtTopRevealMatchingToHand`.
+ */
+val RadagastTheBrown = card("Radagast the Brown") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 2
+    toughness = 5
+    oracleText = "Whenever Radagast or another nontoken creature you control enters, look at the " +
+        "top X cards of your library, where X is that creature's mana value. You may reveal a " +
+        "creature card that doesn't share a creature type with a creature you control from among " +
+        "those cards and put it into your hand. Put the rest on the bottom of your library in a " +
+        "random order."
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().nontoken(),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmounts.triggeringManaValue(),
+            filter = GameObjectFilter.Creature
+                .notSharingCreatureTypeWithPermanentYouControl(GameObjectFilter.Creature),
+            prompt = "You may reveal a creature card that doesn't share a creature type with a " +
+                "creature you control and put it into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "184"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg?1686969557"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShadowfaxLordOfHorses.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShadowfaxLordOfHorses.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Shadowfax, Lord of Horses
+ * {3}{R}{W}
+ * Legendary Creature — Horse
+ * 4/4
+ *
+ * Horses you control have haste.
+ * Whenever Shadowfax attacks, you may put a creature card with lesser power from your
+ * hand onto the battlefield tapped and attacking.
+ *
+ * Engine notes:
+ * - "Horses you control have haste" is the standard keyword-anthem lord static:
+ *   `GrantKeyword(HASTE, Creature.withSubtype(Horse).youControl())`. Shadowfax is itself
+ *   a Horse you control, so it grants itself haste too — matching the literal wording.
+ * - "with lesser power" = the chosen hand card's power is strictly less than Shadowfax's
+ *   (the source's) power, modeled with `GameObjectFilter.Creature.powerLessThanEntity(Source)`.
+ *   Hand cards are matched on their printed/characteristic power; Shadowfax's power is read
+ *   from projected state (so anthems/+1/+1 counters on Shadowfax raise the cap).
+ * - "tapped and attacking" reuses `Patterns.Hand.putFromHand(entersAttacking = true)`, which
+ *   moves the chosen card to the battlefield with `ZonePlacement.TappedAndAttacking`; the
+ *   `MoveCollectionExecutor`/`ZoneTransitionService` adds the `AttackingComponent` against the
+ *   defending player. "you may" is the `ChooseUpTo(1)` selection (choosing zero declines).
+ */
+val ShadowfaxLordOfHorses = card("Shadowfax, Lord of Horses") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Horse"
+    power = 4
+    toughness = 4
+    oracleText = "Horses you control have haste. (They can attack and {T} as soon as they come under your control.)\n" +
+        "Whenever Shadowfax attacks, you may put a creature card with lesser power from your hand onto the battlefield tapped and attacking."
+
+    // Horses you control have haste.
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.HORSE).youControl())
+        )
+    }
+
+    // Whenever Shadowfax attacks, you may put a creature card with lesser power from your
+    // hand onto the battlefield tapped and attacking.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Hand.putFromHand(
+            filter = GameObjectFilter.Creature.powerLessThanEntity(EntityReference.Source),
+            entersAttacking = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg?1686970028"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -4442,6 +4442,65 @@
     ]
 }
 
+// Ent-Draught Basin
+{
+    "name": "Ent-Draught Basin",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{X}, {T}: Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    "PowerEqualsX"
+                                ]
+                            }
+                        },
+                        "id": "creature with power X"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Torgeir Fjereide",
+        "flavorText": "The effect of the draught began at the toes, and rose steadily through every limb, bringing refreshment and vigor as it coursed upward, right to the tips of the hair.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg?1686970148"
+    }
+}
+
 // Entish Restoration
 {
     "name": "Entish Restoration",
@@ -5273,6 +5332,156 @@
     ]
 }
 
+// Faramir, Prince of Ithilien
+{
+    "name": "Faramir, Prince of Ithilien",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "At the beginning of your end step, choose an opponent. At the beginning of that player's next end step, you draw a card if they didn't attack you that turn. Otherwise, create three 1/1 white Human Soldier creature tokens.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "Not",
+                                "condition": {
+                                    "type": "PlayerAttackedPlayerThisTurn",
+                                    "attacker": "TriggeringPlayer"
+                                }
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "otherwise": {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "WHITE"
+                            ],
+                            "creatureTypes": [
+                                "Human",
+                                "Soldier"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6181330-7521-4ec6-be6c-b35487c2d2d4.jpg?1699974464"
+                        }
+                    },
+                    "fireOnPlayer": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": "TargetOpponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "RARE",
+        "artist": "Tomas Duchek",
+        "flavorText": "The City was made more fair than it had ever been, even in the days of its first glory.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg?1686969755"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Fear, Fire, Foes!
+{
+    "name": "Fear, Fire, Foes!",
+    "manaCost": "{X}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Damage can't be prevented this turn. Fear, Fire, Foes! deals X damage to target creature and 1 damage to each other creature with the same controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "DamageCantBePreventedThisTurn",
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControlledByReferencedPlayer",
+                                    "target": "TargetController"
+                                }
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Hristo D. Chukov",
+        "flavorText": "\"Open, in the name of Mordor!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg?1686968914"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fiery Inscription
 {
     "name": "Fiery Inscription",
@@ -5382,6 +5591,117 @@
         "artist": "Jeremy Paillotin",
         "flavorText": "The barricade was scattered as if by a thunderbolt.",
         "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b5871c5-bb94-4803-93ba-cd1a630b00d6.jpg?1686968936"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fires of Mount Doom
+{
+    "name": "Fires of Mount Doom",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Enchantment",
+    "oracleText": "When Fires of Mount Doom enters, it deals 2 damage to target creature an opponent controls. Destroy all Equipment attached to that creature.\n{2}{R}: Exile the top card of your library. You may play that card this turn. When you play a card this way, Fires of Mount Doom deals 2 damage to each player.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            },
+                            "damageSource": "Self"
+                        },
+                        {
+                            "type": "DestroyAllEquipmentOnTarget",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiledCard",
+                            "onPlayRider": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "Each"
+                                },
+                                "damageSource": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "294",
+        "rarity": "RARE",
+        "artist": "Shahab Alizadeh",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg?1687424796"
     },
     "colorIdentityOverride": [
         "RED"
@@ -7940,6 +8260,85 @@
     ]
 }
 
+// Gollum, Scheming Guide
+{
+    "name": "Gollum, Scheming Guide",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Halfling Horror",
+    "oracleText": "Whenever Gollum attacks, look at the top two cards of your library, put them back in any order, then choose land or nonland. An opponent guesses whether the top card of your library is the chosen kind. Reveal that card. If they guessed right, remove Gollum from combat. Otherwise, you draw a card and Gollum can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "looked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        {
+                            "type": "OpponentGuessesTopCardKindEffect",
+                            "onGuessedRight": {
+                                "type": "RemoveFromCombat",
+                                "target": "Self"
+                            },
+                            "onGuessedWrong": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "CANT_BE_BLOCKED",
+                                        "target": "Self"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "292",
+        "rarity": "RARE",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg?1687424790"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gorbag of Minas Morgul
 {
     "name": "Gorbag of Minas Morgul",
@@ -8225,6 +8624,162 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Grishnákh, Brash Instigator
+{
+    "name": "Grishnákh, Brash Instigator",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Goblin Soldier",
+    "oracleText": "When Grishnákh enters, amass Orcs 2. When you do, until end of turn, gain control of target nonlegendary creature an opponent controls with power less than or equal to the amassed Army's power. Untap that creature. It gains haste until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Amass",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "subtype": "Orc"
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GainControl",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "tap": false
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsNonlegendary",
+                                        {
+                                            "type": "PowerAtMostEntity",
+                                            "reference": "AmassedArmy"
+                                        }
+                                    ],
+                                    "controllerPredicate": "ControlledByOpponent"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Victor Harmatiuk",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg?1686969015",
+        "rulings": [
+            {
+                "date": "2023-06-16",
+                "text": "You don't choose a target for Grishnákh, Brash Instigator's ability at the time it triggers. Rather, a second \"reflexive\" ability triggers when you amass Orcs this way. You choose a target for that ability as it goes on the stack. Each player may respond to this triggered ability as normal."
+            },
+            {
+                "date": "2023-06-16",
+                "text": "Some cards refer to the \"amassed Army.\" That means the Army creature you chose to receive counters, even if no counters were placed on it for some reason."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Grond, the Gatebreaker
+{
+    "name": "Grond, the Gatebreaker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Trample\nAs long as it's your turn and you control an Army, Grond is an artifact creature.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantCardType",
+                    "cardType": "CREATURE"
+                },
+                "condition": {
+                    "type": "All",
+                    "conditions": [
+                        "IsYourTurn",
+                        {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature Army ctrl:you"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Ramazan Kazaliev",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg?1738052978"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -10185,6 +10740,95 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lost Isle Calling
+{
+    "name": "Lost Isle Calling",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you scry, put a verse counter on this enchantment.\n{4}{U}{U}, Exile this enchantment: Draw a card for each verse counter on this enchantment. If it had seven or more verse counters on it, take an extra turn after this one. Activate only as a sorcery.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "ScriedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "verse",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}{U}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "LastKnownSourceCounters",
+                                "counterType": {
+                                    "type": "Named",
+                                    "name": "verse"
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "LastKnownSourceCounters",
+                                        "counterType": {
+                                            "type": "Named",
+                                            "name": "verse"
+                                        }
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 7
+                                    }
+                                }
+                            },
+                            "then": "TakeExtraTurn"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "RARE",
+        "artist": "Wangjie Li",
+        "flavorText": "\"To the Sea, to the Sea!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg?1686968202"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -12566,6 +13210,161 @@
     ]
 }
 
+// Palantír of Orthanc
+{
+    "name": "Palantír of Orthanc",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "At the beginning of your end step, put an influence counter on Palantír of Orthanc and scry 2. Then target opponent may have you draw a card. If that player doesn't, you mill X cards, where X is the number of influence counters on Palantír of Orthanc, and that player loses life equal to the total mana value of those cards.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "influence",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "scried"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "scried",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "toBottom",
+                                    "storeRemainder": "toTop",
+                                    "selectedLabel": "Put on bottom",
+                                    "remainderLabel": "Put on top"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toBottom",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Bottom"
+                                    }
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toTop",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Top"
+                                    },
+                                    "order": "ControllerChooses"
+                                },
+                                "EmitScriedEvent"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "otherwise": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "TopOfLibrary",
+                                                    "count": {
+                                                        "type": "EntityProperty",
+                                                        "entity": "Source",
+                                                        "numericProperty": {
+                                                            "type": "CounterCount",
+                                                            "counterType": {
+                                                                "type": "Named",
+                                                                "name": "influence"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "storeAs": "milled"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "milled",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Graveyard"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "ManaValueSumOfCollection",
+                                            "collectionName": "milled"
+                                        },
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target opponent"
+                                        }
+                                    }
+                                ]
+                            },
+                            "decisionMaker": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            },
+                            "descriptionOverride": "Have Palantír of Orthanc's controller draw a card?"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "MYTHIC",
+        "artist": "Tatiana Veryayskaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg?1686970247"
+    }
+}
+
 // Pelargir Survivor
 {
     "name": "Pelargir Survivor",
@@ -12652,6 +13451,56 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Peregrin Took
+{
+    "name": "Peregrin Took",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Halfling Citizen",
+    "oracleText": "If one or more tokens would be created under your control, those tokens plus an additional Food token are created instead. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nSacrifice three Foods: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact Food",
+                        "count": 3
+                    }
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "CreateAdditionalToken",
+                "additionalTokenType": "Food"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Campbell White",
+        "flavorText": "\"Sam! Get breakfast ready for half-past nine!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg?1686969525"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -13140,6 +13989,100 @@
         "artist": "Tomas Duchek",
         "flavorText": "\"It is only a nickname, of course. They have called me that ever since I said yes to an elder Ent before he had finished his question.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/b/8/b889037f-b95f-4756-80aa-04097d2818c3.jpg?1686969546"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Radagast the Brown
+{
+    "name": "Radagast the Brown",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Whenever Radagast or another nontoken creature you control enters, look at the top X cards of your library, where X is that creature's mana value. You may reveal a creature card that doesn't share a creature type with a creature you control from among those cards and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "EntityProperty",
+                                    "entity": "Triggering",
+                                    "numericProperty": "ManaValue"
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "DoesNotShareCreatureTypeWithPermanentYouControl",
+                                        "filter": "creature"
+                                    }
+                                ]
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card that doesn't share a creature type with a creature you control and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "MYTHIC",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg?1686969557"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -14952,6 +15895,88 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Shadowfax, Lord of Horses
+{
+    "name": "Shadowfax, Lord of Horses",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Legendary Creature — Horse",
+    "oracleText": "Horses you control have haste. (They can attack and {T} as soon as they come under your control.)\nWhenever Shadowfax attacks, you may put a creature card with lesser power from your hand onto the battlefield tapped and attacking.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "PowerLessThanEntity",
+                                            "reference": "Source"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "putting"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "TappedAndAttacking"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Horse ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg?1686970028"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -19044,6 +20069,121 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "WHITE"
+    ]
+}
+
+// Éowyn, Lady of Rohan
+{
+    "name": "Éowyn, Lady of Rohan",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "At the beginning of combat on your turn, target creature gains your choice of first strike or vigilance until end of turn. If that creature is equipped, it gains first strike and vigilance until end of turn instead.\nEquip abilities you activate cost {1} less to activate.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsEquipped"
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "FIRST_STRIKE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "FIRST_STRIKE",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    }
+                                },
+                                "description": "First strike"
+                            },
+                            {
+                                "effect": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "VIGILANCE",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    }
+                                },
+                                "description": "Vigilance"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceEquipCost",
+                "amount": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "UNCOMMON",
+        "artist": "Sean Vo",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg?1686967724"
+    },
+    "colorIdentityOverride": [
         "WHITE"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EntDraughtBasinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EntDraughtBasinScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.EntDraughtBasin
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ent-Draught Basin
+ * {2} Artifact
+ * {X}, {T}: Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.
+ *
+ * Proves the new [com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerEqualsX] target
+ * filter for an X-cost activated ability: with X=3 only a power-3 creature is a legal target
+ * (a power-2 and a power-4 creature are rejected by activation-time validation, since X is bound
+ * on the action). Also covers the +1/+1 counter payload and the sorcery-speed activation gate.
+ */
+class EntDraughtBasinScenarioTest : FunSpec({
+
+    val abilityId = EntDraughtBasin.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EntDraughtBasin))
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun counterCount(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /**
+     * Set up a precombat main phase with Ent-Draught Basin in play (ready to tap) and three
+     * creatures of power 2, 3 and 4. The power-4 creature is a 3/3 Centaur Courser with a +1/+1
+     * counter so its projected power is 4. Returns (driver, activePlayer, basin, p2, p3, p4).
+     */
+    fun setup(): Setup {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val basin = driver.putPermanentOnBattlefield(activePlayer, "Ent-Draught Basin")
+        driver.removeSummoningSickness(basin)
+
+        val power2 = driver.putCreatureOnBattlefield(activePlayer, "Goblin Guide")       // 2/1
+        val power3 = driver.putCreatureOnBattlefield(activePlayer, "Centaur Courser")    // 3/3
+        val power4 = driver.putCreatureOnBattlefield(activePlayer, "Centaur Courser")    // 3/3 -> 4/4
+        addCounters(driver, power4, 1)
+
+        // Pay for {X=3}: five untapped Forests to auto-tap for the {X} cost.
+        repeat(5) { driver.putLandOnBattlefield(activePlayer, "Forest") }
+        return Setup(driver, activePlayer, basin, power2, power3, power4)
+    }
+
+    test("X=3 cannot target a power-2 creature") {
+        val s = setup()
+        s.driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = s.activePlayer,
+                sourceId = s.basin,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(s.power2)),
+                xValue = 3
+            )
+        )
+    }
+
+    test("X=3 cannot target a power-4 creature") {
+        val s = setup()
+        s.driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = s.activePlayer,
+                sourceId = s.basin,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(s.power4)),
+                xValue = 3
+            )
+        )
+    }
+
+    test("X=3 can target the power-3 creature and puts a +1/+1 counter on it") {
+        val s = setup()
+        counterCount(s.driver, s.power3) shouldBe 0
+
+        s.driver.submitSuccess(
+            ActivateAbility(
+                playerId = s.activePlayer,
+                sourceId = s.basin,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(s.power3)),
+                xValue = 3
+            )
+        )
+        // Resolve the ability off the stack.
+        s.driver.bothPass()
+
+        counterCount(s.driver, s.power3) shouldBe 1
+        s.driver.isTapped(s.basin) shouldBe true
+    }
+
+    test("cannot be activated at instant speed (sorcery-speed gate)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        // Advance into combat — not a main phase with an empty stack, so sorcery-speed is illegal.
+        val basin = driver.putPermanentOnBattlefield(activePlayer, "Ent-Draught Basin")
+        driver.removeSummoningSickness(basin)
+        val power3 = driver.putCreatureOnBattlefield(activePlayer, "Centaur Courser")
+        repeat(5) { driver.putLandOnBattlefield(activePlayer, "Forest") }
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = basin,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(power3)),
+                xValue = 3
+            )
+        )
+    }
+})
+
+private data class Setup(
+    val driver: GameTestDriver,
+    val activePlayer: EntityId,
+    val basin: EntityId,
+    val power2: EntityId,
+    val power3: EntityId,
+    val power4: EntityId
+)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EowynLadyOfRohanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EowynLadyOfRohanScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.EowynLadyOfRohan
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Éowyn, Lady of Rohan (LTR).
+ *
+ * - At the beginning of combat on your turn, target creature gains your choice of first strike or
+ *   vigilance until end of turn. If that creature is equipped, it gains both instead.
+ * - "Equip abilities you activate cost {1} less to activate." (new [ReduceEquipCost] static).
+ *
+ * The equip-cost-reduction clause is pinned with an inline Equip {3} equipment so the {1} discount
+ * is observable (the creature equips for {2} instead of {3}), distinct from Forge Anew's
+ * free-first-equip behaviour.
+ */
+class EowynLadyOfRohanScenarioTest : FunSpec({
+
+    // Inline Equip {3} equipment so the {1} reduction is visible as a {2} payment.
+    val testBlade = card("Test Blade") {
+        manaCost = "{1}"
+        typeLine = "Artifact — Equipment"
+        oracleText = "Equipped creature gets +1/+0.\nEquip {3}"
+        equipAbility("{3}")
+    }
+    val equipId = testBlade.activatedAbilities.first().id
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EowynLadyOfRohan, testBlade))
+        return driver
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1(targetStep: Step) {
+        passPriorityUntil(targetStep)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(targetStep)
+            safety++
+        }
+    }
+
+    test("unequipped target: controller chooses first strike") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Éowyn, Lady of Rohan")
+
+        driver.advanceToPlayer1(Step.BEGIN_COMBAT)
+
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(driver.player1, listOf(bear))
+        driver.bothPass()
+
+        // Modal choice: option 0 = First strike, option 1 = Vigilance.
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(driver.player1, OptionChosenResponse(modeDecision.id, 0))
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bear, Keyword.FIRST_STRIKE) shouldBe true
+        projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe false
+    }
+
+    test("unequipped target: controller chooses vigilance") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Éowyn, Lady of Rohan")
+
+        driver.advanceToPlayer1(Step.BEGIN_COMBAT)
+
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(driver.player1, listOf(bear))
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(driver.player1, OptionChosenResponse(modeDecision.id, 1))
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+        projected.hasKeyword(bear, Keyword.FIRST_STRIKE) shouldBe false
+    }
+
+    test("equipped target gains both first strike and vigilance, with no modal choice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Éowyn, Lady of Rohan")
+        val blade = driver.putPermanentOnBattlefield(driver.player1, "Test Blade")
+
+        // Equip the blade onto the bear during player1's precombat main, then advance to combat.
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        driver.giveColorlessMana(driver.player1, 2)
+        driver.submit(
+            ActivateAbility(driver.player1, blade, equipId, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(blade)?.get<AttachedToComponent>()?.targetId shouldBe bear
+
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(driver.player1, listOf(bear))
+        driver.bothPass()
+
+        // Equipped: no modal decision — both keywords are granted directly.
+        (driver.pendingDecision as? ChooseOptionDecision).shouldBeNull()
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bear, Keyword.FIRST_STRIKE) shouldBe true
+        projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("equip abilities you activate cost {1} less: Equip {3} resolves paying {2}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Éowyn, Lady of Rohan")
+        val blade = driver.putPermanentOnBattlefield(driver.player1, "Test Blade")
+
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+
+        // With only {2} available, Equip {3} reduced by Éowyn's {1} is payable and resolves.
+        driver.giveColorlessMana(driver.player1, 2)
+        driver.submit(
+            ActivateAbility(driver.player1, blade, equipId, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(blade)?.get<AttachedToComponent>()?.targetId shouldBe bear
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaramirPrinceOfIthilienScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaramirPrinceOfIthilienScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Faramir, Prince of Ithilien.
+ *
+ * Oracle: "At the beginning of your end step, choose an opponent. At the beginning of
+ * that player's next end step, you draw a card if they didn't attack you that turn.
+ * Otherwise, create three 1/1 white Human Soldier creature tokens."
+ *
+ * Exercises:
+ *  - the choose-an-opponent end-step trigger scheduling a delayed trigger keyed to the
+ *    chosen opponent's next end step (new [CreateDelayedTriggerEffect.fireOnPlayer] usage
+ *    driven by a targeted opponent), and
+ *  - the new `PlayerAttackedPlayerThisTurn` condition (CR 508.6) reading the per-player
+ *    attacked-players record stamped at declare-attackers time: didn't attack → draw,
+ *    did attack → three Human Soldier tokens.
+ */
+class FaramirPrinceOfIthilienScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Faramir, Prince of Ithilien") {
+
+            test("opponent did NOT attack you: you draw a card at their next end step") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Faramir, Prince of Ithilien")
+                    .withActivePlayer(1)
+                repeat(10) {
+                    builder.withCardInLibrary(1, "Plains")
+                    builder.withCardInLibrary(2, "Island")
+                }
+                val game = builder.build()
+
+                // P1's end step: Faramir's trigger fires, auto-chooses the lone opponent (P2),
+                // and schedules a delayed trigger at P2's next end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Faramir scheduled a delayed trigger gated to P2's end step") {
+                    game.state.delayedTriggers.size shouldBe 1
+                    game.state.delayedTriggers[0].fireAtStep shouldBe Step.END
+                    game.state.delayedTriggers[0].fireOnPlayerId shouldBe game.player2Id
+                }
+
+                // Cross into P2's turn (the next BEGINNING). P2 takes no combat action.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("It is now P2's turn") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                }
+                // Now P2's end step: the delayed trigger fires. P2 didn't attack P1 → P1 draws.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                val handBefore = game.handSize(1)
+                game.resolveStack()
+
+                withClue("P2 never attacked P1, so the delayed trigger draws P1 a card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("No Human Soldier tokens are created in the draw branch") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 0
+                }
+                withClue("Delayed trigger is consumed") {
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+
+            test("opponent DID attack you: you create three 1/1 white Human Soldier tokens instead") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Faramir, Prince of Ithilien")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                repeat(10) {
+                    builder.withCardInLibrary(1, "Plains")
+                    builder.withCardInLibrary(2, "Island")
+                }
+                val game = builder.build()
+
+                // P1's end step schedules the delayed trigger keyed to P2's end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                game.state.delayedTriggers.size shouldBe 1
+
+                // P2's turn: advance to P2's declare-attackers and swing the Bears at P1.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("It is now P2's turn") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                }
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+
+                // Advance to P2's end step: P2 attacked P1 this turn → P1 makes three tokens.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                val handBefore = game.handSize(1)
+                val tokensBefore = game.findAllPermanents("Human Soldier Token").size
+                game.resolveStack()
+
+                withClue("P2 attacked P1, so the otherwise branch creates three Human Soldier tokens") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe tokensBefore + 3
+                }
+                withClue("No card is drawn in the token branch") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("Delayed trigger is consumed") {
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearFireFoesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearFireFoesScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.FearFireFoes
+import com.wingedsheep.mtg.sets.definitions.ons.cards.BattlefieldMedic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fear, Fire, Foes! — {X}{R} sorcery.
+ *
+ * "Damage can't be prevented this turn. Fear, Fire, Foes! deals X damage to target creature
+ *  and 1 damage to each other creature with the same controller."
+ *
+ * Exercises the two new building blocks:
+ *  - GroupFilter.excludeTarget + ControlledByReferencedPlayer(TargetController): the 1-damage
+ *    sweep hits only OTHER creatures controlled by the target creature's controller.
+ *  - DamageCantBePreventedThisTurnEffect: the turn-scoped prevention shutoff ignores a
+ *    prevention shield set up by Battlefield Medic.
+ */
+class FearFireFoesScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(FearFireFoes)
+        d.registerCard(BattlefieldMedic)
+        return d
+    }
+
+    fun damageOn(d: GameTestDriver, id: EntityId): Int =
+        d.state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    fun named(d: GameTestDriver, creatures: List<EntityId>, name: String): EntityId =
+        creatures.first { d.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    test("X damage to target, 1 to each OTHER creature of the target's controller; other player's creatures untouched") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // P2 (the target's controller) has the target plus two other creatures.
+        val target = d.putCreatureOnBattlefield(p2, "Force of Nature")   // 5/5, the target
+        d.putCreatureOnBattlefield(p2, "Centaur Courser")                 // 3/3, other p2 creature
+        d.putCreatureOnBattlefield(p2, "Gurmag Angler")                   // 5/5, other p2 creature
+
+        // P1 controls a creature that must NOT be hit (different controller).
+        val p1Bystander = d.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3
+
+        val p2Creatures = d.getCreatures(p2)
+        val p2Centaur = named(d, p2Creatures, "Centaur Courser")
+        val p2Angler = named(d, p2Creatures, "Gurmag Angler")
+
+        // Cast Fear, Fire, Foes! with X=2 at the Force of Nature.
+        d.giveColorlessMana(p1, 2)  // X
+        d.giveMana(p1, Color.RED, 1)
+        val spell = d.putCardInHand(p1, "Fear, Fire, Foes!")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(target)),
+            xValue = 2
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+        d.bothPass()
+
+        // Target took X = 2.
+        damageOn(d, target) shouldBe 2
+        // Each OTHER creature with the same controller (P2) took 1.
+        damageOn(d, p2Centaur) shouldBe 1
+        damageOn(d, p2Angler) shouldBe 1
+        // P1's creature (different controller) took nothing.
+        damageOn(d, p1Bystander) shouldBe 0
+    }
+
+    test("damage can't be prevented this turn — a prevention shield is ignored") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // P1 (the active player, who holds priority) controls the target (Force of Nature 5/5),
+        // a Battlefield Medic (1 Cleric → shield of 1) and another sturdy creature to read the
+        // 1-damage sweep on. The spell can target any creature.
+        val target = d.putCreatureOnBattlefield(p1, "Force of Nature")
+        val medic = d.putCreatureOnBattlefield(p1, "Battlefield Medic")
+        val bystander = d.putCreatureOnBattlefield(p1, "Gurmag Angler") // 5/5, survives the sweep
+        d.removeSummoningSickness(medic)
+
+        // Put a "prevent the next 1 damage" shield on the Force of Nature.
+        val medicAbilityId = BattlefieldMedic.activatedAbilities.first().id
+        d.submit(ActivateAbility(
+            playerId = p1,
+            sourceId = medic,
+            abilityId = medicAbilityId,
+            targets = listOf(ChosenTarget.Permanent(target))
+        )).isSuccess shouldBe true
+        d.bothPass()
+
+        // Sanity: the prevention shield is live.
+        d.state.floatingEffects.any {
+            it.effect.modification is com.wingedsheep.engine.mechanics.layers.SerializableModification.PreventNextDamage
+        } shouldBe true
+
+        // P1 casts Fear, Fire, Foes! X=3 at the Force of Nature. "Damage can't be prevented this
+        // turn" shuts off the shield, so the full 3 lands (shield would otherwise reduce it to 2).
+        d.giveColorlessMana(p1, 3)
+        d.giveMana(p1, Color.RED, 1)
+        val spell = d.putCardInHand(p1, "Fear, Fire, Foes!")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(target)),
+            xValue = 3
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+        d.bothPass()
+
+        // Full 3 damage applied despite the prevent-1 shield (it would otherwise reduce it to 2).
+        damageOn(d, target) shouldBe 3
+        // The 1-damage sweep also can't be prevented: it hit each other creature P1 controls. The
+        // 1/1 medic took 1 (lethal) and was destroyed; the 5/5 bystander shows 1 marked damage.
+        d.findPermanent(p1, "Battlefield Medic") shouldBe null
+        damageOn(d, bystander) shouldBe 1
+        // The turn-scoped flag is set.
+        d.state.damageCantBePreventedThisTurn shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiresOfMountDoomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiresOfMountDoomScenarioTest.kt
@@ -1,0 +1,185 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ktk.cards.HeartPiercerBow
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.FiresOfMountDoom
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Fires of Mount Doom {2}{R} — Legendary Enchantment
+ *
+ * ETB: 2 damage to target creature an opponent controls, then destroy all Equipment
+ * attached to that creature.
+ * {2}{R}: Exile the top card of your library; you may play that card this turn. When you
+ * play a card this way, Fires of Mount Doom deals 2 damage to each player.
+ */
+class FiresOfMountDoomScenarioTest : FunSpec({
+
+    val tester = CardDefinition.creature(
+        name = "Test Brute",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 3,
+        toughness = 3,
+        oracleText = ""
+    )
+
+    // The card we impulse-exile and replay: a simple creature castable for {R}.
+    val burnFodder = CardDefinition.creature(
+        name = "Test Fodder",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 1,
+        toughness = 1,
+        oracleText = ""
+    )
+
+    fun GameTestDriver.attachEquipment(
+        playerId: EntityId,
+        cardDef: CardDefinition,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = EntityId.generate()
+        val cardComponent = CardComponent(
+            cardDefinitionId = cardDef.name,
+            name = cardDef.name,
+            manaCost = cardDef.manaCost,
+            typeLine = cardDef.typeLine,
+            oracleText = cardDef.oracleText,
+            baseStats = cardDef.creatureStats,
+            baseKeywords = cardDef.keywords,
+            baseFlags = cardDef.flags,
+            colors = cardDef.colors,
+            ownerId = playerId,
+            spellEffect = cardDef.spellEffect
+        )
+        val container = ComponentContainer.of(
+            cardComponent,
+            OwnerComponent(playerId),
+            ControllerComponent(playerId),
+            AttachedToComponent(targetCreatureId)
+        )
+        var newState = state.withEntity(equipmentId, container)
+        newState = newState.addToZone(ZoneKey(playerId, Zone.BATTLEFIELD), equipmentId)
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FiresOfMountDoom, HeartPiercerBow, tester, burnFodder))
+        return driver
+    }
+
+    test("ETB deals 2 to target opponent creature and destroys Equipment attached to it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a 3/3 with an Equipment attached.
+        val brute = driver.putCreatureOnBattlefield(p2, "Test Brute")
+        val equipment = driver.attachEquipment(p2, HeartPiercerBow, brute)
+        driver.state.getEntity(equipment)?.get<AttachedToComponent>() shouldNotBe null
+
+        // Cast Fires of Mount Doom.
+        val fires = driver.putCardInHand(p1, "Fires of Mount Doom")
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 2)
+        driver.castSpell(p1, fires)
+
+        // Resolve the enchantment spell, then the ETB trigger goes on the stack and asks for a target.
+        driver.passPriority(p1)
+        driver.passPriority(p2)
+
+        val targetDecision = driver.state.pendingDecision as? ChooseTargetsDecision
+            ?: error("expected ChooseTargetsDecision for the ETB trigger; got ${driver.state.pendingDecision}")
+        driver.submitDecision(p1, TargetsResponse(targetDecision.id, mapOf(0 to listOf(brute))))
+
+        // Resolve the ETB triggered ability.
+        driver.passPriority(p1)
+        driver.passPriority(p2)
+
+        // 2 damage marked on the 3/3, and the Equipment is destroyed.
+        driver.getPermanents(p2).contains(equipment) shouldBe false
+        driver.getPermanents(p2).contains(brute) shouldBe true
+    }
+
+    test("activated ability impulse-exiles the top card and the rider deals 2 to each player when it's played") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Fires already on the battlefield (skip the ETB for this test).
+        val fires = driver.putPermanentOnBattlefield(p1, "Fires of Mount Doom")
+
+        // Known top card we can replay.
+        driver.putCardOnTopOfLibrary(p1, "Test Fodder")
+
+        // Activate {2}{R}: exile the top card.
+        val abilityId = driver.cardRegistry.requireCard("Fires of Mount Doom").activatedAbilities[0].id
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 2)
+        driver.submit(ActivateAbility(playerId = p1, sourceId = fires, abilityId = abilityId)).error shouldBe null
+
+        // Resolve the activated ability — exiles 1 card, grants may-play.
+        driver.passPriority(p1)
+        driver.passPriority(p2)
+
+        driver.getExileCardNames(p1) shouldBe listOf("Test Fodder")
+        // A may-play permission exists for the exiled card, carrying the rider link.
+        val exiled = driver.getExile(p1).first()
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds && it.riderLinkId != null } shouldBe true
+
+        val p1LifeBefore = driver.getLifeTotal(p1)
+        val p2LifeBefore = driver.getLifeTotal(p2)
+
+        // Play the exiled card this turn (cast Test Fodder for {R} from exile).
+        driver.giveMana(p1, Color.RED, 1)
+        driver.castSpell(p1, exiled).error shouldBe null
+
+        // The rider ("deals 2 damage to each player") is a triggered ability on the stack; resolve it,
+        // then resolve the creature spell.
+        driver.passPriority(p1)
+        driver.passPriority(p2)
+        driver.passPriority(p1)
+        driver.passPriority(p2)
+
+        // Both players took 2 from the rider.
+        driver.getLifeTotal(p1) shouldBe p1LifeBefore - 2
+        driver.getLifeTotal(p2) shouldBe p2LifeBefore - 2
+        // The exiled card was actually played (now a creature on the battlefield).
+        driver.getExileCardNames(p1).contains("Test Fodder") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumSchemingGuideScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumSchemingGuideScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gollum, Scheming Guide — "Whenever Gollum attacks, look at the top two cards of your library, put
+ * them back in any order, then choose land or nonland. An opponent guesses whether the top card of
+ * your library is the chosen kind. Reveal that card. If they guessed right, remove Gollum from
+ * combat. Otherwise, you draw a card and Gollum can't be blocked this turn."
+ *
+ * Exercises the new opponent-guess primitive (Gap 38): controller chooses a framing kind, an
+ * opponent guesses the actual land/nonland kind of the top card, the card is revealed and compared,
+ * and the matching branch resolves. Both outcomes are proven:
+ *  - guess matches the actual top kind → Gollum removed from combat;
+ *  - guess wrong → controller draws a card and Gollum becomes unblockable this turn.
+ */
+class GollumSchemingGuideScenarioTest : FunSpec({
+
+    /** Land vs nonland are encoded as option index 0 = Land, 1 = Nonland. */
+    val LAND = 0
+    val NONLAND = 1
+
+    /**
+     * Drives Gollum's attack trigger to the point where the reveal/branch resolves.
+     *
+     * @param topCardIsLand whether the top card (after reorder) is a land.
+     * @param controllerChoiceIndex controller's framing land/nonland pick.
+     * @param opponentGuessIndex opponent's guess (this is what's compared to reality).
+     */
+    data class AttackResult(
+        val driver: GameTestDriver,
+        val gollum: EntityId,
+        val attacker: EntityId,
+        val handBefore: Int,
+    )
+
+    fun runAttack(
+        topCardIsLand: Boolean,
+        controllerChoiceIndex: Int,
+        opponentGuessIndex: Int
+    ): AttackResult {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val gollum = driver.putCreatureOnBattlefield(attacker, "Gollum, Scheming Guide")
+        driver.removeSummoningSickness(gollum)
+
+        // Seed the top two cards of the library: one land (Swamp) and one nonland (Grizzly Bears).
+        // putCardOnTopOfLibrary prepends, so the LAST call ends up on top before the reorder.
+        val land = driver.putCardOnTopOfLibrary(attacker, "Swamp")
+        val nonland = driver.putCardOnTopOfLibrary(attacker, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val handBefore = driver.getHandSize(attacker)
+        driver.declareAttackers(attacker, listOf(gollum), defender)
+        driver.bothPass()
+
+        // 1. Look at top two, put back in any order: put the desired card on top.
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        val desiredTop = if (topCardIsLand) land else nonland
+        val other = if (topCardIsLand) nonland else land
+        driver.submitOrderedResponse(attacker, listOf(desiredTop, other))
+
+        // 2. Controller chooses land or nonland (framing).
+        val controllerChoice = driver.pendingDecision as ChooseOptionDecision
+        controllerChoice.playerId shouldBe attacker
+        driver.submitDecision(attacker, OptionChosenResponse(controllerChoice.id, controllerChoiceIndex))
+
+        // 3. Opponent guesses land or nonland about the top card.
+        val guess = driver.pendingDecision as ChooseOptionDecision
+        guess.playerId shouldBe defender
+        driver.submitDecision(defender, OptionChosenResponse(guess.id, opponentGuessIndex))
+
+        return AttackResult(driver, gollum, attacker, handBefore)
+    }
+
+    test("opponent guesses right (top is land, guesses land) -> Gollum removed from combat") {
+        val r = runAttack(
+            topCardIsLand = true,
+            controllerChoiceIndex = LAND,
+            opponentGuessIndex = LAND
+        )
+
+        // Correct guess: Gollum is removed from combat, no draw, not unblockable.
+        r.driver.state.getEntity(r.gollum)?.has<AttackingComponent>() shouldBe false
+        r.driver.getHandSize(r.attacker) shouldBe r.handBefore
+        r.driver.state.projectedState.hasKeyword(r.gollum, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+    }
+
+    test("opponent guesses wrong (top is land, guesses nonland) -> draw a card and Gollum unblockable") {
+        val r = runAttack(
+            topCardIsLand = true,
+            controllerChoiceIndex = LAND,
+            opponentGuessIndex = NONLAND
+        )
+
+        // Wrong guess: Gollum stays attacking, controller drew a card, Gollum is unblockable this turn.
+        r.driver.state.getEntity(r.gollum)?.has<AttackingComponent>() shouldBe true
+        r.driver.getHandSize(r.attacker) shouldBe r.handBefore + 1
+        r.driver.state.projectedState.hasKeyword(r.gollum, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+    }
+
+    test("opponent guesses right when top is nonland (guesses nonland) -> Gollum removed from combat") {
+        val r = runAttack(
+            topCardIsLand = false,
+            controllerChoiceIndex = NONLAND,
+            opponentGuessIndex = NONLAND
+        )
+
+        r.driver.state.getEntity(r.gollum)?.has<AttackingComponent>() shouldBe false
+        r.driver.getHandSize(r.attacker) shouldBe r.handBefore
+        r.driver.state.projectedState.hasKeyword(r.gollum, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrishnakhBrashInstigatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrishnakhBrashInstigatorScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Grishnákh, Brash Instigator (LTR #134) — {2}{R} Legendary Creature.
+ *
+ * "When Grishnákh enters, amass Orcs 2. When you do, until end of turn, gain control of target
+ *  nonlegendary creature an opponent controls with power less than or equal to the amassed Army's
+ *  power. Untap that creature. It gains haste until end of turn."
+ *
+ * Exercises the new pipeline-target-filter primitive: the reflexive target requirement filters by
+ * "power <= the amassed Army's power", a value only known at resolution time. After "amass Orcs 2"
+ * produces a 2/2 Army, a power-2 Grizzly Bears is a legal target while a power-3 Hill Giant is not.
+ * Then verifies the steal: control flips until end of turn, the stolen creature untaps and gains
+ * haste, and control reverts to its owner during the cleanup step.
+ */
+class GrishnakhBrashInstigatorScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Grishnákh, Brash Instigator") {
+
+            test("amasses Orcs 2, then can only steal a creature with power <= the Army's power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Grishnákh, Brash Instigator")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    // Opponent's board: a 2/2 (legal) and a 3/3 (illegal under power <= 2).
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Grishnákh, Brash Instigator")
+                withClue("Casting Grishnákh should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                // Grishnákh resolves and enters; its ETB amass resolves first, then the reflexive
+                // trigger lands on the stack and pauses for target selection.
+                game.resolveStack()
+
+                // Amass Orcs 2 made a 2/2 Orc Army.
+                val army = game.findPermanent("Orc Army") ?: error("Amass should create an Orc Army token")
+                withClue("Amass Orcs 2 → 2/2 Army") {
+                    projector.project(game.state).getPower(army) shouldBe 2
+                }
+
+                // The reflexive trigger asks for a target — its legal targets must include the
+                // power-2 Grizzly Bears and exclude the power-3 Hill Giant.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val legal = decision.legalTargets[0] ?: emptyList()
+                withClue("Power-2 Grizzly Bears is a legal target (power <= 2)") {
+                    legal shouldContain bear
+                }
+                withClue("Power-3 Hill Giant is NOT a legal target (power > 2)") {
+                    legal shouldNotContain giant
+                }
+
+                // Steal the bear.
+                game.selectTargets(listOf(bear))
+                game.resolveStack()
+
+                // Control flips to player 1, the stolen creature untaps, and it has haste.
+                val projected = projector.project(game.state)
+                withClue("Control of the bear flips to the caster until end of turn") {
+                    projected.getController(bear) shouldBe game.player1Id
+                }
+                withClue("Stolen creature is untapped") {
+                    game.state.getEntity(bear)?.has<TappedComponent>() shouldBe false
+                }
+                withClue("Stolen creature gains haste until end of turn") {
+                    projected.hasKeyword(bear, Keyword.HASTE) shouldBe true
+                }
+
+                // Advance to the cleanup step: the until-end-of-turn control effect wears off.
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+                withClue("Control reverts to the original owner at end of turn") {
+                    projector.project(game.state).getController(bear) shouldBe game.player2Id
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrondTheGatebreakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrondTheGatebreakerScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GrondTheGatebreaker
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Grond, the Gatebreaker — Legendary Artifact — Vehicle, 5/5.
+ *   Trample
+ *   As long as it's your turn and you control an Army, Grond is an artifact creature.
+ *   Crew 3
+ *
+ * Verifies three things:
+ *  - A Vehicle is not a creature by default (printed P/T but only an artifact).
+ *  - Crew 3 (tap creatures totalling power >= 3) animates it to an artifact creature
+ *    until end of turn, with its printed P/T and Trample.
+ *  - The conditional static makes it an artifact creature while it's your turn AND you
+ *    control an Army, and not when no Army is present.
+ */
+class GrondTheGatebreakerScenarioTest : FunSpec({
+
+    // Minimal Army creature for the static-condition tests (a 2/2 Zombie Army).
+    val zombieArmy = CardDefinition.creature(
+        name = "Test Zombie Army",
+        manaCost = ManaCost.parse("{1}{B}"),
+        subtypes = setOf(Subtype("Zombie"), Subtype("Army")),
+        power = 2,
+        toughness = 2,
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(GrondTheGatebreaker, zombieArmy))
+        return driver
+    }
+
+    test("Grond is not a creature by default — only an artifact") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val grond = driver.putPermanentOnBattlefield(you, "Grond, the Gatebreaker")
+
+        // No Army present: not a creature even though it's your turn.
+        driver.state.projectedState.isCreature(grond) shouldBe false
+    }
+
+    test("Crew 3 makes Grond an artifact creature with Trample until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val grond = driver.putPermanentOnBattlefield(you, "Grond, the Gatebreaker")
+        // Force of Nature is 5/5 — power 5 >= Crew 3.
+        val crewer = driver.putCreatureOnBattlefield(you, "Force of Nature")
+
+        driver.state.projectedState.isCreature(grond) shouldBe false
+
+        driver.submit(CrewVehicle(you, grond, listOf(crewer))).isSuccess shouldBe true
+        driver.bothPass() // resolve the Crew ability
+
+        // Now an artifact creature with printed 5/5 and Trample.
+        val projected = driver.state.projectedState
+        projected.isCreature(grond) shouldBe true
+        projected.getPower(grond) shouldBe 5
+        projected.getToughness(grond) shouldBe 5
+        projected.hasKeyword(grond, Keyword.TRAMPLE) shouldBe true
+
+        // It can attack (was on the battlefield since the turn began).
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val opponent = driver.getOpponent(you)
+        driver.declareAttackers(you, listOf(grond), opponent).isSuccess shouldBe true
+    }
+
+    test("static makes Grond an artifact creature on your turn while you control an Army") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val grond = driver.putPermanentOnBattlefield(you, "Grond, the Gatebreaker")
+
+        // No Army yet — not a creature.
+        driver.state.projectedState.isCreature(grond) shouldBe false
+
+        // Control an Army on your turn — now a creature.
+        driver.putCreatureOnBattlefield(you, "Test Zombie Army")
+        driver.state.projectedState.isCreature(grond) shouldBe true
+    }
+
+    test("static does not apply on your turn without an Army") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val grond = driver.putPermanentOnBattlefield(you, "Grond, the Gatebreaker")
+        // A non-Army creature does not satisfy the condition.
+        driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        driver.state.projectedState.isCreature(grond) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LostIsleCallingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LostIsleCallingScenarioTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lost Isle Calling (LTR #61).
+ *
+ * "Whenever you scry, put a verse counter on this enchantment.
+ *  {4}{U}{U}, Exile this enchantment: Draw a card for each verse counter on this enchantment.
+ *  If it had seven or more verse counters on it, take an extra turn after this one.
+ *  Activate only as a sorcery."
+ *
+ * The activated ability exiles its own source as a cost (CR 122.2 wipes the counters on the zone
+ * change), so the draw amount and the seven-or-more test read the pre-cost count snapshotted into
+ * the resolution context — `DynamicAmount.LastKnownSourceCounters`.
+ */
+class LostIsleCallingScenarioTest : ScenarioTestBase() {
+
+    // Substrate "Scry 1" sorcery so the test can drive a real scry → "Whenever you scry" trigger.
+    private val scryOne = card("Test Scry One") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Scry 1."
+        spell { effect = Patterns.Library.scry(1) }
+    }
+
+    init {
+        cardRegistry.register(scryOne)
+
+        context("Lost Isle Calling") {
+
+            fun ScenarioBuilder.withLibrary(playerNumber: Int, cardName: String, count: Int): ScenarioBuilder {
+                repeat(count) { withCardInLibrary(playerNumber, cardName) }
+                return this
+            }
+
+            fun TestGame.setVerseCounters(id: EntityId, n: Int) {
+                state = state.updateEntity(id) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.VERSE to n)))
+                }
+            }
+
+            fun TestGame.verseCounters(id: EntityId): Int =
+                state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.VERSE) ?: 0
+
+            // Resolve a scry's "put any number on bottom / reorder top" decisions, keeping order.
+            fun TestGame.resolveScryKeepingOrder() {
+                var guard = 0
+                while (hasPendingDecision() && guard++ < 6) {
+                    when (val d = getPendingDecision()) {
+                        is SelectCardsDecision -> skipSelection()
+                        is ReorderLibraryDecision -> submitDecision(OrderedResponse(d.id, d.cards))
+                        else -> return
+                    }
+                }
+            }
+
+            test("scry puts a verse counter on Lost Isle Calling") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lost Isle Calling")
+                    .withCardInHand(1, "Test Scry One")
+                    .withLibrary(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val isle = game.findPermanent("Lost Isle Calling")!!
+                game.verseCounters(isle) shouldBe 0
+
+                game.castSpell(1, "Test Scry One")
+                game.resolveStack()           // resolve the scry sorcery
+                game.resolveScryKeepingOrder() // drive the scry decisions
+                game.resolveStack()           // resolve the "Whenever you scry" trigger
+
+                withClue("Scrying once adds exactly one verse counter") {
+                    game.verseCounters(isle) shouldBe 1
+                }
+            }
+
+            test("activating with N verse counters draws N cards and exiles the enchantment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lost Isle Calling")
+                    .withLandsOnBattlefield(1, "Island", 6) // {4}{U}{U}
+                    .withLibrary(1, "Island", 10)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val isle = game.findPermanent("Lost Isle Calling")!!
+                game.setVerseCounters(isle, 3)
+
+                val handBefore = game.handSize(1)
+                val ability = cardRegistry.getCard("Lost Isle Calling")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = isle, abilityId = ability.id)
+                )
+                withClue("Activating Lost Isle Calling should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The enchantment is exiled as part of the cost") {
+                    game.isOnBattlefield("Lost Isle Calling") shouldBe false
+                }
+                withClue("Draws a card for each of the 3 pre-exile verse counters") {
+                    game.handSize(1) shouldBe handBefore + 3
+                }
+                withClue("Fewer than seven counters: no extra turn (opponent is not set to skip)") {
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe false
+                }
+            }
+
+            test("activating with seven or more verse counters grants an extra turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lost Isle Calling")
+                    .withLandsOnBattlefield(1, "Island", 6) // {4}{U}{U}
+                    .withLibrary(1, "Island", 12)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val isle = game.findPermanent("Lost Isle Calling")!!
+                game.setVerseCounters(isle, 7)
+
+                val handBefore = game.handSize(1)
+                val ability = cardRegistry.getCard("Lost Isle Calling")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = isle, abilityId = ability.id)
+                )
+                withClue("Activating Lost Isle Calling should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Draws a card for each of the 7 pre-exile verse counters") {
+                    game.handSize(1) shouldBe handBefore + 7
+                }
+                withClue("Seven or more counters: Player 1 takes an extra turn, so Player 2 skips") {
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe true
+                    game.state.getEntity(game.player1Id)?.has<SkipNextTurnComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PalantirOfOrthancScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PalantirOfOrthancScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Palantír of Orthanc — Gap 6.
+ *
+ * At the beginning of your end step: put an influence counter on Palantír and scry 2. Then the
+ * *targeted opponent* (not the controller) may have you draw a card. If they decline, you mill X
+ * cards (X = influence counters on Palantír) and that opponent loses life equal to the total mana
+ * value of those milled cards.
+ *
+ * Exercises the two reusable primitives this card introduced:
+ *  - the opponent-decides "may" (MayEffect.decisionMaker = the targeted opponent),
+ *  - DynamicAmount.ManaValueSumOfCollection ("total mana value of those cards").
+ */
+class PalantirOfOrthancScenarioTest : ScenarioTestBase() {
+
+    private fun influenceCount(game: TestGame): Int {
+        val palantir = game.findPermanent("Palantír of Orthanc")!!
+        return game.state.getEntity(palantir)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.INFLUENCE) ?: 0
+    }
+
+    /**
+     * Drains the scry-2 decisions (keep everything on top, original order) until we land on the
+     * targeted opponent's may-decision. Scry surfaces a "put on bottom" select and/or a reorder of
+     * the cards kept on top, depending on the choices; resolve whichever appears.
+     */
+    private fun resolveScryThenReturnMayDecision(game: TestGame): YesNoDecision {
+        var guard = 0
+        while (guard++ < 10) {
+            when (val decision = game.getPendingDecision()) {
+                is YesNoDecision -> return decision
+                is SelectCardsDecision -> game.skipSelection() // nothing to the bottom
+                is ReorderLibraryDecision ->
+                    game.submitDecision(OrderedResponse(decision.id, decision.cards)) // keep order
+                else -> error("unexpected scry decision: $decision")
+            }
+            game.resolveStack()
+        }
+        error("never reached the may-decision; last = ${game.getPendingDecision()}")
+    }
+
+    init {
+        test("opponent says yes: you draw a card, no mill, no life loss") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Palantír of Orthanc")
+                .withCardInLibrary(1, "Grizzly Bears") // top of library (scry fodder + draw)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Island")
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .withActivePlayer(1)
+                .build()
+
+            val handBefore = game.handSize(1)
+            val libBefore = game.librarySize(1)
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            // Influence counter added.
+            influenceCount(game) shouldBe 1
+
+            // Scry 2 surfaces first; keep all on top, then reach the may-decision.
+            val mayDecision = resolveScryThenReturnMayDecision(game)
+
+            // The targeted opponent (player 2) makes the decision.
+            mayDecision.playerId shouldBe game.player2Id
+            game.submitDecision(YesNoResponse(mayDecision.id, true))
+            game.resolveStack()
+
+            // Yes -> controller drew exactly one card; nothing milled; opponent unharmed.
+            game.handSize(1) shouldBe handBefore + 1
+            game.librarySize(1) shouldBe libBefore - 1
+            game.graveyardSize(1) shouldBe 0
+            game.getLifeTotal(2) shouldBe 20
+        }
+
+        test("opponent says no: you mill X and that opponent loses life = total mana value milled") {
+            // Influence counters start at 2 (we add one at end step -> X = 3 milled cards).
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Palantír of Orthanc")
+                // Library top order (drawn/milled from top): three known cards with known MV.
+                // Grizzly Bears MV 2, Hill Giant MV 4, Lightning Bolt MV 1 => total MV 7.
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withLifeTotal(2, 20)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .withActivePlayer(1)
+                .build()
+
+            // Pre-load Palantír with 2 influence counters so X = 3 after the end-step increment.
+            val palantir = game.findPermanent("Palantír of Orthanc")!!
+            run {
+                val counters = (game.state.getEntity(palantir)?.get<CountersComponent>()
+                    ?: CountersComponent()).withCounters(CounterType.INFLUENCE, 2)
+                game.state = game.state.updateEntity(palantir) { it.with(counters) }
+            }
+
+            val handBefore = game.handSize(1)
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            influenceCount(game) shouldBe 3
+
+            val mayDecision = resolveScryThenReturnMayDecision(game)
+            mayDecision.playerId shouldBe game.player2Id
+            // Opponent declines.
+            game.submitDecision(YesNoResponse(mayDecision.id, false))
+            game.resolveStack()
+
+            // No draw for the controller.
+            game.handSize(1) shouldBe handBefore
+            // X = 3 cards milled (Grizzly Bears, Hill Giant, Lightning Bolt).
+            game.graveyardSize(1) shouldBe 3
+            game.isInGraveyard(1, "Grizzly Bears") shouldNotBe false
+            // Opponent loses life equal to total mana value of milled cards: 2 + 4 + 1 = 7.
+            game.getLifeTotal(2) shouldBe 13
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeregrinTookScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeregrinTookScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Peregrin Took (LTR #181, {2}{G}, 2/3 Legendary Halfling Citizen).
+ *
+ *   If one or more tokens would be created under your control, those tokens plus an additional
+ *   Food token are created instead.  ([com.wingedsheep.sdk.scripting.CreateAdditionalToken])
+ *   Sacrifice three Foods: Draw a card.
+ */
+class PeregrinTookScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Peregrin Took") {
+
+            test("creating two tokens under your control yields the two tokens plus one Food") {
+                // Rally at the Hornburg ({1}{R}, "Create two 1/1 white Human Soldier creature
+                // tokens.") is the token source — it resolves without any decision/target, so the
+                // creation event flows straight through Peregrin's replacement.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Peregrin Took")
+                    .withCardInHand(1, "Rally at the Hornburg")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rally at the Hornburg")
+                game.resolveStack()
+
+                withClue("Rally at the Hornburg makes two Human Soldiers") {
+                    game.findPermanents("Human Soldier Token").size shouldBe 2
+                }
+                withClue("Peregrin Took adds exactly one additional Food token (fires once, not per token)") {
+                    game.findPermanents("Food").size shouldBe 1
+                }
+            }
+
+            test("a Food-making source yields exactly two Foods — the added Food does not loop (CR 614.5)") {
+                // Brandywine Farmer ({2}{G}) creates one Food token when it enters. With Peregrin
+                // Took out, that single-token creation event is replaced to add one more Food:
+                // total exactly 2. If the added Food itself re-triggered the replacement, we'd see
+                // 3+ (or a runaway loop). Its ETB trigger resolves with no decision/target.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Peregrin Took")
+                    .withCardInHand(1, "Brandywine Farmer")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Brandywine Farmer")
+                game.resolveStack()
+
+                withClue("One Food from Brandywine Farmer + one additional Food from Peregrin = 2, no runaway loop") {
+                    game.findPermanents("Food").size shouldBe 2
+                }
+            }
+
+            test("Sacrifice three Foods: Draw a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Peregrin Took")
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.state.getHand(game.player1Id).size
+                game.findPermanents("Food").size shouldBe 3
+
+                val took = game.findPermanent("Peregrin Took")!!
+                val foods = game.findPermanents("Food")
+                val drawAbility = cardRegistry.getCard("Peregrin Took")!!.script.activatedAbilities[0]
+                // The "Sacrifice three Foods" cost requires the activator to choose which three
+                // Foods to sacrifice — supply them via the cost payment.
+                game.execute(
+                    ActivateAbility(
+                        game.player1Id,
+                        took,
+                        drawAbility.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = foods)
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("All three Foods are sacrificed to pay the cost") {
+                    game.findPermanents("Food").size shouldBe 0
+                }
+                withClue("One card is drawn") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastTheBrownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastTheBrownScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.RadagastTheBrown
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Radagast the Brown — "Whenever Radagast or another nontoken creature you control enters,
+ * look at the top X cards of your library, where X is that creature's mana value. You may
+ * reveal a creature card that doesn't share a creature type with a creature you control from
+ * among those cards and put it into your hand. Put the rest on the bottom in a random order."
+ *
+ * Exercises the new `notSharingCreatureTypeWithPermanentYouControl` filter + the
+ * `Patterns.Library.lookAtTopRevealMatchingToHand` pipeline, with X driven by the *triggering*
+ * creature's mana value.
+ */
+class RadagastTheBrownScenarioTest : FunSpec({
+
+    // A 3-mana Soldier we cast to trigger Radagast (X = 3).
+    val TestSoldier = CardDefinition.creature("Test Soldier", ManaCost.parse("{2}{G}"), setOf(Subtype("Soldier")), 2, 2)
+    // A Bear we already control — gives our creatures the "Bear" creature type.
+    val TestBear = CardDefinition.creature("Test Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2)
+    // Library candidates.
+    val LibraryBear = CardDefinition.creature("Library Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 1, 1)
+    val LibrarySoldier = CardDefinition.creature("Library Soldier", ManaCost.parse("{1}{W}"), setOf(Subtype("Soldier")), 1, 1)
+    val LibrarySpirit = CardDefinition.creature("Library Spirit", ManaCost.parse("{1}{U}"), setOf(Subtype("Spirit")), 1, 1)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                RadagastTheBrown, TestSoldier, TestBear, LibraryBear, LibrarySoldier, LibrarySpirit
+            )
+        )
+        return driver
+    }
+
+    fun libraryNames(driver: GameTestDriver, player: EntityId): List<String> =
+        driver.state.getZone(ZoneKey(player, Zone.LIBRARY)).mapNotNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    test("only a creature sharing no creature type with your creatures is revealable; rest go to bottom") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        // Radagast (Avatar Wizard) and a Bear are already on the battlefield under our control,
+        // so our creatures' types include Avatar, Wizard, Bear.
+        driver.putCreatureOnBattlefield(active, "Radagast the Brown")
+        driver.putCreatureOnBattlefield(active, "Test Bear")
+
+        // Stack the top three of our library: a Bear (shares Bear), a Soldier (shares Soldier
+        // once the cast creature enters), and a Spirit (shares nothing). putCardOnTopOfLibrary
+        // prepends, so push in reverse to get [Bear, Soldier, Spirit] from the top.
+        val spiritId = driver.putCardOnTopOfLibrary(active, "Library Spirit")
+        val soldierId = driver.putCardOnTopOfLibrary(active, "Library Soldier")
+        val bearId = driver.putCardOnTopOfLibrary(active, "Library Bear")
+
+        // Cast a 3-mana Soldier; X = 3 → look at exactly those three cards.
+        val caster = driver.putCardInHand(active, "Test Soldier")
+        driver.giveMana(active, Color.GREEN, 3)
+        driver.castSpell(active, caster)
+        driver.bothPass() // resolve the creature spell — it enters and fires Radagast's trigger
+        driver.bothPass() // resolve the triggered ability → look at top 3
+
+        val decision = driver.pendingDecision
+        decision shouldNotBe null
+        val select = decision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        // "May" reveal → 0..1 selections.
+        select.minSelections shouldBe 0
+        select.maxSelections shouldBe 1
+
+        // Only the Spirit (shares no creature type with our creatures) is selectable.
+        // The Bear and the Soldier share a type, so they're shown but not selectable.
+        select.options shouldContainExactlyInAnyOrder listOf(spiritId)
+        select.nonSelectableOptions shouldContainExactlyInAnyOrder listOf(bearId, soldierId)
+
+        // Reveal the Spirit and put it into hand.
+        driver.submitCardSelection(active, listOf(spiritId))
+
+        // Spirit is in hand; the other two looked-at cards are on the bottom of the library.
+        driver.getHand(active).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Library Spirit"
+        } shouldBe true
+
+        val library = libraryNames(driver, active)
+        library.contains("Library Spirit") shouldBe false
+        // Bear and Soldier are at the bottom of the library.
+        library.takeLast(2) shouldContainExactlyInAnyOrder listOf("Library Bear", "Library Soldier")
+    }
+
+    test("the reveal is optional — declining leaves all looked-at cards on the bottom") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Radagast the Brown")
+
+        val spiritId = driver.putCardOnTopOfLibrary(active, "Library Spirit")
+        val soldierId = driver.putCardOnTopOfLibrary(active, "Library Soldier")
+        val bearId = driver.putCardOnTopOfLibrary(active, "Library Bear")
+
+        val caster = driver.putCardInHand(active, "Test Soldier")
+        driver.giveMana(active, Color.GREEN, 3)
+        driver.castSpell(active, caster)
+        driver.bothPass()
+        driver.bothPass()
+
+        val select = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // No Bear in play this time, so the Spirit and the Bear are both revealable, but the
+        // Soldier shares a type with the just-cast Test Soldier.
+        select.options shouldContainExactlyInAnyOrder listOf(spiritId, bearId)
+        select.nonSelectableOptions shouldContainExactlyInAnyOrder listOf(soldierId)
+        // Decline the optional reveal.
+        driver.submitCardSelection(active, emptyList())
+
+        // Nothing went to hand from the look; all three are on the bottom of the library.
+        driver.getHand(active).none {
+            val n = driver.state.getEntity(it)?.get<CardComponent>()?.name
+            n == "Library Spirit" || n == "Library Bear" || n == "Library Soldier"
+        } shouldBe true
+
+        val library = libraryNames(driver, active)
+        library.takeLast(3) shouldContainExactlyInAnyOrder
+            listOf("Library Bear", "Library Soldier", "Library Spirit")
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastTheBrownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastTheBrownScenarioTest.kt
@@ -40,12 +40,18 @@ class RadagastTheBrownScenarioTest : FunSpec({
     val LibraryBear = CardDefinition.creature("Library Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 1, 1)
     val LibrarySoldier = CardDefinition.creature("Library Soldier", ManaCost.parse("{1}{W}"), setOf(Subtype("Soldier")), 1, 1)
     val LibrarySpirit = CardDefinition.creature("Library Spirit", ManaCost.parse("{1}{U}"), setOf(Subtype("Spirit")), 1, 1)
+    // Shares "Wizard" with Radagast itself (Avatar Wizard) → never selectable while Radagast is in play.
+    val LibraryWizard = CardDefinition.creature("Library Wizard", ManaCost.parse("{1}{U}"), setOf(Subtype("Wizard")), 1, 1)
+    // A 5th card stacked beneath the top four: with X = 4 it must NOT be looked at, proving X is
+    // Radagast's own mana value (4) and not the {2}{G} = 3 used by the other-creature tests.
+    val LibraryDruid = CardDefinition.creature("Library Druid", ManaCost.parse("{1}{G}"), setOf(Subtype("Druid")), 1, 1)
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(
             TestCards.all + listOf(
-                RadagastTheBrown, TestSoldier, TestBear, LibraryBear, LibrarySoldier, LibrarySpirit
+                RadagastTheBrown, TestSoldier, TestBear,
+                LibraryBear, LibrarySoldier, LibrarySpirit, LibraryWizard, LibraryDruid
             )
         )
         return driver
@@ -143,5 +149,53 @@ class RadagastTheBrownScenarioTest : FunSpec({
         val library = libraryNames(driver, active)
         library.takeLast(3) shouldContainExactlyInAnyOrder
             listOf("Library Bear", "Library Soldier", "Library Spirit")
+    }
+
+    test("Radagast's own ETB fires the trigger with X = its own mana value (4)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        // Stack five distinguishable cards on top. Radagast's mana value is 4, so only the top
+        // four are looked at; the Druid (5th) must remain on top, untouched. putCardOnTopOfLibrary
+        // prepends, so push in reverse to get [Wizard, Soldier, Bear, Spirit, Druid] from the top.
+        val druidId = driver.putCardOnTopOfLibrary(active, "Library Druid")
+        val spiritId = driver.putCardOnTopOfLibrary(active, "Library Spirit")
+        val bearId = driver.putCardOnTopOfLibrary(active, "Library Bear")
+        val soldierId = driver.putCardOnTopOfLibrary(active, "Library Soldier")
+        val wizardId = driver.putCardOnTopOfLibrary(active, "Library Wizard")
+
+        // Cast Radagast itself (no other creatures in play). Its own entry triggers the ability.
+        val radagast = driver.putCardInHand(active, "Radagast the Brown")
+        driver.giveMana(active, Color.GREEN, 4)
+        driver.castSpell(active, radagast)
+        driver.bothPass() // resolve Radagast — it enters and fires its own ETB trigger
+        driver.bothPass() // resolve the triggered ability → look at top 4 (X = Radagast's MV)
+
+        val select = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        select.minSelections shouldBe 0
+        select.maxSelections shouldBe 1
+
+        // Exactly the top FOUR are presented (Druid, the 5th card, is not — proving X = 4 not 3).
+        // Radagast (Avatar Wizard) is the only creature we control, so the Wizard shares a type
+        // and is non-selectable; Soldier, Bear, and Spirit share nothing and are selectable.
+        (select.options + select.nonSelectableOptions) shouldContainExactlyInAnyOrder
+            listOf(wizardId, soldierId, bearId, spiritId)
+        select.options shouldContainExactlyInAnyOrder listOf(soldierId, bearId, spiritId)
+        select.nonSelectableOptions shouldContainExactlyInAnyOrder listOf(wizardId)
+
+        driver.submitCardSelection(active, listOf(spiritId))
+
+        driver.getHand(active).any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Library Spirit"
+        } shouldBe true
+
+        // The Druid was never looked at, so it's still on top; the three unselected looked-at
+        // cards went to the bottom.
+        val library = libraryNames(driver, active)
+        library.first() shouldBe "Library Druid"
+        library.takeLast(3) shouldContainExactlyInAnyOrder
+            listOf("Library Wizard", "Library Soldier", "Library Bear")
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowfaxLordOfHorsesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowfaxLordOfHorsesScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shadowfax, Lord of Horses (LTR #227) — {3}{R}{W} Legendary Horse, 4/4.
+ *
+ * - Horses you control have haste. (Keyword-anthem lord static over
+ *   `Creature.withSubtype(Horse).youControl()`.)
+ * - Whenever Shadowfax attacks, you may put a creature card with lesser power from your hand
+ *   onto the battlefield tapped and attacking. ("lesser power" = strict
+ *   `powerLessThanEntity(Source)` over hand cards; tapped+attacking entry via
+ *   `Patterns.Hand.putFromHand(entersAttacking = true)`.)
+ */
+class ShadowfaxLordOfHorsesScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A summoning-sick Horse to prove the haste anthem lets it attack the turn it enters.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Pony",
+                manaCost = ManaCost.parse("{1}{W}"),
+                subtypes = setOf(Subtype("Horse")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        // Power-3 creature card: eligible (3 < 4) to be put in via Shadowfax's attack trigger.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Lesser Beast",
+                manaCost = ManaCost.parse("{2}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 3,
+                toughness = 3
+            )
+        )
+        // Power-5 creature card: NOT eligible (5 >= 4).
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Greater Beast",
+                manaCost = ManaCost.parse("{4}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 5,
+                toughness = 5
+            )
+        )
+
+        context("Shadowfax, Lord of Horses") {
+
+            test("Horses you control have haste — a Horse can attack the turn it enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shadowfax, Lord of Horses", summoningSickness = false)
+                    // Test Pony just entered (summoning sick) — only haste lets it attack now.
+                    .withCardOnBattlefield(1, "Test Pony", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pony = game.findPermanent("Test Pony")!!
+                withClue("Test Pony has haste from Shadowfax's anthem") {
+                    game.state.projectedState.hasKeyword(pony, Keyword.HASTE) shouldBe true
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Test Pony" to 2))
+                withClue("summoning-sick Horse with haste can be declared as an attacker: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                withClue("Test Pony is attacking") {
+                    game.state.getEntity(pony)?.has<AttackingComponent>() shouldBe true
+                }
+            }
+
+            test("attack: may put a lesser-power creature from hand onto the battlefield tapped and attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shadowfax, Lord of Horses", summoningSickness = false)
+                    .withCardInHand(1, "Lesser Beast")  // power 3 < 4: eligible
+                    .withCardInHand(1, "Greater Beast") // power 5 >= 4: NOT eligible
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Shadowfax, Lord of Horses" to 2)).error shouldBe null
+
+                // The attack trigger goes on the stack; resolving it asks the controller to choose
+                // up to one eligible creature card from hand.
+                game.resolveStack()
+
+                withClue("attack trigger paused for the hand-card selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // The power-5 Greater Beast must NOT be a selectable option (5 is not < 4); only
+                // the power-3 Lesser Beast qualifies. Select it.
+                val lesser = game.findCardsInHand(1, "Lesser Beast").single()
+                game.selectCards(listOf(lesser)).error shouldBe null
+                game.resolveStack()
+
+                val beast = game.findPermanents("Lesser Beast").singleOrNull()
+                    ?: error("Lesser Beast should be on the battlefield once, found ${game.findPermanents("Lesser Beast").size}")
+                withClue("the put creature enters tapped") {
+                    game.state.getEntity(beast)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("the put creature enters attacking") {
+                    game.state.getEntity(beast)?.has<AttackingComponent>() shouldBe true
+                }
+                withClue("Greater Beast (power 5) stayed in hand — not eligible") {
+                    game.isInHand(1, "Greater Beast") shouldBe true
+                }
+            }
+
+            test("the power-5 creature is not eligible to be put in even when it's the only option") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shadowfax, Lord of Horses", summoningSickness = false)
+                    .withCardInHand(1, "Greater Beast") // power 5 >= 4: NOT eligible
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Shadowfax, Lord of Horses" to 2)).error shouldBe null
+                game.resolveStack()
+
+                // No eligible card → the trigger finds nothing to put in. Greater Beast stays put.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+                withClue("no power-5 creature was cheated onto the battlefield") {
+                    game.findPermanents("Greater Beast").size shouldBe 0
+                }
+                withClue("Greater Beast remains in hand") {
+                    game.isInHand(1, "Greater Beast") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/894

Stacked on #<ltr-pr-5>. Review only the commits after that PR's tip; merge it first.

Adds 13 LTR cards, each composed from existing SDK primitives — **zero new
engine/SDK types** in this PR.

| Card | Notable reuse |
|------|---------------|
| Éowyn, Lady of Rohan | conditional + modal keyword grant, `ReduceEquipCost` |
| Faramir, Prince of Ithilien | `CreateDelayedTriggerEffect.fireOnPlayer`, `PlayerAttackedPlayerThisTurn` |
| Grishnákh, Brash Instigator | reflexive trigger, `powerAtMostEntity(AmassedArmy)` |
| Radagast the Brown | self+others ETB union, `notSharingCreatureTypeWithPermanentYouControl` |
| Palantír of Orthanc | `MayEffect.decisionMaker` (opponent), mana-value-sum life loss |
| Lost Isle Calling | exile-self cost reading `lastKnownSourceCounters` |
| Ent-Draught Basin | `powerEqualsX` X-cost target |
| Shadowfax, Lord of Horses | Horse-haste lord, put-from-hand attacking |
| Gollum, Scheming Guide | reorder top-2 + opponent guess-kind |
| Grond, the Gatebreaker | conditional Layer-4 type change, Crew 3 |
| Fires of Mount Doom | ETB damage + impulse-play rider |
| Fear, Fire, Foes! | `DamageCantBePreventedThisTurn` + group damage |
| Peregrin Took | `CreateAdditionalToken` replacement (self-limiting, CR 614.5) |

**Testing:** a scenario test per card (all green), LTR snapshot golden re-blessed.
All `oracleText` verified verbatim against Scryfall; cited CR rules checked
against the Comprehensive Rules (508.6, 614.5, 615.12, 122.2, 301.7, 702.122).
Printing placement confirmed canonical-in-LTR for every card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)