### PR TITLE
Add 9 LTR cards + GatherCards LookAudience (private-look visibility control)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4652,6 +4652,17 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
   `Player.EachOpponent`) and fan out across every relevant player's copy of the zone in a single gather —
   e.g. "all creature cards in each player's graveyard" (Bringer of the Last Gift). Pair with
   `MoveCollectionEffect(underOwnersControl = true)` to return each card to its owner.
+  `revealed = true` makes a public reveal (every player sees the cards while they stay in a hidden
+  zone, persisted via `RevealedToComponent` and emitting a reveal event). For a non-public library
+  *look* (`revealed = false`), `lookAudience` chooses who privately sees the cards:
+  `LookAudience.Controller` (default — Scry / Surveil / look-at-top-N), `LookAudience.Opponent`
+  ("an opponent looks at the top N of your library"), or `LookAudience.None` (no one is auto-shown;
+  a downstream decision is the only window — used by **Sauron's Ransom**, where the opponent who
+  partitions sees the cards through their own `SelectFromCollection` decision but the caster does
+  not). `lookAudience` is ignored when `revealed = true` or for non-library sources. To then turn a
+  single pile face up for everyone — including the caster, before a `ChoosePileEffect` — re-gather
+  that pile via `GatherCards(FromVariable("pile"), revealed = true)`; any pile never revealed
+  renders to the caster as opaque card backs (Sauron's Ransom's concealed face-down pile).
 - `CaptureControllersEffect(from, storeAs)` — snapshot each entity's current controller into a parallel
   `List<EntityId>` under `storedCollections[storeAs]`. Required when a later step needs "who controlled
   this card before it left the battlefield" — `ControllerComponent` is stripped on move-out.

--- a/manual-scenarios/cards/s/saurons-ransom.json
+++ b/manual-scenarios/cards/s/saurons-ransom.json
@@ -1,0 +1,39 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Sauron's Ransom"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Nimble Hobbit"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mirkwood Spider",
+      "Plains",
+      "Pelargir Survivor",
+      "Forest",
+      "Oliphaunt",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Easterling Vanguard", "Island", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -515,6 +515,29 @@ enum class Chooser {
 }
 
 /**
+ * Who privately sees a non-public library "look" performed by [GatherCardsEffect].
+ *
+ * Only meaningful when [GatherCardsEffect.revealed] is `false` and the source is a library
+ * (a public reveal — `revealed = true` — always shows the cards to every player and ignores
+ * this). Scry / Surveil / look-at-top-N use [Controller]; "an opponent looks at the top N of
+ * your library" (e.g. Sauron's Ransom) uses [None] so the cards stay hidden from the caster and
+ * are seen only by the opponent through their own pending decision; [Opponent] additionally
+ * persists that knowledge to the opponent(s).
+ */
+@Serializable
+enum class LookAudience {
+    /** The cards are revealed to the controller of the spell/ability (the default look). */
+    Controller,
+    /** The cards are revealed to the controller's opponent(s). */
+    Opponent,
+    /**
+     * No player is automatically shown the cards. A downstream decision (e.g. an opponent's
+     * [SelectFromCollectionEffect]) is the only window into them, so only that decider sees them.
+     */
+    None
+}
+
+/**
  * How to order cards when moving a collection.
  */
 @Serializable
@@ -540,13 +563,17 @@ enum class CardOrder {
  * @property source Where to get the cards from
  * @property storeAs Name of the collection to store the cards in
  * @property revealed Whether the gathered cards are revealed to all players
+ * @property lookAudience For a non-public library look (`revealed = false`), who privately sees
+ *   the cards. Defaults to [LookAudience.Controller] (Scry / Surveil / look-at-top-N). Ignored
+ *   when [revealed] is `true` (a public reveal shows everyone) or for non-library sources.
  */
 @SerialName("GatherCards")
 @Serializable
 data class GatherCardsEffect(
     val source: CardSource,
     val storeAs: String,
-    val revealed: Boolean = false
+    val revealed: Boolean = false,
+    val lookAudience: LookAudience = LookAudience.Controller
 ) : Effect {
     override val description: String = buildString {
         if (revealed) append("Reveal ") else append("Look at ")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BewitchingLeechcraft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BewitchingLeechcraft.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bewitching Leechcraft
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature has "If this creature would untap during your untap step,
+ * remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it
+ * doesn't untap.)
+ *
+ * Modeled with [AbilityFlag.REMOVE_COUNTER_TO_UNTAP], a granted untap-step
+ * replacement (CR 614, applied during the untap step CR 502): during the
+ * enchanted creature's controller's untap step the engine tries to remove a
+ * +1/+1 counter; the creature untaps only if a counter was removed, otherwise it
+ * stays tapped. Granted via projection (a [GrantKeyword] static on the Aura) so
+ * it disappears when the Aura leaves play.
+ */
+val BewitchingLeechcraft = card("Bewitching Leechcraft") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature has \"If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it.\" (Otherwise, it doesn't untap.)"
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.REMOVE_COUNTER_TO_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Wei Guan"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg?1686968013"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GoldberryRiverDaughter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GoldberryRiverDaughter.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Goldberry, River-Daughter
+ * {1}{U}
+ * Legendary Creature — Nymph
+ * 1/3
+ *
+ * {T}: Move a counter of each kind not on Goldberry from another target permanent you control
+ * onto Goldberry.
+ * {U}, {T}: Move one or more counters from Goldberry onto another target permanent you control.
+ * If you do, draw a card.
+ */
+val GoldberryRiverDaughter = card("Goldberry, River-Daughter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Nymph"
+    power = 1
+    toughness = 3
+    oracleText = "{T}: Move a counter of each kind not on Goldberry from another target permanent " +
+        "you control onto Goldberry.\n" +
+        "{U}, {T}: Move one or more counters from Goldberry onto another target permanent you control. " +
+        "If you do, draw a card."
+
+    // {T}: Move a counter of each kind not on Goldberry from another target permanent you control onto Goldberry.
+    activatedAbility {
+        cost = Costs.Tap
+        val source = target(
+            "another target permanent you control",
+            TargetPermanent(filter = TargetFilter.PermanentYouControl.other())
+        )
+        effect = Effects.MoveCountersEachKindMissing(
+            source = source,
+            destination = EffectTarget.Self
+        )
+    }
+
+    // {U}, {T}: Move one or more counters from Goldberry onto another target permanent you control. If you do, draw a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val destination = target(
+            "another target permanent you control",
+            TargetPermanent(filter = TargetFilter.PermanentYouControl.other())
+        )
+        effect = Effects.MoveChosenCountersToTarget(
+            source = EffectTarget.Self,
+            destination = destination,
+            drawCardOnMove = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "52"
+        artist = "Marie Magny"
+        flavorText = "\"Fear nothing! For tonight you are under the roof of Tom Bombadil.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg?1686968111"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HewTheEntwood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HewTheEntwood.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Hew the Entwood
+ * {3}{R}{R}
+ * Sorcery
+ *
+ * Sacrifice any number of lands. Reveal the top X cards of your library, where X is the number
+ * of lands sacrificed this way. Choose any number of artifact and/or land cards revealed this
+ * way. Put all nonland cards chosen this way onto the battlefield, then put all land cards chosen
+ * this way onto the battlefield tapped, then put the rest on the bottom of your library in a
+ * random order.
+ *
+ * Composes the existing library pipeline:
+ *  1. `SacrificeAnyNumber(Land)` — controller sacrifices 0+ of their lands; the sacrifice
+ *     executor records them so X is readable downstream.
+ *  2. `GatherCards(TopOfLibrary(X))` where X = `permanentsSacrificedThisWay` + reveal.
+ *  3. `SelectFromCollection(any number, filter = Artifact OR Land)` partitions the revealed pile
+ *     into `chosen` (the artifact/land cards the player picked) and `rest`.
+ *  4. Three filtered `MoveCollection`s: chosen nonland (artifacts that aren't lands) → battlefield
+ *     untapped; chosen lands → battlefield tapped; the rest → bottom of library in random order.
+ */
+val HewTheEntwood = card("Hew the Entwood") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Sacrifice any number of lands. Reveal the top X cards of your library, where X " +
+        "is the number of lands sacrificed this way. Choose any number of artifact and/or land " +
+        "cards revealed this way. Put all nonland cards chosen this way onto the battlefield, " +
+        "then put all land cards chosen this way onto the battlefield tapped, then put the rest " +
+        "on the bottom of your library in a random order."
+
+    spell {
+        effect = Effects.SacrificeAnyNumber(GameObjectFilter.Land)
+            .then(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        DynamicAmounts.permanentsSacrificedThisWay(),
+                        Player.You
+                    ),
+                    storeAs = "revealed"
+                )
+            )
+            .then(RevealCollectionEffect(from = "revealed"))
+            .then(
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    filter = GameObjectFilter.Artifact or GameObjectFilter.Land,
+                    storeSelected = "chosen",
+                    storeRemainder = "rest",
+                    prompt = "Choose any number of artifact and/or land cards to put onto the battlefield"
+                )
+            )
+            .then(
+                MoveCollectionEffect(
+                    from = "chosen",
+                    filter = GameObjectFilter.Nonland,
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        player = Player.You,
+                        placement = ZonePlacement.Default
+                    )
+                )
+            )
+            .then(
+                MoveCollectionEffect(
+                    from = "chosen",
+                    filter = GameObjectFilter.Land,
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        player = Player.You,
+                        placement = ZonePlacement.Tapped
+                    )
+                )
+            )
+            .then(
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(
+                        Zone.LIBRARY,
+                        player = Player.You,
+                        placement = ZonePlacement.Bottom
+                    ),
+                    order = CardOrder.Random
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "136"
+        artist = "Manuel Castañón"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg?1686969039"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OneRingToRuleThemAll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OneRingToRuleThemAll.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * One Ring to Rule Them All
+ * {2}{B}{B}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — The Ring tempts you, then each player mills cards equal to your Ring-bearer's power.
+ * II — Destroy all nonlegendary creatures.
+ * III — Each opponent loses 1 life for each creature card in that player's graveyard.
+ *
+ * Chapter I composes [Effects.TheRingTemptsYou] with a mill-each-player whose amount is
+ * `EntityProperty(RingBearer(Player.You), Power)` — the power of the Saga controller's
+ * designated Ring-bearer (0 if none). The mill applies to every player ([Player.Each]) while
+ * the amount stays anchored to *your* Ring-bearer, because [EntityReference.RingBearer] reads
+ * the referenced player's bearer rather than the player being milled.
+ *
+ * Chapter II is a board wipe over `Creature.nonlegendary()` (legendary creatures survive).
+ *
+ * Chapter III runs per opponent ([Player.EachOpponent]): each loses life equal to the number
+ * of creature cards in *that* player's graveyard. [Effects.ForEachPlayer] rebinds the loop's
+ * controller to each opponent, so `Player.You` inside resolves to the opponent being processed
+ * — hence `Count(Player.You, GRAVEYARD, Creature)` counts that opponent's own graveyard.
+ */
+val OneRingToRuleThemAll = card("One Ring to Rule Them All") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — The Ring tempts you, then each player mills cards equal to your Ring-bearer's power.\n" +
+        "II — Destroy all nonlegendary creatures.\n" +
+        "III — Each opponent loses 1 life for each creature card in that player's graveyard."
+
+    sagaChapter(1) {
+        effect = Effects.Composite(
+            Effects.TheRingTemptsYou(),
+            Patterns.Library.mill(
+                count = DynamicAmount.EntityProperty(
+                    EntityReference.RingBearer(Player.You),
+                    EntityNumericProperty.Power
+                ),
+                target = EffectTarget.PlayerRef(Player.Each)
+            )
+        )
+    }
+
+    sagaChapter(2) {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.nonlegendary())
+    }
+
+    sagaChapter(3) {
+        effect = Effects.ForEachPlayer(
+            players = Player.EachOpponent,
+            effects = listOf(
+                Effects.LoseLife(
+                    amount = DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature),
+                    target = EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "102"
+        artist = "L J Koh"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg?1688569235"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanOfManyColors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanOfManyColors.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Saruman of Many Colors — The Lord of the Rings: Tales of Middle-earth #223
+ * {3}{W}{U}{B} · Legendary Creature — Avatar Wizard · 5/4 · Mythic
+ *
+ * Ward—Discard an enchantment, instant, or sorcery card.
+ * Whenever you cast your second spell each turn, each opponent mills two cards. When one or
+ * more cards are milled this way, exile target enchantment, instant, or sorcery card with equal
+ * or lesser mana value than that spell from an opponent's graveyard. Copy the exiled card. You
+ * may cast the copy without paying its mana cost.
+ *
+ * Composed from existing primitives:
+ *  - **Ward—Discard a filtered card** via [KeywordAbility.wardDiscard] now carrying a
+ *    [GameObjectFilter] (enchantment OR instant OR sorcery card). The ward executor only counts
+ *    matching hand cards toward the can-pay check and offers only matching cards for discard.
+ *  - **Second-spell trigger** via [Triggers.NthSpellCast] (n = 2, you).
+ *  - **Reflexive after mill** via [ReflexiveTriggerEffect]: the action mills two from each
+ *    opponent (storing the milled cards under `"milled"`); the reflexive part is gated on that
+ *    collection being non-empty ("when one or more cards are milled this way") and chooses its
+ *    target *after* the mill. The target — an enchantment/instant/sorcery card in an opponent's
+ *    graveyard with mana value ≤ the triggering (second) spell — is expressed with
+ *    `manaValueAtMostEntity(EntityReference.Triggering)`; the trigger's
+ *    `triggeringEntityId` is the second spell (still on the stack as the ability resolves above
+ *    it), so its mana value is read directly.
+ *  - **Copy-a-card-then-cast** via the [Effects.CopyCardIntoCollection] +
+ *    [Effects.CastFromCollectionWithoutPayingCost] pattern (same as Shiko, Paragon of the Way):
+ *    exile the target, copy it in exile, then `MayEffect`-wrap the free cast. A declined or
+ *    uncastable copy is removed by the Rule 707.10a state-based action.
+ */
+val SarumanOfManyColors = card("Saruman of Many Colors") {
+    manaCost = "{3}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 5
+    toughness = 4
+    oracleText = "Ward—Discard an enchantment, instant, or sorcery card.\n" +
+        "Whenever you cast your second spell each turn, each opponent mills two cards. When one " +
+        "or more cards are milled this way, exile target enchantment, instant, or sorcery card " +
+        "with equal or lesser mana value than that spell from an opponent's graveyard. Copy the " +
+        "exiled card. You may cast the copy without paying its mana cost."
+
+    // "enchantment, instant, or sorcery card" — a flat type union (homogeneous OR).
+    val enchantmentInstantSorcery =
+        GameObjectFilter.Enchantment or GameObjectFilter.Instant or GameObjectFilter.Sorcery
+
+    // Ward—Discard an enchantment, instant, or sorcery card.
+    keywordAbility(KeywordAbility.wardDiscard(filter = enchantmentInstantSorcery))
+
+    // Whenever you cast your second spell each turn, each opponent mills two cards.
+    // When one or more cards are milled this way, exile target enchantment/instant/sorcery card
+    // with mana value ≤ that spell from an opponent's graveyard, copy it, then you may cast it free.
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        description = "Whenever you cast your second spell each turn, each opponent mills two " +
+            "cards. When one or more cards are milled this way, exile target enchantment, " +
+            "instant, or sorcery card with equal or lesser mana value than that spell from an " +
+            "opponent's graveyard. Copy the exiled card. You may cast the copy without paying " +
+            "its mana cost."
+
+        // The exile target is chosen when the reflexive trigger goes on the stack (after the
+        // mill), so it is supplied as a reflexive target requirement — NOT an ability-level
+        // target — and referenced as ContextTarget(0) in the reflexive effect (Wick's Patrol
+        // pattern). "that spell" is the triggering second spell (EntityReference.Triggering).
+        val exiledCardTarget = TargetObject(
+            filter = TargetFilter(
+                baseFilter = enchantmentInstantSorcery
+                    .ownedByOpponent()
+                    .manaValueAtMostEntity(EntityReference.Triggering),
+                zone = Zone.GRAVEYARD,
+            )
+        )
+        val exiledCard = EffectTarget.ContextTarget(0)
+
+        effect = ReflexiveTriggerEffect(
+            // Each opponent mills two. Modeled as a flat Gather→Move mill aimed at every opponent
+            // (rather than a ForEachPlayer wrapper) so the milled cards surface in the `"milled"`
+            // pipeline collection — that collection is what the reflexive's "one or more cards
+            // milled this way" gate reads.
+            action = Patterns.Library.mill(2, EffectTarget.PlayerRef(Player.EachOpponent)),
+            optional = false,
+            // Gate on "one or more cards milled this way": only exile/copy/cast if a card was milled.
+            reflexiveEffect = ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch("milled"),
+                effect = Effects.Composite(
+                    Effects.Move(exiledCard, Zone.EXILE),
+                    Effects.CopyCardIntoCollection(exiledCard, storeAs = "copy"),
+                    MayEffect(
+                        Effects.CastFromCollectionWithoutPayingCost("copy"),
+                        descriptionOverride = "You may cast the copy without paying its mana cost.",
+                    ),
+                ),
+            ),
+            reflexiveTargetRequirements = listOf(exiledCardTarget),
+            descriptionOverride = "Each opponent mills two cards. When one or more cards are " +
+                "milled this way, exile target enchantment, instant, or sorcery card with equal " +
+                "or lesser mana value than that spell from an opponent's graveyard. Copy the " +
+                "exiled card. You may cast the copy without paying its mana cost.",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "223"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg?1686969983"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheDarkLord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheDarkLord.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sauron, the Dark Lord — The Lord of the Rings: Tales of Middle-earth #224
+ * {3}{U}{B}{R} · Legendary Creature — Avatar Horror · 7/6 · Mythic
+ *
+ * Ward—Sacrifice a legendary artifact or legendary creature.
+ * Whenever an opponent casts a spell, amass Orcs 1.
+ * Whenever an Army you control deals combat damage to a player, the Ring tempts you.
+ * Whenever the Ring tempts you, you may discard your hand. If you do, draw four cards.
+ *
+ * All four pieces compose existing primitives:
+ *  - Ward—sacrifice via [KeywordAbility.wardSacrifice] over a "legendary artifact or legendary
+ *    creature" filter (legendary supertype + (artifact OR creature)).
+ *  - Opponent-cast amass via [Triggers.OpponentCastsSpell] + [Effects.Amass].
+ *  - Army-damage Ring-tempt via the generic [Triggers.dealsDamage] factory bound ANY with a
+ *    source filter of "an Army you control" (Subtype Army, controlled by you), recipient any player.
+ *  - Ring-tempt payoff via [Triggers.RingTemptsYou] + the standard [MayEffect]/[IfYouDoEffect]
+ *    pair wrapping [Patterns.Hand.discardHand] then drawing four.
+ */
+val SauronTheDarkLord = card("Sauron, the Dark Lord") {
+    manaCost = "{3}{U}{B}{R}"
+    colorIdentity = "UBR"
+    typeLine = "Legendary Creature — Avatar Horror"
+    power = 7
+    toughness = 6
+    oracleText = "Ward—Sacrifice a legendary artifact or legendary creature.\n" +
+        "Whenever an opponent casts a spell, amass Orcs 1.\n" +
+        "Whenever an Army you control deals combat damage to a player, the Ring tempts you.\n" +
+        "Whenever the Ring tempts you, you may discard your hand. If you do, draw four cards."
+
+    keywordAbility(
+        KeywordAbility.wardSacrifice(
+            GameObjectFilter.Artifact.legendary() or GameObjectFilter.Creature.legendary()
+        )
+    )
+
+    // Whenever an opponent casts a spell, amass Orcs 1.
+    triggeredAbility {
+        trigger = Triggers.OpponentCastsSpell
+        effect = Effects.Amass(1, "Orc")
+    }
+
+    // Whenever an Army you control deals combat damage to a player, the Ring tempts you.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().withSubtype("Army"),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    // Whenever the Ring tempts you, you may discard your hand. If you do, draw four cards.
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = Patterns.Hand.discardHand(EffectTarget.Controller),
+                ifYouDo = Effects.DrawCards(4)
+            )
+        )
+        description = "You may discard your hand. If you do, draw four cards."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "224"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg?1693611218"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
@@ -20,10 +20,13 @@ import com.wingedsheep.sdk.model.Rarity
  * (the shared pile-split primitive) with `count = 4`, chained with "The Ring tempts
  * you". In a two-player game the lone opponent is the chooser automatically.
  *
- * Note: the printed face-down / face-up distinction is an information-visibility
- * nuance only (the chooser of the split sees both piles either way; the controller
- * then picks where each pile goes). The split-and-choose and hand/graveyard routing —
- * the mechanically load-bearing part — are modeled exactly.
+ * KNOWN LIMITATION — hidden-pile information: the printed card hides one pile
+ * (face-down) from the controller when they choose where each pile goes, whereas
+ * [Patterns.Library.factOrFiction] reveals both piles. The controller therefore chooses
+ * with strictly more information than the printed card intends. The split-and-choose and
+ * hand/graveyard routing — the mechanically load-bearing part — are modeled exactly;
+ * faithfully hiding the face-down pile needs an engine primitive for a pile the chooser
+ * can't see (add-feature territory), tracked for when that lands.
  */
 val SauronsRansom = card("Sauron's Ransom") {
     manaCost = "{1}{U}{B}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sauron's Ransom
+ * {1}{U}{B}
+ * Instant
+ *
+ * Choose an opponent. They look at the top four cards of your library and separate
+ * them into a face-down pile and a face-up pile. Put one pile into your hand and the
+ * other into your graveyard. The Ring tempts you.
+ *
+ * A Fact or Fiction variant (CR 700.3 "divvy"): reveal/look at the top four, an
+ * opponent partitions them into two piles, then you choose which pile goes to your
+ * hand and which goes to your graveyard — reusing [Patterns.Library.factOrFiction]
+ * (the shared pile-split primitive) with `count = 4`, chained with "The Ring tempts
+ * you". In a two-player game the lone opponent is the chooser automatically.
+ *
+ * Note: the printed face-down / face-up distinction is an information-visibility
+ * nuance only (the chooser of the split sees both piles either way; the controller
+ * then picks where each pile goes). The split-and-choose and hand/graveyard routing —
+ * the mechanically load-bearing part — are modeled exactly.
+ */
+val SauronsRansom = card("Sauron's Ransom") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Instant"
+    oracleText = "Choose an opponent. They look at the top four cards of your library and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard. The Ring tempts you."
+
+    spell {
+        effect = Patterns.Library.factOrFiction(count = 4)
+            .then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Alex Brock"
+        flavorText = "\"He was dear to you, I see. And now he shall endure the slow torment of years.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg?1686970005"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
@@ -1,9 +1,19 @@
 package com.wingedsheep.mtg.sets.definitions.ltr.cards
 
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
 
 /**
  * Sauron's Ransom
@@ -14,19 +24,21 @@ import com.wingedsheep.sdk.model.Rarity
  * them into a face-down pile and a face-up pile. Put one pile into your hand and the
  * other into your graveyard. The Ring tempts you.
  *
- * A Fact or Fiction variant (CR 700.3 "divvy"): reveal/look at the top four, an
- * opponent partitions them into two piles, then you choose which pile goes to your
- * hand and which goes to your graveyard — reusing [Patterns.Library.factOrFiction]
- * (the shared pile-split primitive) with `count = 4`, chained with "The Ring tempts
- * you". In a two-player game the lone opponent is the chooser automatically.
+ * A "divvy" variant (CR 700.3) with one concealed pile: the opponent looks at the top
+ * four and partitions them, but only the face-up pile is shown to you when you choose
+ * where each pile goes — the face-down pile stays hidden (you see only its size). The
+ * Gather → Select → Reveal → ChoosePile → Move pipeline models this with masking alone,
+ * no bespoke decision type:
+ *  1. Gather the top four with [LookAudience.None] — the cards stay hidden from you (the
+ *     caster); the opponent sees them only through their split decision below.
+ *  2. The opponent separates them into a face-up pile (the cards they select) and a
+ *     face-down pile (the rest).
+ *  3. Publicly reveal the face-up pile (`revealed = true`) so you can see it when choosing;
+ *     the face-down pile is never revealed, so it renders to you as opaque card backs.
+ *  4. You choose which pile goes to your hand; the other goes to your graveyard.
+ * Then "The Ring tempts you."
  *
- * KNOWN LIMITATION — hidden-pile information: the printed card hides one pile
- * (face-down) from the controller when they choose where each pile goes, whereas
- * [Patterns.Library.factOrFiction] reveals both piles. The controller therefore chooses
- * with strictly more information than the printed card intends. The split-and-choose and
- * hand/graveyard routing — the mechanically load-bearing part — are modeled exactly;
- * faithfully hiding the face-down pile needs an engine primitive for a pile the chooser
- * can't see (add-feature territory), tracked for when that lands.
+ * In a two-player game the lone opponent is the looker/partitioner automatically.
  */
 val SauronsRansom = card("Sauron's Ransom") {
     manaCost = "{1}{U}{B}"
@@ -35,8 +47,57 @@ val SauronsRansom = card("Sauron's Ransom") {
     oracleText = "Choose an opponent. They look at the top four cards of your library and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard. The Ring tempts you."
 
     spell {
-        effect = Patterns.Library.factOrFiction(count = 4)
-            .then(Effects.TheRingTemptsYou())
+        effect = Effects.Composite(
+            listOf(
+                // 1. The chosen opponent looks at the top four cards. LookAudience.None keeps
+                //    them hidden from you; the opponent sees them only via their split below.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "looked",
+                    lookAudience = LookAudience.None
+                ),
+                // 2. The opponent separates them: the cards they select become the face-up
+                //    pile, the rest the face-down pile.
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Opponent,
+                    storeSelected = "faceUp",
+                    storeRemainder = "faceDown",
+                    selectedLabel = "Face-up pile",
+                    remainderLabel = "Face-down pile",
+                    prompt = "Separate the top four cards into a face-up pile and a face-down pile. The cards you select are placed face up; the rest stay face down.",
+                    alwaysPrompt = true
+                ),
+                // 3. Reveal the face-up pile to everyone (including the caster, who now sees it
+                //    when choosing). The face-down pile is never revealed.
+                GatherCardsEffect(
+                    source = CardSource.FromVariable("faceUp"),
+                    storeAs = "faceUp",
+                    revealed = true
+                ),
+                // 4. You choose which pile goes to your hand; the other to your graveyard. You
+                //    see the face-up pile's cards and only the size of the face-down pile.
+                ChoosePileEffect(
+                    pileA = "faceUp",
+                    pileB = "faceDown",
+                    pileALabel = "Face-up pile",
+                    pileBLabel = "Face-down pile",
+                    chooser = Chooser.Controller,
+                    storeChosenAs = "keepPile",
+                    storeOtherAs = "otherPile",
+                    prompt = "Choose which pile goes to your hand; the other goes to your graveyard."
+                ),
+                MoveCollectionEffect(
+                    from = "keepPile",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "otherPile",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                )
+            )
+        ).then(Effects.TheRingTemptsYou())
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronsRansom.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -38,7 +39,11 @@ import com.wingedsheep.sdk.scripting.effects.SelectionMode
  *  4. You choose which pile goes to your hand; the other goes to your graveyard.
  * Then "The Ring tempts you."
  *
- * In a two-player game the lone opponent is the looker/partitioner automatically.
+ * "Choose an opponent" is the caster picking which opponent looks/partitions. It is modeled
+ * with [Targets.Opponent] (the engine's mechanism for "choose an opponent", as on Faramir,
+ * Prince of Ithilien); the split decision then uses [Chooser.TargetPlayer] so the chosen
+ * opponent — not just "an opponent" — is the one who looks and separates the cards. In a
+ * two-player game the lone opponent is the only legal choice.
  */
 val SauronsRansom = card("Sauron's Ransom") {
     manaCost = "{1}{U}{B}"
@@ -47,6 +52,8 @@ val SauronsRansom = card("Sauron's Ransom") {
     oracleText = "Choose an opponent. They look at the top four cards of your library and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard. The Ring tempts you."
 
     spell {
+        // "Choose an opponent." — the caster picks which opponent looks and partitions.
+        target = Targets.Opponent
         effect = Effects.Composite(
             listOf(
                 // 1. The chosen opponent looks at the top four cards. LookAudience.None keeps
@@ -56,12 +63,12 @@ val SauronsRansom = card("Sauron's Ransom") {
                     storeAs = "looked",
                     lookAudience = LookAudience.None
                 ),
-                // 2. The opponent separates them: the cards they select become the face-up
-                //    pile, the rest the face-down pile.
+                // 2. The chosen opponent separates them: the cards they select become the
+                //    face-up pile, the rest the face-down pile.
                 SelectFromCollectionEffect(
                     from = "looked",
                     selection = SelectionMode.ChooseAnyNumber,
-                    chooser = Chooser.Opponent,
+                    chooser = Chooser.TargetPlayer,
                     storeSelected = "faceUp",
                     storeRemainder = "faceDown",
                     selectedLabel = "Face-up pile",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SharkeyTyrantOfTheShire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SharkeyTyrantOfTheShire.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sharkey, Tyrant of the Shire
+ * Legendary Creature — Avatar Rogue
+ * {2}{U}{B}, 2/4
+ *
+ * Activated abilities of lands your opponents control can't be activated unless they're mana abilities.
+ * Sharkey has all activated abilities of lands your opponents control except mana abilities.
+ * Mana of any type can be spent to activate Sharkey's abilities.
+ *
+ * Modeled with three reusable static abilities:
+ *  - [PreventActivatedAbilities] with `nonManaAbilitiesOnly = true` over `Land.opponentControls()`
+ *    locks opponents' lands' non-mana abilities while leaving their mana abilities usable (piece 1).
+ *  - [GainActivatedAbilitiesOfPermanents] grants Sharkey (Self) copies of the non-mana activated
+ *    abilities of opponents' lands; the copies use Sharkey as their source (piece 2).
+ *  - [SpendAnyManaTypeForActivatedAbilities] relaxes the colored requirements of Sharkey's own
+ *    activated-ability mana costs to "any type" (piece 3).
+ */
+val SharkeyTyrantOfTheShire = card("Sharkey, Tyrant of the Shire") {
+    typeLine = "Legendary Creature — Avatar Rogue"
+    manaCost = "{2}{U}{B}"
+    power = 2
+    toughness = 4
+    colorIdentity = "UB"
+    oracleText =
+        "Activated abilities of lands your opponents control can't be activated unless they're mana abilities.\n" +
+        "Sharkey has all activated abilities of lands your opponents control except mana abilities.\n" +
+        "Mana of any type can be spent to activate Sharkey's abilities."
+
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Land.opponentControls(),
+            nonManaAbilitiesOnly = true
+        )
+    }
+    staticAbility {
+        ability = GainActivatedAbilitiesOfPermanents(
+            grantedTo = GroupFilter.source(),
+            sourceFilter = GameObjectFilter.Land.opponentControls(),
+            includeManaAbilities = false
+        )
+    }
+    staticAbility {
+        ability = SpendAnyManaTypeForActivatedAbilities(filter = GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "229"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg?1686970050"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
@@ -53,24 +53,23 @@ val TomBombadil = card("Tom Bombadil") {
         "the rest on the bottom of your library in a random order. This ability triggers only " +
         "once each turn."
 
+    // Four or more lore counters among Sagas you control (CR 714 lore counters).
+    val fourLoreAmongYourSagas = Conditions.CounterKindAmongYouControlAtLeast(
+        count = 4,
+        counterType = CounterTypeFilter.Named("lore"),
+        filter = GameObjectFilter.Enchantment.withSubtype("Saga").youControl()
+    )
+
     staticAbility {
         ability = ConditionalStaticAbility(
             ability = GrantKeyword(Keyword.HEXPROOF, GroupFilter.source()),
-            condition = Conditions.CounterKindAmongYouControlAtLeast(
-                count = 4,
-                counterType = CounterTypeFilter.Named("lore"),
-                filter = GameObjectFilter.Enchantment.withSubtype("Saga").youControl()
-            )
+            condition = fourLoreAmongYourSagas
         )
     }
     staticAbility {
         ability = ConditionalStaticAbility(
             ability = GrantKeyword(Keyword.INDESTRUCTIBLE, GroupFilter.source()),
-            condition = Conditions.CounterKindAmongYouControlAtLeast(
-                count = 4,
-                counterType = CounterTypeFilter.Named("lore"),
-                filter = GameObjectFilter.Enchantment.withSubtype("Saga").youControl()
-            )
+            condition = fourLoreAmongYourSagas
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Tom Bombadil
+ * {W}{U}{B}{R}{G}
+ * Legendary Creature — God Bard
+ * 4/4
+ *
+ * As long as there are four or more lore counters among Sagas you control, Tom Bombadil has
+ * hexproof and indestructible.
+ * Whenever the final chapter ability of a Saga you control resolves, reveal cards from the top
+ * of your library until you reveal a Saga card. Put that card onto the battlefield and the rest
+ * on the bottom of your library in a random order. This ability triggers only once each turn.
+ *
+ * The static gate uses [Conditions.CounterKindAmongYouControlAtLeast] to sum lore counters across
+ * Sagas you control (CR 714 lore counters), and a ConditionalStaticAbility granting hexproof +
+ * indestructible to itself. The trigger fires on [Triggers.WheneverFinalChapterOfYourSagaResolves]
+ * (`oncePerTurn`) and composes GatherUntilMatch (until a Saga, from your library) + RevealCollection
+ * + two filtered MoveCollections: the Saga → your battlefield, the rest → the bottom of your library
+ * in random order.
+ */
+val TomBombadil = card("Tom Bombadil") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Creature — God Bard"
+    power = 4
+    toughness = 4
+    oracleText = "As long as there are four or more lore counters among Sagas you control, Tom " +
+        "Bombadil has hexproof and indestructible.\n" +
+        "Whenever the final chapter ability of a Saga you control resolves, reveal cards from the " +
+        "top of your library until you reveal a Saga card. Put that card onto the battlefield and " +
+        "the rest on the bottom of your library in a random order. This ability triggers only " +
+        "once each turn."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HEXPROOF, GroupFilter.source()),
+            condition = Conditions.CounterKindAmongYouControlAtLeast(
+                count = 4,
+                counterType = CounterTypeFilter.Named("lore"),
+                filter = GameObjectFilter.Enchantment.withSubtype("Saga").youControl()
+            )
+        )
+    }
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.INDESTRUCTIBLE, GroupFilter.source()),
+            condition = Conditions.CounterKindAmongYouControlAtLeast(
+                count = 4,
+                counterType = CounterTypeFilter.Named("lore"),
+                filter = GameObjectFilter.Enchantment.withSubtype("Saga").youControl()
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverFinalChapterOfYourSagaResolves
+        oncePerTurn = true
+        effect = Effects.Composite(
+            listOf(
+                GatherUntilMatchEffect(
+                    player = Player.You,
+                    filter = GameObjectFilter().withSubtype("Saga"),
+                    storeMatch = "revealedSaga",
+                    storeRevealed = "allRevealed"
+                ),
+                RevealCollectionEffect(from = "allRevealed"),
+                // The Saga enters the battlefield under your control.
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter().withSubtype("Saga"),
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        player = Player.You
+                    )
+                ),
+                // The rest go to the bottom of your library in a random order.
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    filter = GameObjectFilter().notSubtype(Subtype("Saga")),
+                    destination = CardDestination.ToZone(
+                        Zone.LIBRARY,
+                        player = Player.You,
+                        placement = ZonePlacement.Bottom
+                    ),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "234"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg?1686970104"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TomBombadil.kt
@@ -85,10 +85,9 @@ val TomBombadil = card("Tom Bombadil") {
                     storeRevealed = "allRevealed"
                 ),
                 RevealCollectionEffect(from = "allRevealed"),
-                // The Saga enters the battlefield under your control.
+                // The revealed Saga (the match) enters the battlefield under your control.
                 MoveCollectionEffect(
-                    from = "allRevealed",
-                    filter = GameObjectFilter().withSubtype("Saga"),
+                    from = "revealedSaga",
                     destination = CardDestination.ToZone(
                         Zone.BATTLEFIELD,
                         player = Player.You

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -1375,6 +1375,49 @@
     ]
 }
 
+// Bewitching Leechcraft
+{
+    "name": "Bewitching Leechcraft",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature has \"If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it.\" (Otherwise, it doesn't untap.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "REMOVE_COUNTER_TO_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Wei Guan",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg?1686968013"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Bilbo's Ring
 {
     "name": "Bilbo's Ring",
@@ -8130,6 +8173,89 @@
     ]
 }
 
+// Goldberry, River-Daughter
+{
+    "name": "Goldberry, River-Daughter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Creature — Nymph",
+    "oracleText": "{T}: Move a counter of each kind not on Goldberry from another target permanent you control onto Goldberry.\n{U}, {T}: Move one or more counters from Goldberry onto another target permanent you control. If you do, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveCountersEachKindMissing",
+                    "source": {
+                        "type": "BoundVariable",
+                        "name": "another target permanent you control"
+                    },
+                    "destination": "Self"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target permanent you control"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveChosenCountersToTarget",
+                    "source": "Self",
+                    "destination": {
+                        "type": "BoundVariable",
+                        "name": "another target permanent you control"
+                    },
+                    "drawCardOnMove": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target permanent you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "RARE",
+        "artist": "Marie Magny",
+        "flavorText": "\"Fear nothing! For tonight you are under the roof of Tom Bombadil.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg?1686968111"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Gollum's Bite
 {
     "name": "Gollum's Bite",
@@ -9099,6 +9225,85 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Hew the Entwood
+{
+    "name": "Hew the Entwood",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sacrifice any number of lands. Reveal the top X cards of your library, where X is the number of lands sacrificed this way. Choose any number of artifact and/or land cards revealed this way. Put all nonland cards chosen this way onto the battlefield, then put all land cards chosen this way onto the battlefield tapped, then put the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Sacrifice",
+                    "filter": "land",
+                    "any": true
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": "PermanentsSacrificedThisWay"
+                    },
+                    "storeAs": "revealed"
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "revealed"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealed",
+                    "selection": "ChooseAnyNumber",
+                    "filter": "artifact|land",
+                    "storeSelected": "chosen",
+                    "storeRemainder": "rest",
+                    "prompt": "Choose any number of artifact and/or land cards to put onto the battlefield"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosen",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "filter": "nonland"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosen",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    },
+                    "filter": "land"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "MYTHIC",
+        "artist": "Manuel Castañón",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg?1686969039"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -13037,6 +13242,113 @@
     ]
 }
 
+// One Ring to Rule Them All
+{
+    "name": "One Ring to Rule Them All",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — The Ring tempts you, then each player mills cards equal to your Ring-bearer's power.\nII — Destroy all nonlegendary creatures.\nIII — Each opponent loses 1 life for each creature card in that player's graveyard.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "TheRingTemptsYou",
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "EntityProperty",
+                                            "entity": "RingBearer",
+                                            "numericProperty": "Power"
+                                        },
+                                        "player": "Each"
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard",
+                                        "player": "Each"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsNonlegendary"
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "creature"
+                        },
+                        "target": "Controller"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "RARE",
+        "artist": "L J Koh",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg?1688569235"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Orcish Bowmasters
 {
     "name": "Orcish Bowmasters",
@@ -15336,6 +15648,152 @@
     ]
 }
 
+// Saruman of Many Colors
+{
+    "name": "Saruman of Many Colors",
+    "manaCost": "{3}{W}{U}{B}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Ward—Discard an enchantment, instant, or sorcery card.\nWhenever you cast your second spell each turn, each opponent mills two cards. When one or more cards are milled this way, exile target enchantment, instant, or sorcery card with equal or lesser mana value than that spell from an opponent's graveyard. Copy the exiled card. You may cast the copy without paying its mana cost.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Discard",
+                "filter": "enchantment|instant|sorcery"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "player": "EachOpponent"
+                                },
+                                "storeAs": "milled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        ]
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "CollectionContainsMatch",
+                                "collection": "milled"
+                            }
+                        },
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "MoveToZone",
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "destination": "Exile"
+                                },
+                                {
+                                    "type": "CopyCardIntoCollection",
+                                    "storeAs": "copy"
+                                },
+                                {
+                                    "type": "Gated",
+                                    "gate": "Gate.MayDecide",
+                                    "then": {
+                                        "type": "CastFromCollectionWithoutPayingCost",
+                                        "from": "copy"
+                                    },
+                                    "descriptionOverride": "You may cast the copy without paying its mana cost."
+                                }
+                            ]
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                {
+                                                    "type": "Or",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        "IsInstant"
+                                                    ]
+                                                },
+                                                "IsSorcery"
+                                            ]
+                                        },
+                                        {
+                                            "type": "ManaValueAtMostEntity",
+                                            "reference": "Triggering"
+                                        }
+                                    ],
+                                    "controllerPredicate": "OwnedByOpponent"
+                                },
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Each opponent mills two cards. When one or more cards are milled this way, exile target enchantment, instant, or sorcery card with equal or lesser mana value than that spell from an opponent's graveyard. Copy the exiled card. You may cast the copy without paying its mana cost."
+                },
+                "descriptionOverride": "Whenever you cast your second spell each turn, each opponent mills two cards. When one or more cards are milled this way, exile target enchantment, instant, or sorcery card with equal or lesser mana value than that spell from an opponent's graveyard. Copy the exiled card. You may cast the copy without paying its mana cost."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "MYTHIC",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg?1686969983"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Saruman the White
 {
     "name": "Saruman the White",
@@ -15427,6 +15885,210 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sauron's Ransom
+{
+    "name": "Sauron's Ransom",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose an opponent. They look at the top four cards of your library and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard. The Ring tempts you.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "revealed",
+                    "revealed": true
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealed",
+                    "selection": "ChooseAnyNumber",
+                    "chooser": "Opponent",
+                    "storeSelected": "pileA",
+                    "storeRemainder": "pileB",
+                    "prompt": "Separate the revealed cards into two piles. The cards you select form Pile 1; the rest form Pile 2.",
+                    "selectedLabel": "Pile 1",
+                    "remainderLabel": "Pile 2",
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "ChoosePile",
+                    "pileA": "pileA",
+                    "pileB": "pileB",
+                    "storeChosenAs": "keepPile",
+                    "storeOtherAs": "otherPile",
+                    "prompt": "Choose which pile goes to your Hand; the other goes to your Graveyard."
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "keepPile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "otherPile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                },
+                "TheRingTemptsYou"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Alex Brock",
+        "flavorText": "\"He was dear to you, I see. And now he shall endure the slow torment of years.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg?1686970005"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Sauron, the Dark Lord
+{
+    "name": "Sauron, the Dark Lord",
+    "manaCost": "{3}{U}{B}{R}",
+    "typeLine": "Legendary Creature — Avatar Horror",
+    "oracleText": "Ward—Sacrifice a legendary artifact or legendary creature.\nWhenever an opponent casts a spell, amass Orcs 1.\nWhenever an Army you control deals combat damage to a player, the Ring tempts you.\nWhenever the Ring tempts you, you may discard your hand. If you do, draw four cards.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Sacrifice",
+                "filter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Or",
+                            "predicates": [
+                                {
+                                    "type": "And",
+                                    "predicates": [
+                                        "IsArtifact",
+                                        "IsLegendary"
+                                    ]
+                                },
+                                {
+                                    "type": "And",
+                                    "predicates": [
+                                        "IsCreature",
+                                        "IsLegendary"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Amass",
+                    "subtype": "Orc"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "creature Army ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": "TheRingTemptsYou"
+            },
+            {
+                "id": "ability_3",
+                "trigger": "RingTemptedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "discardedHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discardedHand",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "You may discard your hand. If you do, draw four cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "MYTHIC",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg?1693611218"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -16040,6 +16702,52 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Sharkey, Tyrant of the Shire
+{
+    "name": "Sharkey, Tyrant of the Shire",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Legendary Creature — Avatar Rogue",
+    "oracleText": "Activated abilities of lands your opponents control can't be activated unless they're mana abilities.\nSharkey has all activated abilities of lands your opponents control except mana abilities.\nMana of any type can be spent to activate Sharkey's abilities.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": "land ctrl:opponent",
+                "nonManaAbilitiesOnly": true
+            },
+            {
+                "type": "GainActivatedAbilitiesOfPermanents",
+                "grantedTo": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "sourceFilter": "land ctrl:opponent"
+            },
+            {
+                "type": "SpendAnyManaTypeForActivatedAbilities",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg?1686970050"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -18807,6 +19515,143 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// Tom Bombadil
+{
+    "name": "Tom Bombadil",
+    "manaCost": "{W}{U}{B}{R}{G}",
+    "typeLine": "Legendary Creature — God Bard",
+    "oracleText": "As long as there are four or more lore counters among Sagas you control, Tom Bombadil has hexproof and indestructible.\nWhenever the final chapter ability of a Saga you control resolves, reveal cards from the top of your library until you reveal a Saga card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SagaChapterResolvedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "Saga",
+                            "storeMatch": "revealedSaga",
+                            "storeRevealed": "allRevealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "allRevealed"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "allRevealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "filter": "Saga"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "allRevealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random",
+                            "filter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Saga"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "enchantment Saga ctrl:you",
+                        "aggregation": "SUM",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "lore"
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "enchantment Saga ctrl:you",
+                        "aggregation": "SUM",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "lore"
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "MYTHIC",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg?1686970104"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -15907,28 +15907,39 @@
                             "amount": 4
                         }
                     },
-                    "storeAs": "revealed",
-                    "revealed": true
+                    "storeAs": "looked",
+                    "lookAudience": "None"
                 },
                 {
                     "type": "SelectFromCollection",
-                    "from": "revealed",
+                    "from": "looked",
                     "selection": "ChooseAnyNumber",
                     "chooser": "Opponent",
-                    "storeSelected": "pileA",
-                    "storeRemainder": "pileB",
-                    "prompt": "Separate the revealed cards into two piles. The cards you select form Pile 1; the rest form Pile 2.",
-                    "selectedLabel": "Pile 1",
-                    "remainderLabel": "Pile 2",
+                    "storeSelected": "faceUp",
+                    "storeRemainder": "faceDown",
+                    "prompt": "Separate the top four cards into a face-up pile and a face-down pile. The cards you select are placed face up; the rest stay face down.",
+                    "selectedLabel": "Face-up pile",
+                    "remainderLabel": "Face-down pile",
                     "alwaysPrompt": true
                 },
                 {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromVariable",
+                        "variableName": "faceUp"
+                    },
+                    "storeAs": "faceUp",
+                    "revealed": true
+                },
+                {
                     "type": "ChoosePile",
-                    "pileA": "pileA",
-                    "pileB": "pileB",
+                    "pileA": "faceUp",
+                    "pileB": "faceDown",
+                    "pileALabel": "Face-up pile",
+                    "pileBLabel": "Face-down pile",
                     "storeChosenAs": "keepPile",
                     "storeOtherAs": "otherPile",
-                    "prompt": "Choose which pile goes to your Hand; the other goes to your Graveyard."
+                    "prompt": "Choose which pile goes to your hand; the other goes to your graveyard."
                 },
                 {
                     "type": "MoveCollection",

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -15914,7 +15914,7 @@
                     "type": "SelectFromCollection",
                     "from": "looked",
                     "selection": "ChooseAnyNumber",
-                    "chooser": "Opponent",
+                    "chooser": "TargetPlayer",
                     "storeSelected": "faceUp",
                     "storeRemainder": "faceDown",
                     "prompt": "Separate the top four cards into a face-up pile and a face-down pile. The cards you select are placed face up; the rest stay face down.",
@@ -15959,7 +15959,10 @@
                 },
                 "TheRingTemptsYou"
             ]
-        }
+        },
+        "targetRequirements": [
+            "TargetOpponent"
+        ]
     },
     "metadata": {
         "collectorNumber": "225",
@@ -19560,12 +19563,11 @@
                         },
                         {
                             "type": "MoveCollection",
-                            "from": "allRevealed",
+                            "from": "revealedSaga",
                             "destination": {
                                 "type": "ToZone",
                                 "zone": "Battlefield"
-                            },
-                            "filter": "Saga"
+                            }
                         },
                         {
                             "type": "MoveCollection",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
@@ -255,14 +256,21 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
 
         // Persist reveals for cards that came from a library source.
         // - Public reveal (`revealed = true`) → revealed to every player.
-        // - Private look (Scry / Surveil / look-at-top-N) → revealed to the looking player only.
+        // - Private look (Scry / Surveil / look-at-top-N) → revealed to the audience named by
+        //   [GatherCardsEffect.lookAudience]: the controller by default, an opponent for "they
+        //   look at the top N of your library" (Sauron's Ransom), or no one when a downstream
+        //   decision is the only window into the cards.
         // HAND is intentionally excluded: the owner already sees their own hand, and the caster
         // should never automatically see another player's hand from a gather. Cards that genuinely
         // reveal/look at an opponent's hand use [RevealHandEffect] or [LookAtTargetHandEffect]
         // as an explicit prior step.
         val revealAudience: Set<EntityId> = when {
             effect.revealed -> state.turnOrder.toSet()
-            isLibrarySource(effect.source) -> setOf(context.controllerId)
+            isLibrarySource(effect.source) -> when (effect.lookAudience) {
+                LookAudience.Controller -> setOf(context.controllerId)
+                LookAudience.Opponent -> state.getOpponents(context.controllerId).toSet()
+                LookAudience.None -> emptySet()
+            }
             else -> emptySet()
         }
         val newState = if (revealAudience.isNotEmpty()) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BewitchingLeechcraftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BewitchingLeechcraftScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.BewitchingLeechcraft
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Bewitching Leechcraft (LTR #41).
+ *
+ * Proves the granted untap-step replacement
+ * ([com.wingedsheep.sdk.core.AbilityFlag.REMOVE_COUNTER_TO_UNTAP]):
+ *  - The ETB trigger taps the enchanted creature.
+ *  - On the enchanted creature's controller's next untap step, if it has a +1/+1
+ *    counter, one is removed and the creature untaps.
+ *  - With no +1/+1 counter, the creature stays tapped (does not untap).
+ */
+class BewitchingLeechcraftScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BewitchingLeechcraft))
+        return driver
+    }
+
+    fun addPlusOneCounters(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // Cast Bewitching Leechcraft on the active player's own creature and resolve
+    // the spell plus its ETB tap trigger. Returns the creature entity.
+    fun enchantOwnCreature(driver: GameTestDriver): Pair<EntityId, EntityId> {
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val aura = driver.putCardInHand(p1, "Bewitching Leechcraft")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.castSpellWithTargets(p1, aura, listOf(ChosenTarget.Permanent(creature)))
+            .isSuccess shouldBe true
+
+        // Resolve the Aura, then its ETB "tap enchanted creature" trigger.
+        driver.bothPass() // Aura resolves, ETB trigger goes on the stack
+        driver.bothPass() // ETB trigger resolves
+
+        return p1 to creature
+    }
+
+    // Drive from the active player's main phase all the way back to their next
+    // untap step (one full turn cycle), passing through the untap step.
+    fun advanceToNextUntapStep(driver: GameTestDriver, activePlayer: EntityId) {
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(activePlayer)
+        driver.passPriority(opponent)
+        // Opponent's turn.
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(opponent)
+        driver.passPriority(activePlayer)
+        // Back to active player's turn — untap step already happened.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("ETB taps the enchanted creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Grizzly Bears" to 20))
+
+        val (_, creature) = enchantOwnCreature(driver)
+
+        driver.isTapped(creature) shouldBe true
+    }
+
+    test("with a +1/+1 counter, the creature untaps and one counter is removed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Grizzly Bears" to 20))
+
+        val (p1, creature) = enchantOwnCreature(driver)
+        addPlusOneCounters(driver, creature, 2)
+
+        driver.isTapped(creature) shouldBe true
+        plusOneCounters(driver, creature) shouldBe 2
+
+        advanceToNextUntapStep(driver, p1)
+
+        // Untapped, and exactly one +1/+1 counter was removed.
+        driver.isTapped(creature) shouldBe false
+        plusOneCounters(driver, creature) shouldBe 1
+    }
+
+    test("with no +1/+1 counters, the creature stays tapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Grizzly Bears" to 20))
+
+        val (p1, creature) = enchantOwnCreature(driver)
+
+        driver.isTapped(creature) shouldBe true
+        plusOneCounters(driver, creature) shouldBe 0
+
+        advanceToNextUntapStep(driver, p1)
+
+        // Did not untap; nothing to remove.
+        driver.isTapped(creature) shouldBe true
+        plusOneCounters(driver, creature) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldberryRiverDaughterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldberryRiverDaughterScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GoldberryRiverDaughter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Goldberry, River-Daughter ({1}{U} Legendary Creature — Nymph, 1/3)
+ *
+ * Ability A — {T}: Move a counter of each kind not on Goldberry from another target permanent
+ *   you control onto Goldberry.
+ * Ability B — {U}, {T}: Move one or more counters from Goldberry onto another target permanent
+ *   you control. If you do, draw a card.
+ */
+class GoldberryRiverDaughterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GoldberryRiverDaughter))
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, type: CounterType, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(type, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun count(driver: GameTestDriver, entityId: EntityId, type: CounterType): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(type) ?: 0
+
+    test("Ability A moves one counter of each kind Goldberry lacks; a kind it already has is not moved") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        val goldberry = driver.putCreatureOnBattlefield(active, "Goldberry, River-Daughter")
+        driver.removeSummoningSickness(goldberry)
+        val target = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+
+        // Target has +1/+1 and charge; Goldberry already has a charge counter.
+        addCounters(driver, target, CounterType.PLUS_ONE_PLUS_ONE, 1)
+        addCounters(driver, target, CounterType.CHARGE, 1)
+        addCounters(driver, goldberry, CounterType.CHARGE, 1)
+
+        val abilityA = GoldberryRiverDaughter.activatedAbilities[0].id
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = active,
+                sourceId = goldberry,
+                abilityId = abilityA,
+                targets = listOf(entityIdToChosenTarget(driver.state, target))
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Goldberry gained a +1/+1 (it lacked it) but NOT another charge (already had one).
+        count(driver, goldberry, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        count(driver, goldberry, CounterType.CHARGE) shouldBe 1
+
+        // The bear lost the moved +1/+1 but kept its charge (that kind was not moved).
+        count(driver, target, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 0
+        count(driver, target, CounterType.CHARGE) shouldBe 1
+    }
+
+    test("Ability B moves chosen counters from Goldberry to another permanent and draws a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        val goldberry = driver.putCreatureOnBattlefield(active, "Goldberry, River-Daughter")
+        driver.removeSummoningSickness(goldberry)
+        val target = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+
+        // Goldberry has two +1/+1 counters to move.
+        addCounters(driver, goldberry, CounterType.PLUS_ONE_PLUS_ONE, 2)
+        driver.giveMana(active, Color.BLUE, 1)
+
+        val handBefore = driver.getHandSize(active)
+
+        val abilityB = GoldberryRiverDaughter.activatedAbilities[1].id
+        val activateResult = driver.submit(
+            ActivateAbility(
+                playerId = active,
+                sourceId = goldberry,
+                abilityId = abilityB,
+                targets = listOf(entityIdToChosenTarget(driver.state, target))
+            )
+        )
+        activateResult.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Engine prompts how many +1/+1 counters to move. Move both.
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseNumberDecision>()
+        driver.submitDecision(active, NumberChosenResponse(decision.id, 2))
+
+        // Both counters moved onto the bear; Goldberry has none left.
+        count(driver, target, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+        count(driver, goldberry, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 0
+
+        // Drew a card because counters were moved.
+        driver.getHandSize(active) shouldBe (handBefore + 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HewTheEntwoodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HewTheEntwoodScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.HewTheEntwood
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hew the Entwood — "Sacrifice any number of lands. Reveal the top X cards of your library, where
+ * X is the number of lands sacrificed this way. Choose any number of artifact and/or land cards
+ * revealed this way. Put all nonland cards chosen this way onto the battlefield, then put all land
+ * cards chosen this way onto the battlefield tapped, then put the rest on the bottom of your
+ * library in a random order."
+ *
+ * Exercises SacrificeAnyNumber (records X) → GatherCards(TopOfLibrary(X)) → reveal →
+ * SelectFromCollection(any number, filter = Artifact OR Land) → partitioned MoveCollections:
+ * chosen nonland → battlefield untapped, chosen land → battlefield tapped, rest → bottom random.
+ */
+class HewTheEntwoodScenarioTest : FunSpec({
+
+    val TestArtifact = CardDefinition.artifact("Test Artifact", ManaCost.parse("{2}"))
+    val TestOgre = CardDefinition.creature("Test Ogre", ManaCost.parse("{3}"), emptySet(), 3, 3)
+
+    test("sacrifice 3 lands, reveal top 3, choose the artifact + land; nonland goes to bottom") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(HewTheEntwood, TestArtifact, TestOgre))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        // Three lands on the battlefield to sacrifice → X = 3.
+        val land1 = driver.putLandOnBattlefield(active, "Mountain")
+        val land2 = driver.putLandOnBattlefield(active, "Mountain")
+        val land3 = driver.putLandOnBattlefield(active, "Mountain")
+
+        // Top of library (top-most last): Ogre (non-artifact, non-land), Forest (land),
+        // Test Artifact (artifact). Reveal top 3 surfaces all three.
+        driver.putCardOnTopOfLibrary(active, "Test Ogre")
+        driver.putCardOnTopOfLibrary(active, "Forest")
+        val artifactId = driver.putCardOnTopOfLibrary(active, "Test Artifact")
+
+        val spell = driver.putCardInHand(active, "Hew the Entwood")
+        driver.giveMana(active, Color.RED, 5)
+        driver.castSpell(active, spell)
+        driver.bothPass()
+
+        val sacrificeOptions = setOf(land1, land2, land3)
+        var guard = 0
+        while (guard++ < 12) {
+            val pd = driver.pendingDecision
+            when {
+                pd is SelectCardsDecision && pd.options.toSet() == sacrificeOptions -> {
+                    // Sacrifice all three lands.
+                    driver.submitCardSelection(active, listOf(land1, land2, land3))
+                }
+                pd is SelectCardsDecision -> {
+                    // Choose the artifact and the revealed land; the Ogre is not selectable.
+                    val forestId = pd.options.first { opt ->
+                        driver.state.getEntity(opt)?.get<CardComponent>()?.name == "Forest"
+                    }
+                    pd.options.any {
+                        driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+                    } shouldBe false
+                    driver.submitCardSelection(active, listOf(artifactId, forestId))
+                }
+                driver.state.stack.isNotEmpty() -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        fun onBattlefield(name: String): com.wingedsheep.sdk.model.EntityId? =
+            driver.state.getBattlefield().firstOrNull {
+                driver.state.getEntity(it)?.get<CardComponent>()?.name == name
+            }
+
+        // Chosen artifact (nonland) entered the battlefield untapped.
+        val artifactOnBf = onBattlefield("Test Artifact")
+        (artifactOnBf != null) shouldBe true
+        driver.state.getEntity(artifactOnBf!!)?.has<TappedComponent>() shouldBe false
+
+        // Chosen land entered the battlefield tapped.
+        val forestOnBf = onBattlefield("Forest")
+        (forestOnBf != null) shouldBe true
+        driver.state.getEntity(forestOnBf!!)?.has<TappedComponent>() shouldBe true
+
+        // The non-artifact, non-land Ogre was not choosable and went to the bottom of the library.
+        onBattlefield("Test Ogre") shouldBe null
+        val library = driver.state.getLibrary(active)
+        library.any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Ogre"
+        } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAudienceOpponentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAudienceOpponentScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exercises [LookAudience.Opponent] on [GatherCardsEffect] — "an opponent looks at the top N
+ * cards of your library." The non-public library look is persisted as revealed to the
+ * opponent(s) and NOT to the controller, who never sees the cards. (The [LookAudience.None]
+ * and default [LookAudience.Controller] branches are covered by SauronsRansomScenarioTest and
+ * the Scry/Surveil tests respectively; this pins the remaining branch.)
+ */
+class LookAudienceOpponentScenarioTest : FunSpec({
+
+    // {U} sorcery: an opponent looks at the top two cards of your library (no further effect).
+    val opponentLooks = card("Opponent Looks") {
+        manaCost = "{U}"
+        colorIdentity = "U"
+        typeLine = "Sorcery"
+        oracleText = "An opponent looks at the top two cards of your library."
+        spell {
+            effect = GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2)),
+                storeAs = "looked",
+                lookAudience = LookAudience.Opponent
+            )
+        }
+    }
+
+    fun GameTestDriver.revealedTo(card: EntityId, player: EntityId): Boolean =
+        state.getEntity(card)?.get<RevealedToComponent>()?.isRevealedTo(player) == true
+
+    test("an opponent looking at your top cards reveals them to the opponent, not to you") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(opponentLooks)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val top1 = driver.putCardOnTopOfLibrary(active, "Island")
+        val top2 = driver.putCardOnTopOfLibrary(active, "Forest")
+
+        val spell = driver.putCardInHand(active, "Opponent Looks")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.castSpell(active, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isPaused shouldBe false
+
+        // The opponent (the looker) privately sees both cards; the controller never does.
+        driver.revealedTo(top1, opponent) shouldBe true
+        driver.revealedTo(top2, opponent) shouldBe true
+        driver.revealedTo(top1, active) shouldBe false
+        driver.revealedTo(top2, active) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OneRingToRuleThemAllScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OneRingToRuleThemAllScenarioTest.kt
@@ -1,0 +1,175 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.OneRingToRuleThemAll
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for One Ring to Rule Them All (LTR #102), a three-chapter Saga.
+ *
+ * I — The Ring tempts you, then each player mills cards equal to your Ring-bearer's power.
+ * II — Destroy all nonlegendary creatures.
+ * III — Each opponent loses 1 life for each creature card in that player's graveyard.
+ *
+ * Chapters are driven the realistic way: cast the Saga (chapter I fires on entry as lore 1 is
+ * added) and advance turns so the upkeep lore counter triggers chapters II and III.
+ */
+class OneRingToRuleThemAllScenarioTest : FunSpec({
+
+    // Power-3 vanilla creature — designated as the Ring-bearer so chapter I mills 3.
+    val powerThree = card("Test Power Three") {
+        manaCost = "{3}"
+        typeLine = "Creature — Bear"
+        power = 3
+        toughness = 3
+    }
+    val vanilla = card("Test Vanilla") {
+        manaCost = "{2}"
+        typeLine = "Creature — Goblin"
+        power = 2
+        toughness = 2
+    }
+    val legend = card("Test Legend") {
+        manaCost = "{2}"
+        typeLine = "Legendary Creature — Elf Noble"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OneRingToRuleThemAll, powerThree, vanilla, legend))
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack(designateBearer: EntityId? = null) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 80) {
+            val decision = state.pendingDecision
+            when {
+                decision is SelectCardsDecision && designateBearer != null &&
+                    designateBearer in decision.options ->
+                    submitDecision(decision.playerId, CardsSelectedResponse(decision.id, listOf(designateBearer)))
+                decision != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.advanceToMain(targetRound: Int) {
+        var guard = 0
+        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 600) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+            guard++
+        }
+    }
+
+    /** Cast the Saga as the active player; resolves chapter I, designating [bearer] if prompted. */
+    fun GameTestDriver.castSaga(controller: EntityId, bearer: EntityId?): EntityId {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(controller, Color.BLACK, 4)
+        val saga = putCardInHand(controller, "One Ring to Rule Them All")
+        castSpell(controller, saga)
+        resolveStack(designateBearer = bearer)
+        return saga
+    }
+
+    fun GameTestDriver.graveyardSize(player: EntityId): Int =
+        state.getZone(ZoneKey(player, Zone.GRAVEYARD)).size
+
+    test("Chapter I: the Ring tempts you, then each player mills cards equal to your Ring-bearer's power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // A power-3 creature to designate as the Ring-bearer.
+        val bearer = driver.putCreatureOnBattlefield(controller, "Test Power Three")
+
+        val gyControllerBefore = driver.graveyardSize(controller)
+        val gyOpponentBefore = driver.graveyardSize(opponent)
+
+        driver.castSaga(controller, bearer = bearer)
+
+        // The chosen creature is now the Ring-bearer.
+        driver.state.getEntity(bearer)
+            ?.get<com.wingedsheep.engine.state.components.identity.RingBearerComponent>()
+            ?.ownerId shouldBe controller
+
+        // Each player milled exactly 3 (the Ring-bearer's power) into their graveyard.
+        (driver.graveyardSize(controller) - gyControllerBefore) shouldBe 3
+        (driver.graveyardSize(opponent) - gyOpponentBefore) shouldBe 3
+    }
+
+    test("Chapter II: destroys nonlegendary creatures but not legendary ones") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        // Designate a bearer so chapter I's mill resolves cleanly.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val bearer = driver.putCreatureOnBattlefield(controller, "Test Power Three")
+        driver.castSaga(controller, bearer = bearer)
+
+        // Board to wipe on chapter II.
+        val nonlegendary = driver.putCreatureOnBattlefield(opponent, "Test Vanilla")
+        val legendary = driver.putCreatureOnBattlefield(opponent, "Test Legend")
+
+        driver.advanceToMain(2) // upkeep adds lore 2 → chapter II triggers
+        driver.resolveStack()
+
+        val battlefield = driver.state.getBattlefield()
+        (nonlegendary in battlefield) shouldBe false
+        (legendary in battlefield) shouldBe true
+    }
+
+    test("Chapter III: each opponent loses life equal to creature cards in that opponent's graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val bearer = driver.putCreatureOnBattlefield(controller, "Test Power Three")
+        driver.castSaga(controller, bearer = bearer)
+
+        // Put exactly two creature cards (plus a noncreature) in the opponent's graveyard.
+        driver.putCardInGraveyard(opponent, "Test Vanilla")
+        driver.putCardInGraveyard(opponent, "Test Legend")
+        driver.putCardInGraveyard(opponent, "Mountain") // noncreature — must NOT count
+
+        val opponentLifeBefore = driver.getLifeTotal(opponent)
+        val controllerLifeBefore = driver.getLifeTotal(controller)
+
+        driver.advanceToMain(2) // chapter II (board wipe — no creatures, no-op for life)
+        driver.resolveStack()
+        driver.advanceToMain(3) // chapter III
+        driver.resolveStack()
+
+        // Opponent had 2 creature cards in their graveyard → loses 2 life.
+        (opponentLifeBefore - driver.getLifeTotal(opponent)) shouldBe 2
+        // Controller is not an opponent of themselves — unaffected by chapter III.
+        driver.getLifeTotal(controller) shouldBe controllerLifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarumanOfManyColorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarumanOfManyColorsScenarioTest.kt
@@ -94,6 +94,47 @@ class SarumanOfManyColorsScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("declining the free cast leaves the copy to cease to exist (CR 707.10a); nothing is drawn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Saruman of Many Colors")
+                    .withCardsInHand(1, "Palladium Myr", 2)
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Centaur Courser")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInGraveyard(2, "Divination")
+                    // Cards the copy WOULD draw if (wrongly) cast — proves nothing is drawn.
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val controllerHandBefore = game.handSize(1)
+                val targetDivination = graveyardCardId(game, 2, "Divination")
+
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+
+                // Exile + copy the Divination, then DECLINE the optional free cast.
+                game.hasPendingDecision() shouldBe true
+                game.selectTargets(listOf(targetDivination))
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("The targeted Divination was still exiled from the opponent's graveyard") {
+                    game.isInGraveyard(2, "Divination") shouldBe false
+                }
+                withClue("The declined copy ceased to exist; no card was drawn (only the two Myrs left hand)") {
+                    game.handSize(1) shouldBe (controllerHandBefore - 2)
+                }
+            }
+
             test("a graveyard card with mana value greater than the second spell is not a legal target") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarumanOfManyColorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarumanOfManyColorsScenarioTest.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Saruman of Many Colors (LTR #223) — {3}{W}{U}{B} Legendary Avatar Wizard 5/4.
+ *
+ *   Ward—Discard an enchantment, instant, or sorcery card.
+ *   Whenever you cast your second spell each turn, each opponent mills two cards. When one or
+ *   more cards are milled this way, exile target enchantment, instant, or sorcery card with equal
+ *   or lesser mana value than that spell from an opponent's graveyard. Copy the exiled card. You
+ *   may cast the copy without paying its mana cost.
+ *
+ * Proves:
+ *  - Casting your SECOND spell each turn mills two cards from each opponent.
+ *  - The reflexive trigger then lets you exile a legal enchantment/instant/sorcery card from an
+ *    opponent's graveyard, copy it, and cast the copy for free (here a copied Divination draws
+ *    two cards for Saruman's controller).
+ *  - A graveyard card with mana value GREATER than the triggering second spell is NOT a legal
+ *    target (Divination MV 3 is legal under an MV-3 second spell; Lórien Revealed MV 5 is not).
+ */
+class SarumanOfManyColorsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Saruman of Many Colors — second-spell mill + reflexive exile/copy/cast") {
+
+            test("second spell mills two from each opponent; exile, copy, and cast a legal graveyard card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Saruman of Many Colors")
+                    // Two no-target {3} creature spells (MV 3) — the second one triggers Saruman.
+                    .withCardsInHand(1, "Palladium Myr", 2)
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    // Opponent has a library to mill and a legal graveyard target (Divination, MV 3).
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Centaur Courser")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInGraveyard(2, "Divination")
+                    // Saruman's controller needs cards to draw from the copied Divination (draw 2).
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentGraveyardBefore = game.graveyardSize(2)
+                val opponentLibraryBefore = game.librarySize(2)
+                val controllerHandBefore = game.handSize(1)
+                val targetDivination = graveyardCardId(game, 2, "Divination")
+
+                // First spell of the turn (no second-spell trigger yet).
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+
+                // Second spell — fires Saruman's "whenever you cast your second spell each turn".
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+
+                // Trigger resolves: each opponent mills two; then the reflexive targets a graveyard
+                // enchantment/instant/sorcery with MV <= the second Divination (MV 3).
+                withClue("Each opponent milled two cards (library -2)") {
+                    game.librarySize(2) shouldBe (opponentLibraryBefore - 2)
+                }
+                withClue("...into their graveyard (the milled cards + the pre-existing Divination)") {
+                    game.graveyardSize(2) shouldBe (opponentGraveyardBefore + 2)
+                }
+
+                // Choose the legal target — the opponent's Divination (MV 3 <= 3).
+                game.hasPendingDecision() shouldBe true
+                game.selectTargets(listOf(targetDivination))
+
+                // The reflexive ability is still on the stack; resolving it exiles the targeted
+                // Divination, copies it, and prompts "you may cast the copy" — accept the copy.
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                // The copied Divination has no target — resolve it (draws two for the controller).
+                game.resolveStack()
+
+                withClue("The targeted Divination was exiled from the opponent's graveyard") {
+                    game.isInGraveyard(2, "Divination") shouldBe false
+                }
+                withClue("Casting the free Divination copy drew Saruman's controller two cards") {
+                    // Hand: cast both Myrs (-2), the copied Divination draws 2 (+2).
+                    game.handSize(1) shouldBe (controllerHandBefore - 2 + 2)
+                }
+            }
+
+            test("a graveyard card with mana value greater than the second spell is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Saruman of Many Colors")
+                    .withCardsInHand(1, "Palladium Myr", 2)
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Centaur Courser")
+                    .withCardInLibrary(2, "Forest")
+                    // Legal target (MV 3) and an illegal one (Lórien Revealed, MV 5 > 3).
+                    .withCardInGraveyard(2, "Divination")
+                    .withCardInGraveyard(2, "Lórien Revealed")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val legalDivination = graveyardCardId(game, 2, "Divination")
+                val illegalLorien = graveyardCardId(game, 2, "Lórien Revealed")
+
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+                game.castSpell(1, "Palladium Myr")
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                val decision = game.getPendingDecision()
+                (decision is ChooseTargetsDecision) shouldBe true
+                val legal = (decision as ChooseTargetsDecision).legalTargets[0] ?: emptyList()
+
+                withClue("Divination (MV 3 <= 3) is a legal target") {
+                    legal.contains(legalDivination) shouldBe true
+                }
+                withClue("Lórien Revealed (MV 5 > 3) is NOT a legal target") {
+                    legal.contains(illegalLorien) shouldBe false
+                }
+            }
+        }
+    }
+
+    private fun graveyardCardId(game: TestGame, playerNumber: Int, name: String): EntityId {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getGraveyard(playerId).first { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronTheDarkLordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronTheDarkLordScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.SauronTheDarkLord
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Sauron, the Dark Lord (LTR #224).
+ *
+ *   Ward—Sacrifice a legendary artifact or legendary creature.
+ *   Whenever an opponent casts a spell, amass Orcs 1.
+ *   Whenever an Army you control deals combat damage to a player, the Ring tempts you.
+ *   Whenever the Ring tempts you, you may discard your hand. If you do, draw four cards.
+ *
+ * All four pieces compose existing primitives — the test proves the three triggered abilities
+ * (opponent-cast amass, Army-damage Ring-tempt, Ring-tempt discard/draw) and that the
+ * Ward—Sacrifice keyword is present with the right cost shape.
+ */
+class SauronTheDarkLordScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // {R} instant the opponent can cast to fire Sauron's "opponent casts a spell" trigger.
+    val bolt = card("Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        spell { effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent)) }
+    }
+
+    // A vanilla 2/2 Army to attack with (mirrors AmassScenarioTest's Zombie Army shape).
+    val orcArmy = card("Test Orc Army") {
+        manaCost = "{0}"
+        typeLine = "Creature — Orc Army"
+        power = 2; toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SauronTheDarkLord, bolt, orcArmy))
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.armiesControlledBy(player: EntityId): List<EntityId> {
+        val projected = projector.project(state)
+        return projected.getBattlefieldControlledBy(player)
+            .filter { projected.isCreature(it) && projected.hasSubtype(it, "Army") }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.temptCount(player: EntityId): Int =
+        state.getEntity(player)?.get<TheRingComponent>()?.temptCount ?: 0
+
+    test("Ward—Sacrifice a legendary artifact or legendary creature keyword is present") {
+        val ward = SauronTheDarkLord.keywordAbilities
+            .filterIsInstance<KeywordAbility.Ward>()
+            .single()
+        (ward.cost is WardCost.Sacrifice) shouldBe true
+    }
+
+    test("opponent casting a spell amasses Orcs 1 (an Army appears and grows)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Sauron, the Dark Lord")
+        driver.armiesControlledBy(controller).size shouldBe 0
+
+        // Opponent casts a spell — Sauron's controller amasses Orcs 1. The non-active opponent only
+        // has priority after the active player passes, so hand priority over before casting.
+        driver.giveMana(opponent, Color.RED, 1)
+        val boltCard = driver.putCardInHand(opponent, "Test Bolt")
+        driver.passPriority(controller)
+        driver.castSpell(opponent, boltCard)
+        driver.resolveStack()
+
+        val army = driver.armiesControlledBy(controller).single()
+        projector.project(driver.state).hasSubtype(army, "Orc") shouldBe true
+        driver.plusOneCounters(army) shouldBe 1
+
+        // A second opponent spell grows the same Army to 2 counters.
+        driver.giveMana(opponent, Color.RED, 1)
+        val boltCard2 = driver.putCardInHand(opponent, "Test Bolt")
+        driver.passPriority(controller)
+        driver.castSpell(opponent, boltCard2)
+        driver.resolveStack()
+
+        driver.armiesControlledBy(controller) shouldBe listOf(army)
+        driver.plusOneCounters(army) shouldBe 2
+    }
+
+    test("an Army you control dealing combat damage to a player tempts you, then you may discard to draw four") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val defender = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Sauron, the Dark Lord")
+        val army = driver.putCreatureOnBattlefield(controller, "Test Orc Army")
+        driver.removeSummoningSickness(army)
+        driver.temptCount(controller) shouldBe 0
+
+        // Give the controller a couple of cards to discard so the draw is observable.
+        repeat(2) { driver.putCardInHand(controller, "Mountain") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(controller, listOf(army), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(defender)
+
+        // Combat damage is dealt: the Army hits the defending player → the Ring tempts the controller.
+        // The Ring-tempt trigger then offers "you may discard your hand; if you do, draw four".
+        var guard = 0
+        while (driver.state.pendingDecision == null && guard < 30) { driver.bothPass(); guard++ }
+
+        driver.temptCount(controller) shouldNotBe 0
+        driver.temptCount(controller) shouldBe 1
+
+        // First pending decision is the Ring-bearer choice (resolve it), then the discard yes/no.
+        driver.autoResolveDecision()
+        guard = 0
+        while (driver.state.pendingDecision == null && guard < 30) { driver.bothPass(); guard++ }
+
+        driver.submitYesNo(controller, true)
+        driver.resolveStack()
+
+        // The hand (2 lands) was discarded and exactly four cards were drawn.
+        driver.getHand(controller).size shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.TheRingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.SauronsRansom
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Sauron's Ransom: choose an opponent; they split your top four into two piles;
+ * you put one pile into your hand and the other into your graveyard; the Ring tempts you.
+ *
+ * Exercises the shared Fact-or-Fiction pile-split primitive
+ * ([com.wingedsheep.sdk.dsl.Patterns.Library.factOrFiction], count = 4) chained
+ * with TheRingTemptsYou.
+ */
+class SauronsRansomScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SauronsRansom)
+        return driver
+    }
+
+    test("opponent splits top four; controller routes piles to hand and graveyard; Ring tempts") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack a known top four (top first as pushed last).
+        val c1 = driver.putCardOnTopOfLibrary(active, "Island")
+        val c2 = driver.putCardOnTopOfLibrary(active, "Forest")
+        val c3 = driver.putCardOnTopOfLibrary(active, "Mountain")
+        val c4 = driver.putCardOnTopOfLibrary(active, "Plains")
+        // Library from top: c4, c3, c2, c1, <deck...>
+
+        // A creature to designate as Ring-bearer when the Ring tempts.
+        val bearer = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(active, "Sauron's Ransom")
+        driver.giveMana(active, Color.BLUE, 2)
+        driver.giveMana(active, Color.BLACK, 1)
+
+        val handBefore = driver.getHandSize(active)
+        val graveBefore = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size
+
+        driver.castSpell(active, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 1. Opponent separates the revealed top four into two piles.
+        driver.isPaused shouldBe true
+        val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        split.playerId shouldBe opponent
+        split.options.size shouldBe 4
+        // Opponent puts c4 and c3 in Pile 1 (selected); c2 and c1 form Pile 2 (remainder).
+        driver.submitDecision(opponent, CardsSelectedResponse(split.id, listOf(c4, c3)))
+
+        // 2. Controller chooses which pile goes to hand vs graveyard.
+        driver.isPaused shouldBe true
+        val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        choose.playerId shouldBe active
+        // Pile 1 (option 0 = c4, c3) is the "keep" pile → goes to hand; the other → graveyard.
+        driver.submitDecision(active, OptionChosenResponse(choose.id, 0))
+
+        // 3. The Ring tempts you → choose a Ring-bearer.
+        driver.isPaused shouldBe true
+        val tempt = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        tempt.playerId shouldBe active
+        driver.submitDecision(active, CardsSelectedResponse(tempt.id, listOf(bearer)))
+
+        driver.isPaused shouldBe false
+
+        // Pile 1 (c4, c3) went to hand; Pile 2 (c2, c1) went to graveyard.
+        val hand = driver.state.getZone(ZoneKey(active, Zone.HAND))
+        hand.contains(c4) shouldBe true
+        hand.contains(c3) shouldBe true
+
+        val grave = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD))
+        grave.contains(c2) shouldBe true
+        grave.contains(c1) shouldBe true
+
+        // Hand: before - 1 (spell cast) + 2 (kept pile).
+        driver.getHandSize(active) shouldBe handBefore - 1 + 2
+        // Graveyard: 2 discarded cards + the Sauron's Ransom spell itself.
+        driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size shouldBe graveBefore + 2 + 1
+
+        // The Ring tempted the controller exactly once.
+        driver.state.getEntity(active)?.get<TheRingComponent>()?.temptCount shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
@@ -67,7 +67,7 @@ class SauronsRansomScenarioTest : FunSpec({
         val handBefore = driver.getHandSize(active)
         val graveBefore = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size
 
-        driver.castSpell(active, spell).isSuccess shouldBe true
+        driver.castSpell(active, spell, targets = listOf(opponent)).isSuccess shouldBe true
         driver.bothPass()
 
         // 1. The opponent — not the caster — separates the top four. The opponent looks at them
@@ -143,7 +143,7 @@ class SauronsRansomScenarioTest : FunSpec({
         driver.giveMana(active, Color.BLUE, 2)
         driver.giveMana(active, Color.BLACK, 1)
 
-        driver.castSpell(active, spell).isSuccess shouldBe true
+        driver.castSpell(active, spell, targets = listOf(opponent)).isSuccess shouldBe true
         driver.bothPass()
 
         // Opponent selects nothing → the whole face-down pile, an empty face-up pile (CR 700.3d).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SauronsRansomScenarioTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.OptionChosenResponse
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.player.TheRingComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -13,17 +14,20 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
- * Sauron's Ransom: choose an opponent; they split your top four into two piles;
- * you put one pile into your hand and the other into your graveyard; the Ring tempts you.
+ * Sauron's Ransom: choose an opponent; they look at your top four and split them into a
+ * face-up pile and a face-down pile; you put one pile into your hand and the other into your
+ * graveyard; the Ring tempts you.
  *
- * Exercises the shared Fact-or-Fiction pile-split primitive
- * ([com.wingedsheep.sdk.dsl.Patterns.Library.factOrFiction], count = 4) chained
- * with TheRingTemptsYou.
+ * The point of the card — and of the engine support behind it — is the *hidden information*:
+ * the opponent looks (the caster does not), and only the face-up pile is shown to the caster
+ * when they choose where each pile goes. These tests pin that visibility, expressed through the
+ * [RevealedToComponent] the engine uses to decide what a player may see in a hidden zone.
  */
 class SauronsRansomScenarioTest : FunSpec({
 
@@ -34,7 +38,10 @@ class SauronsRansomScenarioTest : FunSpec({
         return driver
     }
 
-    test("opponent splits top four; controller routes piles to hand and graveyard; Ring tempts") {
+    fun GameTestDriver.revealedTo(card: EntityId, player: EntityId): Boolean =
+        state.getEntity(card)?.get<RevealedToComponent>()?.isRevealedTo(player) == true
+
+    test("opponent looks and splits; only the face-up pile is shown to the caster; piles route to hand and graveyard; Ring tempts") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
 
@@ -63,19 +70,32 @@ class SauronsRansomScenarioTest : FunSpec({
         driver.castSpell(active, spell).isSuccess shouldBe true
         driver.bothPass()
 
-        // 1. Opponent separates the revealed top four into two piles.
+        // 1. The opponent — not the caster — separates the top four. The opponent looks at them
+        //    through this decision; the caster has not been shown any of the four.
         driver.isPaused shouldBe true
         val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
         split.playerId shouldBe opponent
         split.options.size shouldBe 4
-        // Opponent puts c4 and c3 in Pile 1 (selected); c2 and c1 form Pile 2 (remainder).
+        // The opponent's decision carries the real identities so they can look at the cards.
+        listOf(c1, c2, c3, c4).forEach { (split.cardInfo?.containsKey(it) == true) shouldBe true }
+        // The caster is still blind to every looked-at card.
+        listOf(c1, c2, c3, c4).forEach { driver.revealedTo(it, active) shouldBe false }
+
+        // Opponent puts c4 and c3 face up; c2 and c1 stay face down.
         driver.submitDecision(opponent, CardsSelectedResponse(split.id, listOf(c4, c3)))
 
-        // 2. Controller chooses which pile goes to hand vs graveyard.
+        // 2. The caster chooses which pile goes to hand vs graveyard. Now — and only now — the
+        //    face-up pile (c4, c3) is visible to the caster; the face-down pile (c2, c1) is not.
         driver.isPaused shouldBe true
         val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
         choose.playerId shouldBe active
-        // Pile 1 (option 0 = c4, c3) is the "keep" pile → goes to hand; the other → graveyard.
+        driver.revealedTo(c4, active) shouldBe true
+        driver.revealedTo(c3, active) shouldBe true
+        driver.revealedTo(c2, active) shouldBe false
+        driver.revealedTo(c1, active) shouldBe false
+        // The face-up pile is option 0; the caster keeps it (→ hand).
+        choose.optionCardIds?.get(0) shouldBe listOf(c4, c3)
+        choose.optionCardIds?.get(1) shouldBe listOf(c2, c1)
         driver.submitDecision(active, OptionChosenResponse(choose.id, 0))
 
         // 3. The Ring tempts you → choose a Ring-bearer.
@@ -86,7 +106,7 @@ class SauronsRansomScenarioTest : FunSpec({
 
         driver.isPaused shouldBe false
 
-        // Pile 1 (c4, c3) went to hand; Pile 2 (c2, c1) went to graveyard.
+        // The kept (face-up) pile went to hand; the other (face-down) pile went to graveyard.
         val hand = driver.state.getZone(ZoneKey(active, Zone.HAND))
         hand.contains(c4) shouldBe true
         hand.contains(c3) shouldBe true
@@ -97,10 +117,53 @@ class SauronsRansomScenarioTest : FunSpec({
 
         // Hand: before - 1 (spell cast) + 2 (kept pile).
         driver.getHandSize(active) shouldBe handBefore - 1 + 2
-        // Graveyard: 2 discarded cards + the Sauron's Ransom spell itself.
+        // Graveyard: 2 face-down cards + the Sauron's Ransom spell itself.
         driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size shouldBe graveBefore + 2 + 1
 
         // The Ring tempted the controller exactly once.
         driver.state.getEntity(active)?.get<TheRingComponent>()?.temptCount shouldBe 1
+    }
+
+    test("opponent may keep the whole pile face down; the caster then sees neither pile and chooses by size") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val c1 = driver.putCardOnTopOfLibrary(active, "Island")
+        val c2 = driver.putCardOnTopOfLibrary(active, "Forest")
+        val c3 = driver.putCardOnTopOfLibrary(active, "Mountain")
+        val c4 = driver.putCardOnTopOfLibrary(active, "Plains")
+
+        val bearer = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        val spell = driver.putCardInHand(active, "Sauron's Ransom")
+        driver.giveMana(active, Color.BLUE, 2)
+        driver.giveMana(active, Color.BLACK, 1)
+
+        driver.castSpell(active, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Opponent selects nothing → the whole face-down pile, an empty face-up pile (CR 700.3d).
+        val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(opponent, CardsSelectedResponse(split.id, emptyList()))
+
+        // Nothing was turned face up, so the caster sees none of the four when choosing.
+        val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        choose.playerId shouldBe active
+        listOf(c1, c2, c3, c4).forEach { driver.revealedTo(it, active) shouldBe false }
+
+        // Keep the (empty) face-up pile → nothing to hand; the four face-down cards go to graveyard.
+        val faceUpOption = choose.optionCardIds?.entries?.first { it.value.isEmpty() }?.key ?: 0
+        driver.submitDecision(active, OptionChosenResponse(choose.id, faceUpOption))
+
+        val tempt = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(active, CardsSelectedResponse(tempt.id, listOf(bearer)))
+
+        driver.isPaused shouldBe false
+        val grave = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD))
+        listOf(c1, c2, c3, c4).forEach { grave.contains(it) shouldBe true }
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkeyTyrantOfTheShireScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkeyTyrantOfTheShireScenarioTest.kt
@@ -158,7 +158,8 @@ class SharkeyTyrantOfTheShireScenarioTest : ScenarioTestBase() {
                 withClue("The gained draw-two ability should resolve and draw two cards") {
                     game.handSize(1) shouldBe handBefore + 2
                 }
-                // SacrificeSelf in the copied ability sacrifices the gainer (Sharkey), CR 113.2.
+                // The gained ability's source is Sharkey, so its "Sacrifice this permanent" cost
+                // sacrifices Sharkey itself, not the land it was copied from.
                 withClue("Sharkey should be sacrificed by the gained ability's SacrificeSelf cost") {
                     game.isOnBattlefield("Sharkey, Tyrant of the Shire") shouldBe false
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkeyTyrantOfTheShireScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkeyTyrantOfTheShireScenarioTest.kt
@@ -1,0 +1,168 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sharkey, Tyrant of the Shire (LTR):
+ *  - "Activated abilities of lands your opponents control can't be activated unless they're mana abilities."
+ *  - "Sharkey has all activated abilities of lands your opponents control except mana abilities."
+ *  - "Mana of any type can be spent to activate Sharkey's abilities."
+ *
+ * Test land: Memorial to Genius (DOM) — a land with both a mana ability ({T}: Add {U})
+ * and a non-mana activated ability ({4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards).
+ */
+class SharkeyTyrantOfTheShireScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Piece 1: opponents' lands' non-mana abilities are locked, mana abilities are not") {
+            test("the opponent's Memorial to Genius cannot activate its non-mana draw ability while Sharkey is out") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Sharkey, Tyrant of the Shire", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Memorial to Genius")
+                    .withLandsOnBattlefield(2, "Island", 5)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val memorial = game.findPermanent("Memorial to Genius")!!
+                val memorialDef = cardRegistry.getCard("Memorial to Genius")!!
+                val drawAbility = memorialDef.script.activatedAbilities.first { !it.isManaAbility }
+
+                val p2Legal = game.getLegalActions(2)
+                val drawActivation = p2Legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == memorial && a.abilityId == drawAbility.id
+                }
+                withClue("Opponent's land non-mana ability must be locked while Sharkey is in play") {
+                    drawActivation shouldBe null
+                }
+
+                // The handler must also reject a direct activation attempt.
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player2Id, sourceId = memorial, abilityId = drawAbility.id)
+                )
+                withClue("Engine should reject the opponent's non-mana land ability") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("the opponent's Memorial to Genius can still activate its mana ability while Sharkey is out") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Sharkey, Tyrant of the Shire", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Memorial to Genius")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val memorial = game.findPermanent("Memorial to Genius")!!
+
+                val p2Legal = game.getLegalActions(2)
+                val manaActivation = p2Legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == memorial
+                }
+                withClue("Mana abilities of opponents' lands remain usable ('unless they're mana abilities')") {
+                    (manaActivation != null).shouldBeTrue()
+                }
+            }
+        }
+
+        context("Piece 2: Sharkey gains the opponent's land's non-mana activated abilities") {
+            test("Sharkey has Memorial to Genius's draw ability available as a legal action") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Sharkey, Tyrant of the Shire", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Memorial to Genius")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sharkey = game.findPermanent("Sharkey, Tyrant of the Shire")!!
+                val memorialDef = cardRegistry.getCard("Memorial to Genius")!!
+                val drawAbility = memorialDef.script.activatedAbilities.first { !it.isManaAbility }
+
+                val p1Legal = game.getLegalActions(1)
+                val sharkeyDraw = p1Legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == sharkey && a.abilityId == drawAbility.id
+                }
+                withClue("Sharkey should have gained Memorial to Genius's draw ability") {
+                    (sharkeyDraw != null).shouldBeTrue()
+                }
+            }
+
+            test("Sharkey does NOT gain the opponent's land's mana ability") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Sharkey, Tyrant of the Shire", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Memorial to Genius")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sharkey = game.findPermanent("Sharkey, Tyrant of the Shire")!!
+                val memorialDef = cardRegistry.getCard("Memorial to Genius")!!
+                val manaAbility = memorialDef.script.activatedAbilities.first { it.isManaAbility }
+
+                val p1Legal = game.getLegalActions(1)
+                val sharkeyMana = p1Legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == sharkey && a.abilityId == manaAbility.id
+                }
+                withClue("'except mana abilities' — Sharkey must not gain the land's mana ability") {
+                    sharkeyMana shouldBe null
+                }
+            }
+        }
+
+        context("Piece 3: any mana type can pay for Sharkey's (gained) abilities") {
+            test("Sharkey activates the gained {4}{U} draw ability paying entirely with red mana") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Sharkey, Tyrant of the Shire", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Memorial to Genius")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sharkey = game.findPermanent("Sharkey, Tyrant of the Shire")!!
+                val memorialDef = cardRegistry.getCard("Memorial to Genius")!!
+                val drawAbility = memorialDef.script.activatedAbilities.first { !it.isManaAbility }
+
+                val handBefore = game.handSize(1)
+
+                // 5 Mountains can only produce {R}{R}{R}{R}{R}; the gained ability costs {4}{U}.
+                // Without "mana of any type can be spent" the {U} pip would be unpayable.
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = sharkey, abilityId = drawAbility.id)
+                )
+                withClue("Sharkey's gained ability must be activatable with any mana type (5 red pays {4}{U})") {
+                    (result.error == null) shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("The gained draw-two ability should resolve and draw two cards") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+                // SacrificeSelf in the copied ability sacrifices the gainer (Sharkey), CR 113.2.
+                withClue("Sharkey should be sacrificed by the gained ability's SacrificeSelf cost") {
+                    game.isOnBattlefield("Sharkey, Tyrant of the Shire") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TomBombadilScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TomBombadilScenarioTest.kt
@@ -1,0 +1,176 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.TomBombadil
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tom Bombadil — {W}{U}{B}{R}{G} Legendary Creature — God Bard 4/4.
+ *
+ * Static: "As long as there are four or more lore counters among Sagas you control, Tom Bombadil
+ * has hexproof and indestructible." (new [com.wingedsheep.sdk.dsl.Conditions.CounterKindAmongYouControlAtLeast]
+ * summing lore counters across Sagas you control).
+ *
+ * Trigger: "Whenever the final chapter ability of a Saga you control resolves, reveal cards from
+ * the top of your library until you reveal a Saga card. Put that card onto the battlefield and the
+ * rest on the bottom of your library in a random order. This ability triggers only once each turn."
+ * (new [com.wingedsheep.sdk.scripting.EventPattern.SagaChapterResolvedEvent] +
+ * [com.wingedsheep.sdk.dsl.Triggers.WheneverFinalChapterOfYourSagaResolves], oncePerTurn).
+ */
+class TomBombadilScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A one-chapter test Saga: chapter I (its final chapter) gains 1 life — no targets, so it
+    // resolves cleanly. Casting it adds the first lore counter, which both triggers and (being the
+    // final chapter) fires Tom's "final chapter resolves" ability.
+    val OneChapterSaga = card("One-Chapter Saga") {
+        manaCost = "{1}"
+        typeLine = "Enchantment — Saga"
+        oracleText = "I — You gain 1 life."
+        sagaChapter(1) {
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    // A three-chapter test Saga used as the library reveal target: entering with one lore counter
+    // it is far from its final chapter (III), so it stays on the battlefield after being revealed.
+    val ThreeChapterSaga = card("Three-Chapter Saga") {
+        manaCost = "{2}"
+        typeLine = "Enchantment — Saga"
+        oracleText = "I, II, III — You gain 1 life."
+        sagaChapter(1) { effect = Effects.GainLife(1) }
+        sagaChapter(2) { effect = Effects.GainLife(1) }
+        sagaChapter(3) { effect = Effects.GainLife(1) }
+    }
+
+    fun setLoreCounters(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(CounterType.LORE, count))
+                .with(SagaComponent(triggeredChapters = (1..count).toSet()))
+        }
+        driver.replaceState(newState)
+    }
+
+    test("4+ lore counters among Sagas you control grant Tom hexproof and indestructible") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TomBombadil, OneChapterSaga))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        val tom = driver.putCreatureOnBattlefield(active, "Tom Bombadil")
+
+        // No Sagas yet → no hexproof / indestructible.
+        val projected0 = projector.project(driver.state)
+        projected0.hasKeyword(tom, Keyword.HEXPROOF) shouldBe false
+        projected0.hasKeyword(tom, Keyword.INDESTRUCTIBLE) shouldBe false
+
+        // Two Sagas with 2 lore counters each = 4 total → both keywords granted.
+        val sagaA = driver.putPermanentOnBattlefield(active, "One-Chapter Saga")
+        val sagaB = driver.putPermanentOnBattlefield(active, "One-Chapter Saga")
+        setLoreCounters(driver, sagaA, 2)
+        setLoreCounters(driver, sagaB, 2)
+
+        val projected4 = projector.project(driver.state)
+        projected4.hasKeyword(tom, Keyword.HEXPROOF) shouldBe true
+        projected4.hasKeyword(tom, Keyword.INDESTRUCTIBLE) shouldBe true
+
+        // Drop below 4 (3 total) → keywords gone.
+        val downState = driver.state.updateEntity(sagaB) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withRemoved(CounterType.LORE, 1))
+        }
+        driver.replaceState(downState)
+
+        val projected3 = projector.project(driver.state)
+        projected3.hasKeyword(tom, Keyword.HEXPROOF) shouldBe false
+        projected3.hasKeyword(tom, Keyword.INDESTRUCTIBLE) shouldBe false
+    }
+
+    test("final chapter resolving reveals a Saga onto the battlefield, once per turn") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TomBombadil, OneChapterSaga, ThreeChapterSaga))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Tom Bombadil")
+
+        // Library top: a Forest (nonsaga) over a Three-Chapter Saga; reveal-until-Saga skips the
+        // Forest (→ bottom) and finds the Saga, which survives on the battlefield (chapter III is
+        // far off). Top-most is the last pushed.
+        driver.putCardOnTopOfLibrary(active, "Three-Chapter Saga")
+        driver.putCardOnTopOfLibrary(active, "Forest")
+
+        // Cast a one-chapter Saga; its only (final) chapter resolves, firing Tom's trigger.
+        val sagaSpell = driver.putCardInHand(active, "One-Chapter Saga")
+        driver.giveColorlessMana(active, 1)
+        driver.castSpell(active, sagaSpell)
+        driver.bothPass()
+
+        // Resolve the chapter ability and Tom's triggered ability (no decisions expected).
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty()) {
+            driver.bothPass()
+        }
+
+        // The revealed Three-Chapter Saga is now on the battlefield (Tom's trigger put it there).
+        driver.state.getBattlefield().any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Three-Chapter Saga"
+        } shouldBe true
+
+        // Tom is still on the battlefield.
+        driver.state.getBattlefield().any {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Tom Bombadil"
+        } shouldBe true
+    }
+
+    test("the final-chapter trigger fires only once each turn") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TomBombadil, OneChapterSaga, ThreeChapterSaga))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Tom Bombadil")
+
+        // Two Sagas sit on top of the library; only the first should be revealed/put out this turn.
+        driver.putCardOnTopOfLibrary(active, "Three-Chapter Saga")
+        driver.putCardOnTopOfLibrary(active, "Three-Chapter Saga")
+
+        // Cast two one-chapter Sagas back-to-back; both final chapters resolve this turn, but Tom's
+        // trigger is once-per-turn, so it fires only on the first.
+        repeat(2) {
+            val spell = driver.putCardInHand(active, "One-Chapter Saga")
+            driver.giveColorlessMana(active, 1)
+            driver.castSpell(active, spell)
+            driver.bothPass()
+            var guard = 0
+            while (guard++ < 20 && driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            }
+        }
+
+        // Only one Three-Chapter Saga was put onto the battlefield (the trigger fired once).
+        val revealed = driver.state.getBattlefield().count {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Three-Chapter Saga"
+        }
+        revealed shouldBe 1
+    }
+})


### PR DESCRIPTION
Adds 9 cards to The Lord of the Rings: Tales of Middle-earth, plus one SDK
primitive that several of them needed.

## SDK
- `LookAudience` enum on `GatherCardsEffect` — controls who privately sees a
  non-public library look: `Controller` (default; Scry/Surveil/look-at-top-N),
  `Opponent` ("an opponent looks at the top N of your library"), or `None`
  (no auto-reveal; a downstream decision is the only window). Additive and
  default-compatible — no change to existing reveals. Doc + golden updated.

## Cards
- **Goldberry, River-Daughter** — counter-moving activated abilities
- **One Ring to Rule Them All** — Saga (Ring tempt + mill, board wipe, drain)
- **Sauron's Ransom** — concealed-pile divvy (CR 700.3) via masking alone
- **Hew the Entwood** — sacrifice lands, reveal X, deploy artifacts/lands
- **Sauron, the Dark Lord** — ward, amass, Army-damage Ring tempt
- **Saruman of Many Colors** — second-spell mill + reflexive exile/copy/cast
- **Sharkey, Tyrant of the Shire** — opponent-land ability lock + steal
- **Tom Bombadil** — lore-count static + final-chapter Saga recursion
- **Bewitching Leechcraft** — Aura, remove-counter-to-untap replacement

Every card composes existing primitives; no new card-specific Effect types.

## Tests
Per-card scenario tests (game-server/rules-engine), exercising the cited rule
corners (707.10a copy SBA, 700.3 piles, MV-≤ targeting, once-per-turn, etc.),
plus `LookAudienceOpponentScenarioTest`. Snapshot + lint nets re-blessed. All green.
