### PR TITLE
Add four DSK creatures + conditional self-graveyard-cast feature

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2937,7 +2937,20 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   `filter` from your graveyard following normal timing, optionally paying `lifeCost` life. Free for
   Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1, duringYourTurnOnly = true` for
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
-  your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
+  your graveyard". Lands are *played*, not cast, so they need the lands permission separately. This
+  grants permission over *other* cards in your graveyard from a battlefield permanent — for a card
+  that grants permission to cast *itself* from a zone, use `MayCastSelfFromZones`.
+- `MayCastSelfFromZones(zones, condition = null)` — intrinsic *self* permission: this card may be
+  cast from any of `zones` (graveyard/exile) following normal timing and for its normal mana cost.
+  Squee, the Immortal = `MayCastSelfFromZones(listOf(GRAVEYARD, EXILE))`. When `condition` is
+  non-null the permission is **gated**: it is available only while the condition holds, evaluated in
+  the casting player's context at cast-legality time *and* re-checked when the cast is authorized
+  (so it can't outlive the permission). Undead Sprinter (DSK) = `MayCastSelfFromZones(listOf(GRAVEYARD),
+  condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))` for "You may cast this card
+  from your graveyard if a non-Zombie creature died this turn." Pair with an
+  `EntersWithCounters(selfOnly = true, condition = Conditions.WasCastFromGraveyard)` rider to model
+  "if you do, this creature enters with a +1/+1 counter on it" — the counter is tied to the
+  graveyard cast (`CastFromGraveyardComponent` stamped on resolution), not to the gate condition.
 - `GrantWarpToCardsInHand(filter, cost)` — cards in the controller's hand matching `filter` gain
   warp (CR 702.185) with mana cost `cost`. Behaves identically to a printed warp keyword: surfaces a
   "Cast (Warp)" legal action, marks `wasWarped` on resolution, and the post-resolution permanent is
@@ -3721,6 +3734,16 @@ default to "you" so card authors don't need to pass it explicitly.
 - `ControlledCreatureDiedThisTurn` — intervening-if "if a creature died **under your control** this
   turn", scoped to the source's controller (reads only that player's `CreaturesDiedThisTurnComponent`).
   Used by Barrensteppe Siege (Mardu). Dual-mode.
+- `SubtypeCreatureDiedThisTurn(subtype)` / `NonSubtypeCreatureDiedThisTurn(subtype)` — **global**,
+  subtype-filtered death gates. Backed by `CreatureSubtypesDiedThisTurnComponent`, which records one
+  entry per death holding the dying creature's **last-known subtypes** (captured from projected state
+  at the moment it left the battlefield, CR 603.10), so a creature whose types change after death is
+  still recorded by the subtypes it had as it died. `SubtypeCreatureDiedThisTurn(Subtype.GOBLIN)` is
+  true iff some dead creature *had* Goblin; `NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE)` is true
+  iff some dead creature *lacked* Zombie (note the asymmetry — a turn in which only Zombies died does
+  not satisfy the non-Zombie form; a Zombie + a Human both dying satisfies both forms). Used by Undead
+  Sprinter (DSK): "if a non-Zombie creature died this turn". Dual-mode. The underlying SDK condition
+  is `CreatureWithSubtypeDiedThisTurn(subtype, present)`. Cleared at end of turn by `CleanupPhaseManager`.
 - `YouHadPermanentLeaveBattlefieldThisTurn` — intervening-if "if a permanent you controlled left
   the battlefield this turn". Per-player, scoped to the source's controller. Counts every permanent
   type (creatures, lands, artifacts, enchantments, planeswalkers) and includes tokens — broader

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1134,6 +1134,21 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.ControlledCreatureDiedThisTurnCondition
 
     /**
+     * "if a [subtype] creature died this turn" — global, matched against each dying creature's
+     * last-known subtypes. Used for "a Goblin died this turn"-style gates.
+     */
+    fun SubtypeCreatureDiedThisTurn(subtype: Subtype): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.CreatureWithSubtypeDiedThisTurn(subtype.value, present = true)
+
+    /**
+     * "if a non-[subtype] creature died this turn" — global, satisfied when at least one creature
+     * that died this turn did *not* have [subtype] among its last-known subtypes. Used by Undead
+     * Sprinter (DSK): "if a non-Zombie creature died this turn".
+     */
+    fun NonSubtypeCreatureDiedThisTurn(subtype: Subtype): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.CreatureWithSubtypeDiedThisTurn(subtype.value, present = false)
+
+    /**
      * Intervening-if: "if a permanent you controlled left the battlefield this turn".
      * Per-player (scoped to the source's controller), counts every permanent type
      * including lands and tokens — broader than [CreatureDiedThisTurn]/[ControlledCreatureDiedThisTurn].

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -357,16 +357,35 @@ data object OpponentsPlayWithHandsRevealed : StaticAbility {
  * This is an intrinsic property of the card, checked when the card is in a matching zone.
  * Used for Squee, the Immortal (graveyard + exile).
  *
- * @property zones The zones from which this card may be cast
+ * When [condition] is non-null the self-cast permission is *gated*: the card may be cast from a
+ * matching zone only while the condition holds. The condition is evaluated in the casting player's
+ * context at cast-legality time (and re-checked when the cast is authorized), so a condition that
+ * stops holding immediately revokes the permission. Used by Undead Sprinter (DSK): "You may cast
+ * this card from your graveyard if a non-Zombie creature died this turn" —
+ * `MayCastSelfFromZones(listOf(Zone.GRAVEYARD), condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))`.
+ *
+ * Normal timing rules still apply — a creature with no flash is castable this way only at sorcery
+ * speed, on the player's turn with an empty stack. The card is cast for its normal mana cost.
+ *
+ * @property zones The zones from which this card may be cast.
+ * @property condition Optional gate; null = always available (the Squee shape).
  */
 @SerialName("MayCastSelfFromZones")
 @Serializable
 data class MayCastSelfFromZones(
-    val zones: List<Zone>
+    val zones: List<Zone>,
+    val condition: Condition? = null
 ) : StaticAbility {
-    override val description: String = "You may cast this card from ${
-        zones.joinToString(" or ") { it.displayName }
-    }."
+    override val description: String = buildString {
+        append("You may cast this card from ${zones.joinToString(" or ") { it.displayName }}")
+        if (condition != null) append(" ${condition.description}")
+        append(".")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newCondition !== condition) copy(condition = newCondition) else this
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -350,6 +350,43 @@ data object ControlledCreatureDiedThisTurnCondition : Condition {
 }
 
 /**
+ * Condition: "if a creature with (or without) the subtype [subtype] died this turn".
+ *
+ * A filtered, subtype-scoped sibling of [CreatureDiedThisTurnCondition]. Global — satisfied by a
+ * matching creature dying under any player's control. Evaluated against each dying creature's
+ * **last-known subtypes** (the subtypes it had as it died, per CR 603.10 / last-known information),
+ * not any creature's current state, so a Zombie that loses its types after death still counts as a
+ * Zombie death.
+ *
+ *  - [present] = true  → "a [subtype] creature died this turn" (some dead creature *had* the subtype).
+ *  - [present] = false → "a non-[subtype] creature died this turn" (some dead creature *lacked* it).
+ *
+ * Note the asymmetry that makes the [present] = false form correct for negated wording: it is true
+ * iff *at least one* creature that died this turn did not have [subtype]. A turn in which only
+ * Zombies died does not satisfy `present = false`, while a turn in which a Zombie and a Human both
+ * died satisfies both forms.
+ *
+ * Backed by the per-player [com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent]
+ * (one entry per death, the dying creature's last-known subtype set), cleared at end of turn.
+ *
+ *  - Undead Sprinter (DSK): `CreatureWithSubtypeDiedThisTurn(Subtype.ZOMBIE.value, present = false)`
+ *    gates its conditional cast-from-graveyard permission ("if a non-Zombie creature died this turn").
+ *
+ * @property subtype The creature subtype to test for, stored as its raw string (e.g. "Zombie").
+ * @property present Whether a creature *with* the subtype (true) or *without* it (false) must have died.
+ */
+@SerialName("CreatureWithSubtypeDiedThisTurn")
+@Serializable
+data class CreatureWithSubtypeDiedThisTurn(
+    val subtype: String,
+    val present: Boolean = true
+) : Condition {
+    override val description: String =
+        if (present) "if a $subtype creature died this turn"
+        else "if a non-$subtype creature died this turn"
+}
+
+/**
  * Intervening-if condition: "if a permanent [player] controlled left the battlefield this turn".
  *
  * True when [player]'s `PermanentLeftBattlefieldThisTurnComponent` has count > 0. Counts

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Anthropede.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Anthropede.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anthropede
+ * {3}{G}
+ * Creature — Insect
+ * 3/4
+ * Reach
+ * When this creature enters, you may discard a card or pay {2}. When you do, destroy target Room.
+ *
+ * The enters trigger is an optional "you may [discard a card or pay {2}]" action; if taken, a
+ * reflexive trigger ("When you do, …") goes on the stack and targets a Room (CR 603.2c — the
+ * target is chosen as the reflexive trigger is put on the stack, not when the enters trigger
+ * resolves). Same shape as Nimble Hobbit (sacrifice-or-pay → reflexive tap). Reuses
+ * [ChooseActionEffect] for the two-way cost choice and [ReflexiveTriggerEffect] for the deferred
+ * targeted destroy.
+ */
+val Anthropede = card("Anthropede") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    oracleText = "Reach\nWhen this creature enters, you may discard a card or pay {2}. " +
+        "When you do, destroy target Room."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            // "you may discard a card or pay {2}"
+            action = ChooseActionEffect(
+                choices = listOf(
+                    EffectChoice(
+                        label = "Discard a card",
+                        effect = Patterns.Hand.discardCards(1),
+                        feasibilityCheck = FeasibilityCheck.HasCardsInZone(Zone.HAND)
+                    ),
+                    EffectChoice(
+                        label = "Pay {2}",
+                        effect = PayManaCostEffect(ManaCost.parse("{2}"))
+                    )
+                )
+            ),
+            optional = true,
+            // "When you do, destroy target Room."
+            reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(
+                TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype("Room")))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Loïc Canavaggia"
+        flavorText = "The touch of its many hands is almost gentle, at first. " +
+            "But then the grip tightens, and the mandibles dig in."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg?1726286480"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BashfulBeastie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BashfulBeastie.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bashful Beastie
+ * {4}{G}
+ * Creature — Beast
+ * 5/4
+ * When this creature dies, manifest dread. (Look at the top two cards of your library. Put one
+ * onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face
+ * up any time for its mana cost if it's a creature card.)
+ *
+ * Dies-trigger flavor of the shared [Patterns.Library.manifestDread] recipe (CR 701.62b).
+ */
+val BashfulBeastie = card("Bashful Beastie") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "When this creature dies, manifest dread. (Look at the top two cards of your " +
+        "library. Put one onto the battlefield face down as a 2/2 creature and the other into your " +
+        "graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
+    power = 5
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.manifestDread()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Aaron Miller"
+        flavorText = "No one knows what hides beneath the beasties' masks."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg?1726286489"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InnocuousRat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/InnocuousRat.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Innocuous Rat
+ * {1}{B}
+ * Creature — Rat
+ * 1/1
+ * When this creature dies, manifest dread. (Look at the top two cards of your library. Put one
+ * onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face
+ * up any time for its mana cost if it's a creature card.)
+ *
+ * Dies-trigger flavor of the shared [Patterns.Library.manifestDread] recipe (CR 701.62b).
+ */
+val InnocuousRat = card("Innocuous Rat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "When this creature dies, manifest dread. (Look at the top two cards of your " +
+        "library. Put one onto the battlefield face down as a 2/2 creature and the other into your " +
+        "graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.manifestDread()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg?1726286232"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UndeadSprinter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UndeadSprinter.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Undead Sprinter
+ * {B}{R}
+ * Creature — Zombie
+ * 2/2
+ * Trample, haste
+ * You may cast this card from your graveyard if a non-Zombie creature died this turn.
+ * If you do, this creature enters with a +1/+1 counter on it.
+ */
+val UndeadSprinter = card("Undead Sprinter") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "Trample, haste\nYou may cast this card from your graveyard if a non-Zombie creature died this turn. If you do, this creature enters with a +1/+1 counter on it."
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    // "You may cast this card from your graveyard if a non-Zombie creature died this turn."
+    // A self-referential, conditional cast-from-graveyard permission. The card grants itself
+    // permission to be cast from its own graveyard, gated on the global death tracker. Normal
+    // (sorcery-speed) timing and the {B}{R} mana cost still apply.
+    staticAbility {
+        ability = MayCastSelfFromZones(
+            zones = listOf(Zone.GRAVEYARD),
+            condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE)
+        )
+    }
+
+    // "If you do, this creature enters with a +1/+1 counter on it." The counter rider is tied to
+    // the graveyard cast — it only applies when this creature was cast from the graveyard, not when
+    // cast normally from hand.
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 1,
+            selfOnly = true,
+            condition = Conditions.WasCastFromGraveyard
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "Nino Vecia"
+        flavorText = "Farley had always been the fastest on the track team. But no one was cheering anymore."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg?1726286754"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -43,6 +43,115 @@
     ]
 }
 
+// Anthropede
+{
+    "name": "Anthropede",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Reach\nWhen this creature enters, you may discard a card or pay {2}. When you do, destroy target Room.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "ChooseAction",
+                        "choices": [
+                            {
+                                "label": "Discard a card",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "HasCardsInZone",
+                                    "zone": "Hand"
+                                }
+                            },
+                            {
+                                "label": "Pay {2}",
+                                "effect": {
+                                    "type": "PayManaCost",
+                                    "cost": "{2}"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent Room"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "The touch of its many hands is almost gentle, at first. But then the grip tightens, and the mandibles dig in.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg?1726286480"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Appendage Amalgam
 {
     "name": "Appendage Amalgam",
@@ -365,6 +474,87 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "GREEN"
+    ]
+}
+
+// Bashful Beastie
+{
+    "name": "Bashful Beastie",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Aaron Miller",
+        "flavorText": "No one knows what hides beneath the beasties' masks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg?1726286489"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }
@@ -3447,6 +3637,86 @@
     ]
 }
 
+// Innocuous Rat
+{
+    "name": "Innocuous Rat",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "When this creature dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg?1726286232"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Inquisitive Glimmer
 {
     "name": "Inquisitive Glimmer",
@@ -6502,6 +6772,59 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Undead Sprinter
+{
+    "name": "Undead Sprinter",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Trample, haste\nYou may cast this card from your graveyard if a non-Zombie creature died this turn. If you do, this creature enters with a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "MayCastSelfFromZones",
+                "zones": [
+                    "Graveyard"
+                ],
+                "condition": {
+                    "type": "CreatureWithSubtypeDiedThisTurn",
+                    "subtype": "Zombie",
+                    "present": false
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "WasCastFromZone",
+                    "zone": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "RARE",
+        "artist": "Nino Vecia",
+        "flavorText": "Farley had always been the fastest on the track team. But no one was cheering anymore.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg?1726286754"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -77,6 +77,13 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // graveyard trigger (Reach for the Sky's "draw a card"). Maps to Triggers.PutIntoGraveyardFromBattlefield;
     // only the SELF (ThisPermanent), any-player shape renders (anything else scaffolds).
     supported("WhenAPermanentIsPutIntoAPlayersGraveyard", "trigger: this permanent put into a graveyard from the battlefield (Triggers.PutIntoGraveyardFromBattlefield)")
+    // "You may cast this card from your graveyard if [condition]. If you do, it enters with a +1/+1
+    // counter." (Undead Sprinter, DSK) — a conditional self-cast-from-graveyard permission with a
+    // cast-this-way counter rider. Maps to staticAbility { ability = MayCastSelfFromZones(Zone.GRAVEYARD,
+    // condition) } + replacementEffect(EntersWithCounters(selfOnly = true, condition = WasCastFromGraveyard)).
+    // The emitter renders ONLY the exact MayCastGraveyardCardWithEnterActions(self, [+1/+1]) body gated by a
+    // nameable died-this-turn condition; any other body/condition scaffolds, so this is the gate.
+    supported("FromGraveyardIf", "rule: conditional self-cast from graveyard + cast-this-way +1/+1 rider (MayCastSelfFromZones(condition) + EntersWithCounters(WasCastFromGraveyard))")
 
     // Intervening-if conditions (CR 603.4) gating a TriggerI, plus the Mount "while saddled" gate. The
     // emitter renders the recognised shapes to `triggerCondition = Conditions.*`; an unrenderable

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2376,7 +2376,7 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
         val bareCreature = filter?.strField("_Permanents") == "IsCardtype" &&
             filter.field("args").asStr() == "Creature"
         if (bareCreature) return "Conditions.CreatureDiedThisTurn"
-        // And(IsCardtype Creature, ControlledByAPlayer You) — "a creature died under your control".
+        // And(IsCardtype Creature, …) — a creature death narrowed by a second clause.
         if (filter?.strField("_Permanents") == "And") {
             val arms = filter["args"].asArr?.filterIsInstance<JsonObject>().orEmpty()
             val hasCreature = arms.any {
@@ -2387,6 +2387,17 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
             }
             if (arms.size == 2 && hasCreature && controlledByYou) {
                 return "Conditions.ControlledCreatureDiedThisTurn"
+            }
+            // "a non-<subtype> creature died this turn" — And(IsNonCreatureType <sub>, IsCardtype Creature)
+            // (Undead Sprinter: "if a non-Zombie creature died this turn"). The negated creature subtype
+            // maps to Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.<SUB>); the positive form
+            // (IsCreatureType) maps to SubtypeCreatureDiedThisTurn. Only the bare two-arm shape (the
+            // subtype clause + the Creature cardtype, nothing else) renders; any extra clause declines.
+            if (arms.size == 2 && hasCreature) {
+                val negSub = arms.firstOrNull { it.strField("_Permanents") == "IsNonCreatureType" }?.field("args").asStr()
+                if (negSub != null) return "Conditions.NonSubtypeCreatureDiedThisTurn(${subtypeArg(negSub)})"
+                val posSub = arms.firstOrNull { it.strField("_Permanents") == "IsCreatureType" }?.field("args").asStr()
+                if (posSub != null) return "Conditions.SubtypeCreatureDiedThisTurn(${subtypeArg(posSub)})"
             }
         }
         return null
@@ -3351,6 +3362,78 @@ internal fun EmitCtx.fromGraveyardBlock(rule: JsonObject): List<Stmt>? {
         "Activated", "ActivatedWithModifiers" -> activatedBlock(inner, activateFromZone = "Zone.GRAVEYARD")
         else -> { reasons.add("FromGraveyard"); return null }
     }
+}
+
+/**
+ * `FromGraveyardIf(condition, PlayerEffect(You, [MayCastGraveyardCardWithEnterActions(ThisGraveyardCard,
+ *   [EntersWithACounter PTCounter[1,1]])]))` -> the conditional self-cast-from-graveyard static ability
+ * plus the cast-this-way +1/+1-counter rider (Undead Sprinter, DSK).
+ *
+ * `FromGraveyardIf(ACreatureOrPlaneswalkerDiedThisTurn(And[IsNonCreatureType Zombie, IsCardtype Creature]),
+ *   PlayerEffect(You, [MayCastGraveyardCardWithEnterActions(ThisGraveyardCard,
+ *     [EntersWithACounter PTCounter[1,1]])]))`
+ * →
+ * ```
+ * staticAbility {
+ *     ability = MayCastSelfFromZones(
+ *         zones = listOf(Zone.GRAVEYARD),
+ *         condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))
+ * }
+ * replacementEffect(EntersWithCounters(count = 1, selfOnly = true, condition = Conditions.WasCastFromGraveyard))
+ * ```
+ *
+ * "You may cast this card from your graveyard if [condition]. If you do, it enters with a +1/+1 counter."
+ * The graveyard-cast permission is a gated [MayCastSelfFromZones] over `Zone.GRAVEYARD`; the "enter with a
+ * counter" is the *cast-this-way* rider, modeled as a self-only [EntersWithCounters] gated on
+ * `Conditions.WasCastFromGraveyard` (it applies only when this creature was cast from the graveyard, not
+ * when cast normally from hand). Renders ONLY this exact shape — a `FromGraveyardIf` whose body is the
+ * You-scoped `MayCastGraveyardCardWithEnterActions(ThisGraveyardCard, [+1/+1 enter counter])`, gated by a
+ * died-this-turn condition the intervening-if recovery can name — and only when the +1/+1 counter is the
+ * lone enter flag; anything else (a different enter action, a non-self graveyard card, an unrecoverable
+ * condition) declines (-> SCAFFOLD).
+ */
+internal fun EmitCtx.fromGraveyardIfBlock(rule: JsonObject): List<Stmt>? {
+    fun bail(): List<Stmt>? { reasons.add("FromGraveyardIf"); return null }
+    val args = rule["args"].asArr ?: return bail()
+    if (args.size != 2) return bail()
+    // 1. The gate condition (e.g. "a non-Zombie creature died this turn"), via the shared intervening-if
+    //    recovery — declines if the condition can't be named exactly (never a dropped/guessed gate).
+    val condNode = args.getOrNull(0) as? JsonObject ?: return bail()
+    val condition = singleInterveningIfDsl(condNode) ?: return bail()
+    // 2. The body: PlayerEffect(You, [ MayCastGraveyardCardWithEnterActions(ThisGraveyardCard, [...]) ]).
+    val player = args.getOrNull(1) as? JsonObject ?: return bail()
+    if (player.strField("_Rule") != "PlayerEffect") return bail()
+    val peArgs = player["args"].asArr ?: return bail()
+    if (!jsonContains(peArgs.getOrNull(0), "_Player", "You")) return bail()
+    val effects = (peArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return bail()
+    val cast = effects.singleOrNull()
+        ?.takeIf { it.strField("_PlayerEffect") == "MayCastGraveyardCardWithEnterActions" } ?: return bail()
+    val castArgs = cast["args"].asArr ?: return bail()
+    // The card cast must be THIS card from its own graveyard (a self-recursion permission).
+    if (!jsonContains(castArgs.getOrNull(0), "_GraveyardCard", "ThisGraveyardCard")) return bail()
+    // 3. The enter actions must be exactly one EntersWithACounter PTCounter[1,1] (+1/+1).
+    val enterActions = (castArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return bail()
+    val enterCounter = enterActions.singleOrNull()
+        ?.takeIf { it.strField("_EnterFlag") == "EntersWithACounter" } ?: return bail()
+    val ptCounter = enterCounter["args"] as? JsonObject
+    val pt = ptCounter?.takeIf { it.strField("_CounterType") == "PTCounter" }?.get("args").asArr
+    if (pt?.getOrNull(0).asInt() != 1 || pt?.getOrNull(1).asInt() != 1) return bail()
+
+    val static = staticAbilityStmt(call(
+        "MayCastSelfFromZones",
+        arg("zones", call("listOf", arg("Zone.GRAVEYARD"))),
+        arg("condition", Lit(condition)),
+    ))
+    val replacement = Eval(call(
+        "replacementEffect",
+        arg(call(
+            "EntersWithCounters",
+            arg("count", "1"),
+            arg("selfOnly", "true"),
+            arg("condition", Lit("Conditions.WasCastFromGraveyard")),
+        )),
+    ))
+    return listOf(static, replacement)
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -168,6 +168,7 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     counterUnlessPaysEffect(actions)?.let { return it }
     counterUnlessPaysWithRiderEffect(actions)?.let { return it }
     mayCostReflexiveDamageEffect(actions)?.let { return it }
+    mayCostReflexiveDestroyRoomEffect(actions)?.let { return it }
     erodeDestroyControllerFetchEffect(actions)?.let { return it }
     heatedArgumentExileRiderEffect(actions)?.let { return it }
     manaSculptCounterWizardManaEffect(actions)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -205,6 +205,14 @@ object Emitter {
                 rname == "AbilitiesTriggerAnAdditionalTime" -> block = ctx.additionalSourceTriggersBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
+                // "You may cast this from your graveyard if [condition]. If you do, it enters with a +1/+1
+                // counter." (Undead Sprinter) — a conditional self-cast permission + cast-this-way counter
+                // rider. Only the exact MayCastGraveyardCardWithEnterActions(self, [+1/+1]) shape gated by a
+                // nameable died-this-turn condition renders; anything else scaffolds with `FromGraveyardIf`.
+                rname == "FromGraveyardIf" -> {
+                    block = ctx.fromGraveyardIfBlock(rule)
+                    if (block == null) { gap(rname)?.let { return it }; continue }
+                }
                 rname == "FromHand" -> block = ctx.fromHandBlock(rule)
                 // A `FromStack` rule wraps a cast trigger that fires while the spell is still on the
                 // stack (Infusion copy — Lumaret's Favor). Only the exact Infusion-copy shape renders;

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
@@ -10,10 +10,12 @@ import com.wingedsheep.tooling.coverage.RawLine
 import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.Sub
 import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
@@ -635,6 +637,120 @@ internal fun EmitCtx.mayCostReflexiveDamageEffect(actions: List<JsonObject>): Ds
         )),
         arg("reflexiveTargetRequirements", call("listOf", arg(reflexiveTarget))),
     )
+}
+
+/**
+ * Anthropede — the "you may [discard a card or pay {N}]. When you do, [reflexive effect targeting]"
+ * idiom, the two-way-cost sibling of [mayCostReflexiveDamageEffect]. mtgish models it as two sibling
+ * actions inside the ETB triggered ability, where the optional cost is an `Or` of two payment options:
+ *
+ * `[ MayCost(Or[ DiscardACard, PayMana {N} ]),
+ *    If(CostWasPaid)[ ReflexiveTrigger(Targeted([TargetPermanent IsEnchantmentType:Room],
+ *        ActionList[ DestroyPermanent Ref_TargetPermanent ])) ] ]`
+ * →
+ * ```
+ * ReflexiveTriggerEffect(
+ *     action = ChooseActionEffect(choices = listOf(
+ *         EffectChoice("Discard a card", Patterns.Hand.discardCards(1),
+ *             feasibilityCheck = FeasibilityCheck.HasCardsInZone(Zone.HAND)),
+ *         EffectChoice("Pay {N}", PayManaCostEffect(ManaCost.parse("{N}"))))),
+ *     optional = true,
+ *     reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+ *     reflexiveTargetRequirements = listOf(<reflexive Room target>))
+ * ```
+ *
+ * The "you may [discard / pay]" is a resolution-time CHOICE between two payments (not a target), so it's a
+ * `ChooseActionEffect` with one [EffectChoice] per arm; the discard arm carries the `HasCardsInZone(HAND)`
+ * feasibility check (you can't choose to discard with an empty hand). The "When you do" reflexive trigger
+ * then chooses its own target as it goes on the stack (`ContextTarget(0)`). Renders ONLY this exact shape —
+ * a two-arm `Or[DiscardACard, PayMana]` optional cost, a `CostWasPaid`-gated single reflexive trigger whose
+ * sole action is destroying its chosen Room target — and only when the reflexive Room target round-trips;
+ * anything else declines (-> SCAFFOLD).
+ */
+internal fun EmitCtx.mayCostReflexiveDestroyRoomEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (mayCost, ifPaid) = actions
+    if (mayCost.strField("_Action") != "MayCost") return null
+    // The optional cost must be exactly Or[ DiscardACard, PayMana {N} ] — a two-arm choice between
+    // discarding a card and paying a fixed mana amount (no filter on the discard, no other arm).
+    val cost = mayCost["args"] as? JsonObject ?: return null
+    if (cost.strField("_Cost") != "Or") return null
+    val arms = cost["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    if (arms.size != 2) return null
+    val discardArm = arms.firstOrNull { it.strField("_Cost") == "DiscardACard" } ?: return null
+    // The bare "discard a card" cost carries no filter/count args — anything richer declines.
+    if (discardArm["args"] != null) return null
+    val payArm = arms.firstOrNull { it.strField("_Cost") == "PayMana" } ?: return null
+    val mana = renderMana(payArm["args"])
+    if (mana.isBlank() || "{?}" in mana) return null
+
+    // The gate must be exactly If(CostWasPaid)[ ReflexiveTrigger(...) ] — no else-branch.
+    if (ifPaid.strField("_Action") != "If") return null
+    val ifArgs = ifPaid["args"].asArr ?: return null
+    if (!jsonContains(ifArgs.getOrNull(0), "_Condition", "CostWasPaid") || ifArgs.getOrNull(2) != null) return null
+    val reflexive = (ifArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+        ?.singleOrNull()?.takeIf { it.strField("_Action") == "ReflexiveTrigger" } ?: return null
+
+    // The reflexive trigger's Targeted envelope: a single Room target, one DestroyPermanent action.
+    val (rTargets, rActions) = extractEnvelope(reflexive)
+    val reflexiveTargetNode = rTargets?.singleOrNull() ?: return null
+    val reflexiveTarget = enchantmentSubtypeTargetExpr(reflexiveTargetNode) ?: return null
+    val destroy = rActions?.singleOrNull()?.takeIf { it.strField("_Action") == "DestroyPermanent" } ?: return null
+    // The destroyed permanent is the reflexive trigger's chosen target (Ref_TargetPermanent).
+    if (!jsonContains(destroy["args"], "_Permanent", "Ref_TargetPermanent")) return null
+
+    val action = call(
+        "ChooseActionEffect",
+        arg("choices", call(
+            "listOf",
+            arg(call(
+                "EffectChoice",
+                arg(Lit("\"Discard a card\"")),
+                arg(call("Patterns.Hand.discardCards", arg("1"))),
+                arg("feasibilityCheck", Lit("FeasibilityCheck.HasCardsInZone(Zone.HAND)")),
+            )),
+            arg(call(
+                "EffectChoice",
+                arg(Lit("\"Pay $mana\"")),
+                arg(call("PayManaCostEffect", arg(Lit("ManaCost.parse(\"$mana\")")))),
+            )),
+        )),
+    )
+    return call(
+        "ReflexiveTriggerEffect",
+        arg("action", action),
+        arg("optional", Lit("true")),
+        arg("reflexiveEffect", call("Effects.Destroy", arg(Lit("EffectTarget.ContextTarget(0)")))),
+        arg("reflexiveTargetRequirements", call("listOf", arg(reflexiveTarget))),
+    )
+}
+
+/**
+ * A `TargetPermanent` whose only restriction is a single enchantment subtype (`IsEnchantmentType:<sub>`,
+ * e.g. "target Room") -> `TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype(
+ * <sub>)))`. The generic [targetExpr] declines a bare enchantment-subtype permanent target (it has no
+ * single GameObjectFilter for it and refuses to widen to "any enchantment"); this narrow helper recovers
+ * exactly the permanent-with-subtype shape the hand-authored card uses. Only the lone subtype renders — a
+ * count, controller clause, self-exclusion, or any other predicate declines (-> SCAFFOLD).
+ */
+private fun EmitCtx.enchantmentSubtypeTargetExpr(tnode: JsonObject): Dsl? {
+    if (tnode.strField("_Target") != "TargetPermanent") return null
+    val args = tnode["args"]
+    val subs = args.argWordsTagged("IsEnchantmentType")
+    if (subs.size != 1) return null
+    val blob = compact(args)
+    // Reject anything beyond the bare enchantment-subtype clause so a dropped restriction never widens
+    // the target (no controller scope, no count, no self-exclusion, no other type/predicate).
+    val extras = listOf(
+        "ControlledByAPlayer", "Other", "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking",
+        "PowerIs", "ToughnessIs", "ManaValueIs", "ManaValueAtMost", "ManaValueAtLeast", "IsColor",
+        "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken", "IsToken", "IsSupertype",
+        "IsNonSupertype", "IsCardtype", "IsNonCardtype", "IsCreatureType", "IsNonCreatureType",
+        "IsArtifactType", "IsLandType", "HasACounterOfType",
+    )
+    if (extras.any { it in blob }) return null
+    val base = Lit("GameObjectFilter.Permanent").dot("withSubtype", arg(subtypeArg(subs[0])))
+    return call("TargetPermanent", arg("filter", call("TargetFilter", arg(base))))
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -589,6 +589,9 @@ class CleanupPhaseManager(
                 if (result.has<CreaturesDiedThisTurnComponent>()) {
                     result = result.without<CreaturesDiedThisTurnComponent>()
                 }
+                if (result.has<com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent>()) {
+                    result = result.without<com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent>()
+                }
                 if (result.has<PermanentLeftBattlefieldThisTurnComponent>()) {
                     result = result.without<PermanentLeftBattlefieldThisTurnComponent>()
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -457,6 +457,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CardsLeftGraveyardThisTurnComponent::class)
         subclass(CardsPutIntoExileThisTurnComponent::class)
         subclass(CreaturesDiedThisTurnComponent::class)
+        subclass(CreatureSubtypesDiedThisTurnComponent::class)
         subclass(PermanentLeftBattlefieldThisTurnComponent::class)
         subclass(DamageBonusComponent::class)
         subclass(DamageReceivedThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -117,6 +117,8 @@ import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
 import com.wingedsheep.sdk.scripting.conditions.RingHasTemptedPlayerAtLeast
 import com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition
 import com.wingedsheep.sdk.scripting.conditions.ControlledCreatureDiedThisTurnCondition
+import com.wingedsheep.sdk.scripting.conditions.CreatureWithSubtypeDiedThisTurn
+import com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent
 import com.wingedsheep.sdk.scripting.conditions.SourcePlottedOnPriorTurn
 import com.wingedsheep.engine.handlers.triggers.CreatureDiedThisTurnConditionEvaluator
 import com.wingedsheep.engine.state.components.identity.PlottedComponent
@@ -302,6 +304,16 @@ class ConditionEvaluator(
             // Global facts (no controller/source needed).
             is VoidCondition ->
                 state.nonlandPermanentLeftBattlefieldThisTurn || state.spellWarpedThisTurn
+
+            // Global, subtype-filtered death tracker — matched against each dying creature's
+            // last-known subtypes recorded across every player. present=true: some dead creature
+            // had the subtype; present=false: some dead creature lacked it ("a non-Zombie died").
+            is CreatureWithSubtypeDiedThisTurn -> state.turnOrder.any { playerId ->
+                val died = state.getEntity(playerId)
+                    ?.get<CreatureSubtypesDiedThisTurnComponent>()
+                    ?.diedSubtypeSets.orEmpty()
+                died.any { subtypes -> (condition.subtype in subtypes) == condition.present }
+            }
 
             // Existential over all players: some player has at most [threshold] life.
             // Reads each player's LifeTotalComponent from state.turnOrder.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -133,16 +133,23 @@ class CastZoneResolver(
     ): Boolean {
         val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return false
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return false
-        val mayCastAbility = cardDef.script.staticAbilities
-            .filterIsInstance<MayCastSelfFromZones>()
-            .firstOrNull() ?: return false
 
-        // Find what zone the card is in for this player
-        for (zone in mayCastAbility.zones) {
-            val zoneKey = ZoneKey(playerId, zone)
-            if (cardId in state.getZone(zoneKey)) return true
-        }
-        return false
+        // A permission applies if the card is currently in one of its named zones for this player
+        // AND its optional condition (e.g. Undead Sprinter's "a non-Zombie creature died this turn")
+        // holds — mirroring the enumerator gate so the authorization can't outlive the permission.
+        return cardDef.script.staticAbilities
+            .filterIsInstance<MayCastSelfFromZones>()
+            .any { ability ->
+                val inNamedZone = ability.zones.any { zone ->
+                    cardId in state.getZone(ZoneKey(playerId, zone))
+                }
+                inNamedZone && (ability.condition == null ||
+                    conditionEvaluator.evaluate(
+                        state,
+                        ability.condition!!,
+                        EffectContext(sourceId = cardId, controllerId = playerId)
+                    ))
+            }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CardsPutIntoExileThisTurnComponent
+import com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.NonTokenCreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.OpponentCreaturesExiledThisTurnComponent
@@ -467,6 +468,18 @@ object ZoneTransitionService {
                         ?: NonTokenCreaturesDiedThisTurnComponent()
                     playerContainer.with(NonTokenCreaturesDiedThisTurnComponent(existing.count + 1))
                 }
+            }
+            // Record the dying creature's last-known subtypes (CR 603.10 / last-known information)
+            // so subtype-filtered death conditions can match it (e.g. "a non-Zombie creature died
+            // this turn"). Falls back to the base type line if no projected snapshot was captured.
+            val diedSubtypes = (lastKnownTypeLine ?: cardComponent.typeLine)
+                .subtypes.map { it.value }.toSet()
+            newState = newState.updateEntity(controllerId) { playerContainer ->
+                val existing = playerContainer.get<CreatureSubtypesDiedThisTurnComponent>()
+                    ?: CreatureSubtypesDiedThisTurnComponent()
+                playerContainer.with(
+                    CreatureSubtypesDiedThisTurnComponent(existing.diedSubtypeSets + listOf(diedSubtypes))
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -841,9 +841,21 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 if (zone == Zone.EXILE && cardId in linkedExileCardIds) continue
                 val cardComponent = container.get<CardComponent>() ?: continue
                 val cardDef = context.cardRegistry.getCard(cardComponent.name) ?: continue
+                // The card grants its own cast-from-zone permission only if some MayCastSelfFromZones
+                // names this zone AND its optional condition (e.g. Undead Sprinter's "a non-Zombie
+                // creature died this turn") currently holds in the casting player's context.
                 val hasCastFromZone = cardDef.script.staticAbilities
                     .filterIsInstance<MayCastSelfFromZones>()
-                    .any { zone in it.zones }
+                    .any { ability ->
+                        zone in ability.zones && (ability.condition == null ||
+                            context.conditionEvaluator.evaluate(
+                                state,
+                                ability.condition!!,
+                                com.wingedsheep.engine.handlers.EffectContext(
+                                    sourceId = cardId, controllerId = playerId
+                                )
+                            ))
+                    }
                 if (!hasCastFromZone) continue
 
                 // Only non-land spells (Squee is a creature)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -714,6 +714,25 @@ data class CreaturesDiedThisTurnComponent(
 ) : Component
 
 /**
+ * Records the last-known subtypes of each creature that died under this player's control during
+ * the current turn — one [diedSubtypeSets] entry per death, in death order. Subtypes are stored
+ * as their raw strings (e.g. "Zombie"), captured from the dying creature's projected type line at
+ * the moment it left the battlefield (CR 603.10 / last-known information), so a creature that loses
+ * its types after death is still recorded with the subtypes it had as it died.
+ *
+ * Cleared at end of turn by CleanupPhaseManager alongside [CreaturesDiedThisTurnComponent].
+ *
+ * Backs the subtype-filtered death conditions
+ * ([com.wingedsheep.sdk.scripting.conditions.CreatureWithSubtypeDiedThisTurn]): "a Goblin died this
+ * turn" / "a non-Zombie creature died this turn" (Undead Sprinter, DSK). Summed across all players
+ * this gives the game-wide record, since the condition is global.
+ */
+@Serializable
+data class CreatureSubtypesDiedThisTurnComponent(
+    val diedSubtypeSets: List<Set<String>> = emptyList()
+) : Component
+
+/**
  * Tracks the number of permanents — of any type, token or nontoken — that left the
  * battlefield this turn while under this player's control. Credited to the last-known
  * controller at the moment of departure (so a Threaten-style steal-and-sacrifice

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnthropedeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnthropedeScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Anthropede (DSK #167) — {3}{G} Creature — Insect 3/4, Reach.
+ *
+ * "When this creature enters, you may discard a card or pay {2}. When you do, destroy target Room."
+ *
+ * The enters trigger is an optional `ReflexiveTriggerEffect`: the action is a two-way
+ * `ChooseActionEffect` (discard a card / pay {2}); taking it queues a reflexive trigger that
+ * targets and destroys a Room. Exercises the may-decline path, the discard branch, and that the
+ * reflexive trigger actually destroys the chosen Room.
+ */
+class AnthropedeScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Resolve the cast spell + ETB reflexive trigger until we hit the optional "you may" decision.
+    fun GameTestDriver.advanceToMayDecision(p1: EntityId) {
+        var guard = 0
+        while (guard++ < 20) {
+            if (pendingDecision is YesNoDecision) return
+            if (state.stack.isNotEmpty() || state.priorityPlayerId != null) bothPass() else break
+        }
+    }
+
+    test("discard a card to destroy a target Room") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        driver.giveMana(p1, Color.GREEN, 4)
+
+        // A Room belonging to the opponent to be destroyed.
+        val room = driver.putPermanentOnBattlefield(driver.player2, "Unholy Annex // Ritual Chamber")
+        // A spare hand card to discard for the cost.
+        driver.putCardInHand(p1, "Forest")
+
+        val anthropede = driver.putCardInHand(p1, "Anthropede")
+        driver.castSpell(p1, anthropede)
+        driver.advanceToMayDecision(p1)
+
+        // The optional "you may discard a card or pay {2}" decision.
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+        driver.submitYesNo(p1, true)
+
+        // Choose the "Discard a card" option.
+        val choose = driver.pendingDecision as ChooseOptionDecision
+        val discardIdx = choose.options.indexOfFirst { it.contains("Discard", ignoreCase = true) }
+        driver.submitDecision(p1, OptionChosenResponse(choose.id, discardIdx))
+
+        // Walk follow-up decisions: discard selection, then the reflexive Room target.
+        var guard = 0
+        while (guard++ < 12) {
+            when (driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(p1, listOf(room))
+                is SelectCardsDecision ->
+                    driver.submitCardSelection(p1, listOf(driver.state.getZone(p1, Zone.HAND).first()))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // The Room is destroyed — no longer on the battlefield.
+        driver.state.getZone(driver.player2, Zone.BATTLEFIELD).contains(room) shouldBe false
+        driver.findPermanent(driver.player2, "Unholy Annex // Ritual Chamber") shouldBe null
+    }
+
+    test("paying {2} also lets you destroy a target Room") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        driver.giveMana(p1, Color.GREEN, 4)   // for casting {3}{G}
+        driver.giveColorlessMana(p1, 2)        // for the "pay {2}" option
+
+        val room = driver.putPermanentOnBattlefield(driver.player2, "Unholy Annex // Ritual Chamber")
+
+        val anthropede = driver.putCardInHand(p1, "Anthropede")
+        driver.castSpell(p1, anthropede)
+        driver.advanceToMayDecision(p1)
+
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+        driver.submitYesNo(p1, true)
+
+        val choose = driver.pendingDecision as ChooseOptionDecision
+        val payIdx = choose.options.indexOfFirst { it.contains("Pay", ignoreCase = true) }
+        driver.submitDecision(p1, OptionChosenResponse(choose.id, payIdx))
+
+        var guard = 0
+        while (guard++ < 12) {
+            when (driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(p1, listOf(room))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        driver.findPermanent(driver.player2, "Unholy Annex // Ritual Chamber") shouldBe null
+    }
+
+    test("declining the may leaves the Room intact") {
+        val driver = newDriver()
+        val p1 = driver.player1
+        driver.giveMana(p1, Color.GREEN, 4)
+
+        driver.putPermanentOnBattlefield(driver.player2, "Unholy Annex // Ritual Chamber")
+
+        val anthropede = driver.putCardInHand(p1, "Anthropede")
+        driver.castSpell(p1, anthropede)
+        driver.advanceToMayDecision(p1)
+
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+        driver.submitYesNo(p1, false)
+
+        var guard = 0
+        while (guard++ < 8 && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The Room survives.
+        driver.findPermanent(driver.player2, "Unholy Annex // Ritual Chamber") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndeadSprinterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndeadSprinterScenarioTest.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.CreatureSubtypesDiedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Undead Sprinter (DSK #237) — {B}{R} 2/2 Creature — Zombie.
+ *
+ * "Trample, haste
+ *  You may cast this card from your graveyard if a non-Zombie creature died this turn.
+ *  If you do, this creature enters with a +1/+1 counter on it."
+ *
+ * Exercises:
+ *  - the conditional self cast-from-graveyard permission
+ *    (`MayCastSelfFromZones(GRAVEYARD, condition = NonSubtypeCreatureDiedThisTurn(ZOMBIE))`),
+ *    gated on the global subtype-filtered death tracker
+ *    ([CreatureSubtypesDiedThisTurnComponent]); and
+ *  - the graveyard-cast-linked +1/+1 counter rider
+ *    (`EntersWithCounters(selfOnly, condition = WasCastFromGraveyard)`).
+ */
+class UndeadSprinterScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun canCastFromGraveyard(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+        return actions.any { it.sourceZone == "GRAVEYARD" && (it.action as? CastSpell)?.cardId == cardId }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Record a single non-Zombie creature death (a Human) under [player]'s control this turn. */
+    fun GameTestDriver.recordNonZombieDeath(player: EntityId) =
+        addComponent(player, CreatureSubtypesDiedThisTurnComponent(listOf(setOf("Human"))))
+
+    /** Record a single Zombie creature death under [player]'s control this turn. */
+    fun GameTestDriver.recordZombieDeath(player: EntityId) =
+        addComponent(player, CreatureSubtypesDiedThisTurnComponent(listOf(setOf("Zombie"))))
+
+    test("a non-Zombie creature died: castable from graveyard, enters 3/3 with a +1/+1 counter, trample+haste") {
+        val d = newDriver()
+        val you = d.player1
+
+        val sprinter = d.putCardInGraveyard(you, "Undead Sprinter")
+        d.recordNonZombieDeath(you)
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+
+        canCastFromGraveyard(d, you, sprinter) shouldBe true
+
+        d.castSpell(you, sprinter)
+        d.bothPass() // resolve onto the battlefield
+
+        val perm = d.findPermanent(you, "Undead Sprinter")!!
+        d.plusOneCounters(perm) shouldBe 1 // 2/2 base + counter = 3/3
+        d.state.projectedState.getPower(perm) shouldBe 3
+        d.state.projectedState.getToughness(perm) shouldBe 3
+        d.state.projectedState.hasKeyword(perm, Keyword.TRAMPLE) shouldBe true
+        d.state.projectedState.hasKeyword(perm, Keyword.HASTE) shouldBe true
+    }
+
+    test("only a Zombie died: NOT castable from graveyard") {
+        val d = newDriver()
+        val you = d.player1
+
+        val sprinter = d.putCardInGraveyard(you, "Undead Sprinter")
+        d.recordZombieDeath(you)
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+
+        canCastFromGraveyard(d, you, sprinter) shouldBe false
+    }
+
+    test("nothing died: NOT castable from graveyard") {
+        val d = newDriver()
+        val you = d.player1
+
+        val sprinter = d.putCardInGraveyard(you, "Undead Sprinter")
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+
+        canCastFromGraveyard(d, you, sprinter) shouldBe false
+    }
+
+    test("an opponent's non-Zombie creature dying also enables the global permission") {
+        val d = newDriver()
+        val you = d.player1
+        val opponent = d.getOpponent(you)
+
+        val sprinter = d.putCardInGraveyard(you, "Undead Sprinter")
+        // Death recorded on the opponent — the condition is global, so it still enables the cast.
+        d.recordNonZombieDeath(opponent)
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+
+        canCastFromGraveyard(d, you, sprinter) shouldBe true
+    }
+
+    test("end-to-end: destroying a real non-Zombie creature records its subtypes and enables the cast") {
+        val d = newDriver()
+        val you = d.player1
+
+        val sprinter = d.putCardInGraveyard(you, "Undead Sprinter")
+        // A real Goblin (Goblin Guide) on the battlefield, killed by Doom Blade → graveyard.
+        val goblin = d.putPermanentOnBattlefield(you, "Goblin Guide")
+        canCastFromGraveyard(d, you, sprinter) shouldBe false // nothing dead yet
+
+        val doomBlade = d.putCardInHand(you, "Doom Blade")
+        d.giveMana(you, Color.BLACK, 2) // {1}{B}
+        d.castSpell(you, doomBlade, targets = listOf(goblin))
+        d.bothPass() // resolve — Goblin Guide is destroyed
+
+        // ZoneTransitionService recorded the dying creature's last-known subtypes.
+        val recorded = d.state.getEntity(you)
+            ?.get<CreatureSubtypesDiedThisTurnComponent>()?.diedSubtypeSets
+        recorded shouldBe listOf(setOf("Goblin", "Scout"))
+
+        // A non-Zombie (Goblin) died, so the graveyard cast is now legal.
+        canCastFromGraveyard(d, you, sprinter) shouldBe true
+    }
+
+    test("cast normally from hand: no +1/+1 counter (stays 2/2)") {
+        val d = newDriver()
+        val you = d.player1
+
+        val sprinter = d.putCardInHand(you, "Undead Sprinter")
+        // A non-Zombie died, proving the counter is tied to the *graveyard* cast, not the death.
+        d.recordNonZombieDeath(you)
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+
+        d.castSpell(you, sprinter)
+        d.bothPass()
+
+        val perm = d.findPermanent(you, "Undead Sprinter")!!
+        d.plusOneCounters(perm) shouldBe 0
+        d.state.projectedState.getPower(perm) shouldBe 2
+        d.state.projectedState.getToughness(perm) shouldBe 2
+    }
+})


### PR DESCRIPTION
Implements four **Duskmourn: House of Horror (DSK)** cards, each via the `add-card` flow with the canonical `CardDefinition` in DSK (the earliest real printing), plus the engine/SDK feature one of them needs and the mtgish-tooling work to auto-generate all four.

## Cards

| Card | Cost | P/T | Notes |
|------|------|-----|-------|
| **Anthropede** | {3}{G} | 3/4 Insect, Reach | ETB: optional "discard a card or pay {2}; when you do, destroy target Room" |
| **Innocuous Rat** | {1}{B} | 1/1 Rat | Dies → manifest dread |
| **Undead Sprinter** | {B}{R} | 2/2 Zombie, Trample, Haste | Conditional self-cast from graveyard + enters-with-counter-if-cast-this-way |
| **Bashful Beastie** | {4}{G} | 5/4 Beast | Dies → manifest dread |

- **Anthropede** composes the existing `ReflexiveTriggerEffect` over a two-way `ChooseActionEffect` (discard / pay {2}), with a Room-subtype reflexive target destroyed via `Effects.Destroy` — same shape as Nimble Hobbit. No new SDK.
- **Innocuous Rat** / **Bashful Beastie** reuse the shared `Patterns.Library.manifestDread()` recipe on a dies trigger. No new SDK.
- **Undead Sprinter** needed new capability (below).

## New engine/SDK capability (Undead Sprinter)

- `MayCastSelfFromZones` gains an optional `condition` gate — the self cast-from-zone permission is available only while the condition holds, evaluated in the casting player's context at both legal-action enumeration and cast authorization (so it can't outlive the gate).
- New **global** conditions `Conditions.SubtypeCreatureDiedThisTurn(subtype)` / `NonSubtypeCreatureDiedThisTurn(subtype)`, backed by a new per-player `CreatureSubtypesDiedThisTurnComponent` that records each dying creature's **last-known subtypes** (CR 603.10), cleared at end of turn. The `non-` form correctly means "at least one dead creature lacked the subtype" (a turn where only Zombies died does not enable the cast).
- The "+1/+1 counter **if cast this way**" rider reuses `EntersWithCounters(selfOnly = true, condition = Conditions.WasCastFromGraveyard)`, tying the counter to the graveyard cast (the `CastFromGraveyardComponent` stamped on resolution) — **not** to the gate condition, so a hand cast while a non-Zombie died still yields no counter.
- `docs/card-sdk-language-reference.md` updated for every new building block.

## mtgish-tooling

Taught the emitter to AUTO-emit both previously-declined cards gameplay-tree-equivalent to their golden cardDefs (correctness, not lossy approximation):
- **Anthropede**: a recognizer for `MayCost(Or[DiscardACard, PayMana])` + `If(CostWasPaid)` + `ReflexiveTrigger(destroy Room)` (the two-way-cost sibling of the Boilerbilges Ripper shape), declining anything but that exact shape.
- **Undead Sprinter**: a `FromGraveyardIf` rule recognizer emitting `MayCastSelfFromZones(GRAVEYARD, condition)` + `EntersWithCounters(condition = WasCastFromGraveyard)`, plus subtype-filtered died-condition recovery and a `supported("FromGraveyardIf", …)` bridge entry.
- **Innocuous Rat** / **Bashful Beastie** already auto-emit (manifest dread).

Gates: **POR stays 0-mismatch (158/158, GATE PASS)**. DSK auto-emit gameplay-tree MATCH 78→80, NOT-EMITTED 33→31. The 4 pre-existing DSK mismatches (Beastie Beatdown, Get Out, Glimmer Seeker, Razorkin Needlehead) are unrelated and untouched.

## Tests

- `AnthropedeScenarioTest` — discard / pay-{2} / decline branches; Room destroyed when taken, survives when declined.
- `UndeadSprinterScenarioTest` (6 cases) — filtered died-this-turn gate (non-Zombie enables, only-Zombie/nothing does not, opponent's death counts), cast-this-way → 3/3 with counter + trample/haste, hand cast → no counter.
- `CardDefinitionSnapshotTest` re-blessed (only the 4 new cards added). `CardLintTest`, `:mtgish-tooling:test` (incl. EmitterGoldenTest), and touched-module compiles all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)