### PR TITLE
FIN warm-ups: devotion + Equipment-count dynamic amounts, surveil triggers

### DIFF
--- a/backlog/compact-library-action-serialization.md
+++ b/backlog/compact-library-action-serialization.md
@@ -1,0 +1,95 @@
+# Compact serialization for scry / surveil (and siblings)
+
+## Problem
+
+`Patterns.Library.scry(n)` / `surveil(n)` are **factories that return a `CompositeEffect`** of atomic
+steps (Gather → Select → Move → Move → `EmitScried/SurveiledEvent`). A card stores the *expanded*
+composite, so:
+
+- Every scry/surveil card serializes the full 5-step pipeline into its `CardDefinitionSnapshotTest`
+  golden (≈81 scry + ≈105 surveil cards across most sets).
+- Any change to the shared pipeline internals (e.g. adding the `EmitSurveiledEventEffect` completion
+  tail in the FIN warm-ups PR #901) churns the golden of *every* card that uses the mechanic, even
+  though no card's behavior was authored differently.
+
+The atomic-composition design is correct and must stay (`CLAUDE.md`: "Prefer atomic pipeline
+effects … over monolithic executors"). The issue is purely the **serialized representation**: a
+card whose effect *is* "surveil 2" should serialize as `{"type":"Surveil","n":2}`, not as the
+unrolled pipeline — while still executing via the shared atoms.
+
+## Goal
+
+In-memory and on-the-wire, a library keyword action is one compact node; at **execution** it expands
+into the existing pipeline atoms. Net effects:
+
+- Goldens shrink to one line per scry/surveil and stop churning when pipeline internals change.
+- New mechanics keep reusing the same Gather/Select/Move atoms (no monolithic executor logic).
+- Card SDK reads more like the oracle text (`Effects.Surveil(2)`).
+
+## Design
+
+A thin **macro effect** per keyword action — a serializable marker whose executor delegates to the
+existing composite, reusing all pause/continuation handling:
+
+- **SDK** (`mtg-sdk`):
+  - Add `SurveilEffect(n: Int)` and `ScryEffect(n: Int)` (`@Serializable`, in `LibraryEffects.kt`),
+    with `Effects.Surveil(n)` / `Effects.Scry(n)` facades.
+  - Repoint `Patterns.Library.surveil(n)` / `scry(n)` to return the marker. Keep the current
+    composite bodies as **public** builders `surveilPipeline(n)` / `scryPipeline(n)` (data only) so
+    the engine can expand them. The `EmitScried/SurveiledEventEffect` tails live inside the pipeline
+    builders, exactly as today.
+- **Engine** (`rules-engine`):
+  - `ScryExecutor` / `SurveilExecutor`: build `Patterns.Library.scryPipeline(n)` /
+    `surveilPipeline(n)` and delegate to the registry's composite execution
+    (`CompositeEffectExecutor` is already constructed with the registry `effectExecutor`, and it owns
+    the choose-pause → `EffectContinuation` plumbing — so the macro executor adds **zero** new
+    gather/select/move logic and the SelectCardsDecision pause still works).
+  - Register both in `LibraryExecutors` (satisfies `EffectExecutorCoverageTest`).
+
+### The real work: effect-tree introspection sites
+
+Several places **walk the unrolled tree** instead of executing it. With scry/surveil collapsed to an
+opaque node they no longer see the inner `GatherCardsEffect` / `SelectFromCollectionEffect`, so each
+must either expand the macro first or grow a branch for it. Audit (trace per `add-feature` Step 4):
+
+- `TriggerProcessor.findSelectionAmount` / `findStoreNumberAmount` (`TriggerProcessor.kt:829/843`) —
+  recurse into `CompositeEffect` to read a Select's amount; add a `ScryEffect`/`SurveilEffect` branch
+  (return the pipeline's select amount) or expand before walking.
+- `ClientStateTransformer` — scry/surveil reveal/look-at UI and any `effectTree*` walkers; confirm the
+  reveal path keys off resolution events (it should, via `ScriedEvent`/`SurveiledEvent` +
+  `LookedAtCardsEvent`) and not off statically finding the gather node.
+- `ManaSolver` / legal-action enumerators — they pattern-match composites for mana/selection; verify
+  none assume scry/surveil internals.
+- `FacadeBoundaryTest` / `CardLinter` — ensure the new facade is allowed and the markers are
+  classified if they touch pipeline variables (they don't read/write named vars, so likely no
+  dataflow classification needed — verify).
+
+Decision point: **expand-at-walk vs teach-each-walker.** Prefer a single shared
+`Effect.expandMacros()` helper (or have the macro executors be the *only* expansion point and make the
+walkers call a shared `expandLibraryMacro(effect)`), so there's one place that knows scry/surveil →
+pipeline, rather than N call sites each re-deriving it.
+
+## Scope
+
+- **Do scry *and* surveil together** — converting only surveil leaves the two inconsistent and only
+  half-removes the golden bloat.
+- Consider extending to `mill(n)` and `searchLibrary(...)` in the same pass (same factory-returns-
+  composite shape) **only if** the introspection audit shows they're clean; otherwise leave them and
+  note it. Don't widen scope past what the audit covers.
+
+## Validation
+
+1. `EffectExecutorCoverageTest` green (new executors registered).
+2. Existing scry/surveil scenario tests (`ScryTriggerScenarioTest`, `SurveilTriggerScenarioTest`,
+   plus the many cards that scry/surveil) pass unchanged — behavior must be identical.
+3. Re-bless `CardDefinitionSnapshotTest` goldens; diff must show **only** the pipeline collapsing to a
+   single `Scry`/`Surveil` node — no behavioral field lost.
+4. `:mtg-sdk:test` JSON round-trip for the new effects; a card with `Effects.Surveil(2)` round-trips
+   to the same object.
+5. Client check: surveil/scry reveal UI still renders (drive a real game, per `verify`).
+
+## Why this is its own PR
+
+It's a cross-cutting **representation** change (SDK node + executor + every effect-tree walker +
+~186 golden re-bless) that is independent of the FIN warm-ups it surfaced in (PR #901). Landing it
+separately keeps the warm-up diff readable and gives this the layer-by-layer trace it needs.

--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -168,14 +168,14 @@ structural template; needs a sibling layout + loader so the land becomes the pla
 
 ## Tier 2 — Small recurring primitives (cheap, scattered unlocks)
 
-6. **Equipment / equipped-creature count as a `DynamicAmount`** — ❌ GAP. No `equipmentYouControl()` /
-   `equippedCreaturesYouControl()` dynamic amount; the `Filters.EquippedCreature` *filter* exists but not a count.
-   Add `DynamicAmounts.equipmentYouControl()` (a `battlefield(...).count()` over an Equipment filter) and an
-   equipped-creature count. → Adelbert Steiner (+1/+1 per Equipment), Barret Wallace, Slash of Light, Judgment Bolt.
+6. **Equipment / equipped-creature count as a `DynamicAmount`** — ✅ DONE. Added
+   `DynamicAmounts.equipmentYouControl()` (count over `Any.withSubtype(Equipment)`) and
+   `equippedCreaturesYouControl()` (count over `Creature.equipped()`) — pure composition, no new SDK type.
+   → Adelbert Steiner (+1/+1 per Equipment), Barret Wallace, Slash of Light, Judgment Bolt.
 
-7. **Devotion as a `DynamicAmount`** — 🟡 PARTIAL. A devotion *predicate* exists (`CardPredicate`) but there is no
-   `DynamicAmount.DevotionTo(color)` to feed "draw cards equal to your devotion to red." → Clive, Ifrit's Dominant
-   (ETB). Small surface-it task.
+7. **Devotion as a `DynamicAmount`** — ✅ DONE. Added `DynamicAmount.DevotionTo(colors, player)` (CR 700.5) +
+   `DynamicAmounts.devotionTo(vararg colors)`; the evaluator counts colored mana symbols (incl. hybrid / monocolored
+   hybrid / Phyrexian) on controlled permanents, read via projected controller. → Clive, Ifrit's Dominant (ETB).
 
 8. **"First combat phase of the turn" condition + additional-combat rider** — ❌ GAP. `AddCombatPhaseEffect` exists,
    but nothing tests *"if it's the first combat phase of the turn"* to gate the extra phase (and untap-the-attacker
@@ -191,9 +191,10 @@ structural template; needs a sibling layout + loader so the land becomes the pla
     more coins each turn, those coins come up heads and you win those flips"); The Gold Saucer is a plain flip (no
     replacement). New coin-flip replacement keyed once-per-turn.
 
-11. **"Whenever you scry or surveil" trigger** — verify/extend. The Strixhaven/TLA passes flagged a missing combined
-    scry-or-surveil trigger. → Matoya, Archon Elder; Golbez (surveil trigger). Confirm `WheneverYouSurveil` /
-    combined trigger exists before building.
+11. **"Whenever you scry or surveil" trigger** — ✅ DONE. Added `SurveiledEvent` (mirroring `ScriedEvent`) emitted by
+    `Patterns.Library.surveil(N)` via `EmitSurveiledEventEffect`, plus `Triggers.WheneverYouSurveil` and the combined
+    `Triggers.WheneverYouScryOrSurveil` (indexed under both categories). Surveil reuses `TRIGGER_SCRY_COUNT` for
+    "cards looked at." → Matoya, Archon Elder; Golbez (surveil trigger).
 
 12. **`SubtypeCount` on a single creature with a cap** — verify. "+2/+2 for each of its creature types" patterns and
     self-type counts use `EntityNumericProperty.SubtypeCount` (`EntityNumericProperty.kt:93`); confirm it's reusable
@@ -238,7 +239,7 @@ structural template; needs a sibling layout + loader so the land becomes the pla
 
 ## Recommended build order
 
-1. **Warm-ups (Tier 2, cheap):** Equipment/equipped-creature count `DynamicAmount` (§6), devotion dynamic amount
+1. ✅ **Warm-ups (Tier 2, cheap) — DONE:** Equipment/equipped-creature count `DynamicAmount` (§6), devotion dynamic amount
    (§7), scry-or-surveil trigger (§11). These unlock ~10 scattered cards with trivial engine work, and the bulk of
    the standard cycling/flashback/kicker/affinity/crew cards are already buildable today via the `add-card` skill.
 2. **Job select (§3)** — publish the created-token id into the pipeline, then `jobSelect()` shell. Unlocks all 16

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2314,12 +2314,20 @@ Triggers.youCastSpell(
   actually designates a creature (the event's `bearerId` is non-null) — not when you control none to
   choose. Used by Call of the Ring.
 
-### Scry
+### Scry / Surveil
 
-- `WheneverYouScry` — fires once per scry resolution (CR 701.18), after the cards have
+- `WheneverYouScry` — fires once per scry resolution (CR 701.22), after the cards have
   been placed on top/bottom. Pair with `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_SCRY_COUNT)`
   for "for each card looked at" payoffs (Celeborn the Wise, Elrond Master of Healing).
   Automatically emitted by `Patterns.Library.scry(N)`; no card has to opt in.
+- `WheneverYouSurveil` — the surveil twin (CR 701.25), fired once per surveil resolution.
+  Automatically emitted by `Patterns.Library.surveil(N)`. Reads the same `TRIGGER_SCRY_COUNT`
+  ("cards looked at"). Used by Golbez.
+- `WheneverYouScryOrSurveil` — the combined look-at-top trigger; fires once per scry **and**
+  once per surveil (Matoya, Archon Elder).
+- A literal "scry 0" / "surveil 0" produces no event and fires no trigger (CR 701.22b / 701.25c);
+  the trigger still fires when the library was empty and zero cards were looked at (CR 701.22d /
+  701.25d).
 
 ### Saga chapter resolution (CR 714)
 
@@ -3845,6 +3853,15 @@ Numbers computed at resolution time.
   `CastRecordComponent` afterward), so it reads correctly both at resolution and as the permanent enters
   (the common use: feeding `EntersWithDynamicCounters`). Facade: `DynamicAmounts.colorsOfManaSpent()`.
   A permanent put onto the battlefield without being cast spent no mana, so this is 0 for it.
+- `DevotionTo(colors, player = You)` — a player's **devotion** to one or more colors (CR 700.5):
+  the number of mana symbols of those colors among the mana costs of permanents the player controls.
+  One color = "devotion to red"; several = devotion to that combination ("white and black"), where a
+  symbol matching more than one listed color is counted once. Every colored symbol contributes —
+  plain colored, both halves of a two-color hybrid ({W/U} counts for white *and* blue), monocolored
+  twobrid ({2/B} is black), and Phyrexian ({B/P} is black); generic/colorless/{X} never count.
+  Face-down permanents have no mana cost and contribute 0. Controller read via projected state.
+  Facade: `DynamicAmounts.devotionTo(color, …)`. Used by "draw cards equal to your devotion to red"
+  (Clive, Ifrit's Dominant).
 - `UnlockedDoors(player = You, distinctNames = false)` — the number of unlocked doors among Rooms
   `player` controls (CR 709.5). Reads per-face door state, so a single Room with **both** doors
   unlocked counts as **two** — an entity-level `AggregateBattlefield`/`Count` cannot see this. With
@@ -3892,6 +3909,10 @@ Numbers computed at resolution time.
 - `AggregateZone(player, zone, filter?, aggregation?)` — count cards in a zone.
 - `CountPermanentsOfType(player, subtype)` — count by creature type.
 - `CountCreaturesYouControl` — shorthand for "your creatures".
+- Facades: `DynamicAmounts.equipmentYouControl(player = You)` — Equipment you control (counts
+  permanents whose projected subtypes include Equipment), and `equippedCreaturesYouControl(player = You)`
+  — creatures with at least one Equipment attached (`GameObjectFilter.Creature.equipped()`). Used by
+  Adelbert Steiner (+1/+1 per Equipment), Barret Wallace.
 - Facades: `DynamicAmounts.cardsInYourGraveyard()` / `creatureCardsInYourGraveyard()`
   (graveyard counts), and `DynamicAmounts.cardsInYourHand()` — cards in your hand,
   e.g. Stingerback Terror's "-1/-1 for each card in your hand" (multiply by `-1` and feed
@@ -4125,8 +4146,9 @@ Army just amassed by a sibling/action effect, or any cost-chosen entity. The plu
     mana value, where {X} counts as 0). Populated from `SpellCastEvent.xValue`; `0` for non-cast /
     no-{X} triggers. Pair with `SpellCastPredicate.HasXInCost`. Facade:
     `DynamicAmounts.xValueOfTriggeringSpell()`.
-  - `TRIGGER_SCRY_COUNT` — cards looked at by the scry that fired the trigger (Celeborn the
-    Wise, Elrond Master of Healing). Equals the scry N parameter.
+  - `TRIGGER_SCRY_COUNT` — cards looked at by the scry **or surveil** that fired the trigger
+    (Celeborn the Wise, Elrond Master of Healing). Equals the scry/surveil N parameter unless the
+    library held fewer cards.
   - `TRIGGER_EXCESS_DAMAGE_AMOUNT` — damage past lethal in the trigger payload (CR 120.4a).
     Set from `DamageDealtEvent.excessAmount`; non-zero only for `DealsDamageEvent(requireExcess = true)`
     triggers — Fall of Cair Andros' "amass Orcs X, where X is the excess damage."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -150,6 +150,14 @@ object DynamicAmounts {
     fun colorsSpentOnTriggeringSpell(): DynamicAmount =
         DynamicAmount.ContextProperty(ContextPropertyKey.COLORS_SPENT_ON_TRIGGERING_SPELL)
 
+    /**
+     * Your devotion to [colors] (CR 700.5) — the number of mana symbols of those colors among
+     * the mana costs of permanents you control. Pass one color for "devotion to red", or several
+     * for a colored combination ("devotion to white and black"). See [DynamicAmount.DevotionTo].
+     */
+    fun devotionTo(vararg colors: Color): DynamicAmount =
+        DynamicAmount.DevotionTo(colors.toList())
+
     fun creaturesYouControl(): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Creature).count()
 
@@ -203,6 +211,28 @@ object DynamicAmounts {
 
     fun landsWithSubtype(subtype: Subtype): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Land.withSubtype(subtype)).count()
+
+    // =========================================================================
+    // Equipment counting (convenience shortcuts)
+    // =========================================================================
+
+    /**
+     * The number of Equipment [player] controls — "for each Equipment you control"
+     * (Adelbert Steiner, Barret Wallace). Equipment is an artifact subtype (CR 301.5c),
+     * so this counts permanents whose projected subtypes include Equipment, picking up
+     * permanents turned into Equipment by a continuous effect as well.
+     */
+    fun equipmentYouControl(player: Player = Player.You): DynamicAmount =
+        battlefield(player, GameObjectFilter.Any.withSubtype(Subtype.EQUIPMENT)).count()
+
+    /**
+     * The number of equipped creatures [player] controls — creatures with at least one
+     * Equipment attached (CR 301.5). Reads the attachment state, so a creature equipped
+     * by several Equipment still counts once. Used by "for each equipped creature you
+     * control" payoffs.
+     */
+    fun equippedCreaturesYouControl(player: Player = Player.You): DynamicAmount =
+        battlefield(player, GameObjectFilter.Creature.equipped()).count()
 
     // =========================================================================
     // "Other" counting (subtract 1 for self)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.EmitScriedEventEffect
+import com.wingedsheep.sdk.scripting.effects.EmitSurveiledEventEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
@@ -268,7 +269,7 @@ object LibraryPatterns {
     )
 
     fun surveil(count: Int): CompositeEffect = CompositeEffect(
-        listOf(
+        listOfNotNull(
             GatherCardsEffect(
                 source = CardSource.TopOfLibrary(DynamicAmount.Fixed(count)),
                 storeAs = "surveiled"
@@ -289,7 +290,14 @@ object LibraryPatterns {
                 from = "toTop",
                 destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top),
                 order = CardOrder.ControllerChooses
-            )
+            ),
+            // Fire "Whenever you surveil" / "scry or surveil" triggers (CR 701.25) after the
+            // pipeline finishes. The event count is the actual size of the "surveiled" gather
+            // collection at resolution time, not the literal N (handles library-smaller-than-N).
+            // Per CR 701.25d the trigger still fires when the library was empty and zero cards
+            // were looked at, so the tail emits unconditionally — it is only omitted for a literal
+            // "surveil 0" (CR 701.25c: no surveil event occurs).
+            if (count > 0) EmitSurveiledEventEffect() else null
         )
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1665,6 +1665,25 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * Whenever you surveil (CR 701.25). The surveil twin of [WheneverYouScry] — fires once per
+     * surveil resolution, after the kept/graveyard moves resolve. Pair with TRIGGER_SCRY_COUNT to
+     * scale by "the number of cards looked at." Used by Golbez and similar surveil payoffs.
+     */
+    val WheneverYouSurveil: TriggerSpec = TriggerSpec(
+        event = SurveiledEvent(Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you scry **or** surveil (CR 701.22 / 701.25) — the combined look-at-top trigger
+     * (Matoya, Archon Elder). Fires once per scry and once per surveil.
+     */
+    val WheneverYouScryOrSurveil: TriggerSpec = TriggerSpec(
+        event = ScriedOrSurveiledEvent(Player.You),
+        binding = TriggerBinding.ANY
+    )
+
     // =========================================================================
     // Saga Chapter Resolution Triggers (CR 714)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -345,6 +345,35 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         override val description: String = "${player.description} scries"
     }
 
+    /**
+     * Whenever a player surveils (CR 701.25). Fires once per surveil, after the kept/graveyard
+     * moves have all resolved. Carries the number of cards actually looked at (equals the surveil
+     * N parameter unless the library had fewer cards). Read this count via
+     * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TRIGGER_SCRY_COUNT] ("the number of
+     * cards looked at"). A literal "surveil 0" produces no event (CR 701.25c).
+     */
+    @SerialName("SurveiledEvent")
+    @Serializable
+    data class SurveiledEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} surveils"
+    }
+
+    /**
+     * Whenever a player scries **or** surveils (CR 701.22 / 701.25) — the combined look-at-top
+     * trigger used by "Whenever you scry or surveil, …" (Matoya, Archon Elder). Matches either a
+     * scry or a surveil event from [player]; the cards-looked-at count is exposed the same way as
+     * the individual triggers (TRIGGER_SCRY_COUNT).
+     */
+    @SerialName("ScriedOrSurveiledEvent")
+    @Serializable
+    data class ScriedOrSurveiledEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} scries or surveils"
+    }
+
     // =========================================================================
     // Extra Turn Events
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -52,6 +52,32 @@ data class EmitScriedEventEffect(
     override val description: String = ""
 }
 
+/**
+ * Emit a `SurveiledEvent` after a surveil pipeline finishes resolving — the surveil twin of
+ * [EmitScriedEventEffect]. Appended internally by [com.wingedsheep.sdk.dsl.LibraryPatterns.surveil]
+ * so "Whenever you surveil" / "Whenever you scry or surveil" triggers
+ * ([com.wingedsheep.sdk.dsl.Triggers.WheneverYouSurveil],
+ * [com.wingedsheep.sdk.dsl.Triggers.WheneverYouScryOrSurveil]) fire exactly once per surveil,
+ * carrying the actual number of cards looked at.
+ *
+ * The count is the size of the named gather collection (`"surveiled"` by default) at resolution
+ * time — the cards `GatherCardsEffect` actually pulled, which equals the surveil N parameter unless
+ * the library held fewer (CR 701.25a). The count can be zero when the library was empty; the event
+ * still fires, because CR 701.25d triggers "whenever you surveil" abilities "even if some or all of
+ * those actions were impossible." Suppression of a literal "surveil 0" (CR 701.25c) is handled by
+ * `surveil()` omitting this tail entirely, not here.
+ *
+ * Card authors should not use this directly; it is wired into the surveil primitive.
+ */
+@SerialName("EmitSurveiledEvent")
+@Serializable
+data class EmitSurveiledEventEffect(
+    val gatherCollection: String = "surveiled"
+) : Effect {
+    // Intentionally blank: this is an internal pipeline tail with no player-facing text.
+    override val description: String = ""
+}
+
 
 /**
  * Destination for searched cards.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -442,6 +442,36 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * A player's **devotion** to one or more colors (CR 700.5): the number of mana symbols of
+     * [colors] among the mana costs of permanents that [player] controls. A single-element list
+     * is devotion to one color ("your devotion to red"); several colors give devotion to that
+     * combination ("your devotion to white and black"), where a symbol that is any of the listed
+     * colors is counted once.
+     *
+     * Every kind of mana symbol that carries a color contributes: a plain colored symbol, both
+     * halves of a two-color hybrid ({W/U} adds to both white and blue devotion), a monocolored
+     * "twobrid" ({2/B} is a black symbol), and a Phyrexian symbol ({B/P} is a black symbol).
+     * Generic, colorless ({C}), and {X} symbols never contribute. Face-down permanents have no
+     * mana cost and contribute 0 (CR 711.4). Reads the controller via projected state so
+     * control-changing effects are honored.
+     *
+     * Used by "draw cards equal to your devotion to red" / "gain life equal to your devotion to
+     * white" payoffs (Clive, Ifrit's Dominant).
+     */
+    @SerialName("DevotionTo")
+    @Serializable
+    data class DevotionTo(
+        val colors: List<Color>,
+        val player: Player = Player.You
+    ) : DynamicAmount {
+        override val description: String = buildString {
+            append(if (player == Player.You) "your" else player.possessive)
+            append(" devotion to ")
+            append(colors.joinToString(" and ") { it.displayName.lowercase() })
+        }
+    }
+
+    /**
      * Reference to a stored variable by name.
      * Used for effects that need to reference a previously computed/stored value.
      * Example: Scapeshift stores "sacrificedCount" and SearchLibrary reads it.

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -4945,6 +4945,7 @@
                     },
                     "order": "ControllerChooses"
                 },
+                "EmitSurveiledEvent",
                 {
                     "type": "DrawCards",
                     "count": {
@@ -7489,7 +7490,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -7642,7 +7644,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -8570,7 +8573,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -10692,7 +10696,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -10802,7 +10807,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "restrictions": [
@@ -12012,7 +12018,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -12265,7 +12272,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -14500,7 +14508,8 @@
                                     "placement": "Top"
                                 },
                                 "order": "ControllerChooses"
-                            }
+                            },
+                            "EmitSurveiledEvent"
                         ]
                     }
                 }
@@ -17726,6 +17735,7 @@
                                 },
                                 "order": "ControllerChooses"
                             },
+                            "EmitSurveiledEvent",
                             {
                                 "type": "DrawCards",
                                 "count": {
@@ -18419,7 +18429,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "triggerCondition": {

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -662,7 +662,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1835,7 +1836,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -3907,7 +3909,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -3996,7 +3999,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -107,7 +107,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -760,7 +761,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1535,7 +1537,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -2176,7 +2179,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -5752,7 +5756,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "Eerie — Whenever an enchantment you control enters, surveil 1."
@@ -5807,7 +5812,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "Eerie — Whenever you fully unlock a Room, surveil 1."
@@ -7053,7 +7059,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -7405,7 +7412,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -7462,7 +7470,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -4746,7 +4746,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -7600,7 +7601,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -9976,6 +9978,7 @@
                             },
                             "order": "ControllerChooses"
                         },
+                        "EmitSurveiledEvent",
                         {
                             "type": "RemoveCounters",
                             "counterType": "-1/-1",
@@ -11745,7 +11748,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -11802,7 +11806,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -12751,7 +12756,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -16212,7 +16218,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -19478,7 +19485,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -19871,7 +19879,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "triggerCondition": "IsNotYourTurn"
@@ -20547,7 +20556,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "triggerCondition": {

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -7319,6 +7319,7 @@
                     },
                     "order": "ControllerChooses"
                 },
+                "EmitSurveiledEvent",
                 {
                     "type": "DrawCards",
                     "count": {
@@ -9079,7 +9080,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -13941,7 +13943,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -14941,7 +14944,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -15187,7 +15191,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -17827,7 +17832,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -17884,7 +17890,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -18673,7 +18680,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "Sacrifice another creature or artifact: Surveil 1."
@@ -19969,7 +19977,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -2696,7 +2696,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1823,7 +1823,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 {
@@ -2528,7 +2529,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -3000,7 +3002,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -4664,7 +4667,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -11372,7 +11372,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -12118,7 +12119,8 @@
                         "placement": "Top"
                     },
                     "order": "ControllerChooses"
-                }
+                },
+                "EmitSurveiledEvent"
             ]
         }
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -245,7 +245,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 {

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -58,7 +58,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -139,7 +140,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -709,7 +711,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -855,7 +858,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1055,7 +1059,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1328,7 +1333,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1467,7 +1473,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1585,7 +1592,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1660,7 +1668,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1819,7 +1828,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -1896,7 +1906,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -2089,7 +2100,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -2175,7 +2187,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -2256,7 +2269,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -5575,7 +5575,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -12769,7 +12769,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -798,7 +798,8 @@
                                             "placement": "Top"
                                         },
                                         "order": "ControllerChooses"
-                                    }
+                                    },
+                                    "EmitSurveiledEvent"
                                 ]
                             }
                         ]
@@ -4176,7 +4177,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -4371,7 +4373,8 @@
                                     "placement": "Top"
                                 },
                                 "order": "ControllerChooses"
-                            }
+                            },
+                            "EmitSurveiledEvent"
                         ]
                     }
                 }
@@ -5628,7 +5631,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "{2}{U}: Surveil 1."
@@ -6086,7 +6090,8 @@
                                     "placement": "Top"
                                 },
                                 "order": "ControllerChooses"
-                            }
+                            },
+                            "EmitSurveiledEvent"
                         ]
                     }
                 }
@@ -12027,7 +12032,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "oncePerTurn": true,
@@ -12759,7 +12765,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -14440,7 +14447,8 @@
                                     "placement": "Top"
                                 },
                                 "order": "ControllerChooses"
-                            }
+                            },
+                            "EmitSurveiledEvent"
                         ]
                     }
                 },
@@ -18879,7 +18887,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -1263,7 +1263,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -5438,7 +5439,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -5971,7 +5973,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -6780,6 +6783,7 @@
                             },
                             "order": "ControllerChooses"
                         },
+                        "EmitSurveiledEvent",
                         {
                             "type": "Gated",
                             "gate": {
@@ -7784,7 +7788,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -8099,7 +8104,8 @@
                                         "placement": "Top"
                                     },
                                     "order": "ControllerChooses"
-                                }
+                                },
+                                "EmitSurveiledEvent"
                             ]
                         }
                     ]
@@ -10574,7 +10580,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -10999,7 +11006,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             },
@@ -11213,7 +11221,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -12343,6 +12352,7 @@
                                 },
                                 "order": "ControllerChooses"
                             },
+                            "EmitSurveiledEvent",
                             {
                                 "type": "DrawCards",
                                 "count": {
@@ -13280,7 +13290,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "timing": "SorcerySpeed",
@@ -15432,7 +15443,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -16362,7 +16374,8 @@
                                         "placement": "Top"
                                     },
                                     "order": "ControllerChooses"
-                                }
+                                },
+                                "EmitSurveiledEvent"
                             ]
                         }
                     ]
@@ -17497,7 +17510,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -17841,7 +17855,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }
@@ -18420,7 +18435,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]
@@ -18864,7 +18880,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1308,6 +1308,7 @@
                     },
                     "order": "ControllerChooses"
                 },
+                "EmitSurveiledEvent",
                 {
                     "type": "DrawCards",
                     "count": {

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -2032,7 +2032,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "Whenever this creature attacks, surveil 1."
@@ -3091,7 +3092,8 @@
                                         "placement": "Top"
                                     },
                                     "order": "ControllerChooses"
-                                }
+                                },
+                                "EmitSurveiledEvent"
                             ]
                         }
                     ]
@@ -3180,6 +3182,7 @@
                     },
                     "order": "ControllerChooses"
                 },
+                "EmitSurveiledEvent",
                 {
                     "type": "DrawCards",
                     "count": {
@@ -5397,7 +5400,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "At the beginning of your upkeep, surveil 1."
@@ -5535,7 +5539,8 @@
                                                     "placement": "Top"
                                                 },
                                                 "order": "ControllerChooses"
-                                            }
+                                            },
+                                            "EmitSurveiledEvent"
                                         ]
                                     }
                                 ]
@@ -8698,7 +8703,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "Surveil 2."
@@ -11085,7 +11091,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 },
                 "descriptionOverride": "When this creature enters, surveil 1."
@@ -11489,7 +11496,8 @@
                                     "placement": "Top"
                                 },
                                 "order": "ControllerChooses"
-                            }
+                            },
+                            "EmitSurveiledEvent"
                         ]
                     }
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -686,7 +686,8 @@
                                 "placement": "Top"
                             },
                             "order": "ControllerChooses"
-                        }
+                        },
+                        "EmitSurveiledEvent"
                     ]
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -328,6 +328,24 @@ data class ScriedEvent(
 ) : GameEvent
 
 /**
+ * A player just finished a `surveil N` (CR 701.25). Fires once per surveil, after the
+ * kept/graveyard moves have all resolved. Drives "Whenever you surveil" and "Whenever you
+ * scry or surveil" triggers; see [com.wingedsheep.sdk.scripting.EventPattern.SurveiledEvent].
+ *
+ * @property playerId The player who surveiled.
+ * @property count Number of cards actually looked at (equals surveil N unless the library held
+ *   fewer cards). Surfaced via `TRIGGER_SCRY_COUNT` ("the number of cards looked at").
+ * @property sourceName The card/ability that caused the surveil (for display).
+ */
+@Serializable
+@SerialName("SurveiledEvent")
+data class SurveiledEvent(
+    val playerId: EntityId,
+    val count: Int,
+    val sourceName: String
+) : GameEvent
+
+/**
  * A player chose a creature type (e.g., "Choose a creature type" for Walking Desecration).
  * This is a public announcement visible to all players.
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -122,6 +122,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MaximumHandSizeRemovedEvent::class)
         subclass(RingTemptedEvent::class)
         subclass(ScriedEvent::class)
+        subclass(SurveiledEvent::class)
         subclass(LibraryReorderedEvent::class)
         subclass(LookedAtCardsEvent::class)
         subclass(LoyaltyChangedEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -201,6 +201,12 @@ data class TriggerContext(
                     triggeringPlayerId = event.playerId,
                     scryCount = event.count
                 )
+                // Surveil reuses the "cards looked at" count slot (TRIGGER_SCRY_COUNT) — the
+                // field is the number of cards looked at, common to scry and surveil.
+                is com.wingedsheep.engine.core.SurveiledEvent -> TriggerContext(
+                    triggeringPlayerId = event.playerId,
+                    scryCount = event.count
+                )
                 is CardsDiscardedEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is CardRevealedFromDrawEvent -> TriggerContext(
                     triggeringEntityId = event.cardEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -74,6 +74,7 @@ enum class TriggerCategory {
     DISCARD,
     RING_TEMPTED,
     SCRIED,
+    SURVEILED,
     BECAME_SADDLED,
     BECOMES_ATTACHED,
     SAGA_CHAPTER_RESOLVED,
@@ -241,6 +242,10 @@ class TriggerIndex(
                 is SdkGameEvent.DiscardEvent -> listOf(TriggerCategory.DISCARD)
                 is SdkGameEvent.RingTemptedEvent -> RING_TEMPTED_LIST
                 is SdkGameEvent.ScriedEvent -> SCRIED_LIST
+                is SdkGameEvent.SurveiledEvent -> SURVEILED_LIST
+                // "Whenever you scry or surveil" indexes under both buckets so either engine event
+                // finds it; the matcher confirms the event is a scry or a surveil.
+                is SdkGameEvent.ScriedOrSurveiledEvent -> SCRIED_OR_SURVEILED_LIST
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
@@ -280,6 +285,7 @@ class TriggerIndex(
             is CardsDiscardedEvent -> DISCARD_LIST
             is com.wingedsheep.engine.core.RingTemptedEvent -> RING_TEMPTED_LIST
             is com.wingedsheep.engine.core.ScriedEvent -> SCRIED_LIST
+            is com.wingedsheep.engine.core.SurveiledEvent -> SURVEILED_LIST
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
             is com.wingedsheep.engine.core.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
@@ -311,6 +317,8 @@ class TriggerIndex(
         private val DISCARD_LIST = listOf(TriggerCategory.DISCARD)
         private val RING_TEMPTED_LIST = listOf(TriggerCategory.RING_TEMPTED)
         private val SCRIED_LIST = listOf(TriggerCategory.SCRIED)
+        private val SURVEILED_LIST = listOf(TriggerCategory.SURVEILED)
+        private val SCRIED_OR_SURVEILED_LIST = listOf(TriggerCategory.SCRIED, TriggerCategory.SURVEILED)
         private val BECAME_SADDLED_LIST = listOf(TriggerCategory.BECAME_SADDLED)
         private val BECOMES_ATTACHED_LIST = listOf(TriggerCategory.BECOMES_ATTACHED)
         private val SAGA_CHAPTER_RESOLVED_LIST = listOf(TriggerCategory.SAGA_CHAPTER_RESOLVED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -417,6 +417,17 @@ class TriggerMatcher(
                 event is com.wingedsheep.engine.core.ScriedEvent &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            is EventPattern.SurveiledEvent -> {
+                event is com.wingedsheep.engine.core.SurveiledEvent &&
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+            }
+            is EventPattern.ScriedOrSurveiledEvent -> when (event) {
+                is com.wingedsheep.engine.core.ScriedEvent ->
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                is com.wingedsheep.engine.core.SurveiledEvent ->
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                else -> false
+            }
             is EventPattern.BecomesTargetEvent -> {
                 event is BecomesTargetEvent && matchesBecomesTargetTrigger(trigger, binding, event, sourceId, controllerId, state)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -18,7 +18,9 @@ import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CharacteristicValue
@@ -262,6 +264,26 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.AggregateZone ->
                 evaluateZoneAggregate(state, amount, context, projectedState)
+
+            // Devotion (CR 700.5): the number of mana symbols of the named colors among the mana
+            // costs of permanents the player controls. Hybrid ({W/U}), monocolored hybrid ({2/B}),
+            // and Phyrexian ({B/P}) symbols each count toward their color(s); a symbol matching more
+            // than one of the requested colors is still counted once. Controller is read from
+            // projection so control-changing effects are honored (700.5a). Face-down permanents have
+            // no mana cost (CR 711.4) and contribute nothing.
+            is DynamicAmount.DevotionTo -> {
+                val playerIds = resolveUnifiedPlayerIds(state, amount.player, context).toSet()
+                if (playerIds.isEmpty()) return 0
+                val projection = resolveProjection(state, projectedState)
+                val wanted = amount.colors.toSet()
+                state.getBattlefield().sumOf { entityId ->
+                    if (controllerOf(state, projection, entityId) !in playerIds) return@sumOf 0
+                    val entity = state.getEntity(entityId) ?: return@sumOf 0
+                    if (entity.has<FaceDownComponent>()) return@sumOf 0
+                    val cost = entity.get<CardComponent>()?.manaCost ?: return@sumOf 0
+                    cost.symbols.count { symbol -> manaSymbolColors(symbol).any { it in wanted } }
+                }
+            }
 
             is DynamicAmount.Conditional -> {
                 val eval = conditionEvaluator ?: ConditionEvaluator()
@@ -1109,6 +1131,19 @@ class DynamicAmountEvaluator(
             is CounterTypeFilter.Any -> counters.counters.values.sum()
             else -> counters.getCount(resolveCounterType(filter))
         }
+    }
+
+    /**
+     * The color(s) a single mana symbol contributes to devotion (CR 700.5). A two-color hybrid
+     * contributes both halves; a monocolored hybrid ({2/B}) and a Phyrexian symbol ({B/P})
+     * contribute their one color. Generic, colorless, and {X} symbols contribute nothing.
+     */
+    private fun manaSymbolColors(symbol: ManaSymbol): List<Color> = when (symbol) {
+        is ManaSymbol.Colored -> listOf(symbol.color)
+        is ManaSymbol.Hybrid -> listOf(symbol.color1, symbol.color2)
+        is ManaSymbol.Phyrexian -> listOf(symbol.color)
+        is ManaSymbol.MonocolorHybrid -> listOf(symbol.color)
+        else -> emptyList()
     }
 
     private fun resolveCounterType(filter: CounterTypeFilter): CounterType {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitSurveiledEventExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitSurveiledEventExecutor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.SurveiledEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.EmitSurveiledEventEffect
+import kotlin.reflect.KClass
+
+/**
+ * Tail of the [com.wingedsheep.sdk.dsl.Patterns.Library.surveil] composite: emits a
+ * [SurveiledEvent] so "Whenever you surveil" / "Whenever you scry or surveil" triggers
+ * (CR 701.25) fire exactly once per surveil, after the kept/graveyard moves have all resolved.
+ *
+ * The carried count is the size of the named gather collection (`"surveiled"` by default) at
+ * resolution time — the cards `GatherCardsEffect` actually pulled, which equals the surveil N
+ * parameter unless the library held fewer (CR 701.25a). That count can be zero when the library
+ * was empty; the event is still emitted, because CR 701.25d fires "whenever you surveil" triggers
+ * "even if some or all of those actions were impossible." A literal "surveil 0" (CR 701.25c: no
+ * surveil event occurs) never reaches this executor —
+ * [com.wingedsheep.sdk.dsl.Patterns.Library.surveil] omits the tail entirely for N == 0.
+ */
+class EmitSurveiledEventExecutor : EffectExecutor<EmitSurveiledEventEffect> {
+
+    override val effectType: KClass<EmitSurveiledEventEffect> = EmitSurveiledEventEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: EmitSurveiledEventEffect,
+        context: EffectContext
+    ): EffectResult {
+        // Actual cards looked at (CR 701.25a); may be 0 if the library was empty, in
+        // which case the trigger still fires per CR 701.25d.
+        val count = context.pipeline.storedCollections[effect.gatherCollection]?.size ?: 0
+
+        val playerId = context.controllerId
+        val sourceName = context.sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+            ?: "Surveil"
+
+        return EffectResult.success(
+            state,
+            listOf(SurveiledEvent(playerId = playerId, count = count, sourceName = sourceName))
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -67,6 +67,7 @@ class LibraryExecutors(
         PutOnTopOrBottomOfLibraryExecutor(),
         StoreNumberExecutor(),
         StoreCardNameExecutor(),
-        EmitScriedEventExecutor()
+        EmitScriedEventExecutor(),
+        EmitSurveiledEventExecutor()
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1182,6 +1182,7 @@ is PermanentsSacrificedEvent -> {
             is MaximumHandSizeRemovedEvent,
             is RingTemptedEvent,
             is ScriedEvent,
+            is SurveiledEvent,
             is TurnedFaceDownEvent,
             is CreatureTypeChangedEvent,
             is BecomesTargetEvent,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DevotionAndEquipmentCountScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DevotionAndEquipmentCountScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CoralSword
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the §6 (Equipment / equipped-creature count) and §7 (devotion) DynamicAmount facades
+ * from the FIN engine-gap warm-ups. Each is exercised through a characteristic-defining creature
+ * whose power *is* the dynamic amount, so the projected power reads the value back.
+ *
+ * Devotion (CR 700.5): the number of mana symbols of the chosen color(s) among the mana costs of
+ * permanents you control — plain colored, both halves of a two-color hybrid, monocolored twobrid,
+ * and Phyrexian symbols all count; opponents' permanents and off-color symbols do not.
+ */
+class DevotionAndEquipmentCountScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // ----- devotion fixtures -----------------------------------------------------------------
+
+    // power = your devotion to red (toughness padded so the 0/0 case can't die to an SBA).
+    val DevotionMeterRed = card("Devotion Meter Red") {
+        manaCost = "{1}{R}" // contributes 1 to its controller's own red devotion
+        typeLine = "Creature — Test"
+        dynamicStats(DynamicAmounts.devotionTo(Color.RED), toughnessOffset = 20)
+    }
+    // power = your devotion to red and green (a symbol that is either colour counts once).
+    val DevotionMeterRedGreen = card("Devotion Meter Red Green") {
+        manaCost = "{G}{G}" // contributes 2 to red-or-green devotion
+        typeLine = "Creature — Test"
+        dynamicStats(DynamicAmounts.devotionTo(Color.RED, Color.GREEN), toughnessOffset = 20)
+    }
+
+    fun vanilla(name: String, cost: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse(cost),
+        subtypes = emptySet(),
+        power = 2, toughness = 2
+    )
+    val RedRed = vanilla("Devotion RedRed", "{R}{R}")     // +2 red
+    val HybridRedGreen = vanilla("Devotion Hybrid RG", "{R/G}") // +1 red, +1 green, +1 red-or-green
+    val TwobridRed = vanilla("Devotion Twobrid R", "{2/R}")     // +1 red
+    val PhyrexianRed = vanilla("Devotion Phyrexian R", "{R/P}") // +1 red
+    val BlueBlue = vanilla("Devotion BlueBlue", "{U}{U}")       // +0 red, +0 green
+
+    // ----- equipment fixtures ----------------------------------------------------------------
+
+    val EquipmentMeter = card("Equipment Meter") {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        dynamicStats(DynamicAmounts.equipmentYouControl(), toughnessOffset = 20)
+    }
+    val EquippedMeter = card("Equipped Meter") {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        dynamicStats(DynamicAmounts.equippedCreaturesYouControl(), toughnessOffset = 20)
+    }
+
+    fun devotionDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                DevotionMeterRed, DevotionMeterRedGreen,
+                RedRed, HybridRedGreen, TwobridRed, PhyrexianRed, BlueBlue
+            )
+        )
+        return driver
+    }
+
+    context("§7 devotion (CR 700.5)") {
+
+        test("devotion to red counts every red symbol on your permanents, ignoring opponents and off-color") {
+            val driver = devotionDriver()
+            driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+
+            val meter = driver.putCreatureOnBattlefield(me, "Devotion Meter Red") // {1}{R} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion RedRed")                // {R}{R} → +2
+            driver.putCreatureOnBattlefield(me, "Devotion Hybrid RG")             // {R/G} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion Twobrid R")             // {2/R} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion Phyrexian R")           // {R/P} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion BlueBlue")             // {U}{U} → +0
+            driver.putCreatureOnBattlefield(opp, "Devotion RedRed")              // opponent's → ignored
+
+            // 1 + 2 + 1 + 1 + 1 + 0 = 6
+            projector.getProjectedPower(driver.state, meter) shouldBe 6
+        }
+
+        test("devotion to red and green counts a hybrid symbol once") {
+            val driver = devotionDriver()
+            driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val me = driver.activePlayer!!
+
+            val meter = driver.putCreatureOnBattlefield(me, "Devotion Meter Red Green") // {G}{G} → +2
+            driver.putCreatureOnBattlefield(me, "Devotion Meter Red")  // {1}{R} → +1 (red)
+            driver.putCreatureOnBattlefield(me, "Devotion RedRed")     // {R}{R} → +2
+            driver.putCreatureOnBattlefield(me, "Devotion Hybrid RG")  // {R/G} → +1 (counted once)
+            driver.putCreatureOnBattlefield(me, "Devotion Twobrid R")  // {2/R} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion Phyrexian R")// {R/P} → +1
+            driver.putCreatureOnBattlefield(me, "Devotion BlueBlue")  // {U}{U} → +0
+
+            // 2 + 1 + 2 + 1 + 1 + 1 = 8
+            projector.getProjectedPower(driver.state, meter) shouldBe 8
+        }
+    }
+
+    context("§6 Equipment / equipped-creature counts") {
+
+        test("equipmentYouControl and equippedCreaturesYouControl track a real equip") {
+            val driver = GameTestDriver()
+            driver.registerCards(TestCards.all + listOf(EquipmentMeter, EquippedMeter))
+            driver.registerCard(CoralSword)
+            driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val me = driver.activePlayer!!
+
+            val equipmentMeter = driver.putCreatureOnBattlefield(me, "Equipment Meter")
+            val equippedMeter = driver.putCreatureOnBattlefield(me, "Equipped Meter")
+            val courser = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+
+            // No Equipment yet, no equipped creatures.
+            projector.getProjectedPower(driver.state, equipmentMeter) shouldBe 0
+            projector.getProjectedPower(driver.state, equippedMeter) shouldBe 0
+
+            // Cast Coral Sword; its ETB attaches it to a creature you control (CR — equip).
+            val sword = driver.putCardInHand(me, "Coral Sword")
+            driver.giveMana(me, Color.RED, 1)
+            driver.castSpell(me, sword)
+            driver.bothPass() // resolve the artifact -> enters -> ETB trigger on stack
+            driver.bothPass() // resolve ETB trigger -> pauses for target selection
+            driver.submitTargetSelection(me, listOf(courser))
+            driver.bothPass()
+
+            // One Equipment on the battlefield; one equipped creature (the Courser).
+            projector.getProjectedPower(driver.state, equipmentMeter) shouldBe 1
+            projector.getProjectedPower(driver.state, equippedMeter) shouldBe 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurveilTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurveilTriggerScenarioTest.kt
@@ -1,0 +1,289 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.ScriedEvent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SurveiledEvent
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Substrate tests for the "Whenever you surveil" (CR 701.25) and combined "Whenever you scry or
+ * surveil" (CR 701.22 / 701.25) triggers: `Patterns.Library.surveil(N)` ends by emitting
+ * [SurveiledEvent], which drives `Triggers.WheneverYouSurveil` /
+ * `Triggers.WheneverYouScryOrSurveil` and surfaces "the number of cards looked at" via
+ * [ContextPropertyKey.TRIGGER_SCRY_COUNT]. The event is distinct from the scry event, so a scry
+ * never fires a surveil trigger (and vice versa) — proven by the isolation test.
+ */
+class SurveilTriggerScenarioTest : FunSpec({
+
+    fun surveilSpell(name: String, n: Int) = card(name) {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Surveil $n."
+        spell { effect = Patterns.Library.surveil(n) }
+    }
+    fun scrySpell(name: String, n: Int) = card(name) {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Scry $n."
+        spell { effect = Patterns.Library.scry(n) }
+    }
+    val SurveilOne = surveilSpell("Surveil One", 1)
+    val SurveilThree = surveilSpell("Surveil Three", 3)
+    val SurveilZero = surveilSpell("Surveil Zero", 0)
+    val ScryOne = scrySpell("Scry One", 1)
+
+    // "Whenever you surveil, put a +1/+1 counter on it." — fires once per surveil.
+    val SurveilWatcher = card("Surveil Watcher") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouSurveil
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // "Whenever you scry, put a +1/+1 counter on it." — must NOT fire on a surveil.
+    val ScryWatcher = card("Scry Watcher Iso") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouScry
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // "Whenever you scry or surveil, put a +1/+1 counter on it." — fires on both.
+    val BothWatcher = card("Look Watcher") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouScryOrSurveil
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // "Whenever you surveil, put X +1/+1 counters on it, where X is the number of cards looked at."
+    val SurveilCounter = card("Surveil Counter") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouSurveil
+            effect = Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_SCRY_COUNT),
+                EffectTarget.Self
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                SurveilOne, SurveilThree, SurveilZero, ScryOne,
+                SurveilWatcher, ScryWatcher, BothWatcher, SurveilCounter
+            )
+        )
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // Truncate a player's library to exactly [size] cards so surveil can be exercised against a
+    // library shorter than N (CR 701.25a) or empty (701.25d).
+    fun GameTestDriver.truncateLibrary(player: EntityId, size: Int) {
+        val key = ZoneKey(player, Zone.LIBRARY)
+        replaceState(state.copy(zones = state.zones + (key to state.getZone(key).take(size))))
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    // Cast the named scry/surveil spell, then drive all resolution-time decisions:
+    // - SelectCardsDecision ("put any number into graveyard / on the bottom") → choose none
+    // - ReorderLibraryDecision ("in what order on top") → keep printed order
+    fun GameTestDriver.castLook(player: EntityId, cardName: String) {
+        val cardId = putCardInHand(player, cardName)
+        castSpell(player, cardId)
+        bothPass()
+        repeat(4) {
+            when (val decision = pendingDecision) {
+                is SelectCardsDecision ->
+                    submitDecision(player, CardsSelectedResponse(decision.id, emptyList()))
+                is ReorderLibraryDecision ->
+                    submitDecision(player, OrderedResponse(decision.id, decision.cards))
+                else -> return
+            }
+        }
+    }
+
+    test("surveil emits a SurveiledEvent with the count looked at") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val before = driver.events.size
+        driver.castLook(active, "Surveil Three")
+        val events = driver.events.drop(before).filterIsInstance<SurveiledEvent>()
+
+        events.size shouldBe 1
+        events.single().playerId shouldBe active
+        events.single().count shouldBe 3
+    }
+
+    test("Whenever-you-surveil trigger fires once per surveil") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Surveil Watcher")
+        driver.castLook(active, "Surveil One")
+        driver.bothPass()
+        driver.plusOneCounters(watcher) shouldBe 1
+
+        driver.castLook(active, "Surveil Three")
+        driver.bothPass()
+        driver.plusOneCounters(watcher) shouldBe 2
+    }
+
+    test("TRIGGER_SCRY_COUNT delivers the cards-looked-at count to a surveil trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val counter = driver.putCreatureOnBattlefield(active, "Surveil Counter")
+
+        driver.castLook(active, "Surveil Three")
+        driver.bothPass()
+        driver.plusOneCounters(counter) shouldBe 3
+
+        driver.castLook(active, "Surveil One")
+        driver.bothPass()
+        driver.plusOneCounters(counter) shouldBe 4
+    }
+
+    test("scry-or-surveil trigger fires on both a scry and a surveil") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Look Watcher")
+
+        driver.castLook(active, "Scry One")
+        driver.bothPass()
+        driver.plusOneCounters(watcher) shouldBe 1 // fired on the scry
+
+        driver.castLook(active, "Surveil One")
+        driver.bothPass()
+        driver.plusOneCounters(watcher) shouldBe 2 // ... and on the surveil
+    }
+
+    test("scry and surveil triggers don't cross-fire (distinct events)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val surveilWatcher = driver.putCreatureOnBattlefield(active, "Surveil Watcher")
+        val scryWatcher = driver.putCreatureOnBattlefield(active, "Scry Watcher Iso")
+
+        // A scry fires only the scry watcher.
+        driver.castLook(active, "Scry One")
+        driver.bothPass()
+        driver.plusOneCounters(scryWatcher) shouldBe 1
+        driver.plusOneCounters(surveilWatcher) shouldBe 0
+
+        // A surveil fires only the surveil watcher.
+        driver.castLook(active, "Surveil One")
+        driver.bothPass()
+        driver.plusOneCounters(surveilWatcher) shouldBe 1
+        driver.plusOneCounters(scryWatcher) shouldBe 1 // unchanged
+    }
+
+    test("surveil counts only the cards actually looked at when the library is shorter than N (CR 701.25a)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val counter = driver.putCreatureOnBattlefield(active, "Surveil Counter")
+        driver.truncateLibrary(active, 2) // only two cards available to a "surveil 3"
+
+        val before = driver.events.size
+        driver.castLook(active, "Surveil Three")
+        driver.bothPass()
+
+        val surveiled = driver.events.drop(before).filterIsInstance<SurveiledEvent>().single()
+        surveiled.count shouldBe 2
+        driver.plusOneCounters(counter) shouldBe 2
+    }
+
+    test("surveil with an empty library still fires the trigger with count 0 (CR 701.25d)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Surveil Watcher")
+        val counter = driver.putCreatureOnBattlefield(active, "Surveil Counter")
+        driver.truncateLibrary(active, 0) // empty library: zero cards looked at, but you still surveil
+
+        val before = driver.events.size
+        driver.castLook(active, "Surveil Three")
+        driver.resolveStack()
+
+        val surveiled = driver.events.drop(before).filterIsInstance<SurveiledEvent>().single()
+        surveiled.count shouldBe 0
+        driver.plusOneCounters(watcher) shouldBe 1 // trigger fired (701.25d)
+        driver.plusOneCounters(counter) shouldBe 0 // ... but scaled to 0 cards looked at
+    }
+
+    test("surveil 0 fires no trigger and emits no event (CR 701.25c)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Surveil Watcher")
+
+        val before = driver.events.size
+        driver.castLook(active, "Surveil Zero")
+        driver.bothPass()
+
+        driver.events.drop(before).filterIsInstance<SurveiledEvent>() shouldBe emptyList()
+        driver.events.drop(before).filterIsInstance<ScriedEvent>() shouldBe emptyList()
+        driver.plusOneCounters(watcher) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements the **first item of `backlog/fin-engine-gaps.md`** — recommended build order #1, the Tier-2 warm-ups (§6, §7, §11). Each is a small, reusable SDK primitive that unlocks a scattered set of FIN cards.

## §6 — Equipment / equipped-creature counts (pure composition, no new type)
- `DynamicAmounts.equipmentYouControl(player)` — count over `Any.withSubtype(Equipment)`.
- `DynamicAmounts.equippedCreaturesYouControl(player)` — count over `Creature.equipped()`.
- → Adelbert Steiner (+1/+1 per Equipment), Barret Wallace, Slash of Light, Judgment Bolt.

## §7 — Devotion (CR 700.5)
- New `DynamicAmount.DevotionTo(colors, player)` + `DynamicAmounts.devotionTo(vararg colors)`.
- Evaluator counts colored mana symbols among permanents the player controls — plain colored, **both** halves of a two-color hybrid (`{W/U}`), monocolored twobrid (`{2/B}`), and Phyrexian (`{B/P}`); generic/colorless/`{X}` never count. Reads the controller via projected state (700.5a). Face-down permanents contribute 0.
- → Clive, Ifrit's Dominant.

## §11 — Scry-or-surveil triggers
- New `SurveiledEvent` (mirrors `ScriedEvent`), emitted by `Patterns.Library.surveil(N)` via `EmitSurveiledEventEffect` (+ executor).
- `Triggers.WheneverYouSurveil` and the combined `Triggers.WheneverYouScryOrSurveil` (indexed under both `SCRIED` and `SURVEILED` categories; the matcher confirms the event).
- Surveil reuses `TRIGGER_SCRY_COUNT` for "cards looked at." `surveil 0` emits no event/fires nothing (CR 701.25c); an empty library still fires with count 0 (CR 701.25d) — mirroring scry.
- → Matoya, Archon Elder; Golbez.

## Tests
New engine scenario tests pin every CR clause:
- `SurveilTriggerScenarioTest` — fires once per surveil, `TRIGGER_SCRY_COUNT` delivery, scry-or-surveil fires on both, **scry/surveil don't cross-fire** (distinct events), library-shorter-than-N, empty-library-still-fires, surveil-0-fires-nothing.
- `DevotionAndEquipmentCountScenarioTest` — devotion to one color (colored + hybrid + twobrid + Phyrexian, opponents/off-color excluded), devotion to a color combination (hybrid counted once), and a real equip flow driving both Equipment counts.

`EffectExecutorCoverageTest`, `:mtg-sdk:test`, and `:mtg-sets` compile all pass. SDK reference (`docs/card-sdk-language-reference.md`) updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)