### PR TITLE
Add four DSK Fear enchantment creatures (Immobility, Burning Alive, Infinity, Impostors)

### DIFF
--- a/backlog/dsk-engine-gaps.md
+++ b/backlog/dsk-engine-gaps.md
@@ -176,8 +176,12 @@ to a **player** that have no home yet.
   (Chainsaw's "rev" counter is cosmetic — reuse an existing counter type feeding `ModifyStats`.)
 - **Manifest dread directed at another player's library** — "its controller manifests dread" must
   target a *non-controller* player's library, with the face-down creature controlled by that player.
-  Buildable iff the manifest composition is already player-parameterized (verify).
-  → **Fear of Impostors**, **Unwanted Remake**.
+  RESOLVED: wrap the shared `Patterns.Library.manifestDread()` steps in
+  `Effects.ForEachPlayer(Player.ControllerOf("target spell"), …)` — the per-player iteration rebinds
+  the body's controller (and the manifested creature's control) to that player. Needed a fix so
+  `ForEachExecutor.resolvePlayers` resolves single-player refs like `ControllerOf` instead of
+  falling back to all active players.
+  → **Fear of Impostors** (DONE), **Unwanted Remake** (same shape).
 - **The Mindskinner / Valgavoth, Terror Eater / Marina Vendrell's Grimoire** — deep but pure
   compositions (prevent-damage→mill, Ward—Sacrifice + opponents'-cards-to-exile + pay-life-to-cast,
   no-max-hand + gain/lose-life draw/discard engine).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1364,7 +1364,12 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   mills four cards", "that player sacrifices a creature").
 - `Player.TriggeringPlayer` — the player bound by the trigger (the caster for `SpellCastEvent`,
   the active player for per-player step triggers — "at the beginning of each opponent's upkeep,
-  *that player* …").
+  *that player* …", **and the player dealt the damage** for a `DealsDamageEvent` trigger whose
+  recipient is a player). It resolves inside a target's controller filter, so "deals noncombat
+  damage to an opponent, … to target creature **that player** controls" is
+  `TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.targetPlayerControls(EffectTarget.PlayerRef(Player.TriggeringPlayer))))`
+  on the damage trigger — the legality check and resolution both bind it to the damaged player
+  (Fear of Burning Alive).
 - `Player.AnOpponent` — a genuinely non-targeted "an opponent" (a chooser: "an opponent chooses a
   creature type"). Currently resolves to the first opponent in turn order; the proper multiplayer
   choice flow is tracked in `backlog/multiplayer.md`. Do **not** use it where the text means

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfBurningAlive.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfBurningAlive.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fear of Burning Alive
+ * {4}{R}{R}
+ * Enchantment Creature — Nightmare
+ * 4/4
+ * When this creature enters, it deals 4 damage to each opponent.
+ * Delirium — Whenever a source you control deals noncombat damage to an opponent, if there are four
+ * or more card types among cards in your graveyard, this creature deals that amount of damage to
+ * target creature that player controls.
+ *
+ * Implementation notes:
+ * - The ETB is an [EffectTarget.PlayerRef] over [Player.EachOpponent] (the source attribution is
+ *   the enchantment creature itself, matching "it deals").
+ * - The Delirium ability is an observer trigger: `dealsDamage(NonCombat, Opponent, sourceFilter =
+ *   "you control", binding = ANY)` so any source you control (including this creature's own ETB
+ *   damage to an opponent) re-fires it. The intervening-if (CR 603.4) is [Conditions.Delirium] —
+ *   checked both when the trigger would fire and on resolution. The redealt damage amount is
+ *   [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] ("that amount"), the damaged player is the
+ *   triggering player ([Player.TriggeringPlayer]), and the damage source is this creature
+ *   ([EffectTarget.Self], "this creature deals").
+ */
+val FearOfBurningAlive = card("Fear of Burning Alive") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Nightmare"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, it deals 4 damage to each opponent.\n" +
+        "Delirium — Whenever a source you control deals noncombat damage to an opponent, if there " +
+        "are four or more card types among cards in your graveyard, this creature deals that amount " +
+        "of damage to target creature that player controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = DealDamageEffect(
+            amount = DynamicAmount.Fixed(4),
+            target = EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+        description = "When this creature enters, it deals 4 damage to each opponent."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.NonCombat,
+            recipient = RecipientFilter.Opponent,
+            sourceFilter = GameObjectFilter.Any.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        triggerCondition = Conditions.Delirium()
+        val t = target(
+            "target",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.targetPlayerControls(
+                        EffectTarget.PlayerRef(Player.TriggeringPlayer),
+                    ),
+                ),
+            ),
+        )
+        effect = DealDamageEffect(
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            target = t,
+            damageSource = EffectTarget.Self,
+        )
+        description = "Delirium — Whenever a source you control deals noncombat damage to an " +
+            "opponent, if there are four or more card types among cards in your graveyard, this " +
+            "creature deals that amount of damage to target creature that player controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "J.P. Targete"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg?1726286352"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfImmobility.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfImmobility.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Fear of Immobility
+ * {4}{W}
+ * Enchantment Creature — Nightmare
+ * 4/4
+ * When this creature enters, tap up to one target creature. If an opponent controls that creature,
+ * put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one
+ * from it instead.)
+ *
+ * "Up to one target creature" → an optional [TargetCreature]; the creature is always tapped, and
+ * the stun counter is gated at resolution on the target being controlled by an opponent via
+ * [Conditions.TargetMatchesFilter] over [GameObjectFilter.Creature.opponentControls]. Tapping a
+ * creature you control gives no stun counter, matching the printed text.
+ */
+val FearOfImmobility = card("Fear of Immobility") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Nightmare"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, tap up to one target creature. If an opponent controls " +
+        "that creature, put a stun counter on it. (If a permanent with a stun counter would become " +
+        "untapped, remove one from it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(optional = true))
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.opponentControls()),
+                effect = AddCountersEffect(counterType = Counters.STUN, count = 1, target = t),
+            ),
+        )
+        description = "When this creature enters, tap up to one target creature. If an opponent " +
+            "controls that creature, put a stun counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Martin de Diego Sádaba"
+        flavorText = "As it slunk toward her, Nina told her legs to run, but they stayed rooted and " +
+            "rigid. She screamed—but no sound left her lips."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg?1726285895"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfImpostors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfImpostors.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Fear of Impostors
+ * {1}{U}{U}
+ * Enchantment Creature — Nightmare
+ * 3/2
+ * Flash
+ * When this creature enters, counter target spell. Its controller manifests dread. (That player
+ * looks at the top two cards of their library, then puts one onto the battlefield face down as a
+ * 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face
+ * up any time for its mana cost.)
+ *
+ * Implementation notes:
+ * - The ETB targets a spell, counters it, then the countered spell's controller manifests dread.
+ *   "Its controller" is [Player.ControllerOf] over the spell target; after the counter the spell
+ *   card sits in its owner's graveyard, where `controllerOf` resolves to that owner (= the spell's
+ *   caster for a normal spell), so the right player manifests.
+ * - "That player manifests dread" reuses the shared [Patterns.Library.manifestDread] recipe, but
+ *   run under the spell controller via [Effects.ForEachPlayer] over a single player. The iteration
+ *   rebinds the body's controller to that player (CR — they look at their own library, choose, and
+ *   the face-down 2/2 enters under their control), so no manifest-dread-for-another-player special
+ *   case is needed.
+ */
+val FearOfImpostors = card("Fear of Impostors") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Nightmare"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\nWhen this creature enters, counter target spell. Its controller manifests " +
+        "dread. (That player looks at the top two cards of their library, then puts one onto the " +
+        "battlefield face down as a 2/2 creature and the other into their graveyard. If it's a " +
+        "creature card, it can be turned face up any time for its mana cost.)"
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target spell", TargetSpell())
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            // Its controller manifests dread — run the shared recipe under the spell's controller.
+            Effects.ForEachPlayer(
+                players = Player.ControllerOf("target spell"),
+                effects = Patterns.Library.manifestDread().effects,
+            ),
+        )
+        description = "When this creature enters, counter target spell. Its controller manifests dread."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "David Szabo"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg?1726286066"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfInfinity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfInfinity.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fear of Infinity
+ * {1}{U}{B}
+ * Enchantment Creature — Nightmare
+ * 2/2
+ * Flying, lifelink
+ * This creature can't block.
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, you may
+ * return this card from your graveyard to your hand.
+ *
+ * The Eerie ability triggers from the graveyard (CR 603.10a — a triggered ability that returns the
+ * card from a graveyard functions there). Both halves of the Eerie keyword (an enchantment you
+ * control entering, and fully unlocking a Room) are modeled as two `triggerZone = GRAVEYARD`
+ * triggered abilities, each a [MayEffect] ("you may") wrapping [Effects.Move] of [EffectTarget.Self]
+ * to hand.
+ */
+val FearOfInfinity = card("Fear of Infinity") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Enchantment Creature — Nightmare"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, lifelink\nThis creature can't block.\n" +
+        "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, " +
+        "you may return this card from your graveyard to your hand."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK, Keyword.EERIE)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters (functions from graveyard).
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        triggerZone = Zone.GRAVEYARD
+        effect = MayEffect(Effects.Move(target = EffectTarget.Self, destination = Zone.HAND))
+        description = "Eerie — Whenever an enchantment you control enters, you may return this card " +
+            "from your graveyard to your hand."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room (functions from graveyard).
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        triggerZone = Zone.GRAVEYARD
+        effect = MayEffect(Effects.Move(target = EffectTarget.Self, destination = Zone.HAND))
+        description = "Eerie — Whenever you fully unlock a Room, you may return this card from your " +
+            "graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Fernando Falcone"
+        flavorText = "There are some nightmares so terrible, you're never truly rid of them."
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg?1726286668"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1871,6 +1871,105 @@
     ]
 }
 
+// Fear of Burning Alive
+{
+    "name": "Fear of Burning Alive",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "When this creature enters, it deals 4 damage to each opponent.\nDelirium — Whenever a source you control deals noncombat damage to an opponent, if there are four or more card types among cards in your graveyard, this creature deals that amount of damage to target creature that player controls.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, it deals 4 damage to each opponent."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageNonCombat",
+                    "recipient": "RecipientOpponent",
+                    "sourceFilter": "ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "damageSource": "Self"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "controllerPredicate": {
+                                "type": "ControlledByReferencedPlayer",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        }
+                    },
+                    "id": "target"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Delirium — Whenever a source you control deals noncombat damage to an opponent, if there are four or more card types among cards in your graveyard, this creature deals that amount of damage to target creature that player controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "UNCOMMON",
+        "artist": "J.P. Targete",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg?1726286352"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fear of Exposure
 {
     "name": "Fear of Exposure",
@@ -2016,6 +2115,261 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Fear of Immobility
+{
+    "name": "Fear of Immobility",
+    "manaCost": "{4}{W}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "When this creature enters, tap up to one target creature. If an opponent controls that creature, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature ctrl:opponent"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "stun",
+                                "count": 1,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, tap up to one target creature. If an opponent controls that creature, put a stun counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Martin de Diego Sádaba",
+        "flavorText": "As it slunk toward her, Nina told her legs to run, but they stayed rooted and rigid. She screamed—but no sound left her lips.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg?1726285895"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Fear of Impostors
+{
+    "name": "Fear of Impostors",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "Flash\nWhen this creature enters, counter target spell. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "Counter",
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": {
+                                    "type": "ControllerOf",
+                                    "targetDescription": "target spell"
+                                }
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            }
+                                        },
+                                        "storeAs": "manifestDreadLooked"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "manifestDreadLooked",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "manifestDreadManifested",
+                                        "storeRemainder": "manifestDreadGraveyard",
+                                        "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                        "remainderLabel": "Put into your graveyard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "manifestDreadManifested",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        },
+                                        "faceDown": "MANIFEST"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "manifestDreadGraveyard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Stack"
+                    },
+                    "id": "target spell"
+                },
+                "descriptionOverride": "When this creature enters, counter target spell. Its controller manifests dread."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "David Szabo",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg?1726286066"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fear of Infinity
+{
+    "name": "Fear of Infinity",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "Flying, lifelink\nThis creature can't block.\nEerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, you may return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK",
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, you may return this card from your graveyard to your hand."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, you may return this card from your graveyard to your hand."
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Fernando Falcone",
+        "flavorText": "There are some nightmares so terrible, you're never truly rid of them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg?1726286668"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1903,6 +1903,17 @@ internal fun EmitCtx.triggerBlock(
     // (which would double-wrap vs the golden — Elvish Pioneer).
     val selfOptional = mayInner?.strField("_Action") in SELF_OPTIONAL_ACTIONS
 
+    // A triggered ability that returns its own source from the graveyard (Eerie recursion — Fear of
+    // Infinity's "Whenever an enchantment you control enters …, you may return this card from your
+    // graveyard to your hand") must function from the graveyard: the hand-authored idiom is
+    // `triggerZone = Zone.GRAVEYARD` plus a resolution-time `MayEffect`. This envelope emits neither
+    // (it would wrongly render a battlefield-zone `optional = true` trigger), so decline to SCAFFOLD
+    // rather than emit a trigger that never fires from the graveyard.
+    if (effectActions.any { jsonContains(it, "_GraveyardCard", "ThisGraveyardCard") }) {
+        reasons.add("graveyard-active-trigger")
+        return null
+    }
+
     // An intervening-if written in the trigger's effect — "Whenever ~ attacks, create a token IF you
     // control a creature with power 4 or greater" (Scalestorm Summoner) — is modeled in mtgish as a lone
     // `If{cond}[then]` action, not a TriggerI. Per CR 603.4 this IS an intervening-if ability: the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
@@ -246,9 +246,14 @@ class DamageTriggerDetector(
                             // The triggering entity is the damage SOURCE (e.g. "a source you
                             // control deals damage… exile it"). Still carry the recipient creature's
                             // toughness so "equal to that creature's toughness" payoffs (Taii Wakeen)
-                            // can read it via ContextPropertyKey.TRIGGER_RECIPIENT_TOUGHNESS.
+                            // can read it via ContextPropertyKey.TRIGGER_RECIPIENT_TOUGHNESS. When the
+                            // recipient is a player, also carry it as the triggering player so
+                            // "…to a player, [that player] …" payoffs (Fear of Burning Alive's
+                            // "target creature that player controls") resolve Player.TriggeringPlayer
+                            // to the damaged player rather than the source.
                             TriggerContext(
                                 triggeringEntityId = event.sourceId,
+                                triggeringPlayerId = event.targetId.takeIf { it in state.turnOrder },
                                 damageAmount = event.amount,
                                 recipientToughnessAtDamage = event.targetToughnessAtDamage
                             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -528,7 +528,15 @@ class TriggerProcessor(
                 requirement = req,
                 controllerId = trigger.controllerId,
                 sourceId = trigger.sourceId,
-                triggeringEntityId = trigger.triggerContext.triggeringEntityId
+                triggeringEntityId = trigger.triggerContext.triggeringEntityId,
+                // Carry the triggering player so "target … that player controls" filters
+                // (ControllerPredicate.ControlledByReferencedPlayer over Player.TriggeringPlayer)
+                // resolve at legality time — Fear of Burning Alive's delirium payoff.
+                pipelineContext = com.wingedsheep.engine.handlers.PredicateContext(
+                    controllerId = trigger.controllerId,
+                    triggeringEntityId = trigger.triggerContext.triggeringEntityId,
+                    triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+                ),
             )
             allLegalTargets[index] = legalTargets
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -39,6 +39,7 @@ import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
@@ -1166,6 +1167,13 @@ data class PredicateContext(
     /** The entity that caused the trigger to fire (for SharesCreatureTypeWithTriggeringEntity) */
     val triggeringEntityId: EntityId? = null,
     /**
+     * The player associated with the trigger (the damaged player for damage triggers, the player
+     * whose event fired otherwise). Lets a target filter resolve
+     * [EffectTarget.PlayerRef] of [Player.TriggeringPlayer] — e.g. "target creature **that player**
+     * controls" on Fear of Burning Alive's "deals noncombat damage to an opponent" trigger.
+     */
+    val triggeringPlayerId: EntityId? = null,
+    /**
      * The entity a continuous effect is being applied to during projection (e.g. the creature an
      * Aura is enchanting). Lets filters resolve [EntityReference.AffectedEntity] — needed by
      * `AggregateBattlefield(filter = ...sharingCreatureTypeWith(AffectedEntity))` for Alpha Status.
@@ -1227,6 +1235,12 @@ data class PredicateContext(
             is EffectTarget.BoundVariable -> namedTargets[target.name]
             is EffectTarget.ContextTarget -> targets.getOrNull(target.index)
             EffectTarget.Controller -> return controllerId
+            is EffectTarget.PlayerRef -> return when (target.player) {
+                Player.You -> controllerId
+                Player.TriggeringPlayer -> triggeringPlayerId
+                Player.TargetPlayer, Player.TargetOpponent -> targetPlayerId
+                else -> null
+            }
             else -> null
         }
         return (chosen as? ChosenTarget.Player)?.playerId
@@ -1248,6 +1262,7 @@ data class PredicateContext(
                 targetPlayerId = chosenPlayerTarget,
                 sourceId = context.sourceId,
                 triggeringEntityId = context.triggeringEntityId,
+                triggeringPlayerId = context.triggeringPlayerId,
                 affectedEntityId = context.affectedEntityId,
                 chosenValues = context.pipeline.chosenValues,
                 storedStringLists = context.pipeline.storedStringLists,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -210,7 +210,13 @@ class ForEachExecutor(
             Player.TargetOpponent, Player.TargetPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
-            else -> state.activePlayers
+            // Single-player references (e.g. ControllerOf a targeted spell — Fear of Impostors'
+            // "its controller manifests dread") resolve to exactly that player. Fall back to all
+            // active players only when the reference yields nothing (a truly multi-player or
+            // unresolved ref).
+            else -> TargetResolutionUtils.resolvePlayerRef(player, context, state)
+                ?.let { listOf(it) }
+                ?: state.activePlayers
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1914,7 +1914,9 @@ class StackResolver(
                 abilityComponent.controllerId, targetsComponent.targetRequirements,
                 sourceId = abilityComponent.sourceId,
                 targetingSourceType = TargetingSourceType.ABILITY,
-                xValue = abilityComponent.xValue
+                xValue = abilityComponent.xValue,
+                triggeringEntityId = abilityComponent.triggeringEntityId,
+                triggeringPlayerId = abilityComponent.triggeringPlayerId,
             )
             if (validTargets.isEmpty()) {
                 // Fizzle - remove ability entity
@@ -2460,11 +2462,19 @@ class StackResolver(
         targetRequirements: List<TargetRequirement> = emptyList(),
         sourceId: EntityId? = null,
         targetingSourceType: TargetingSourceType = TargetingSourceType.ANY,
-        xValue: Int? = null
+        xValue: Int? = null,
+        triggeringEntityId: EntityId? = null,
+        triggeringPlayerId: EntityId? = null
     ): List<ChosenTarget> {
         // Always project state for shroud/hexproof checks (Rule 702.18, 702.11)
         val projected = state.projectedState
-        val predicateContext = PredicateContext(controllerId = controllerId, sourceId = sourceId, xValue = xValue)
+        val predicateContext = PredicateContext(
+            controllerId = controllerId,
+            sourceId = sourceId,
+            xValue = xValue,
+            triggeringEntityId = triggeringEntityId,
+            triggeringPlayerId = triggeringPlayerId,
+        )
 
         return targets.filterIndexed { index, target ->
             when (target) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfBurningAliveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfBurningAliveScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FearOfBurningAlive
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fear of Burning Alive (DSK #135) — {4}{R}{R} Enchantment Creature — Nightmare 4/4.
+ *
+ *   "When this creature enters, it deals 4 damage to each opponent.
+ *    Delirium — Whenever a source you control deals noncombat damage to an opponent, if there are
+ *    four or more card types among cards in your graveyard, this creature deals that amount of
+ *    damage to target creature that player controls."
+ *
+ * Verifies: the ETB deals 4 to the opponent; with delirium active, the delirium ability re-fires
+ * (the ETB damage is itself "a source you control deals noncombat damage to an opponent") and deals
+ * 4 to a creature that opponent controls. Without delirium, the ability does not re-deal.
+ */
+class FearOfBurningAliveScenarioTest : FunSpec({
+
+    // Four distinct card types in the graveyard: creature, instant, sorcery, enchantment.
+    val deliriumGraveyard = listOf("Grizzly Bears", "Lightning Bolt", "Goad Spell", "Test Enchantment")
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + FearOfBurningAlive)
+        initMirrorMatch(deck = Deck.of("Mountain" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("ETB deals 4 to each opponent; with delirium, redeals 4 to a creature that opponent controls") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        deliriumGraveyard.forEach { d.putCardInGraveyard(me, it) }
+        val oppBears = d.putCreatureOnBattlefield(opp, "Grizzly Bears") // 2/2
+
+        val fear = d.putCardInHand(me, "Fear of Burning Alive")
+        d.giveMana(me, Color.RED, 6)
+        d.castSpell(me, fear).error shouldBe null
+        // Resolve the spell. The ETB damage triggers the Delirium ability, which pauses for its target.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Opponent took 4 from the ETB.
+        d.getLifeTotal(opp) shouldBe 16
+
+        println("DBGB2 gyTypes=" + d.getGraveyardCardNames(me) + " fearOnBf=" + d.getPermanents(me).map{d.getCardName(it)} + " oppBearsAlive=" + (d.state.getEntity(oppBears)!=null) + " pending=" + d.pendingDecision?.javaClass?.simpleName)
+        // The Delirium ability is on the stack, asking for a target creature that opponent controls.
+        (d.pendingDecision as ChooseTargetsDecision)
+        d.submitTargetSelection(me, listOf(oppBears))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        // The 2/2 took 4 noncombat damage from Fear of Burning Alive -> dead, in the graveyard.
+        d.getGraveyard(opp).contains(oppBears) shouldBe true
+    }
+
+    test("without delirium the ETB still deals 4 but the delirium ability does not re-deal") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        // Only one card type in graveyard — no delirium.
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        val oppBears = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val fear = d.putCardInHand(me, "Fear of Burning Alive")
+        d.giveMana(me, Color.RED, 6)
+        d.castSpell(me, fear).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // ETB hit the opponent for 4, and with no delirium the ability never asks for a target.
+        d.getLifeTotal(opp) shouldBe 16
+        (d.pendingDecision is ChooseTargetsDecision) shouldBe false
+        d.getGraveyard(opp).contains(oppBears) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfImmobilityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfImmobilityScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FearOfImmobility
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fear of Immobility (DSK #10) — {4}{W} Enchantment Creature — Nightmare 4/4.
+ *
+ *   "When this creature enters, tap up to one target creature. If an opponent controls that
+ *    creature, put a stun counter on it."
+ *
+ * Verifies: an opposing creature is tapped AND gets a stun counter; a creature you control is
+ * tapped but gets NO stun counter (the stun is gated on opponent control).
+ */
+class FearOfImmobilityScenarioTest : FunSpec({
+
+    fun GameTestDriver.stunCount(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + FearOfImmobility)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("ETB taps an opposing creature and stuns it") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        val bears = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val fear = d.putCardInHand(me, "Fear of Immobility")
+        d.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 5)
+        d.castSpell(me, fear).error shouldBe null
+        // Resolve the spell so the ETB trigger goes on the stack and pauses for its target.
+        d.bothPass()
+
+        // The ETB trigger asks for its (up to one) target.
+        (d.pendingDecision as ChooseTargetsDecision)
+        d.submitTargetSelection(me, listOf(bears))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isTapped(bears) shouldBe true
+        d.stunCount(bears) shouldBe 1
+    }
+
+    test("ETB tapping your own creature gives no stun counter") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val myBears = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val fear = d.putCardInHand(me, "Fear of Immobility")
+        d.giveMana(me, com.wingedsheep.sdk.core.Color.WHITE, 5)
+        d.castSpell(me, fear).error shouldBe null
+        d.bothPass()
+
+        (d.pendingDecision as ChooseTargetsDecision)
+        d.submitTargetSelection(me, listOf(myBears))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isTapped(myBears) shouldBe true
+        d.stunCount(myBears) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfImpostorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfImpostorsScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FearOfImpostors
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Fear of Impostors (DSK #57) — {1}{U}{U} Enchantment Creature — Nightmare 3/2, Flash.
+ *
+ *   "When this creature enters, counter target spell. Its controller manifests dread."
+ *
+ * Verifies: the targeted spell is countered (goes to its controller's graveyard), and the
+ * countered spell's controller — not Fear of Impostors' controller — manifests dread (looks at the
+ * top two of *their* library, manifests one as a face-down 2/2 under their control, bins the other).
+ */
+class FearOfImpostorsScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + FearOfImpostors)
+        initMirrorMatch(deck = Deck.of("Island" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("counters the spell and makes that spell's controller manifest dread") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        // Stack the opponent's top two cards: a creature on top, a land beneath.
+        val oppLand = d.putCardOnTopOfLibrary(opp, "Island")
+        val oppCreature = d.putCardOnTopOfLibrary(opp, "Grizzly Bears") // now the top card
+
+        // Active player (me) passes priority so the opponent can cast a spell.
+        d.passPriority(me)
+
+        // Opponent casts a spell, then passes priority back so I can respond.
+        val oppSpell = d.putCardInHand(opp, "Lightning Bolt")
+        d.giveMana(opp, Color.RED, 1)
+        d.castSpell(opp, oppSpell, targets = listOf(me)).error shouldBe null
+        d.passPriority(opp)
+
+        // I flash in Fear of Impostors. Its counter is an ETB triggered ability (not a spell
+        // target), so it picks its target after the creature resolves.
+        val fear = d.putCardInHand(me, "Fear of Impostors")
+        d.giveMana(me, Color.BLUE, 3)
+        d.castSpell(me, fear).error shouldBe null
+
+        // Resolve Fear of Impostors; its ETB pauses to choose the spell to counter.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        (d.pendingDecision as com.wingedsheep.engine.core.ChooseTargetsDecision)
+        d.submitTargetSelection(me, listOf(oppSpell))
+
+        // Resolve the ETB (counter + manifest dread) until the opponent's manifest pick pauses.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The countered spell is in the opponent's graveyard.
+        d.getGraveyard(opp) shouldContain oppSpell
+
+        // The OPPONENT (the countered spell's controller) is the one choosing which card to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.options.toSet() shouldBe setOf(oppCreature, oppLand)
+        pick.playerId shouldBe opp
+        d.submitDecision(opp, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(oppCreature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The opponent's chosen card is a face-down 2/2 under the opponent's control; the other binned.
+        d.getPermanents(opp) shouldContain oppCreature
+        val entity = d.state.getEntity(oppCreature)
+        entity?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        entity?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        d.state.projectedState.getPower(oppCreature) shouldBe 2
+        d.getGraveyard(opp) shouldContain oppLand
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfInfinityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfInfinityScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FearOfInfinity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Fear of Infinity (DSK #214) — {1}{U}{B} Enchantment Creature — Nightmare 2/2.
+ *
+ *   "Flying, lifelink. This creature can't block.
+ *    Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, you
+ *    may return this card from your graveyard to your hand."
+ *
+ * Verifies the Eerie graveyard-recursion half: while Fear of Infinity is in your graveyard, an
+ * enchantment you control entering offers an optional return to hand. Confirming the "may" returns
+ * the card; declining leaves it in the graveyard.
+ */
+class FearOfInfinityScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + FearOfInfinity)
+        initMirrorMatch(deck = Deck.of("Plains" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("an enchantment you control entering returns Fear of Infinity from graveyard to hand") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val fear = d.putCardInGraveyard(me, "Fear of Infinity")
+
+        // Cast an enchantment you control — its ETB fires the Eerie trigger from the graveyard.
+        val ench = d.putCardInHand(me, "Test Enchantment") // {1}{W}
+        d.giveMana(me, Color.WHITE, 2)
+        d.castSpell(me, ench).error shouldBe null
+        // Resolve the enchantment; its ETB fires the Eerie trigger, which pauses for the "may".
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Optional "you may return" — confirm yes.
+        d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        d.submitYesNo(me, true)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getHand(me) shouldContain fear
+        d.getGraveyard(me) shouldNotContain fear
+    }
+
+    test("declining the Eerie may leaves Fear of Infinity in the graveyard") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val fear = d.putCardInGraveyard(me, "Fear of Infinity")
+
+        val ench = d.putCardInHand(me, "Test Enchantment")
+        d.giveMana(me, Color.WHITE, 2)
+        d.castSpell(me, ench).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        d.submitYesNo(me, false)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getGraveyard(me) shouldContain fear
+        d.getHand(me) shouldNotContain fear
+    }
+})


### PR DESCRIPTION
Implements four Duskmourn: House of Horror Nightmare enchantment creatures, plus the small, general engine fixes their faithful behaviour required.

## Cards

| Card | Cost | P/T | Behaviour |
|------|------|-----|-----------|
| **Fear of Immobility** | {4}{W} | 4/4 | ETB taps up to one target creature; puts a stun counter on it **only if** an opponent controls it. Modeled as `Tap` + `ConditionalEffect(TargetMatchesFilter(opponentControls), AddCounters(STUN))`. |
| **Fear of Burning Alive** | {4}{R}{R} | 4/4 | ETB deals 4 to each opponent; a **Delirium**-gated observer trigger (`dealsDamage` NonCombat → Opponent, source you control) redeals that much to **target creature that player controls**. |
| **Fear of Infinity** | {1}{U}{B} | 2/2 | Flying, lifelink, can't block; **Eerie** returns it from the graveyard to hand (`triggerZone = GRAVEYARD` + `MayEffect`, on both the enchantment-enters and Room-fully-unlocked halves). |
| **Fear of Impostors** | {1}{U}{U} | 3/2 | Flash; ETB counters target spell, then **its controller** manifests dread (`ForEachPlayer(ControllerOf(spell))` over the shared `manifestDread` recipe, so the right player looks/chooses/keeps control). |

All four are DSK-original printings (canonical placement in DSK confirmed).

## Engine fixes (general, not card-specific)

- **`Player.TriggeringPlayer` now resolves to the damaged player** for `DealsDamageEvent` triggers, and resolves **inside a target's controller filter** — both at trigger legality (`TriggerProcessor`) and at resolution-time target validation (`StackResolver`), via a new `PredicateContext.triggeringPlayerId` threaded through. Without this, "target creature that player controls" on a damage trigger found no legal targets and silently fizzled.
- **`ForEachExecutor.resolvePlayers`** now resolves single-player refs like `ControllerOf` instead of falling back to *all* active players (which made "its controller manifests dread" run for the wrong player / every player).

## mtgish-tooling

The emitter now **declines (→ SCAFFOLD)** a triggered ability that returns its own source from the graveyard, since that envelope emits neither the graveyard `activeZone` nor the resolution-time `MayEffect` — fixing a **false AUTO** on Fear of Infinity (it had been emitting a battlefield-zone `optional=true` trigger that never fires from the graveyard).

- POR gate stays **0-mismatch** (158/158 GATE PASS).
- All 7 `EmitterGoldenTest` sets still pass (Gangrenous Goliath, the only other `ReturnGraveyardCardToHand` card, uses an *activated* ability and is unaffected).
- The other three Fear cards remain honest **SCAFFOLD**s — the delirium noncombat-damage redeal, conditional stun, and manifest-dread-for-another-player are card-specific / known-sloppy-area shapes the emitter declines rather than mis-render (per the fidelity policy).

## Tests

- Scenario tests for all four cards (`rules-engine`) — pass.
- Full `rules-engine` suite passes (no regressions from the engine changes).
- `CardLintTest`, `CardDefinitionSnapshotTest` (re-blessed, DSK-only diff), `mtgish-tooling` suite all pass.

Also updates `docs/card-sdk-language-reference.md` (TriggeringPlayer in damage-trigger controller filters) and `backlog/dsk-engine-gaps.md` (marks the manifest-dread-for-another-player gap resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)