### PR TITLE
Add central tap() atom so battlefield taps can't drop their event

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -603,6 +603,39 @@ class TriggerDetector {
 - **Game log.** The event stream is a complete, structured game log that can be replayed, analyzed,
   or displayed to spectators.
 
+**Co-locate the mutation and its event in a single "atom."** The weakness of "every mutation emits
+an event" is that *emitting* is a separate statement from *mutating*, so it's easy to forget — and
+a forgotten event is a silent bug: the state is right but no trigger or animation ever fires. The
+engine has lost tap events exactly this way more than once (station creatures and the
+declare-attackers loop both shipped a `with(TappedComponent)` whose paired `TappedEvent` was missing,
+so "whenever this becomes tapped" triggers never saw the tap). The fix is structural, not vigilance:
+for any state change that is observable — gaining life, tapping, untapping, putting on counters —
+funnel **every** call site through one small helper that performs the mutation *and* returns the
+event, so the two cannot drift apart:
+
+```kotlin
+// The "tap atom": the only place a battlefield permanent becomes tapped. Returns the event so the
+// caller folds it into its result; returns `null` for a non-transition (already tapped — CR 603.2f).
+fun tap(state: GameState, entityId: EntityId): Pair<GameState, TappedEvent?>
+
+// Its untap mirror, which also applies the stun-counter replacement (CR 122.1d).
+fun untapOrConsumeStun(state: GameState, entityId: EntityId, projected: ProjectedState? = null)
+    : Pair<GameState, List<GameEvent>>
+
+// Life changes go through DamageUtils.gainLife / loseLife the same way.
+fun gainLife(state: GameState, playerId: EntityId, amount: Int, ...): Pair<GameState, LifeChangedEvent?>
+```
+
+Two properties make these *atoms* rather than mere helpers: they own the **transition guard** (a
+no-op emits no event, so triggers never fire on a non-transition — CR 603.2f) and they own any
+**replacement** that reshapes the change (a stun counter replacing an untap). Both are rules that
+every call site would otherwise have to remember independently. When you add a new observable
+mutation, build the atom first and route all sites through it; where the corpus must not bypass it,
+back it with a source-scanning hygiene test (e.g. `TapEventEnforcementTest` bans raw
+`with(TappedComponent)` / `without<TappedComponent>()` outside a small allowlist of legitimate
+enters-tapped / cleanup sites, the same way `FacadeBoundaryTest` bans raw effect construction in
+cards). The atom makes the event impossible to forget; the test makes the bypass impossible to add.
+
 ### 2.6 Strategy-Based Registries
 
 **Principle:** Action handling and effect execution are fully decoupled from the core engine loop.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
@@ -10,6 +10,46 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.model.EntityId
 
 /**
+ * Tap a single permanent on the battlefield, emitting the [TappedEvent] that
+ * "whenever this becomes tapped" triggers (Station, Cryptic Gateway, …) and the
+ * client tap animation react to.
+ *
+ * This is the canonical *tap atom* — the analogue of [untapOrConsumeStun] for the
+ * untap direction and of `DamageUtils.gainLife` for life. Route every place a
+ * permanent *becomes tapped while on the battlefield* through here so the mutation
+ * and its event can never drift apart. Past bugs (station creatures, declare-attackers)
+ * came from open-coding `with(TappedComponent)` and forgetting the paired event;
+ * `TapEventEnforcementTest` now bans that pattern outside the legitimate
+ * enters-tapped/cleanup sites.
+ *
+ * Tapping is a transition (CR 603.2f): a permanent that is *already* tapped does not
+ * become tapped again, so this is a no-op that emits no event. The same is true for an
+ * entity that no longer exists. In both cases the original [state] is returned paired
+ * with `null`, so callers can fold the event in without a special case:
+ *
+ * ```
+ * val (next, event) = tap(state, id)
+ * return EffectResult.success(next, listOfNotNull(event))
+ * ```
+ *
+ * **Not for permanents entering tapped.** A permanent that *enters the battlefield
+ * tapped* (taplands, tokens created tapped, phased-in-tapped, sneak/regeneration) is
+ * not transitioning from untapped to tapped, so those sites set [TappedComponent]
+ * directly and emit no event — they are the allowlist in `TapEventEnforcementTest`.
+ *
+ * @return the updated state paired with the emitted [TappedEvent], or `state to null`
+ *   when the permanent was already tapped or doesn't exist (no mutation performed).
+ */
+fun tap(state: GameState, entityId: EntityId): Pair<GameState, TappedEvent?> {
+    val container = state.getEntity(entityId) ?: return state to null
+    // CR 603.2f: tapping an already-tapped permanent is not a transition — no event.
+    if (container.has<TappedComponent>()) return state to null
+    val cardName = container.get<CardComponent>()?.name ?: "Permanent"
+    val newState = state.updateEntity(entityId) { it.with(TappedComponent) }
+    return newState to TappedEvent(entityId, cardName)
+}
+
+/**
  * Apply the untap-step untap replacements to a single permanent that *would*
  * become untapped:
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -8,6 +8,8 @@ import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
 import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.core.tap
+import com.wingedsheep.engine.core.untapOrConsumeStun
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
@@ -231,12 +233,17 @@ class CostHandler(
             }
             is AbilityCost.Atom -> payAtom(state, cost.atom, sourceId, controllerId, manaPool, choices, abilityContext)
             is AbilityCost.Tap -> {
-                val newState = state.updateEntity(sourceId) { it.with(TappedComponent) }
-                CostPaymentResult.success(newState, manaPool)
+                // Route through the tap atom so the "{T}:" cost emits its TappedEvent — every
+                // payAbilityCost caller gets the event for free (ActivateAbilityHandler used to
+                // re-derive it by hand, silently dropping it on any other payment path).
+                val (newState, event) = tap(state, sourceId)
+                CostPaymentResult.success(newState, manaPool, listOfNotNull(event))
             }
             is AbilityCost.Untap -> {
-                val newState = state.updateEntity(sourceId) { it.without<TappedComponent>() }
-                CostPaymentResult.success(newState, manaPool)
+                // Route through the untap atom so a "{Q}:" cost emits UntappedEvent and a stun
+                // counter correctly replaces the untap (CR 122.1d) instead of being ignored.
+                val (newState, events) = untapOrConsumeStun(state, sourceId)
+                CostPaymentResult.success(newState, manaPool, events)
             }
             is AbilityCost.PayXLife -> {
                 val amount = choices.xValue
@@ -363,8 +370,8 @@ class CostHandler(
             is AbilityCost.TapAttachedCreature -> {
                 val attachedId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
                     ?: return CostPaymentResult.failure("Source is not attached to a creature")
-                val newState = state.updateEntity(attachedId) { it.with(TappedComponent) }
-                CostPaymentResult.success(newState, manaPool)
+                val (newState, event) = tap(state, attachedId)
+                CostPaymentResult.success(newState, manaPool, listOfNotNull(event))
             }
             is AbilityCost.TapXPermanents -> {
                 val xCount = choices.xValue
@@ -377,11 +384,14 @@ class CostHandler(
                     }
 
                     var newState = state
+                    val events = mutableListOf<GameEvent>()
                     for (permanentId in toTap.take(xCount)) {
-                        newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
+                        val (tappedState, event) = tap(newState, permanentId)
+                        newState = tappedState
+                        event?.let(events::add)
                     }
 
-                    CostPaymentResult.success(newState, manaPool)
+                    CostPaymentResult.success(newState, manaPool, events)
                 }
             }
             is AbilityCost.RemoveXPlusOnePlusOneCounters -> {
@@ -783,13 +793,13 @@ class CostHandler(
         var newState = state
         val events = mutableListOf<GameEvent>()
         for (permanentId in toTap) {
-            newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
-            // Emit TappedEvent so "whenever this becomes tapped" triggers fire when a creature
-            // is tapped to pay a cost (Station, Cryptic Gateway). Without this, paying the cost
-            // adds TappedComponent silently and the trigger never sees the tap (cf. the analogous
-            // declare-attackers fix in AttackPhaseManager.commitAttackDeclaration).
-            val name = state.getEntity(permanentId)?.get<CardComponent>()?.name ?: "Permanent"
-            events.add(TappedEvent(permanentId, name))
+            // The tap atom emits the TappedEvent so "whenever this becomes tapped" triggers fire
+            // when a creature is tapped to pay a cost (Station, Cryptic Gateway). Open-coding the
+            // mutation here used to drop the event (cf. the declare-attackers fix in
+            // AttackPhaseManager.commitAttackDeclaration).
+            val (tappedState, event) = tap(newState, permanentId)
+            newState = tappedState
+            event?.let(events::add)
         }
         return CostPaymentResult.success(newState, manaPool, events)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.LoyaltyChangedEvent
 import com.wingedsheep.engine.core.ManaAddedEvent
 import com.wingedsheep.engine.core.PaymentStrategy
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.TurnManager
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
@@ -770,12 +770,9 @@ class ActivateAbilityHandler(
                         currentState, action.playerId, manaCost, manaXValue, excludeSources = excluded, xManaRestriction = ability.xManaRestriction
                     ) ?: return ExecutionResult.error(state, "Selected mana sources cannot pay this ability's cost")
                     for (source in solution.sources) {
-                        val sourceName = currentState.getEntity(source.entityId)
-                            ?.get<CardComponent>()?.name ?: source.name
-                        currentState = currentState.updateEntity(source.entityId) { c ->
-                            c.with(TappedComponent)
-                        }
-                        events.add(TappedEvent(source.entityId, sourceName))
+                        val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                        currentState = tappedState
+                        tapEvent?.let(events::add)
                     }
                 }
                 else -> {
@@ -931,38 +928,12 @@ class ActivateAbilityHandler(
             ))
         }
 
-        // Emit events for cost types
+        // Emit events for cost types. Tap/TapAttachedCreature/TapXPermanents taps are emitted by
+        // the tap atom inside costHandler.payAbilityCost (folded in via costResult.events above), so
+        // only the loyalty change — which payAbilityCost mutates without an event — is emitted here.
         val abilityCost = ability.cost
-        when (abilityCost) {
-            is AbilityCost.Tap -> {
-                events.add(TappedEvent(action.sourceId, cardComponent.name))
-            }
-            is AbilityCost.TapAttachedCreature -> {
-                val attachedId = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId
-                if (attachedId != null) {
-                    val attachedName = currentState.getEntity(attachedId)?.get<CardComponent>()?.name ?: "Unknown"
-                    events.add(TappedEvent(attachedId, attachedName))
-                }
-            }
-            is AbilityCost.Composite -> {
-                for (subCost in abilityCost.costs) {
-                    when (subCost) {
-                        is AbilityCost.Tap -> events.add(TappedEvent(action.sourceId, cardComponent.name))
-                        is AbilityCost.TapAttachedCreature -> {
-                            val attachedId = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId
-                            if (attachedId != null) {
-                                val attachedName = currentState.getEntity(attachedId)?.get<CardComponent>()?.name ?: "Unknown"
-                                events.add(TappedEvent(attachedId, attachedName))
-                            }
-                        }
-                        else -> {}
-                    }
-                }
-            }
-            is AbilityCost.Loyalty -> {
-                events.add(LoyaltyChangedEvent(action.sourceId, cardComponent.name, abilityCost.change))
-            }
-            else -> {}
+        if (abilityCost is AbilityCost.Loyalty) {
+            events.add(LoyaltyChangedEvent(action.sourceId, cardComponent.name, abilityCost.change))
         }
 
         // Track per-turn activation if the ability has an OncePerTurn or MaxPerTurn restriction
@@ -1673,10 +1644,9 @@ class ActivateAbilityHandler(
         val events = mutableListOf<GameEvent>()
 
         for (source in solution.sources) {
-            currentState = currentState.updateEntity(source.entityId) { c ->
-                c.with(com.wingedsheep.engine.state.components.battlefield.TappedComponent)
-            }
-            events.add(TappedEvent(source.entityId, source.name))
+            val (tappedState, tapEvent) = tap(currentState, source.entityId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
         }
 
         // Add produced mana to floating pool so costHandler.payAbilityCost can consume it.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.engine.handlers.actions.ability
 import com.wingedsheep.engine.core.CrewVehicle
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.core.EngineServices
@@ -140,12 +140,9 @@ class CrewVehicleHandler(
 
         // Pay the cost: tap each crew creature
         for (creatureId in action.crewCreatures) {
-            val creatureName = currentState.getEntity(creatureId)
-                ?.get<CardComponent>()?.name ?: "Unknown"
-            currentState = currentState.updateEntity(creatureId) { c ->
-                c.with(TappedComponent)
-            }
-            events.add(TappedEvent(creatureId, creatureName))
+            val (tappedState, tapEvent) = tap(currentState, creatureId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
         }
 
         // Record the crew so Vehicle payoffs can read "creatures that crewed it this turn"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
@@ -146,12 +146,9 @@ class CycleCardHandler(
             if (action.paymentStrategy is PaymentStrategy.Explicit) {
                 // Tap specified sources explicitly
                 for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
-                    val sourceName = currentState.getEntity(sourceId)
-                        ?.get<CardComponent>()?.name ?: "Unknown"
-                    currentState = currentState.updateEntity(sourceId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(sourceId, sourceName))
+                    val (tappedState, tapEvent) = tap(currentState, sourceId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
             } else {
                 val solution = manaSolver.solve(currentState, action.playerId, remainingCost, 0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.PlotCard
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.event.TriggerDetector
@@ -187,10 +187,9 @@ class PlotCardHandler(
         if (!remainingCost.isEmpty()) {
             if (action.paymentStrategy is PaymentStrategy.Explicit) {
                 for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
-                    val sourceName = currentState.getEntity(sourceId)
-                        ?.get<CardComponent>()?.name ?: "Unknown"
-                    currentState = currentState.updateEntity(sourceId) { c -> c.with(TappedComponent) }
-                    events.add(TappedEvent(sourceId, sourceName))
+                    val (tappedState, tapEvent) = tap(currentState, sourceId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
             } else {
                 val solution = manaSolver.solve(currentState, action.playerId, remainingCost, 0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.SaddleMount
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.handlers.actions.ActionHandler
@@ -126,12 +126,9 @@ class SaddleMountHandler(
 
         // Pay the cost: tap each saddling creature (CR 702.171c — these creatures "saddle" it).
         for (creatureId in action.saddleCreatures) {
-            val creatureName = currentState.getEntity(creatureId)
-                ?.get<CardComponent>()?.name ?: "Unknown"
-            currentState = currentState.updateEntity(creatureId) { c ->
-                c.with(TappedComponent)
-            }
-            events.add(TappedEvent(creatureId, creatureName))
+            val (tappedState, tapEvent) = tap(currentState, creatureId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
         }
 
         // Record the saddlers so Mount payoffs can read "creatures that saddled it this turn".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/TypecycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/TypecycleCardHandler.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.TypecycleCard
 import com.wingedsheep.engine.core.TypecycleSearchContinuation
 import com.wingedsheep.engine.core.ZoneChangeEvent
@@ -148,12 +148,9 @@ class TypecycleCardHandler(
         if (!remainingCost.isEmpty()) {
             if (action.paymentStrategy is PaymentStrategy.Explicit) {
                 for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
-                    val sourceName = currentState.getEntity(sourceId)
-                        ?.get<CardComponent>()?.name ?: "Unknown"
-                    currentState = currentState.updateEntity(sourceId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(sourceId, sourceName))
+                    val (tappedState, tapEvent) = tap(currentState, sourceId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
             } else {
                 val solution = manaSolver.solve(currentState, action.playerId, remainingCost, 0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.core.TurnFaceUpEvent
 import com.wingedsheep.engine.event.TriggerDetector
@@ -321,13 +321,9 @@ class TurnFaceUpHandler(
 
                     is PaymentStrategy.Explicit -> {
                         for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
-                            val sourceName = currentState.getEntity(sourceId)
-                                ?.get<CardComponent>()?.name ?: "Unknown"
-
-                            currentState = currentState.updateEntity(sourceId) { c ->
-                                c.with(TappedComponent)
-                            }
-                            events.add(TappedEvent(sourceId, sourceName))
+                            val (tappedState, tapEvent) = tap(currentState, sourceId)
+                            currentState = tappedState
+                            tapEvent?.let(events::add)
                         }
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.RoomFullyUnlockedEvent
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.UnlockRoomDoor
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
@@ -257,12 +257,9 @@ class UnlockRoomDoorHandler(
             }
             is PaymentStrategy.Explicit -> {
                 for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
-                    val sourceName = currentState.getEntity(sourceId)
-                        ?.get<CardComponent>()?.name ?: "Unknown"
-                    currentState = currentState.updateEntity(sourceId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(sourceId, sourceName))
+                    val (tappedState, tapEvent) = tap(currentState, sourceId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -28,7 +28,7 @@ import com.wingedsheep.engine.mechanics.MiracleGrants
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.TurnManager
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.event.PendingTrigger
@@ -1924,14 +1924,9 @@ class CastSpellHandler(
                             // Tap permanents as additional cost (e.g., Zahid's tap an artifact)
                             val tappedPerms = action.additionalCostPayment.tappedPermanents
                             for (permId in tappedPerms) {
-                                val permContainer = currentState.getEntity(permId) ?: continue
-                                if (!permContainer.has<TappedComponent>()) {
-                                    currentState = currentState.updateEntity(permId) { c ->
-                                        c.with(TappedComponent)
-                                    }
-                                    val permCard = permContainer.get<CardComponent>()
-                                    events.add(TappedEvent(permId, permCard?.name ?: "Permanent"))
-                                }
+                                val (tappedState, tapEvent) = tap(currentState, permId)
+                                currentState = tappedState
+                                tapEvent?.let(events::add)
                             }
                         }
                         is CostAtom.ReturnToHand -> {
@@ -2231,14 +2226,9 @@ class CastSpellHandler(
         // tapped" self-triggers fire (mirrors the attack-declare TappedEvent fix).
         if (action.conspiredCreatures.isNotEmpty()) {
             for (creatureId in action.conspiredCreatures) {
-                val creatureContainer = currentState.getEntity(creatureId) ?: continue
-                if (!creatureContainer.has<TappedComponent>()) {
-                    currentState = currentState.updateEntity(creatureId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    val creatureName = creatureContainer.get<CardComponent>()?.name ?: "Creature"
-                    events.add(TappedEvent(creatureId, creatureName))
-                }
+                val (tappedState, tapEvent) = tap(currentState, creatureId)
+                currentState = tappedState
+                tapEvent?.let(events::add)
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatTaxContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatTaxContinuationResumer.kt
@@ -7,11 +7,10 @@ import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSourceOption
 import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
@@ -123,8 +122,9 @@ class CombatTaxContinuationResumer(
                 val solver = ManaSolver(services.cardRegistry)
                 val solution = solver.solve(currentState, playerId, remainingCost) ?: return null
                 for (source in solution.sources) {
-                    currentState = currentState.updateEntity(source.entityId) { it.with(TappedComponent) }
-                    events.add(TappedEvent(source.entityId, source.name))
+                    val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
                 for ((_, production) in solution.manaProduced) {
                     pool = if (production.color != null) {
@@ -142,8 +142,9 @@ class CombatTaxContinuationResumer(
                         // to returning null so the caller errors with a clear message.
                         return null
                     }
-                    currentState = currentState.updateEntity(sourceId) { it.with(TappedComponent) }
-                    events.add(TappedEvent(sourceId, source.name))
+                    val (tappedState, tapEvent) = tap(currentState, sourceId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                     pool = when {
                         source.producesColors.isNotEmpty() -> pool.add(source.producesColors.first())
                         source.producesColorless -> pool.addColorless(1)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DrawReplacementContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DrawReplacementContinuationResumer.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.engine.handlers.effects.drawing.DrawCardsExecutor
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.model.EntityId
@@ -115,10 +114,9 @@ class DrawReplacementContinuationResumer(
                             events.add(PermanentsSacrificedEvent(sourceController, listOf(sourceId)))
                             events.addAll(transition.events)
                         } else {
-                            newState = newState.updateEntity(sourceId) { c ->
-                                c.with(TappedComponent)
-                            }
-                            events.add(TappedEvent(sourceId, sourceName))
+                            val (tappedState, tapEvent) = tap(newState, sourceId)
+                            newState = tappedState
+                            tapEvent?.let(events::add)
                         }
 
                         // Add mana from the tapped/sacrificed source

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -444,10 +444,9 @@ class ManaPaymentContinuationResumer(
                     ?: return ExecutionResult.error(state, "Cannot pay mana cost with auto-pay")
 
                 for (source in solution.sources) {
-                    currentState = currentState.updateEntity(source.entityId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(source.entityId, source.name))
+                    val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
                 for ((_, production) in solution.manaProduced) {
                     currentPool = if (production.color != null) {
@@ -831,10 +830,9 @@ class ManaPaymentContinuationResumer(
                     ?: return ExecutionResult.error(state, "Cannot pay mana cost with auto-pay")
 
                 for (source in solution.sources) {
-                    currentState = currentState.updateEntity(source.entityId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(source.entityId, source.name))
+                    val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
                 for ((_, production) in solution.manaProduced) {
                     currentPool = if (production.color != null) {
@@ -1017,10 +1015,9 @@ class ManaPaymentContinuationResumer(
                 ?: return ExecutionResult.error(state, "Cannot pay mana cost")
 
             for (source in solution.sources) {
-                currentState = currentState.updateEntity(source.entityId) { c ->
-                    c.with(TappedComponent)
-                }
-                events.add(TappedEvent(source.entityId, source.name))
+                val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                currentState = tappedState
+                tapEvent?.let(events::add)
             }
 
             for ((_, production) in solution.manaProduced) {
@@ -1110,10 +1107,9 @@ class ManaPaymentContinuationResumer(
                     ?: return ExecutionResult.error(state, "Cannot pay mana cost with auto-pay")
 
                 for (source in solution.sources) {
-                    currentState = currentState.updateEntity(source.entityId) { c ->
-                        c.with(TappedComponent)
-                    }
-                    events.add(TappedEvent(source.entityId, source.name))
+                    val (tappedState, tapEvent) = tap(currentState, source.entityId)
+                    currentState = tappedState
+                    tapEvent?.let(events::add)
                 }
 
                 for ((_, production) in solution.manaProduced) {
@@ -1235,8 +1231,9 @@ class ManaPaymentContinuationResumer(
                 events.add(PermanentsSacrificedEvent(sourceController, listOf(sourceId)))
                 events.addAll(transition.events)
             } else {
-                currentState = currentState.updateEntity(sourceId) { c -> c.with(TappedComponent) }
-                events.add(TappedEvent(sourceId, source.name))
+                val (tappedState, tapEvent) = tap(currentState, sourceId)
+                currentState = tappedState
+                tapEvent?.let(events::add)
             }
 
             if (source.producesColors.isNotEmpty()) {
@@ -1406,14 +1403,13 @@ class ManaPaymentContinuationResumer(
         // Tap the source and each chosen permanent, then credit the source's mana to the pool.
         var currentState = state
         val events = mutableListOf<GameEvent>()
-        currentState = currentState.updateEntity(headSourceId) { c -> c.with(TappedComponent) }
-        events.add(TappedEvent(headSourceId, sourceOption.name))
+        val (headTappedState, headTapEvent) = tap(currentState, headSourceId)
+        currentState = headTappedState
+        headTapEvent?.let(events::add)
         for (chosen in response.selectedCards) {
-            val chosenName = currentState.getEntity(chosen)
-                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name
-                ?: "Permanent"
-            currentState = currentState.updateEntity(chosen) { c -> c.with(TappedComponent) }
-            events.add(TappedEvent(chosen, chosenName))
+            val (tappedState, tapEvent) = tap(currentState, chosen)
+            currentState = tappedState
+            tapEvent?.let(events::add)
         }
 
         // Read current pool, add the source's mana, persist.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -369,12 +369,9 @@ class SacrificeAndPayContinuationResumer(
         val events = mutableListOf<GameEvent>()
 
         for (permanentId in selectedPermanents) {
-            val entity = newState.getEntity(permanentId) ?: continue
-            // Skip already-tapped permanents (defensive — selection UI should already exclude them).
-            if (entity.has<TappedComponent>()) continue
-            val permanentName = entity.get<CardComponent>()?.name ?: "Unknown"
-            newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
-            events.add(TappedEvent(permanentId, permanentName))
+            val (tappedState, tapEvent) = tap(newState, permanentId)
+            newState = tappedState
+            tapEvent?.let(events::add)
         }
 
         return checkForMore(newState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ProvokeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ProvokeExecutor.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.effects.combat
 
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.untapOrConsumeStun
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
@@ -9,7 +10,6 @@ import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.ProvokeEffect
 import kotlin.reflect.KClass
@@ -53,9 +53,8 @@ class ProvokeExecutor : EffectExecutor<ProvokeEffect> {
         }
 
         // Step 1: Untap the target creature
-        var newState = state.updateEntity(targetId) { container ->
-            container.without<TappedComponent>()
-        }
+        val (untappedState, untapEvents) = untapOrConsumeStun(state, targetId)
+        var newState = untappedState
 
         // Step 2: Create a floating effect forcing the target to block the source
         newState = newState.addFloatingEffect(
@@ -66,6 +65,6 @@ class ProvokeExecutor : EffectExecutor<ProvokeEffect> {
             context = context
         )
 
-        return EffectResult.success(newState)
+        return EffectResult.success(newState, untapEvents)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ManaCostPayment.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ManaCostPayment.kt
@@ -2,12 +2,11 @@ package com.wingedsheep.engine.handlers.effects.composite
 
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
@@ -53,10 +52,9 @@ fun payManaCostFromPool(
             ?: return EffectResult.error(state, "Cannot pay mana cost")
 
         for (source in solution.sources) {
-            currentState = currentState.updateEntity(source.entityId) { c ->
-                c.with(TappedComponent)
-            }
-            events.add(TappedEvent(source.entityId, source.name))
+            val (tappedState, tapEvent) = tap(currentState, source.entityId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
         }
 
         for ((_, production) in solution.manaProduced) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
@@ -2,13 +2,11 @@ package com.wingedsheep.engine.handlers.effects.permanent.tapping
 
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.TappedEvent
-import com.wingedsheep.engine.core.UntappedEvent
+import com.wingedsheep.engine.core.tap
+import com.wingedsheep.engine.core.untapOrConsumeStun
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
 import kotlin.reflect.KClass
 
@@ -33,22 +31,17 @@ class TapUntapCollectionExecutor : EffectExecutor<TapUntapCollectionEffect> {
         var currentState = state
         val events = mutableListOf<GameEvent>()
 
+        // The tap/untap atoms own the transition guard (CR 603.2f — no event on a non-transition)
+        // and event emission; untapOrConsumeStun also applies stun-counter replacement (CR 122.1d).
         for (entityId in entityIds) {
-            val container = currentState.getEntity(entityId) ?: continue
-            val cardName = container.get<CardComponent>()?.name ?: "Permanent"
-            val alreadyTapped = container.has<TappedComponent>()
-
             if (effect.tap) {
-                // Only untapped permanents can be tapped (CR 701.21a); tapping an
-                // already-tapped permanent is a no-op that emits no TappedEvent, so
-                // "becomes tapped" triggers don't fire on a non-transition (CR 603.2f).
-                if (alreadyTapped) continue
-                currentState = currentState.updateEntity(entityId) { it.with(TappedComponent) }
-                events.add(TappedEvent(entityId, cardName))
+                val (next, event) = tap(currentState, entityId)
+                currentState = next
+                event?.let(events::add)
             } else {
-                if (!alreadyTapped) continue
-                currentState = currentState.updateEntity(entityId) { it.without<TappedComponent>() }
-                events.add(UntappedEvent(entityId, cardName))
+                val (next, untapEvents) = untapOrConsumeStun(currentState, entityId)
+                currentState = next
+                events.addAll(untapEvents)
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
@@ -1,13 +1,11 @@
 package com.wingedsheep.engine.handlers.effects.permanent.tapping
 
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.untapOrConsumeStun
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 import kotlin.reflect.KClass
 
@@ -30,8 +28,6 @@ class TapUntapExecutor : EffectExecutor<TapUntapEffect> {
         val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid target for tap/untap")
 
-        val cardName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: "Permanent"
-
         if (!effect.tap) {
             // Explicit "untap target" effect — pass projected = null so the
             // untap-step-only REMOVE_COUNTER_TO_UNTAP replacement does not apply.
@@ -39,14 +35,8 @@ class TapUntapExecutor : EffectExecutor<TapUntapEffect> {
             return EffectResult.success(newState, events)
         }
 
-        // Only untapped permanents can be tapped (CR 701.21a). Tapping an
-        // already-tapped permanent is a no-op and must emit no TappedEvent,
-        // or "becomes tapped" triggers would fire on a non-transition (CR 603.2f).
-        if (state.getEntity(targetId)?.has<TappedComponent>() == true) {
-            return EffectResult.success(state)
-        }
-
-        val newState = state.updateEntity(targetId) { it.with(TappedComponent) }
-        return EffectResult.success(newState, listOf(TappedEvent(targetId, cardName)))
+        // The tap atom owns the already-tapped no-op guard (CR 603.2f) and the TappedEvent.
+        val (newState, event) = tap(state, targetId)
+        return EffectResult.success(newState, listOfNotNull(event))
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.state.components.combat.GoadedComponent
 import com.wingedsheep.engine.state.components.combat.MustAttackPlayerComponent
@@ -184,15 +183,14 @@ internal class AttackPhaseManager(
         for ((attackerId, defenderId) in attackers) {
             val hasVigilance = projected.hasKeyword(attackerId, Keyword.VIGILANCE)
             newState = newState.updateEntity(attackerId) { container ->
-                var updated = container.with(AttackingComponent(defenderId, bandIdByAttacker[attackerId]))
-                if (!hasVigilance) {
-                    updated = updated.with(TappedComponent)
-                }
-                updated
+                container.with(AttackingComponent(defenderId, bandIdByAttacker[attackerId]))
             }
+            // Non-vigilance attackers tap as a turn-based action; route through the tap atom so the
+            // TappedEvent fires "becomes tapped" triggers (it was open-coded and once dropped here).
             if (!hasVigilance) {
-                val attackerName = state.getEntity(attackerId)?.get<CardComponent>()?.name ?: "Creature"
-                tapEvents.add(TappedEvent(attackerId, attackerName))
+                val (tappedState, event) = tap(newState, attackerId)
+                newState = tappedState
+                event?.let(tapEvents::add)
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -13,8 +13,8 @@ import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.core.LifeChangedEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
-import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
@@ -26,7 +26,6 @@ import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
@@ -418,11 +417,9 @@ class CostPaymentService(private val services: EngineServices) {
         var newState = state
         val events = mutableListOf<GameEvent>()
         for (permanentId in selected) {
-            val entity = newState.getEntity(permanentId) ?: continue
-            if (entity.has<TappedComponent>()) continue
-            val name = entity.get<CardComponent>()?.name ?: "Unknown"
-            newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
-            events.add(TappedEvent(permanentId, name))
+            val (tappedState, tapEvent) = tap(newState, permanentId)
+            newState = tappedState
+            tapEvent?.let(events::add)
         }
         return CostPaymentExecution(newState, events, success = true)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/AlternativePaymentHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/AlternativePaymentHandler.kt
@@ -1,7 +1,7 @@
 package com.wingedsheep.engine.mechanics.mana
 
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.state.GameState
@@ -192,11 +192,9 @@ class AlternativePaymentHandler(
             }
 
             // Tap the creature
-            currentState = currentState.updateEntity(creatureId) { c ->
-                c.with(TappedComponent)
-            }
-
-            events.add(TappedEvent(creatureId, cardComponent.name))
+            val (tappedState, tapEvent) = tap(currentState, creatureId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
 
             // Apply the payment
             val paymentColor = payment.color
@@ -242,8 +240,8 @@ class AlternativePaymentHandler(
         // Use projected power so continuous effects / +1/+1 counters are honored. A
         // negative power reduces the cost by nothing (you can't add to it).
         val power = (projected.getPower(creatureId) ?: 0).coerceAtLeast(0)
-        val newState = state.updateEntity(creatureId) { c -> c.with(TappedComponent) }
-        val events = listOf<GameEvent>(TappedEvent(creatureId, cardComponent.name))
+        val (newState, tapEvent) = tap(state, creatureId)
+        val events = listOfNotNull<GameEvent>(tapEvent)
         val reducedCost = if (power > 0) reduceGenericCost(cost, power) else cost
         return AlternativePaymentResult(reducedCost, newState, events)
     }
@@ -474,8 +472,9 @@ class AlternativePaymentHandler(
             if (container.has<TappedComponent>()) continue
             if (projected.getController(permanentId) != playerId) continue
 
-            currentState = currentState.updateEntity(permanentId) { c -> c.with(TappedComponent) }
-            events.add(TappedEvent(permanentId, cardComponent.name))
+            val (tappedState, tapEvent) = tap(currentState, permanentId)
+            currentState = tappedState
+            tapEvent?.let(events::add)
             reducedCost = reduceGenericCost(reducedCost, 1)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -3,10 +3,10 @@ package com.wingedsheep.engine.mechanics.mana
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
@@ -63,10 +63,9 @@ class ManaAbilitySideEffectExecutor(
         var currentState = state
         val events = mutableListOf<GameEvent>()
         for (source in solution.sources) {
-            currentState = currentState.updateEntity(source.entityId) { c ->
-                c.with(TappedComponent)
-            }
-            events.add(TappedEvent(source.entityId, source.name))
+            val (tappedState, event) = tap(currentState, source.entityId)
+            currentState = tappedState
+            event?.let(events::add)
 
             val production = solution.manaProduced[source.entityId]
             val (after, sideEvents) = runSideEffects(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unit coverage for the tap/untap atoms ([tap] / [untapOrConsumeStun]) — the single chokepoint
+ * every battlefield tap and untap routes through (enforced corpus-wide by
+ * [com.wingedsheep.engine.hygiene.TapEventEnforcementTest]).
+ *
+ * The atoms exist so the state change and its [TappedEvent] / [UntappedEvent] can never drift
+ * apart — the bug that silently dropped station and declare-attackers taps. These tests pin that
+ * contract: every real transition emits exactly one event, and every non-transition emits none
+ * (CR 603.2f / 603.6e), including the stun-counter replacement (CR 122.1d).
+ */
+class TapAtomTest : ScenarioTestBase() {
+
+    init {
+        test("tap() taps an untapped permanent and emits exactly one TappedEvent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spined Wurm", tapped = false)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (newState, event) = tap(game.state, wurm)
+
+            newState.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+            event.shouldBeInstanceOf<TappedEvent>()
+            event!!.entityId shouldBe wurm
+        }
+
+        test("tap() is a no-op with no event on an already-tapped permanent (CR 603.2f)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spined Wurm", tapped = true)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (newState, event) = tap(game.state, wurm)
+
+            event shouldBe null
+            newState shouldBe game.state
+        }
+
+        test("untapOrConsumeStun() untaps a tapped permanent and emits exactly one UntappedEvent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spined Wurm", tapped = true)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (newState, events) = untapOrConsumeStun(game.state, wurm)
+
+            newState.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+            events.size shouldBe 1
+            events.single().shouldBeInstanceOf<UntappedEvent>()
+        }
+
+        test("untapOrConsumeStun() consumes a stun counter instead of untapping, emitting no event (CR 122.1d)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spined Wurm", tapped = true)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+            game.state = game.state.updateEntity(wurm) {
+                it.with(CountersComponent(mapOf(CounterType.STUN to 2)))
+            }
+
+            val (newState, events) = untapOrConsumeStun(game.state, wurm)
+
+            // Stays tapped; one stun counter removed; no UntappedEvent (it never became untapped).
+            newState.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+            newState.getEntity(wurm)?.get<CountersComponent>()?.getCount(CounterType.STUN) shouldBe 1
+            events.shouldBeEmpty()
+        }
+
+        test("untapOrConsumeStun() is a no-op with no event on an already-untapped permanent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spined Wurm", tapped = false)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (newState, events) = untapOrConsumeStun(game.state, wurm)
+
+            events.shouldBeEmpty()
+            newState shouldBe game.state
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.hygiene
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import java.io.File
+
+/**
+ * Guards the tap/untap event contract: a permanent that *becomes tapped or untapped while on the
+ * battlefield* must go through the [com.wingedsheep.engine.core.tap] /
+ * [com.wingedsheep.engine.core.untapOrConsumeStun] atoms, which own the transition guard
+ * (CR 603.2f — no event on a non-transition) and the [com.wingedsheep.engine.core.TappedEvent] /
+ * [com.wingedsheep.engine.core.UntappedEvent] emission.
+ *
+ * Open-coding `with(TappedComponent)` / `without<TappedComponent>()` is how the engine repeatedly
+ * lost tap events — station creatures and the declare-attackers loop both shipped a silent tap that
+ * "becomes tapped" triggers never saw, because the mutation and its event were two separate lines
+ * and the event got forgotten. Routing through the atoms makes the event structurally impossible to
+ * drop; this test makes the *bypass* structurally impossible to add.
+ *
+ * If this test fails, replace the raw mutation with `tap(state, id)` (emits [TappedEvent]) or
+ * `untapOrConsumeStun(state, id)` (emits [UntappedEvent] / consumes a stun counter), and fold the
+ * returned event(s) into the result.
+ *
+ * Exceptions — files that legitimately set/clear [com.wingedsheep.engine.state.components.battlefield.TappedComponent]
+ * *without* a tap transition — are listed in [ALLOWED_FILES] with a justification. These are
+ * permanents entering the battlefield tapped (taplands, tokens, sneak), phasing in tapped,
+ * regeneration's tap, and the leave-the-battlefield untap cleanup — none of which is a
+ * "becomes tapped/untapped" event (CR 603.2f / 603.6e), so none emits one.
+ */
+class TapEventEnforcementTest : FunSpec({
+
+    test("battlefield tap/untap goes through the tap()/untapOrConsumeStun() atoms, not raw TappedComponent") {
+        val offenders = findRawTapMutations(sourceRoot())
+            .filterNot { it.relativePath in ALLOWED_FILES }
+
+        offenders.map { "${it.relativePath}:${it.lineNumber}: ${it.line.trim()}" }.shouldBeEmpty()
+    }
+}) {
+    companion object {
+        /**
+         * The tap/untap mutation pattern: `with(TappedComponent)` or `without<TappedComponent>()`.
+         * Both the simple and fully-qualified component names are matched.
+         */
+        private val RAW_TAP_PATTERN =
+            Regex("""\.with\(\s*(?:[\w.]+\.)?TappedComponent\s*\)|\.without<\s*(?:[\w.]+\.)?TappedComponent\s*>\s*\(\s*\)""")
+
+        /**
+         * Files permitted to touch [TappedComponent] directly. Each is a *non-transition* write:
+         * a permanent enters/phases-in tapped, regenerates, or is untapped as leave-the-battlefield
+         * cleanup — none of which fires a "becomes tapped/untapped" event, so the atoms (which always
+         * emit) would be wrong here.
+         */
+        private val ALLOWED_FILES = setOf(
+            // The atoms themselves.
+            "com/wingedsheep/engine/core/TapHelpers.kt",
+            // Permanent spells entering the battlefield tapped: the "enters tapped" replacement and
+            // sneak's enters-tapped-and-attacking (CR 506.3a) — entering tapped is not a transition.
+            "com/wingedsheep/engine/mechanics/stack/StackResolver.kt",
+            // Tokens created tapped enter tapped; not a tap transition.
+            "com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt",
+            "com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt",
+            "com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt",
+            // Phasing in tapped restores the pre-phase tapped state (CR 702.26); not a transition.
+            "com/wingedsheep/engine/handlers/effects/permanent/phasing/PhaseInLinkedToSourceExecutor.kt",
+            // Battlefield entry with `tapped`/`tappedAndAttacking` options — enters tapped.
+            "com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt",
+            // Regeneration taps as part of the shield, and a permanent leaving the battlefield is
+            // untapped as cleanup (CR 603.6e) — neither is a tap/untap transition that emits.
+            "com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt",
+            // addToZone strips TappedComponent when a card leaves the battlefield — cleanup, no event.
+            "com/wingedsheep/engine/state/GameState.kt",
+            // A land played from a permission that forces it tapped enters tapped — not a transition.
+            "com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt",
+            // Shock-land "pay life or enter tapped": declining to pay makes the land/permanent
+            // *enter* tapped (CR 614 replacement on entry), which is not a tap transition.
+            "com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt",
+        )
+
+        private data class RawTapMutation(
+            val relativePath: String,
+            val lineNumber: Int,
+            val line: String
+        )
+
+        /**
+         * Resolves the rules-engine `src/main/kotlin` directory regardless of which directory the
+         * test runner is invoked from (module root under Gradle; repo root under some IDEs).
+         */
+        private fun sourceRoot(): File {
+            val candidates = listOf(
+                File("src/main/kotlin"),
+                File("rules-engine/src/main/kotlin")
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error("Could not locate rules-engine/src/main/kotlin from ${File(".").absolutePath}")
+        }
+
+        private fun findRawTapMutations(sourceRoot: File): List<RawTapMutation> {
+            val rootPath = sourceRoot.absolutePath.replace('\\', '/')
+            val results = mutableListOf<RawTapMutation>()
+            sourceRoot.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relative = file.absolutePath.replace('\\', '/').removePrefix("$rootPath/")
+                    file.useLines { lines ->
+                        lines.forEachIndexed { idx, raw ->
+                            val code = stripLineComment(raw)
+                            // Skip block-comment / KDoc continuation lines.
+                            if (code.trimStart().startsWith("*")) return@forEachIndexed
+                            if (RAW_TAP_PATTERN.containsMatchIn(code)) {
+                                results += RawTapMutation(relative, idx + 1, raw)
+                            }
+                        }
+                    }
+                }
+            return results
+        }
+
+        /** Drops a trailing `// …` line comment so commented-out examples don't trip the scan. */
+        private fun stripLineComment(line: String): String {
+            val idx = line.indexOf("//")
+            return if (idx >= 0) line.substring(0, idx) else line
+        }
+    }
+}


### PR DESCRIPTION
## Why

Tapping a permanent was open-coded as `state.updateEntity(id) { it.with(TappedComponent) }` in ~30 places. Each site was *independently* responsible for two things: emitting the paired `TappedEvent` and guarding the already-tapped transition (CR 603.2f — tapping an already-tapped permanent must emit nothing). A forgotten event is a *silent* bug: the state is correct but "whenever this becomes tapped" triggers and the client tap animation never fire. The engine has lost tap events exactly this way more than once (station creatures, the declare-attackers loop).

This is the same shape life gain already solved: every life change goes through `DamageUtils.gainLife`, and every untap already went through `untapOrConsumeStun`. Tapping had no such atom.

## What

- **New `tap(state, id): Pair<GameState, TappedEvent?>`** in `TapHelpers.kt` (the renamed `UntapHelpers.kt`), sitting next to `untapOrConsumeStun`. It owns the transition guard and the event, returning `state to null` on a non-transition so callers fold the event in with `listOfNotNull(event)`.
- **Routed every battlefield tap site through it** (~30 sites across cost payment, mana payment, combat, crew/saddle/cycle/plot/typecycle, continuations, …).
- **Folded the untap-bypass sites onto `untapOrConsumeStun`** — `ProvokeExecutor`, `AbilityCost.Untap`, and `TapUntapCollectionExecutor`'s untap branch. These were doing a raw `without<TappedComponent>()`, which also **silently ignored stun counters** (CR 122.1d); routing through the atom fixes that too.
- **`payAbilityCost` now emits the tap event itself**, so `ActivateAbilityHandler`'s hand-rolled re-derivation of `TappedEvent` from the cost shape (which every *other* caller of `payAbilityCost` silently lacked) is deleted.

## How it's guaranteed

- **`TapEventEnforcementTest`** (hygiene) scans `rules-engine` source and bans raw `with/without<TappedComponent>` outside a small allowlist of legitimate *non-transition* writes (enters-tapped taplands/tokens/shock-lands/sneak, phase-in tapped, regeneration, leave-the-battlefield untap cleanup). Same pattern as `FacadeBoundaryTest`. It already caught **two** fully-qualified sites in `ModalAndCloneContinuationResumer` that the sweep's plain grep missed.
- **`TapAtomTest`** pins the atom semantics: every transition emits exactly one event; already-tapped/already-untapped emit none; a stun counter is consumed instead of untapping with no event.
- Documents the **"mutation atom that emits its event"** pattern in `architecture-principles.md` §2.5.

## Testing

- Full `:rules-engine` test suite green.
- `:game-server`, `:ai`, `:gym`, `:gym-trainer` compile against the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)