### PR TITLE
Fix The Bath Song chapter III targeting prompt

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBathSong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBathSong.kt
@@ -41,10 +41,9 @@ val TheBathSong = card("The Bath Song") {
 
     sagaChapter(3) {
         target(
-            "any number of target cards from your graveyard",
+            "target cards from your graveyard",
             TargetObject(
-                count = 99,
-                optional = true,
+                unlimited = true,
                 filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)
             )
         )

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -18625,13 +18625,12 @@
                 },
                 "targetRequirement": {
                     "type": "TargetObject",
-                    "count": 99,
-                    "optional": true,
+                    "unlimited": true,
                     "filter": {
                         "baseFilter": "own:you",
                         "zone": "Graveyard"
                     },
-                    "id": "any number of target cards from your graveyard"
+                    "id": "target cards from your graveyard"
                 }
             }
         ]

--- a/web-client/src/components/decisions/GraveyardTargetingUI.tsx
+++ b/web-client/src/components/decisions/GraveyardTargetingUI.tsx
@@ -99,13 +99,23 @@ export function GraveyardTargetingUI({
   const title = isOptionalTarget ? `Resolve ${sourceName}` : `Choose from ${pileNoun}`
 
   // Derive the action verb from effectHint so the button/text matches the actual effect
-  // (e.g., "Exile card in a graveyard" → "Exile"; "Return … to its owner's hand" → "Return to Hand").
-  // Effects can be wrapped (ForEachTargetEffect, CompositeEffect, etc.) so the keyword may not be
-  // at the start — match anywhere in the hint.
+  // (e.g., "Exile card in a graveyard" → "Exile"; "Shuffle … into its owner's library" → "Shuffle
+  // into Library"; "Return … to its owner's hand" → "Return to Hand"). Effects can be wrapped
+  // (ForEachTargetEffect, CompositeEffect, etc.) so the keyword may not be at the start — match
+  // anywhere in the hint.
   const effectHint = decision.context.effectHint?.toLowerCase() ?? ''
   const isExile = effectHint.includes('exile')
-  const optionalConfirmText = isExile ? 'Exile' : 'Return to Hand'
-  const actionVerb = isExile ? 'exile' : 'return to your hand'
+  const isShuffleIntoLibrary = effectHint.includes('shuffle') && effectHint.includes('library')
+  const optionalConfirmText = isShuffleIntoLibrary
+    ? 'Shuffle into Library'
+    : isExile
+      ? 'Exile'
+      : 'Return to Hand'
+  const actionVerb = isShuffleIntoLibrary
+    ? 'shuffle into your library'
+    : isExile
+      ? 'exile'
+      : 'return to your hand'
 
   const numWord = (n: number): string =>
     ({ 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five' } as Record<number, string>)[n] ?? String(n)


### PR DESCRIPTION
## Problem

The Bath Song's chapter III (*"Shuffle any number of target cards from your graveyard into your library. Add {U}{U}."*) showed a misleading target-selection prompt:

- It said you could select up to **99** cards.
- It said those cards would be returned **to your hand** — they're actually shuffled into your library.

## Fix

**`TheBathSong.kt`** — the chapter III target used a magic `count = 99, optional = true` instead of the dedicated `unlimited = true` flag. Switched to `unlimited = true`, which the trigger path (`TriggerProcessor`) already caps at the number of legal graveyard cards and exposes as "any number of target cards" (matching the existing convention; see also Builder's Bane). This removes the literal `99`.

**`GraveyardTargetingUI.tsx`** — the action verb was derived only as *exile* vs. *return to hand*, so a shuffle-into-library effect fell through to "return to your hand". Added a shuffle-into-library branch driven off the `effectHint` (which already contains "shuffle … library"), yielding the verb "shuffle into your library" and the confirm button "Shuffle into Library".

Re-blessed the LTR card snapshot golden for the changed target requirement (diff is solely The Bath Song).

## Testing

- `:mtg-sets:test --tests "*CardDefinitionSnapshotTest"` — pass (LTR golden re-blessed)
- `:mtg-sets:test --tests "*CardLintTest"` — pass
- `npm run typecheck` (web-client) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)