### PR TITLE
Add Job select Equipment keyword (FIN §3)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3098,7 +3098,7 @@ activatedAbility {
 > mechanics — `leyline()`, `flurry { }`, `mobilize(…)`, `firebending(n)`, `sneak(cost)`, `decayed()`,
 > `vividEtb { }` / `vividCostReduction()`, `convergeEntersWithCounters(counterType?)`,
 > `impending(time, cost)`, `renew(cost) { }`,
-> `craft(filter, cost)`, `station()` — are `CardBuilder` **extension functions** in
+> `craft(filter, cost)`, `station()`, `jobSelect()` — are `CardBuilder` **extension functions** in
 > `mtg-sdk/.../dsl/mechanics/` (one file per mechanic), not methods on the core `CardBuilder`. They
 > stay in package `com.wingedsheep.sdk.dsl`, so the call syntax is unchanged, but a card file that
 > uses one needs the matching import (e.g. `import com.wingedsheep.sdk.dsl.station`). Evergreen /
@@ -3260,6 +3260,15 @@ composite abilities).
   counter directly: `StateProjector` projects the `DECAYED` keyword + `cantBlock = true`, and `TriggerDetector`
   schedules the end-of-combat self-sacrifice when a decayed-countered creature is declared as an attacker — no
   per-card static/trigger needed for the counter form.
+- `Job select` — "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach
+  this to it.)" (Final Fantasy). Equipment keyword; display-only. Wire it with the `card { jobSelect() }` builder
+  helper, which adds the keyword plus an `EntersBattlefield` triggered ability composing two existing primitives
+  through the token pipeline: `Effects.CreateToken(power = 1, toughness = 1, creatureTypes = setOf("Hero"))` (no
+  colors → colorless) publishes the new token's id to the `createdTokens` slot, then
+  `Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0))` attaches the source Equipment to that
+  freshly-made token. No new effect/executor — it reuses the same create-then-attach-on-ETB chain as Auxiliary
+  Boosters. Author the per-card equip cost and equipped-creature bonus alongside the `jobSelect()` call (e.g. Monk's
+  Fist: `jobSelect()` + `ModifyStats(1, 0)` + `GrantSubtype("Monk", Filters.EquippedCreature)` + `equipAbility("{2}")`).
 - `Toxic(n)` — adds poison counters on combat damage.
 - `Cycling(cost)` — pay cost, discard, draw a card.
 - `BasicLandcycling(cost)` — cycling that fetches a basic land type.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -299,6 +299,21 @@ enum class Keyword(val displayName: String) {
      */
     FIREBENDING("Firebending"),
 
+    /**
+     * Job select (Final Fantasy). A keyword ability on Equipment:
+     * "When this Equipment enters, create a 1/1 colorless Hero creature token, then
+     * attach this to it."
+     *
+     * Display-only on the keyword; the behavior is the enters-the-battlefield triggered
+     * ability wired by the `jobSelect()` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder] — a
+     * [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect] that publishes the new
+     * token's id to the `createdTokens` pipeline slot, followed by an
+     * [com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect] that attaches the
+     * source Equipment to that token.
+     */
+    JOB_SELECT("Job select"),
+
     // ── Ability words (display prefix, no uniform mechanic) ──
     /**
      * Eerie (Duskmourn: House of Horror).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/JobSelectDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/JobSelectDsl.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Add Job select (Final Fantasy) — keyword + enters-the-battlefield triggered ability.
+ *
+ * "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ * then attach this to it.)"
+ *
+ * The keyword is display-only (no separate Job-select handler exists); the behavior is
+ * composed here from two existing primitives chained through the token pipeline:
+ *
+ *  1. [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect] makes a 1/1 colorless Hero
+ *     token and publishes its entity id to the [CREATED_TOKENS] pipeline slot (the same slot
+ *     Outlaw Stitcher / Mardu Monument read to address tokens they just made).
+ *  2. [com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect] attaches the source
+ *     Equipment (`context.sourceId`) to that freshly-created token, read back out of the
+ *     pipeline via `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)`.
+ *
+ * This is the shared shell for the whole Job-select Equipment cycle; the per-card equip cost
+ * and equipped-creature bonus are authored on the card alongside this call.
+ */
+fun CardBuilder.jobSelect() {
+    keywordSet.add(Keyword.JOB_SELECT)
+    triggeredAbilities.add(
+        TriggeredAbility.create(
+            trigger = Triggers.EntersBattlefield.event,
+            binding = Triggers.EntersBattlefield.binding,
+            effect = Effects.Composite(
+                Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Hero")
+                ),
+                Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0))
+            ),
+            descriptionOverride = "Job select (When this Equipment enters, create a 1/1 " +
+                "colorless Hero creature token, then attach this to it.)"
+        )
+    )
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MonksFist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MonksFist.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Monk's Fist
+ * {2}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +1/+0 and is a Monk in addition to its other types.
+ * Equip {2}
+ */
+val MonksFist = card("Monk's Fist") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +1/+0 and is a Monk in addition to its other types.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+    staticAbility {
+        ability = GrantSubtype("Monk", Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "265"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/995033f0-873d-4e46-b0c9-98ec8ef270ff.jpg?1748706776"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3239,6 +3239,102 @@
     ]
 }
 
+// Monk's Fist
+{
+    "name": "Monk's Fist",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+0 and is a Monk in addition to its other types.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ]
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Monk",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "265",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/995033f0-873d-4e46-b0c9-98ec8ef270ff.jpg?1748706776"
+    },
+    "colorIdentityOverride": []
+}
+
 // Mysidian Elder
 {
     "name": "Mysidian Elder",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JobSelectScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JobSelectScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Job select (Final Fantasy) — the shared Equipment shell wired by `jobSelect()`:
+ *
+ *   "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *    then attach this to it.)"
+ *
+ * Proven through Monk's Fist (FIN #265, {2} Equipment, "+1/+0 and is a Monk").
+ *
+ * The shell composes two existing primitives through the token pipeline: a
+ * `CreateTokenEffect` that publishes the new token's id into the `createdTokens` pipeline
+ * slot, followed by an `AttachEquipmentEffect` reading `PipelineTarget(CREATED_TOKENS, 0)`
+ * so the source Equipment attaches to the creature it just made — in a single ETB
+ * resolution with no declared target.
+ */
+class JobSelectScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Job select — Monk's Fist makes its own bearer on ETB") {
+
+            test("ETB creates a 1/1 colorless Hero token and attaches the Equipment to it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Monk's Fist")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Monk's Fist")
+                withClue("Casting Monk's Fist should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // (1) Exactly one Hero token was created.
+                withClue("Job select should create exactly one Hero token") {
+                    game.findPermanents("Hero Token").size shouldBe 1
+                }
+                val heroToken = game.findPermanent("Hero Token")!!
+                val tokenCard = game.state.getEntity(heroToken)!!.get<CardComponent>()!!
+
+                // (2) The token is a real token, colorless, a Hero creature. (Its 1/1 base is
+                //     proven by the projected 2/1 below: toughness stays 1 under a +1/+0 buff.)
+                withClue("Hero token should be a token entity") {
+                    (game.state.getEntity(heroToken)!!.get<TokenComponent>() != null) shouldBe true
+                }
+                withClue("Hero token should be colorless (no colors): ${tokenCard.colors}") {
+                    tokenCard.colors.isEmpty() shouldBe true
+                }
+
+                val projectedBefore = stateProjector.project(game.state)
+                withClue("Hero token should be a creature with subtype Hero") {
+                    projectedBefore.isCreature(heroToken) shouldBe true
+                    projectedBefore.hasSubtype(heroToken, "Hero") shouldBe true
+                }
+
+                // (3) The Equipment auto-attached to the freshly-created token (no target chosen).
+                val monksFist = game.findPermanent("Monk's Fist")
+                withClue("Monk's Fist should be on the battlefield after resolving") {
+                    (monksFist != null) shouldBe true
+                }
+                withClue(
+                    "Monk's Fist should be attached to the Hero token " +
+                        "(observed: ${game.state.getEntity(monksFist!!)?.get<AttachedToComponent>()?.targetId})"
+                ) {
+                    game.state.getEntity(monksFist)?.get<AttachedToComponent>()?.targetId shouldBe heroToken
+                }
+                withClue("Hero token should list Monk's Fist among its attachments") {
+                    game.state.getEntity(heroToken)?.get<AttachmentsComponent>()?.attachedIds shouldBe listOf(monksFist)
+                }
+
+                // (4) The equipped-creature static abilities apply through the attachment:
+                //     1/1 base + (+1/+0) = 2/1, and it gains the Monk subtype.
+                val projected = stateProjector.project(game.state)
+                withClue("Equipped Hero token should be 2/1 (base 1/1 + Monk's Fist +1/+0)") {
+                    projected.getPower(heroToken) shouldBe 2
+                    projected.getToughness(heroToken) shouldBe 1
+                }
+                withClue("Equipped Hero token should be a Monk in addition to its other types") {
+                    projected.hasSubtype(heroToken, "Monk") shouldBe true
+                    projected.hasSubtype(heroToken, "Hero") shouldBe true
+                }
+
+                // (5) The buff is conditional on the attachment — Monk's Fist itself is not a
+                //     creature and gets no +1/+0, and the bonus doesn't leak to other permanents.
+                withClue("Monk's Fist itself should not be a creature") {
+                    projected.isCreature(monksFist) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -209,6 +209,8 @@ export enum Keyword {
   ASCEND = 'ASCEND',
   // Token decay (Innistrad: Midnight Hunt / TDM decayed counter)
   DECAYED = 'DECAYED',
+  // Equipment that makes its own bearer (Final Fantasy)
+  JOB_SELECT = 'JOB_SELECT',
   // Ability words
   EERIE = 'EERIE',
 }
@@ -270,6 +272,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.PERSIST]: 'Persist',
   [Keyword.ASCEND]: 'Ascend',
   [Keyword.DECAYED]: 'Decayed',
+  [Keyword.JOB_SELECT]: 'Job select',
   [Keyword.EERIE]: 'Eerie',
 }
 


### PR DESCRIPTION
## Summary

Implements **Job select** (§3 of `backlog/fin-engine-gaps.md`) — the Final Fantasy Equipment keyword:

> *Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)*

This unlocks all **16** FIN Job-select Equipment as pure `add-card` authoring.

## What was already done vs. what this adds

The backlog framed §3 as two halves: *"publish the created-token id into the pipeline, then `jobSelect()` shell."* The **pipeline half is already in place** — `CreateTokenExecutor` publishes the new token's id to the `createdTokens` slot (`EffectResult.updatedCollections[CREATED_TOKENS]`), and `Effects.AttachEquipment` reads it back via `PipelineTarget(CREATED_TOKENS, 0)`. The shipped **Auxiliary Boosters** (EOE) card + its test already exercise exactly this create-token-then-attach-self chain.

So this PR adds the missing **shared shell**:

- **`Keyword.JOB_SELECT`** (+ web-client display name), mirroring the other display-only keyword-ability shells (Decayed, Firebending).
- **`CardBuilder.jobSelect()`** extension in `dsl/mechanics/JobSelectDsl.kt` — adds the keyword plus an `EntersBattlefield` triggered ability composing `CreateToken(1/1 colorless Hero)` → `AttachEquipment(PipelineTarget(CREATED_TOKENS, 0))`. **No new effect or executor** — pure composition of existing primitives.
- **Monk's Fist** (FIN #265) as the canonical proof card (`+1/+0`, is a Monk, Equip {2}); re-blessed the FIN snapshot golden.
- **`JobSelectScenarioTest`** proving the ETB creates a 1/1 colorless Hero token, auto-attaches the Equipment to it with no chosen target, and applies the equipped-creature buff + subtype through the attachment.
- Documented `jobSelect()` in `docs/card-sdk-language-reference.md`.

## Testing

- `JobSelectScenarioTest` — ✅ green (token created · colorless · Hero subtype · auto-attached · projected 2/1 + Monk · Equipment not itself a creature).
- `CardDefinitionSnapshotTest` (all sets) + `CardLintTest` — ✅ green; FIN golden diff is isolated to Monk's Fist; the `createdTokens` write/read dataflow lints clean.

## Notes

- **mtgish generator (Step 8b): no new bridge/emitter entry needed** — this feature introduces **no new SDK effect or primitive**. `jobSelect()` is pure composition of the existing `CreateToken` and `AttachEquipment` effects, both of which the emitter already renders, so there is no new capability or mtgish IR tag to register. (Step 8b applies when a feature adds a *new* effect that maps to an IR tag.)
- The other 15 Job-select Equipment are now standard `add-card` work (each adds its own equip cost + equipped-creature bonus alongside `jobSelect()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)