### PR TITLE
Enforce within-requirement target distinctness (CR 601.2c)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1486,6 +1486,13 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   creatures" use `dynamicMaxCount = DynamicAmount.XValue` instead — that clamps the count to the chosen X.
 - `dynamicMaxCount: DynamicAmount?` — evaluated when the spell/ability hits the stack; the resolved
   value becomes the max ("up to X target creatures", X = board state or chosen X).
+- **Distinctness (CR 601.2c) is automatic and needs no flag.** A single requirement that picks more
+  than one target ("two / up to two / X target creatures") is one instance of the word "target", so the
+  chosen objects/players must all be **different** — enforced both at cast time (`TargetValidator`) and on
+  interactive target decisions (`DecisionValidators`). Cross-requirement duplicates are a *different*
+  "target" instance and stay **legal by default** (the same object may be chosen once per instance); when
+  a later requirement must differ from an earlier one ("… and up to one **other** target …"), wrap it in
+  `TargetOther` — `.other()`/`excludeSelf` on a filter only excludes the *source*, not another chosen target.
 - `sameController = false` — on `TargetObject` / `TargetCreature(...)`; when `true` and the requirement
   picks more than one target, every chosen target must share a controller ("**two target creatures
   controlled by the same player**"). Enforced cross-target by `TargetValidator` at cast time using

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -188,6 +188,12 @@ object DecisionValidators {
                 }
             }
 
+            // The same object/player can't be chosen more than once for a single targeting
+            // requirement (CR 601.2c — "two target creatures" needs two different creatures).
+            if (selectedIds.size != selectedIds.toSet().size) {
+                return "The same target can't be chosen more than once for requirement $reqIndex"
+            }
+
             val req = decision.targetRequirements.find { it.index == reqIndex }
             if (req != null) {
                 if (selectedIds.size < req.minTargets) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -116,6 +116,14 @@ class TargetValidator {
                 if (error != null) return error
             }
 
+            // "Two/X target ..." — the same object or player can't be chosen more than once for a
+            // single instance of the word "target" (CR 601.2c; applies to abilities via 602.2b).
+            // Cross-requirement duplicates are a different "target" instance and stay legal by
+            // default — that distinctness is opt-in via TargetOther below.
+            if (targetsForReq.size > 1 && targetsForReq.distinct().size != targetsForReq.size) {
+                return "The same target can't be chosen more than once for ${requirement.description}"
+            }
+
             // "Another target" — must differ from any earlier target chosen for this same cast
             if (requirement is TargetOther) {
                 val priorTargets = targets.subList(0, startIdx.coerceAtMost(targets.size))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarangRiverRegentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarangRiverRegentScenarioTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario tests for Marang River Regent // Coil and Catch (TDM #51).
@@ -52,6 +53,30 @@ class MarangRiverRegentScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Marang River Regent (the source) is still on the battlefield — \"other\"") {
                     game.isOnBattlefield("Marang River Regent") shouldBe true
+                }
+            }
+
+            test("the same permanent can't be chosen for both of the two targets") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Marang River Regent")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardOnBattlefield(2, "Phantom Warrior")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Marang River Regent").error shouldBe null
+                game.resolveStack() // creature enters → ETB asks for up to two targets
+
+                // "up to two other target nonland permanents" is one instance of "target"
+                // (CR 601.2c), so the two chosen permanents must be different — picking the same
+                // one twice is rejected.
+                val warrior = game.findPermanent("Phantom Warrior")!!
+                val result = game.selectTargets(listOf(warrior, warrior))
+                withClue("Choosing the same permanent twice is illegal: ${result.error}") {
+                    result.error shouldNotBe null
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TargetDistinctnessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TargetDistinctnessScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * CR 601.2c: "The same target can't be chosen multiple times for any one instance of the word
+ * 'target' on the spell." A single targeting requirement with `count > 1` ("two target creatures")
+ * therefore needs two *different* objects. This exercises the cast-path guard in
+ * [com.wingedsheep.engine.mechanics.targeting.TargetValidator] using a directly-cast spell whose
+ * sole requirement is `count = 2`. (Cross-requirement distinctness — a different "target" instance —
+ * is opt-in via TargetOther and is covered by the Friendly Rivalry scenario test.)
+ */
+class TargetDistinctnessScenarioTest : FunSpec({
+
+    // A minimal instant: "deals 1 damage to each of two target creatures" — one count=2 requirement.
+    val twinPing = card("Test Twin Ping") {
+        manaCost = "{R}"
+        colorIdentity = "R"
+        typeLine = "Instant"
+        oracleText = "Test Twin Ping deals 1 damage to each of two target creatures."
+        spell {
+            target("two target creatures", TargetCreature(count = 2))
+            effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+                .then(Effects.DealDamage(1, EffectTarget.ContextTarget(1)))
+        }
+        metadata {
+            rarity = Rarity.COMMON
+            collectorNumber = "0"
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + twinPing)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("the same creature cannot be chosen twice for a single 'two target creatures' requirement") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val creature = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        driver.putCreatureOnBattlefield(opp, "Centaur Courser") // a second legal target exists
+
+        driver.giveMana(me, Color.RED, 1)
+        val spell = driver.putCardInHand(me, "Test Twin Ping")
+
+        val result = driver.castSpellWithTargets(
+            me,
+            spell,
+            targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(creature))
+        )
+        result.error shouldNotBe null
+    }
+
+    test("two different creatures satisfy the same 'two target creatures' requirement") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val first = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val second = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.giveMana(me, Color.RED, 1)
+        val spell = driver.putCardInHand(me, "Test Twin Ping")
+
+        driver.castSpellWithTargets(
+            me,
+            spell,
+            targets = listOf(ChosenTarget.Permanent(first), ChosenTarget.Permanent(second))
+        ).error shouldBe null
+        driver.bothPass()
+
+        // Both 3/3s took only 1 damage → both survive; the cast was legal and resolved.
+        driver.getPermanents(opp).contains(first) shouldBe true
+        driver.getPermanents(opp).contains(second) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickedPactTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickedPactTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Tests for Wicked Pact's multi-target spell behavior.
@@ -107,9 +108,9 @@ class WickedPactTest : FunSpec({
         driver.getLifeTotal(activePlayer) shouldBe 15
     }
 
-    test("Wicked Pact targets the same creature twice if only one available") {
-        // Note: MTG rules allow targeting the same creature with both targets
-        // if only one nonblack creature exists (though this may be suboptimal)
+    test("Wicked Pact cannot target the same creature twice — 'two target creatures' needs two different ones") {
+        // CR 601.2c: the same creature can't be chosen for both targets of a single "target"
+        // instance, so with only one legal nonblack creature Wicked Pact can't be cast.
         val driver = createDriver()
         driver.initMirrorMatch(
             deck = Deck.of(
@@ -133,23 +134,13 @@ class WickedPactTest : FunSpec({
         val wickedPact = driver.putCardInHand(activePlayer, "Wicked Pact")
         driver.giveMana(activePlayer, Color.BLACK, 3)
 
-        // Cast Wicked Pact targeting the green creature twice
-        // (This tests that the spell can be cast with valid targets)
+        // Casting Wicked Pact targeting the green creature twice is illegal.
         val castResult = driver.castSpell(activePlayer, wickedPact, listOf(greenCreature, greenCreature))
-        castResult.isSuccess shouldBe true
+        castResult.error shouldNotBe null
 
-        // Let the spell resolve
-        driver.bothPass()
-
-        // Green creature should be destroyed (first destroy succeeds, second has no effect)
-        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
-        // Black creature should still be there (cannot be targeted)
-        driver.findPermanent(opponent, "Serpent Assassin") shouldBe opponent.let {
-            driver.findPermanent(it, "Serpent Assassin")
-        }
-
-        // Active player should have lost 5 life
-        driver.getLifeTotal(activePlayer) shouldBe 15
+        // The cast was rejected: nothing is destroyed and no life is lost.
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe greenCreature
+        driver.getLifeTotal(activePlayer) shouldBe 20
     }
 
     test("Wicked Pact costs 1BB to cast and causes life loss") {


### PR DESCRIPTION
Follow-up to #905 (stacked on its branch). The `.other()` sweep there surfaced a separate, related gap.

## Problem

A single targeting requirement with `count > 1` — "**two** target creatures", "up to **two** other target nonland permanents", "**X** target creatures" — is *one* instance of the word "target". Per **CR 601.2c**, the chosen objects/players must all be **different**.

Neither validation path enforced this:
- `TargetValidator` (cast path, pre-supplied targets), and
- `DecisionValidators` (interactive target decisions)

only deduped via `TargetOther`, whose check compares against *prior* requirements — never *within* a single multi-count requirement. So the same creature could be chosen for both halves of "two target creatures" and be destroyed/untapped/returned twice, or deal its power twice.

This is **distinct from the `.other()` misuse in #905**: switching to `TargetOther` would *not* have fixed it, because that check is cross-requirement only.

## Fix

Add a within-requirement distinctness check to both validators. Cross-requirement duplicates stay **legal by default** (a different "target" instance — CR 601.2c allows the same object once per instance); "other/another" distinctness *across* slots remains opt-in via `TargetOther`.

Protects every multi-count card — e.g. Marang River Regent, Ioreth of the Healing House (ability 2), Wicked Pact, Betrayal at the Vault.

## Verification

- **`TargetDistinctnessScenarioTest`** — cast-path guard (`TargetValidator`) via a `count=2` spell: same creature twice → rejected; two distinct → resolves.
- **`MarangRiverRegentScenarioTest`** — interactive decision-path guard (`DecisionValidators`) on a real card: picking the same permanent for both targets → rejected (the existing positive "two distinct" case still passes).
- **`WickedPactTest`** — corrected a pre-existing test that asserted the *old buggy* behavior. Its own comment hedged "this may be suboptimal"; in fact targeting the same creature twice is illegal, and Wicked Pact is uncastable with only one legal nonblack creature (matches its Gatherer ruling).
- Full `:rules-engine` (5100 tests) and `:game-server` suites green.
- Documented in the SDK reference (Target count section).

Rule verified against the Comprehensive Rules (2026-04-17), 601.2c: *"The same target can't be chosen multiple times for any one instance of the word 'target' on the spell. However, if the spell uses the word 'target' in multiple places, the same object or player can be chosen once for each instance…"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)