### PR TITLE
Add DSK common dual lands + mtgish enters-tapped-unless-life emitter

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BleedingWoods.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BleedingWoods.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Bleeding Woods
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {R} or {G}.
+ */
+val BleedingWoods = card("Bleeding Woods") {
+    typeLine = "Land"
+    colorIdentity = "RG"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {G}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Henry Peters"
+        flavorText = "They say if someone lies down to sleep beneath the trees, in the morning nothing will remain but a few scattered bones and a bed of blood-red lilies."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg?1726286833"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EtchedCornfield.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EtchedCornfield.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Etched Cornfield
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {G} or {W}.
+ */
+val EtchedCornfield = card("Etched Cornfield") {
+    typeLine = "Land"
+    colorIdentity = "GW"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {W}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "258"
+        artist = "Randy Gallegos"
+        flavorText = "They say those who lose their way in the fields gradually wither and grow brittle, until at last they put down roots and anchor into the soil as a whispering stalk."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg?1726286836"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MurkySewer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MurkySewer.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Murky Sewer
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {U} or {B}.
+ */
+val MurkySewer = card("Murky Sewer") {
+    typeLine = "Land"
+    colorIdentity = "UB"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {B}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "263"
+        artist = "Martin de Diego Sádaba"
+        flavorText = "They say dripping, hungry things writhe beyond the edge of the light, waiting to drag the unwary into the darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg?1726286856"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -763,6 +763,57 @@
     ]
 }
 
+// Bleeding Woods
+{
+    "name": "Bleeding Woods",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Henry Peters",
+        "flavorText": "They say if someone lies down to sleep beneath the trees, in the morning nothing will remain but a few scattered bones and a bed of blood-red lilies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg?1726286833"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Boilerbilges Ripper
 {
     "name": "Boilerbilges Ripper",
@@ -1995,6 +2046,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Etched Cornfield
+{
+    "name": "Etched Cornfield",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "artist": "Randy Gallegos",
+        "flavorText": "They say those who lose their way in the fields gradually wither and grow brittle, until at last they put down roots and anchor into the soil as a whispering stalk.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg?1726286836"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -4882,6 +4984,57 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Murky Sewer
+{
+    "name": "Murky Sewer",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "artist": "Martin de Diego Sádaba",
+        "flavorText": "They say dripping, hungry things writhe beyond the edge of the light, waiting to drag the unwary into the darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg?1726286856"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -697,6 +697,39 @@ private fun EmitCtx.slowLandEntersTappedConditionDsl(rep: JsonObject): String? {
 }
 
 /**
+ * The Duskmourn (DSK) common dual-land enters-tapped gate (Bleeding Woods, Etched Cornfield,
+ * Murky Sewer, Razortrap Gorge, …): "This land enters tapped unless a player has N or less life."
+ * The IR wraps the tapped replacement in an `Unless{<condition>}[EntersTapped]` whose condition is
+ * `APlayerPassesFilter(AnyPlayer, LifeTotalIs(<= N))` — an existential life threshold over ALL
+ * players. Renders the `unlessCondition` argument for `EntersTapped(...)` as
+ * `Conditions.APlayerLifeAtMost(N)` (true when any player is at N life or below).
+ *
+ * Conservative by design — returns null (-> SCAFFOLD) unless the shape is exactly: the `Unless`
+ * action is a single `EntersTapped`, the condition is `APlayerPassesFilter` over the `AnyPlayer`
+ * subject with a `LifeTotalIs`/`LessThanOrEqualTo`/Integer threshold. Any other subject or
+ * comparison (`GreaterThanOrEqualTo`, an opponent-only subject, …) declines rather than miscount.
+ */
+private fun EmitCtx.aPlayerLifeAtMostEntersTappedConditionDsl(rep: JsonObject): String? {
+    val args = rep["args"].asArr ?: return null
+    // Second arg is the list of replacement actions the Unless gates — must be a lone EntersTapped.
+    val gated = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (gated.singleOrNull()?.strField("_ReplacementActionWouldEnter") != "EntersTapped") return null
+
+    val cond = args.getOrNull(0) as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "APlayerPassesFilter") return null
+    val condArgs = cond["args"].asArr ?: return null
+    // Subject must be the existential "AnyPlayer" (maps to the engine's any-player threshold).
+    if ((condArgs.getOrNull(0) as? JsonObject)?.strField("_Players") != "AnyPlayer") return null
+    val lifeFilter = condArgs.getOrNull(1) as? JsonObject ?: return null
+    if (lifeFilter.strField("_Players") != "LifeTotalIs") return null
+    val comparison = lifeFilter["args"] as? JsonObject ?: return null
+    if (comparison.strField("_Comparison") != "LessThanOrEqualTo") return null
+    val n = (comparison["args"] as? JsonObject)?.takeIf { it.strField("_GameNumber") == "Integer" }
+        ?.get("args").asInt() ?: return null
+    return render(call("Conditions.APlayerLifeAtMost", arg("$n")))
+}
+
+/**
  * A `FlashForCasters { Condition }` rule -> the card-level `conditionalFlash = <condition>`
  * assignment ("<this> has flash as long as <condition>", CR 702.8 / Colossal Rattlewurm). Only the
  * "you control a [filter]" condition the shared [youControlConditionDsl] renders exactly produces a
@@ -3200,7 +3233,12 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject, condition: String? = null):
             // deliberately doesn't render — the at-least condition facade only models `>=`.
             "Unless" -> {
                 if (!onSelf) { reasons.add("AsPermanentEnters"); return null }
+                // Two conservative enters-tapped gates render exactly: the "slow land"
+                // control-N-other-lands threshold, and the DSK common dual-land
+                // "unless a player has N or less life" existential life threshold. Any other
+                // Unless condition declines (-> SCAFFOLD) rather than guess the gate.
                 val cond = slowLandEntersTappedConditionDsl(rep)
+                    ?: aPlayerLifeAtMostEntersTappedConditionDsl(rep)
                     ?: run { reasons.add("AsPermanentEnters"); return null }
                 call("EntersTapped", arg("unlessCondition", Lit(cond)))
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskSurveilLandsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskSurveilLandsScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.BleedingWoods
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.EtchedCornfield
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.MurkySewer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the three Duskmourn: House of Horror common dual lands:
+ * Bleeding Woods (R/G), Etched Cornfield (G/W), Murky Sewer (U/B).
+ *
+ * Each: "This land enters tapped unless a player has 13 or less life. {T}: Add {C1} or {C2}."
+ * The enters-tapped condition is the existential [APlayerLifeAtMost(13)] — true when ANY
+ * player is at 13 life or below, distinct from a controller-only threshold.
+ */
+class DskSurveilLandsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + BleedingWoods + EtchedCornfield + MurkySewer)
+        return driver
+    }
+
+    test("Bleeding Woods enters tapped while both players are at full life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val woods = driver.putCardInHand(p1, "Bleeding Woods")
+        driver.playLand(p1, woods).isSuccess shouldBe true
+
+        driver.state.getEntity(woods)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("Bleeding Woods enters untapped when a player has 13 or less life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(driver.getOpponent(p1), 13)
+        val woods = driver.putCardInHand(p1, "Bleeding Woods")
+        driver.playLand(p1, woods).isSuccess shouldBe true
+
+        driver.state.getEntity(woods)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("Bleeding Woods taps for red and green") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val red = driver.putPermanentOnBattlefield(p1, "Bleeding Woods")
+        driver.submit(ActivateAbility(p1, red, BleedingWoods.activatedAbilities[0].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.red shouldBe 1
+
+        val green = driver.putPermanentOnBattlefield(p1, "Bleeding Woods")
+        driver.submit(ActivateAbility(p1, green, BleedingWoods.activatedAbilities[1].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.green shouldBe 1
+    }
+
+    test("Etched Cornfield enters tapped at full life and taps for green and white") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val field = driver.putCardInHand(p1, "Etched Cornfield")
+        driver.playLand(p1, field).isSuccess shouldBe true
+        driver.state.getEntity(field)?.has<TappedComponent>() shouldBe true
+
+        val green = driver.putPermanentOnBattlefield(p1, "Etched Cornfield")
+        driver.submit(ActivateAbility(p1, green, EtchedCornfield.activatedAbilities[0].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.green shouldBe 1
+
+        val white = driver.putPermanentOnBattlefield(p1, "Etched Cornfield")
+        driver.submit(ActivateAbility(p1, white, EtchedCornfield.activatedAbilities[1].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.white shouldBe 1
+    }
+
+    test("Murky Sewer enters untapped when controller is low on life and taps for blue and black") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(p1, 10)
+        val sewer = driver.putCardInHand(p1, "Murky Sewer")
+        driver.playLand(p1, sewer).isSuccess shouldBe true
+        driver.state.getEntity(sewer)?.has<TappedComponent>() shouldBe false
+
+        val blue = driver.putPermanentOnBattlefield(p1, "Murky Sewer")
+        driver.submit(ActivateAbility(p1, blue, MurkySewer.activatedAbilities[0].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.blue shouldBe 1
+
+        val black = driver.putPermanentOnBattlefield(p1, "Murky Sewer")
+        driver.submit(ActivateAbility(p1, black, MurkySewer.activatedAbilities[1].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.black shouldBe 1
+    }
+})


### PR DESCRIPTION
## Cards (Duskmourn: House of Horror, DSK)

Three common dual lands — a cycle that enters tapped unless any player is low on life, then taps for one of two colors:

- **Bleeding Woods** (R/G) — `{T}: Add {R} or {G}`
- **Etched Cornfield** (G/W) — `{T}: Add {G} or {W}`
- **Murky Sewer** (U/B) — `{T}: Add {U} or {B}`

Each: *"This land enters tapped unless a player has 13 or less life. {T}: Add {C1} or {C2}."*

> Note: the task framed these as "surveil dual lands," but Scryfall's actual oracle text for this DSK common land cycle is the conditional enters-tapped dual above (no surveil). Implemented rules-faithfully to the printed oracle.

All three reuse the existing Razortrap Gorge pattern — `replacementEffect(EntersTapped(unlessCondition = Conditions.APlayerLifeAtMost(13)))` plus two mana abilities. **No new SDK surface**, so the SDK reference needed no change (`APlayerLifeAtMost` and `EntersTapped` are already documented). Canonical placement verified: DSK is each card's earliest real printing. New scenario test `DskSurveilLandsScenarioTest` covers enters-tapped at full life, enters-untapped when a player is at/below 13, and tapping for both colors.

## mtgish emitter change

Taught the `AsPermanentEnters` `Unless` branch a second conservative enters-tapped gate. New recognizer `aPlayerLifeAtMostEntersTappedConditionDsl` renders the `APlayerPassesFilter(AnyPlayer, LifeTotalIs(<= N))` existential life threshold as `Conditions.APlayerLifeAtMost(N)`, sitting alongside the existing slow-land `control-N-other-lands` gate. This promotes the DSK life-threshold dual-land cycle from **SCAFFOLD → AUTOGEN**. Any other subject or comparison still declines (→ SCAFFOLD) rather than miscount.

## Verification

- `just coverage-verify POR` → **GATE PASS, 158/158** (0-mismatch regression gate maintained).
- All three cards emit `fidelity tier: AUTO`; they are not among DSK's pre-existing gameplay-tree mismatches (Beastie Beatdown, Get Out, Glimmer Seeker, Razorkin Needlehead — all unrelated to enters-tapped).
- `EmitterGoldenTest` green — no committed emitter fixture changed.
- `mtg-sets` `CardDefinitionSnapshotTest` (reblessed: only the 3 cards added to `DSK.json`) + `CardLintTest` green.
- Full `just test-rules` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)