### PR TITLE
Add Tiered keyword (CR 702.183) + tiered { } builder and 6 FIN spells

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -140,16 +140,19 @@ reminder text. Once built, all 16 are pure authoring.
   Arsenal, Monk's Fist, Ninja's Blades, Paladin's Arms, Red Mage's Rapier, Sage's Nouliths, Samurai's Katana,
   Summoner's Grimoire, Thief's Knife, Warrior's Sword, White Mage's Staff.
 
-### 4. Tiered (6 spells) — ❌ **GAP** (choose-one escalating additional cost)
+### 4. Tiered (6 spells) — ✅ **DONE** (choose-one escalating additional cost)
 
 *"Tiered (Choose one additional cost.)"* then 2-3 modes, **each with its own additional mana cost** paid at cast and
 its own (usually scaled) effect — e.g. Fire Magic: `Fire — {0} — 1 dmg to each creature / Fira — {2} — 2 dmg / Firaga
-— {5} — 3 dmg`. `ModalEffect.Mode` already carries an `additionalManaCost: String?` and supports `chooseCount = 1,
-allowRepeat = false` (`CompositeEffects.kt:79`), so the *shape* is close — but there is **no cast-time flow that
-charges the chosen mode's additional cost** the way Spree charges per-mode costs. Verify whether the existing
-modal/Spree cast pipeline already collects a single chosen mode's `additionalManaCost`; if not, this is a narrow
-extension of that pipeline plus a `tiered { }` builder + reminder text. *(Closest precedent: Spree single-panel
-selector, [SOS notes].)*
+— {5} — 3 dmg`. Verified against CR 702.183a (*"Choose one. As an additional cost to cast this spell, pay the cost
+associated with that mode."*) that **no engine change was needed**: the modal/Spree cast pipeline already charges a
+single chosen mode's `additionalManaCost` on the choose-1 path — `CastSpellEnumerator.computeModeEnumeration` folds
+the chosen tier's cost into each `CastSpellMode` legal action (only affordable tiers are offered) and
+`CastSpellHandler` adds it on execute. Shipped a `spell { tiered { } }` authoring builder (`CardBuilder.kt`,
+`TieredBuilder` → a `ModalEffect` with `chooseCount = 1` and per-tier `additionalManaCost`) + a `TIERED_REMINDER`
+constant; no `Keyword.TIERED` (Tiered adds no behavior beyond the modal-with-additional-cost shape, mirroring Spree).
+All six cards implemented and covered by `TieredScenarioTest` (per-tier cost charging, choose-one rejection,
+affordability gating, scaled effects, targeting, double/triple P/T, Vincent's dies→return-tapped).
 → Fire Magic, Ice Magic, Thunder Magic, Restoration Magic, Tifa's Limit Break, Vincent's Limit Break.
 
 ### 5. Town land // spell DFC — "play the land from exile later" (≈6) — ❌ **GAP** (new layout)
@@ -244,8 +247,8 @@ structural template; needs a sibling layout + loader so the land becomes the pla
    the standard cycling/flashback/kicker/affinity/crew cards are already buildable today via the `add-card` skill.
 2. ✅ **Job select (§3)** — publish the created-token id into the pipeline, then `jobSelect()` shell. Unlocks all 16
    Equipment at once; isolated and high-yield.
-3. **Tiered (§4)** — extend the modal/Spree cast pipeline to charge the chosen mode's additional cost + `tiered { }`
-   builder. 6 spells, contained.
+3. ✅ **Tiered (§4) — DONE:** the modal/Spree cast pipeline already charged the chosen mode's additional cost on the
+   choose-1 path (no engine change); shipped the `tiered { }` builder + all 6 spells.
 4. **Town land // spell DFC (§5)** — new inverse-Adventure layout. ~6 lands.
 5. **Summon Sagas (§1)** — the headline `add-feature`: make Sagas co-exist with creatures + an opt-out-of-sacrifice
    flag + self-referential chapter resolution. Largest lift; gates ~15 cards.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4405,6 +4405,41 @@ mode-selection pause; choose-1 modal spells remain client-local `CastSpellMode` 
 change is needed to author a Spree card — it is a plain `ModalEffect` with per-mode
 `additionalManaCost` (see Trash the Town).
 
+**Tiered (CR 702.183) — `spell { tiered { } }`.** *"Tiered (Choose one additional cost.)"* is a
+choose-**one** modal spell where each tier carries its own additional mana cost, paid as you cast
+the spell (702.183a: *"Choose one. As an additional cost to cast this spell, pay the cost associated
+with that mode."*). Exactly one tier is chosen and only that tier's (usually scaled) effect resolves.
+Mechanically it is Spree constrained to a single mode: a `ModalEffect` with `chooseCount = 1`,
+`minChooseCount = 1`, and per-mode `additionalManaCost` — **no engine change** beyond Spree, because
+the choose-1 enumerator path (`CastSpellEnumerator.computeModeEnumeration`) already folds the chosen
+tier's cost into each `CastSpellMode` action's effective cost, and `CastSpellHandler` already adds it
+on execute. So the cast surface is the standard choose-1 modal flow: one `CastSpellMode` legal action
+per *affordable* tier (unpayable tiers aren't offered), each showing its full mana cost. The
+`tiered { }` builder is authoring sugar only:
+
+```kotlin
+spell {
+    tiered {
+        tier("Fire", "{0}", "Fire Magic deals 1 damage to each creature.") {
+            effect = Patterns.Group.dealDamageToAll(1, GroupFilter.AllCreatures)
+        }
+        tier("Fira", "{2}", "Fire Magic deals 2 damage to each creature.") {
+            effect = Patterns.Group.dealDamageToAll(2, GroupFilter.AllCreatures)
+        }
+        tier("Firaga", "{5}", "Fire Magic deals 3 damage to each creature.") {
+            effect = Patterns.Group.dealDamageToAll(3, GroupFilter.AllCreatures)
+        }
+    }
+}
+```
+
+`tier(name, cost, text) { … }` builds one `Mode` with `additionalManaCost = cost` and a button label
+of `"<name> — <text>"`; inside the block, set `effect` and (for targeted tiers) `target`, exactly
+like `mode { }`. Use `"{0}"` for a free base tier. Tiered grants no behavior of its own beyond the
+modal-with-additional-cost shape, so there is **no `Keyword.TIERED`** (mirroring Spree); print the
+reminder via the card's `oracleText` (the `TIERED_REMINDER` constant holds the canonical string). See
+Fire / Ice / Thunder / Restoration Magic, Tifa's / Vincent's Limit Break (FIN).
+
 **Cast-time conditional choose count** — for modal *spells* the same `dynamicChooseCount`
 field is evaluated against the battlefield **at cast time** (in `CastSpellHandler`,
 `effectiveModalChooseCounts`), and — unlike `chooseUpToDynamic` — it keeps the `minChooseCount`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1060,6 +1060,43 @@ class SpellBuilder {
         builder.init()
         effect = builder.build()
     }
+
+    /**
+     * Define a **Tiered** spell (CR 702.183) — "Tiered (Choose one additional cost.)".
+     *
+     * Tiered is a choose-one modal spell where each tier carries its own additional mana cost,
+     * paid as you cast the spell (CR 702.183a: "Choose one. As an additional cost to cast this
+     * spell, pay the cost associated with that mode."). Exactly one tier is chosen and only that
+     * tier's effect resolves. Mechanically this is a [ModalEffect] with `chooseCount = 1` and
+     * per-tier [Mode.additionalManaCost] — the same cast-time cost machinery as Spree, constrained
+     * to a single mode (the enumerator folds the chosen tier's cost into the spell's effective cost
+     * and the cast handler charges it).
+     *
+     * Example (Fire Magic, {R}):
+     * ```kotlin
+     * spell {
+     *     tiered {
+     *         tier("Fire", "{0}", "Fire Magic deals 1 damage to each creature.") {
+     *             effect = Patterns.Group.dealDamageToAll(1, GroupFilter.AllCreatures)
+     *         }
+     *         tier("Fira", "{2}", "Fire Magic deals 2 damage to each creature.") {
+     *             effect = Patterns.Group.dealDamageToAll(2, GroupFilter.AllCreatures)
+     *         }
+     *         tier("Firaga", "{5}", "Fire Magic deals 3 damage to each creature.") {
+     *             effect = Patterns.Group.dealDamageToAll(3, GroupFilter.AllCreatures)
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * The card's printed reminder line is [TIERED_REMINDER]; set it in the card's `oracleText`
+     * along with the per-tier text (this builder does not synthesize oracle text).
+     */
+    fun tiered(init: TieredBuilder.() -> Unit) {
+        val builder = TieredBuilder()
+        builder.init()
+        effect = builder.build()
+    }
 }
 
 // =============================================================================
@@ -1132,6 +1169,44 @@ class ModeBuilder(private val description: String) {
         }
         return Mode(effect!!, allTargets, description)
     }
+}
+
+// =============================================================================
+// Tiered Builder (CR 702.183)
+// =============================================================================
+
+/** Reminder text printed under the Tiered keyword (CR 702.183a). */
+const val TIERED_REMINDER: String = "Tiered (Choose one additional cost.)"
+
+/**
+ * Builder for [SpellBuilder.tiered] spells. Each [tier] becomes a [Mode] of a choose-one
+ * [ModalEffect] carrying that tier's [Mode.additionalManaCost].
+ */
+@CardDsl
+class TieredBuilder {
+    private val modes: MutableList<Mode> = mutableListOf()
+
+    /**
+     * Add a tier.
+     *
+     * @param name The tier's flavor name (e.g. "Fira") — shown first in the cast-time button label.
+     * @param cost The additional mana cost paid as you cast the spell when this tier is chosen
+     *   (e.g. "{2}", or "{0}" for the free base tier). Stacked onto the spell's mana cost at cast.
+     * @param text Human-readable description of this tier's effect; the button label is
+     *   "<name> — <text>".
+     */
+    fun tier(name: String, cost: String, text: String, init: ModeBuilder.() -> Unit) {
+        val builder = ModeBuilder("$name — $text")
+        builder.init()
+        modes.add(builder.build().copy(additionalManaCost = cost))
+    }
+
+    internal fun build(): ModalEffect =
+        ModalEffect(
+            modes = modes.toList(),
+            chooseCount = 1,
+            minChooseCount = 1
+        )
 }
 
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FireMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FireMagic.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Fire Magic
+ * {R}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * • Fire — {0} — Fire Magic deals 1 damage to each creature.
+ * • Fira — {2} — Fire Magic deals 2 damage to each creature.
+ * • Firaga — {5} — Fire Magic deals 3 damage to each creature.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. Each tier scales the sweep damage. No targets.
+ */
+val FireMagic = card("Fire Magic") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "• Fire — {0} — Fire Magic deals 1 damage to each creature.\n" +
+        "• Fira — {2} — Fire Magic deals 2 damage to each creature.\n" +
+        "• Firaga — {5} — Fire Magic deals 3 damage to each creature."
+
+    spell {
+        tiered {
+            tier("Fire", "{0}", "Fire Magic deals 1 damage to each creature.") {
+                effect = Patterns.Group.dealDamageToAll(1, GroupFilter.AllCreatures)
+            }
+            tier("Fira", "{2}", "Fire Magic deals 2 damage to each creature.") {
+                effect = Patterns.Group.dealDamageToAll(2, GroupFilter.AllCreatures)
+            }
+            tier("Firaga", "{5}", "Fire Magic deals 3 damage to each creature.") {
+                effect = Patterns.Group.dealDamageToAll(3, GroupFilter.AllCreatures)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Toni Infante"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/415ff6a5-61ef-4b37-ae08-e44476300d4a.jpg?1748706272"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IceMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IceMagic.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ice Magic
+ * {1}{U}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * • Blizzard — {0} — Return target creature to its owner's hand.
+ * • Blizzara — {2} — Target creature's owner puts it on their choice of the top or bottom of their library.
+ * • Blizzaga — {5}{U} — Target creature's owner shuffles it into their library.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. Each tier removes target creature with an escalating destination.
+ */
+val IceMagic = card("Ice Magic") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "• Blizzard — {0} — Return target creature to its owner's hand.\n" +
+        "• Blizzara — {2} — Target creature's owner puts it on their choice of the top or bottom of their library.\n" +
+        "• Blizzaga — {5}{U} — Target creature's owner shuffles it into their library."
+
+    spell {
+        tiered {
+            tier("Blizzard", "{0}", "Return target creature to its owner's hand.") {
+                effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+            tier(
+                "Blizzara", "{2}",
+                "Target creature's owner puts it on their choice of the top or bottom of their library."
+            ) {
+                effect = Effects.PutOnTopOrBottomOfLibrary(EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+            tier("Blizzaga", "{5}{U}", "Target creature's owner shuffles it into their library.") {
+                effect = Effects.ShuffleIntoLibrary(EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Masateru Ikeda"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dabd626-7ec3-4913-babb-d5d3fd5e32d5.jpg?1748705962"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RestorationMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RestorationMagic.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Restoration Magic
+ * {W}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * • Cure — {0} — Target permanent gains hexproof and indestructible until end of turn.
+ * • Cura — {1} — Target permanent gains hexproof and indestructible until end of turn. You gain 3 life.
+ * • Curaga — {3}{W} — Permanents you control gain hexproof and indestructible until end of turn. You gain 6 life.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. The first two tiers protect a single target permanent; the top tier protects all
+ * permanents you control and gains the most life.
+ */
+val RestorationMagic = card("Restoration Magic") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "• Cure — {0} — Target permanent gains hexproof and indestructible until end of turn.\n" +
+        "• Cura — {1} — Target permanent gains hexproof and indestructible until end of turn. You gain 3 life.\n" +
+        "• Curaga — {3}{W} — Permanents you control gain hexproof and indestructible until end of turn. You gain 6 life."
+
+    spell {
+        tiered {
+            tier("Cure", "{0}", "Target permanent gains hexproof and indestructible until end of turn.") {
+                effect = Effects.Composite(
+                    Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.ContextTarget(0)),
+                    Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0))
+                )
+                target = Targets.Permanent
+            }
+            tier(
+                "Cura", "{1}",
+                "Target permanent gains hexproof and indestructible until end of turn. You gain 3 life."
+            ) {
+                effect = Effects.Composite(
+                    Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.ContextTarget(0)),
+                    Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0)),
+                    Effects.GainLife(3)
+                )
+                target = Targets.Permanent
+            }
+            tier(
+                "Curaga", "{3}{W}",
+                "Permanents you control gain hexproof and indestructible until end of turn. You gain 6 life."
+            ) {
+                effect = Effects.Composite(
+                    Patterns.Group.grantKeywordToAll(Keyword.HEXPROOF, Filters.Group.permanentsYouControl),
+                    Patterns.Group.grantKeywordToAll(Keyword.INDESTRUCTIBLE, Filters.Group.permanentsYouControl),
+                    Effects.GainLife(6)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Yumi Yaoshida"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/494e68e9-ecba-4482-82bc-207ad59144c1.jpg?1748705864"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThunderMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThunderMagic.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thunder Magic
+ * {R}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * • Thunder — {0} — Thunder Magic deals 2 damage to target creature.
+ * • Thundara — {3} — Thunder Magic deals 4 damage to target creature.
+ * • Thundaga — {5}{R} — Thunder Magic deals 8 damage to target creature.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. Each tier targets a creature and scales the damage.
+ */
+val ThunderMagic = card("Thunder Magic") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "• Thunder — {0} — Thunder Magic deals 2 damage to target creature.\n" +
+        "• Thundara — {3} — Thunder Magic deals 4 damage to target creature.\n" +
+        "• Thundaga — {5}{R} — Thunder Magic deals 8 damage to target creature."
+
+    spell {
+        tiered {
+            tier("Thunder", "{0}", "Thunder Magic deals 2 damage to target creature.") {
+                effect = Effects.DealDamage(2, EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+            tier("Thundara", "{3}", "Thunder Magic deals 4 damage to target creature.") {
+                effect = Effects.DealDamage(4, EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+            tier("Thundaga", "{5}{R}", "Thunder Magic deals 8 damage to target creature.") {
+                effect = Effects.DealDamage(8, EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Josephine Chang"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f2b202c-91da-40ec-8324-6b6be7cb3bc8.jpg?1748706380"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TifasLimitBreak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TifasLimitBreak.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Tifa's Limit Break
+ * {G}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * • Somersault — {0} — Target creature gets +2/+2 until end of turn.
+ * • Meteor Strikes — {2} — Double target creature's power and toughness until end of turn.
+ * • Final Heaven — {6}{G} — Triple target creature's power and toughness until end of turn.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. Doubling/tripling is modeled as a layer-7 +N/+N modification read from the
+ * target's own power/toughness as the effect begins to apply (CR 702 "double its power and
+ * toughness" ruling): double = +P/+T, triple = +2P/+2T.
+ */
+val TifasLimitBreak = card("Tifa's Limit Break") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "• Somersault — {0} — Target creature gets +2/+2 until end of turn.\n" +
+        "• Meteor Strikes — {2} — Double target creature's power and toughness until end of turn.\n" +
+        "• Final Heaven — {6}{G} — Triple target creature's power and toughness until end of turn."
+
+    spell {
+        tiered {
+            tier("Somersault", "{0}", "Target creature gets +2/+2 until end of turn.") {
+                effect = Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0))
+                target = Targets.Creature
+            }
+            tier("Meteor Strikes", "{2}", "Double target creature's power and toughness until end of turn.") {
+                effect = Effects.ModifyStats(
+                    power = DynamicAmounts.targetPower(0),
+                    toughness = DynamicAmounts.targetToughness(0),
+                    target = EffectTarget.ContextTarget(0)
+                )
+                target = Targets.Creature
+            }
+            tier("Final Heaven", "{6}{G}", "Triple target creature's power and toughness until end of turn.") {
+                effect = Effects.ModifyStats(
+                    power = DynamicAmount.Multiply(DynamicAmounts.targetPower(0), 2),
+                    toughness = DynamicAmount.Multiply(DynamicAmounts.targetToughness(0), 2),
+                    target = EffectTarget.ContextTarget(0)
+                )
+                target = Targets.Creature
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Mikio Masuda"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24d6eab7-22bd-494f-8cbe-204446f24be9.jpg?1748706536"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VincentsLimitBreak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VincentsLimitBreak.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vincent's Limit Break
+ * {1}{B}
+ * Instant
+ *
+ * Tiered (Choose one additional cost.)
+ * Until end of turn, target creature you control gains "When this creature dies, return it to the
+ * battlefield tapped under its owner's control" and has the chosen base power and toughness.
+ * • Galian Beast — {0} — 3/2.
+ * • Death Gigas — {1} — 5/2.
+ * • Hellmasker — {3} — 7/2.
+ *
+ * Tiered (CR 702.183): a choose-one modal spell where the chosen tier's additional mana cost is
+ * paid at cast. Every tier applies the same shared effect — set base power/toughness (layer 7b)
+ * until end of turn plus a granted "dies → return tapped" self-trigger — differing only in the
+ * base power/toughness value.
+ */
+val VincentsLimitBreak = card("Vincent's Limit Break") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Tiered (Choose one additional cost.)\n" +
+        "Until end of turn, target creature you control gains \"When this creature dies, return it " +
+        "to the battlefield tapped under its owner's control\" and has the chosen base power and " +
+        "toughness.\n" +
+        "• Galian Beast — {0} — 3/2.\n" +
+        "• Death Gigas — {1} — 5/2.\n" +
+        "• Hellmasker — {3} — 7/2."
+
+    spell {
+        tiered {
+            tier("Galian Beast", "{0}", "3/2.") {
+                effect = transform(3, 2)
+                target = Targets.CreatureYouControl
+            }
+            tier("Death Gigas", "{1}", "5/2.") {
+                effect = transform(5, 2)
+                target = Targets.CreatureYouControl
+            }
+            tier("Hellmasker", "{3}", "7/2.") {
+                effect = transform(7, 2)
+                target = Targets.CreatureYouControl
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Ryuichi Sakuma"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0502c426-5271-4989-8598-5bc159afe79c.jpg?1748718952"
+    }
+}
+
+/**
+ * The shared per-tier effect: until end of turn, the target creature you control has base
+ * power/toughness [power]/[toughness] and gains a granted "When this creature dies, return it to
+ * the battlefield tapped under its owner's control" self-trigger. The grant lasts until end of
+ * turn, but a creature that dies during that window leaves the ability to resolve from the
+ * graveyard (mirrors the Earthbend "return tapped" composition).
+ */
+private fun transform(power: Int, toughness: Int): Effect {
+    val diesReturnTapped = TriggeredAbility.create(
+        trigger = Triggers.Dies.event,
+        binding = Triggers.Dies.binding,
+        effect = Effects.Move(
+            target = EffectTarget.Self,
+            destination = Zone.BATTLEFIELD,
+            placement = ZonePlacement.Tapped,
+            fromZone = Zone.GRAVEYARD
+        ),
+        descriptionOverride = "When this creature dies, return it to the battlefield tapped under its owner's control."
+    )
+    return Effects.Composite(
+        Effects.SetBasePowerAndToughness(power, toughness, EffectTarget.ContextTarget(0), Duration.EndOfTurn),
+        GrantTriggeredAbilityEffect(diesReturnTapped, EffectTarget.ContextTarget(0), Duration.EndOfTurn)
+    )
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2000,6 +2000,93 @@
     ]
 }
 
+// Fire Magic
+{
+    "name": "Fire Magic",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\n• Fire — {0} — Fire Magic deals 1 damage to each creature.\n• Fira — {2} — Fire Magic deals 2 damage to each creature.\n• Firaga — {5} — Fire Magic deals 3 damage to each creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Fire — Fire Magic deals 1 damage to each creature.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Fira — Fire Magic deals 2 damage to each creature.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Firaga — Fire Magic deals 3 damage to each creature.",
+                    "additionalManaCost": "{5}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Toni Infante",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/415ff6a5-61ef-4b37-ae08-e44476300d4a.jpg?1748706272"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Gladiolus Amicitia
 {
     "name": "Gladiolus Amicitia",
@@ -2416,6 +2503,89 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ice Magic
+{
+    "name": "Ice Magic",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\n• Blizzard — {0} — Return target creature to its owner's hand.\n• Blizzara — {2} — Target creature's owner puts it on their choice of the top or bottom of their library.\n• Blizzaga — {5}{U} — Target creature's owner shuffles it into their library.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Blizzard — Return target creature to its owner's hand.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "PutOnLibraryPositionOfChoice",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Blizzara — Target creature's owner puts it on their choice of the top or bottom of their library.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Library",
+                        "placement": "Shuffled"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Blizzaga — Target creature's owner shuffles it into their library.",
+                    "additionalManaCost": "{5}{U}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Masateru Ikeda",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dabd626-7ec3-4913-babb-d5d3fd5e32d5.jpg?1748705962"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3521,6 +3691,147 @@
     ]
 }
 
+// Restoration Magic
+{
+    "name": "Restoration Magic",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\n• Cure — {0} — Target permanent gains hexproof and indestructible until end of turn.\n• Cura — {1} — Target permanent gains hexproof and indestructible until end of turn. You gain 3 life.\n• Curaga — {3}{W} — Permanents you control gain hexproof and indestructible until end of turn. You gain 6 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            }
+                        }
+                    ],
+                    "description": "Cure — Target permanent gains hexproof and indestructible until end of turn.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            }
+                        }
+                    ],
+                    "description": "Cura — Target permanent gains hexproof and indestructible until end of turn. You gain 3 life.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "permanent ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "HEXPROOF",
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "permanent ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "INDESTRUCTIBLE",
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Curaga — Permanents you control gain hexproof and indestructible until end of turn. You gain 6 life.",
+                    "additionalManaCost": "{3}{W}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Yumi Yaoshida",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/494e68e9-ecba-4482-82bc-207ad59144c1.jpg?1748705864"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ring of the Lucii
 {
     "name": "Ring of the Lucii",
@@ -4022,6 +4333,98 @@
     ]
 }
 
+// Thunder Magic
+{
+    "name": "Thunder Magic",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\n• Thunder — {0} — Thunder Magic deals 2 damage to target creature.\n• Thundara — {3} — Thunder Magic deals 4 damage to target creature.\n• Thundaga — {5}{R} — Thunder Magic deals 8 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Thunder — Thunder Magic deals 2 damage to target creature.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Thundara — Thunder Magic deals 4 damage to target creature.",
+                    "additionalManaCost": "{3}"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 8
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Thundaga — Thunder Magic deals 8 damage to target creature.",
+                    "additionalManaCost": "{5}{R}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Josephine Chang",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f2b202c-91da-40ec-8324-6b6be7cb3bc8.jpg?1748706380"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tidus, Blitzball Star
 {
     "name": "Tidus, Blitzball Star",
@@ -4128,6 +4531,123 @@
         "artist": "Laurel Austin",
         "flavorText": "\"I'm pretty good at taking care of myself, you know.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb781323-2746-405d-a9b2-e778c037a6e9.jpg?1748706535"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tifa's Limit Break
+{
+    "name": "Tifa's Limit Break",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\n• Somersault — {0} — Target creature gets +2/+2 until end of turn.\n• Meteor Strikes — {2} — Double target creature's power and toughness until end of turn.\n• Final Heaven — {6}{G} — Triple target creature's power and toughness until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Somersault — Target creature gets +2/+2 until end of turn.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "toughnessModifier": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Toughness"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Meteor Strikes — Double target creature's power and toughness until end of turn.",
+                    "additionalManaCost": "{2}"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Multiply",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "Power"
+                            },
+                            "multiplier": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Multiply",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "Toughness"
+                            },
+                            "multiplier": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Final Heaven — Triple target creature's power and toughness until end of turn.",
+                    "additionalManaCost": "{6}{G}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "Mikio Masuda",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24d6eab7-22bd-494f-8cbe-204446f24be9.jpg?1748706536"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -4652,6 +5172,179 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Vincent's Limit Break
+{
+    "name": "Vincent's Limit Break",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Tiered (Choose one additional cost.)\nUntil end of turn, target creature you control gains \"When this creature dies, return it to the battlefield tapped under its owner's control\" and has the chosen base power and toughness.\n• Galian Beast — {0} — 3/2.\n• Death Gigas — {1} — 5/2.\n• Hellmasker — {3} — 7/2.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBasePowerToughness",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": 3,
+                                "toughness": 2,
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_1",
+                                    "trigger": {
+                                        "type": "ZoneChangeEvent",
+                                        "from": "Battlefield",
+                                        "to": "Graveyard"
+                                    },
+                                    "effect": {
+                                        "type": "MoveToZone",
+                                        "target": "Self",
+                                        "destination": "Battlefield",
+                                        "placement": "Tapped",
+                                        "fromZone": "Graveyard"
+                                    },
+                                    "descriptionOverride": "When this creature dies, return it to the battlefield tapped under its owner's control."
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        }
+                    ],
+                    "description": "Galian Beast — 3/2.",
+                    "additionalManaCost": "{0}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBasePowerToughness",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": 5,
+                                "toughness": 2,
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_2",
+                                    "trigger": {
+                                        "type": "ZoneChangeEvent",
+                                        "from": "Battlefield",
+                                        "to": "Graveyard"
+                                    },
+                                    "effect": {
+                                        "type": "MoveToZone",
+                                        "target": "Self",
+                                        "destination": "Battlefield",
+                                        "placement": "Tapped",
+                                        "fromZone": "Graveyard"
+                                    },
+                                    "descriptionOverride": "When this creature dies, return it to the battlefield tapped under its owner's control."
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        }
+                    ],
+                    "description": "Death Gigas — 5/2.",
+                    "additionalManaCost": "{1}"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBasePowerToughness",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": 7,
+                                "toughness": 2,
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_3",
+                                    "trigger": {
+                                        "type": "ZoneChangeEvent",
+                                        "from": "Battlefield",
+                                        "to": "Graveyard"
+                                    },
+                                    "effect": {
+                                        "type": "MoveToZone",
+                                        "target": "Self",
+                                        "destination": "Battlefield",
+                                        "placement": "Tapped",
+                                        "fromZone": "Graveyard"
+                                    },
+                                    "descriptionOverride": "When this creature dies, return it to the battlefield tapped under its owner's control."
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        }
+                    ],
+                    "description": "Hellmasker — 7/2.",
+                    "additionalManaCost": "{3}"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Ryuichi Sakuma",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0502c426-5271-4989-8598-5bc159afe79c.jpg?1748718952"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TieredScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TieredScenarioTest.kt
@@ -1,0 +1,387 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.FireMagic
+import com.wingedsheep.mtg.sets.definitions.fin.cards.IceMagic
+import com.wingedsheep.mtg.sets.definitions.fin.cards.RestorationMagic
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ThunderMagic
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TifasLimitBreak
+import com.wingedsheep.mtg.sets.definitions.fin.cards.VincentsLimitBreak
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tiered (CR 702.183) — "Choose one. As an additional cost to cast this spell, pay the cost
+ * associated with that mode." Modeled as a choose-one [com.wingedsheep.sdk.scripting.effects.ModalEffect]
+ * with per-tier `additionalManaCost`, reusing the same cast-time per-mode cost machinery as Spree
+ * (proven generically by ModalPerModeAdditionalCostTest); these tests pin the mechanic through the
+ * six real FIN Tiered cards.
+ *
+ * Each clause of 702.183a gets a paired assertion:
+ * - "Choose one" — exactly one tier may be chosen; choosing two is rejected.
+ * - "pay the cost associated with that mode" — the chosen tier's additional cost is added to the
+ *   spell's cost (an unaffordable higher tier can't be cast; a payable one can).
+ * - the chosen tier's (scaled) effect — and only that tier's — resolves.
+ */
+class TieredScenarioTest : FunSpec({
+
+    // Vanilla creatures with known toughness so sweep/target damage is deterministic.
+    val TwoTwo = CardDefinition.creature(
+        name = "Tiered Test 2/2", manaCost = ManaCost.parse("{2}"),
+        subtypes = emptySet(), power = 2, toughness = 2, oracleText = ""
+    )
+    val ThreeThree = CardDefinition.creature(
+        name = "Tiered Test 3/3", manaCost = ManaCost.parse("{3}"),
+        subtypes = emptySet(), power = 3, toughness = 3, oracleText = ""
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(TwoTwo, ThreeThree))
+        d.registerCard(FireMagic)
+        d.registerCard(IceMagic)
+        d.registerCard(ThunderMagic)
+        d.registerCard(RestorationMagic)
+        d.registerCard(TifasLimitBreak)
+        d.registerCard(VincentsLimitBreak)
+        return d
+    }
+
+    fun life(d: GameTestDriver, p: EntityId): Int =
+        d.state.getEntity(p)!!.get<LifeTotalComponent>()!!.life
+
+    // -------------------------------------------------------------------------
+    // Fire Magic — sweep that scales per tier; no targets.
+    // -------------------------------------------------------------------------
+
+    test("Fire (tier 0, {0}) costs only {R} and deals 1 to each creature — both survive") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val twoTwo = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+        val threeThree = d.putCreatureOnBattlefield(p1, "Tiered Test 3/3")
+        d.giveMana(p1, Color.RED, 1) // exactly base {R}, no extra
+
+        val spell = d.putCardInHand(p1, "Fire Magic")
+        d.submit(
+            CastSpell(p1, spell, chosenModes = listOf(0), paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        // 1 damage to each: both survive.
+        d.state.getBattlefield().contains(twoTwo) shouldBe true
+        d.state.getBattlefield().contains(threeThree) shouldBe true
+    }
+
+    test("Firaga (tier 2, {5}) needs {R} + {5} and deals 3 to each creature — both die") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val twoTwo = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+        val threeThree = d.putCreatureOnBattlefield(p1, "Tiered Test 3/3")
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 5) // the additional {5}
+
+        val spell = d.putCardInHand(p1, "Fire Magic")
+        d.submit(
+            CastSpell(p1, spell, chosenModes = listOf(2), paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        // 3 damage to each: both die.
+        d.state.getBattlefield().contains(twoTwo) shouldBe false
+        d.state.getBattlefield().contains(threeThree) shouldBe false
+    }
+
+    test("Firaga can't be cast without its additional {5} — only base {R} available") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+
+        d.giveMana(p1, Color.RED, 1) // base only; {5} unpaid
+
+        val spell = d.putCardInHand(p1, "Fire Magic")
+        d.submit(
+            CastSpell(p1, spell, chosenModes = listOf(2), paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess.shouldBeFalse()
+    }
+
+    test("Tiered is choose-one — submitting two tiers is rejected") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 7)
+
+        val spell = d.putCardInHand(p1, "Fire Magic")
+        d.submit(
+            CastSpell(p1, spell, chosenModes = listOf(0, 2), paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess.shouldBeFalse()
+    }
+
+    // -------------------------------------------------------------------------
+    // Thunder Magic — targeted, scaling damage.
+    // -------------------------------------------------------------------------
+
+    test("Thundaga (tier 2, {5}{R}) deals 8 to target creature — costs {R}{R}{5}") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        val opp = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val victim = d.putCreatureOnBattlefield(opp, "Tiered Test 3/3")
+
+        d.giveMana(p1, Color.RED, 2)   // base {R} + the {R} in {5}{R}
+        d.giveColorlessMana(p1, 5)     // the {5}
+
+        val spell = d.putCardInHand(p1, "Thunder Magic")
+        val tgt = ChosenTarget.Permanent(victim)
+        d.submit(
+            CastSpell(
+                p1, spell,
+                targets = listOf(tgt),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(tgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(victim) shouldBe false
+    }
+
+    test("Thunder (tier 0, {0}) deals only 2 — a 3/3 survives") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        val opp = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val victim = d.putCreatureOnBattlefield(opp, "Tiered Test 3/3")
+
+        d.giveMana(p1, Color.RED, 1)
+
+        val spell = d.putCardInHand(p1, "Thunder Magic")
+        val tgt = ChosenTarget.Permanent(victim)
+        d.submit(
+            CastSpell(
+                p1, spell,
+                targets = listOf(tgt),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(tgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(victim) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // Ice Magic — Blizzard bounce (tier 0).
+    // -------------------------------------------------------------------------
+
+    test("Blizzard (tier 0) returns target creature to its owner's hand") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = d.activePlayer!!
+        val opp = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val victim = d.putCreatureOnBattlefield(opp, "Tiered Test 2/2")
+
+        d.giveColorlessMana(p1, 1)     // the {1} in {1}{U}
+        d.giveMana(p1, Color.BLUE, 1)  // the {U}
+
+        val spell = d.putCardInHand(p1, "Ice Magic")
+        val tgt = ChosenTarget.Permanent(victim)
+        d.submit(
+            CastSpell(
+                p1, spell,
+                targets = listOf(tgt),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(tgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(victim) shouldBe false
+        d.getHand(opp).contains(victim) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // Restoration Magic — life gain scales with the tier.
+    // -------------------------------------------------------------------------
+
+    test("Curaga (tier 2, {3}{W}) gains 6 life; Cura (tier 1, {1}) gains 3") {
+        // Curaga
+        run {
+            val d = driver()
+            d.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val p1 = d.activePlayer!!
+            d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+            d.giveMana(p1, Color.WHITE, 2) // base {W} + the {W} in {3}{W}
+            d.giveColorlessMana(p1, 3)     // the {3}
+            val before = life(d, p1)
+            val spell = d.putCardInHand(p1, "Restoration Magic")
+            d.submit(
+                CastSpell(p1, spell, chosenModes = listOf(2), paymentStrategy = PaymentStrategy.FromPool)
+            ).isSuccess shouldBe true
+            d.bothPass()
+            life(d, p1) shouldBe (before + 6)
+        }
+        // Cura
+        run {
+            val d = driver()
+            d.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val p1 = d.activePlayer!!
+            d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val perm = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+            d.giveMana(p1, Color.WHITE, 1) // base {W}
+            d.giveColorlessMana(p1, 1)     // the {1}
+            val before = life(d, p1)
+            val spell = d.putCardInHand(p1, "Restoration Magic")
+            val tgt = ChosenTarget.Permanent(perm)
+            d.submit(
+                CastSpell(
+                    p1, spell,
+                    targets = listOf(tgt),
+                    chosenModes = listOf(1),
+                    modeTargetsOrdered = listOf(listOf(tgt)),
+                    paymentStrategy = PaymentStrategy.FromPool
+                )
+            ).isSuccess shouldBe true
+            d.bothPass()
+            life(d, p1) shouldBe (before + 3)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tifa's Limit Break — +N/+N, double, triple of target's own P/T.
+    // -------------------------------------------------------------------------
+
+    test("Tifa tiers scale a 2/2: Somersault → 4/4, Meteor Strikes → 4/4 (double), Final Heaven → 6/6 (triple)") {
+        fun castTifa(modeIndex: Int): Pair<Int?, Int?> {
+            val d = driver()
+            d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+            val p1 = d.activePlayer!!
+            d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val creature = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+            d.giveMana(p1, Color.GREEN, 2)
+            d.giveColorlessMana(p1, 6)
+            val spell = d.putCardInHand(p1, "Tifa's Limit Break")
+            val tgt = ChosenTarget.Permanent(creature)
+            d.submit(
+                CastSpell(
+                    p1, spell,
+                    targets = listOf(tgt),
+                    chosenModes = listOf(modeIndex),
+                    modeTargetsOrdered = listOf(listOf(tgt)),
+                    paymentStrategy = PaymentStrategy.FromPool
+                )
+            ).isSuccess shouldBe true
+            d.bothPass()
+            val proj = d.state.projectedState
+            return proj.getPower(creature) to proj.getToughness(creature)
+        }
+
+        castTifa(0) shouldBe (4 to 4) // +2/+2
+        castTifa(1) shouldBe (4 to 4) // double 2/2
+        castTifa(2) shouldBe (6 to 6) // triple 2/2
+    }
+
+    // -------------------------------------------------------------------------
+    // Vincent's Limit Break — shared effect, tier picks the base P/T.
+    // -------------------------------------------------------------------------
+
+    test("Galian Beast (tier 0) sets target creature you control to base 3/2 and grants dies→return-tapped") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val creature = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+        d.giveColorlessMana(p1, 1) // the {1} of {1}{B}
+        d.giveMana(p1, Color.BLACK, 1)
+
+        val spell = d.putCardInHand(p1, "Vincent's Limit Break")
+        val tgt = ChosenTarget.Permanent(creature)
+        d.submit(
+            CastSpell(
+                p1, spell,
+                targets = listOf(tgt),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(tgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        val proj = d.state.projectedState
+        (proj.getPower(creature) to proj.getToughness(creature)) shouldBe (3 to 2)
+    }
+
+    test("the granted dies trigger returns the creature to the battlefield tapped when it dies that turn") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val creature = d.putCreatureOnBattlefield(p1, "Tiered Test 2/2")
+
+        // Galian Beast: base 2/2 → 3/2 + "when this dies, return it tapped".
+        d.giveColorlessMana(p1, 1)
+        d.giveMana(p1, Color.BLACK, 1)
+        val vincent = d.putCardInHand(p1, "Vincent's Limit Break")
+        val vTgt = ChosenTarget.Permanent(creature)
+        d.submit(
+            CastSpell(
+                p1, vincent,
+                targets = listOf(vTgt),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(vTgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        // Kill it: Thunder (tier 0) deals 2 — lethal to the now-3/2 creature.
+        d.giveMana(p1, Color.RED, 1)
+        val thunder = d.putCardInHand(p1, "Thunder Magic")
+        val tTgt = ChosenTarget.Permanent(creature)
+        d.submit(
+            CastSpell(
+                p1, thunder,
+                targets = listOf(tTgt),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(tTgt)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass() // resolve Thunder → creature dies
+        d.bothPass() // resolve the granted dies trigger → return it tapped
+
+        // The creature died and re-entered the battlefield tapped under its owner's control.
+        val returned = d.findPermanent(p1, "Tiered Test 2/2")
+        (returned != null) shouldBe true
+        d.isTapped(returned!!) shouldBe true
+        d.getGraveyardCardNames(p1).contains("Tiered Test 2/2") shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Tiered** (FIN §4) — *"Tiered (Choose one additional cost.)"* (CR 702.183a: *"Choose one. As an additional cost to cast this spell, pay the cost associated with that mode."*). A choose-**one** modal spell where each tier carries its own additional mana cost, paid as you cast the spell, and only that tier's (usually scaled) effect resolves.

### Key finding: no engine gap

The backlog asked to *"extend the modal/Spree cast pipeline to charge the chosen mode's additional cost."* On investigation, **the engine already does this** for the choose-1 path — there was nothing to extend:

- `CastSpellEnumerator.computeModeEnumeration` folds the chosen tier's `additionalManaCost` into each `CastSpellMode` legal action's effective cost and only offers *affordable* tiers.
- `CastSpellHandler` adds the chosen mode's `additionalManaCost` on execute (the same machinery `ModalPerModeAdditionalCostTest` already proves generically).

So Tiered is mechanically **Spree constrained to a single mode**: a `ModalEffect(chooseCount = 1, minChooseCount = 1)` with per-tier `additionalManaCost`.

### What's shipped (authoring sugar + content)

- **`spell { tiered { } }` / `TieredBuilder`** (`CardBuilder.kt`) — builds the choose-one `ModalEffect`; `tier(name, cost, text) { effect; target }` sets the per-tier additional cost and a `"<name> — <text>"` button label. Plus a `TIERED_REMINDER` constant.
- **No `Keyword.TIERED`** — Tiered grants no behavior beyond the modal-with-additional-cost shape, mirroring how Spree is authored (the reminder lives in `oracleText`).
- **6 FIN spells**, composed from existing effects: Fire / Ice / Thunder / Restoration Magic, Tifa's / Vincent's Limit Break.
- Docs: new "Tiered" subsection in `card-sdk-language-reference.md`; backlog §4 marked done.

### UX

Reuses the existing choose-1 modal `CastSpellMode` selector **unchanged** — one button per affordable tier, each showing its full (base + tier) mana cost. No client code changed; the player flow was traced end-to-end (legal action → `ActionMenu` per-mode buttons with `manaCostString`). The per-mode cost payment is server-authoritative and covered by the engine tests below.

### Tests

`TieredScenarioTest` (rules-engine) pins every clause of 702.183a through the real cards:
- per-tier additional cost is charged (a higher tier is uncastable without its cost; a payable one casts);
- choose-**one** (submitting two tiers is rejected);
- affordability gating;
- scaled effects (Fire 1 vs Firaga 3; Thunder 2 vs Thundaga 8);
- targeting (Thunder, Ice bounce);
- double/triple power & toughness (Tifa);
- Vincent's set-base-P/T + granted **dies → return tapped**.

mtgish Step 8b doesn't apply: pure DSL sugar over the existing modal-with-additional-cost capability — no new SDK `Effect` type and no new IR tag to register.

### Validation
- `:mtg-sdk:test`, `:mtg-sets:test` green (incl. `CardLintTest`, `FacadeBoundaryTest`, re-blessed `FIN.json` snapshot).
- `TieredScenarioTest` green (11 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)