### PR TITLE
Add 4 DSK cards (Attack-in-the-Box, Dashing Bloodsucker, Coordinated Clobbering, Defiant Survivor) + mtgish MayCost-pump emitter

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AttackInTheBox.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AttackInTheBox.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Attack-in-the-Box
+ * {3}
+ * Artifact Creature — Toy
+ * 2/4
+ * Whenever this creature attacks, you may have it get +4/+0 until end of turn. If you do,
+ * sacrifice it at the beginning of the next end step.
+ *
+ * Modeled as an attack trigger whose whole "+4/+0 and arm the delayed sacrifice" body is gated by
+ * a single "you may" decision — so declining skips both the pump and the sacrifice ("if you do"
+ * binds the sacrifice to the same yes choice, per the oracle text). The sacrifice is a delayed
+ * trigger that fires at the next end step on [EffectTarget.Self].
+ */
+val AttackInTheBox = card("Attack-in-the-Box") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Toy"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever this creature attacks, you may have it get +4/+0 until end of turn. " +
+        "If you do, sacrifice it at the beginning of the next end step."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayEffect(
+            Effects.Composite(
+                Effects.ModifyStats(4, 0, EffectTarget.Self),
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = Effects.SacrificeTarget(EffectTarget.Self),
+                ),
+            ),
+            descriptionOverride = "Have Attack-in-the-Box get +4/+0 until end of turn? " +
+                "(If you do, sacrifice it at the beginning of the next end step.)",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "242"
+        artist = "Domenico Cava"
+        flavorText = "Pop goes the evil."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg?1726286774"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CoordinatedClobbering.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CoordinatedClobbering.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Coordinated Clobbering
+ * {G}
+ * Sorcery
+ *
+ * Tap one or two target untapped creatures you control. They each deal damage equal to their
+ * power to target creature an opponent controls.
+ *
+ * Two target slots: the single opponent's creature (declared first, so it stays addressable as
+ * `ContextTarget(0)` across the per-attacker loop) and one or two untapped creatures you control.
+ * At resolution we gather the chosen targets, filter to the creatures you control (excludes the
+ * victim), then tap them all and have each deal damage equal to its own power — read per-iteration
+ * via [EntityReference.IterationEntity] — to the opponent's creature.
+ */
+val CoordinatedClobbering = card("Coordinated Clobbering") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Tap one or two target untapped creatures you control. They each deal damage " +
+        "equal to their power to target creature an opponent controls."
+
+    spell {
+        // Declared first so the victim is a stable target across the per-creature loop.
+        target("creature an opponent controls", Targets.CreatureOpponentControls)
+        target(
+            "untapped creatures you control",
+            TargetCreature(
+                count = 2,
+                minCount = 1,
+                filter = TargetFilter(GameObjectFilter.Creature.untapped().youControl()),
+            ),
+        )
+
+        effect = Effects.Composite(
+            // Gather every chosen target, then keep only the creatures you control (the victim is
+            // an opponent's creature, so it drops out).
+            GatherCardsEffect(
+                source = CardSource.ChosenTargets,
+                storeAs = "allTargets",
+            ),
+            FilterCollectionEffect(
+                from = "allTargets",
+                filter = CollectionFilter.MatchesFilter(GameObjectFilter.Creature.youControl()),
+                storeMatching = "clobberers",
+            ),
+            // Tap all chosen creatures first ("Tap one or two target untapped creatures you control").
+            ForEachInCollectionEffect(
+                collection = "clobberers",
+                effect = Effects.Tap(EffectTarget.Self),
+            ),
+            // Then each deals damage equal to its power to the opponent's creature.
+            ForEachInCollectionEffect(
+                collection = "clobberers",
+                effect = Effects.DealDamage(
+                    amount = DynamicAmount.EntityProperty(
+                        EntityReference.IterationEntity,
+                        EntityNumericProperty.Power,
+                    ),
+                    target = EffectTarget.ContextTarget(0),
+                    damageSource = EffectTarget.Self,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Fajareka Setiawan"
+        flavorText = "Zimone's theory was that the fractalization of atmospheric aether would " +
+            "increase kinetic energy. Tyvar's theory was that if you hit cultists in the face " +
+            "really hard, they would fall down. They were both right."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg?1726286504"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DashingBloodsucker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DashingBloodsucker.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dashing Bloodsucker
+ * {3}{B}
+ * Creature — Vampire Warrior
+ * 2/5
+ *
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room,
+ * this creature gets +2/+0 and gains lifelink until end of turn.
+ *
+ * Eerie is modeled as two triggered abilities (the keyword ability word covers both an
+ * enchantment-you-control entering and fully unlocking a Room). Each pumps the source +2/+0 and
+ * grants lifelink until end of turn via [EffectTarget.Self].
+ */
+val DashingBloodsucker = card("Dashing Bloodsucker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warrior"
+    power = 2
+    toughness = 5
+    oracleText = "Eerie — Whenever an enchantment you control enters and whenever you fully " +
+        "unlock a Room, this creature gets +2/+0 and gains lifelink until end of turn."
+
+    keywords(Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+        )
+        description = "Eerie — Whenever an enchantment you control enters, Dashing Bloodsucker " +
+            "gets +2/+0 and gains lifelink until end of turn."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+        )
+        description = "Eerie — Whenever you fully unlock a Room, Dashing Bloodsucker gets +2/+0 " +
+            "and gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Randy Gallegos"
+        flavorText = "\"There are worse things here than vampires.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg?1726286186"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DefiantSurvivor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DefiantSurvivor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defiant Survivor
+ * {2}{G}
+ * Creature — Human Survivor
+ * 3/2
+ *
+ * Survival — At the beginning of your second main phase, if this creature is tapped, manifest
+ * dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a
+ * 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if
+ * it's a creature card.)
+ *
+ * Survival is an intervening-"if" postcombat-main trigger gated on the source being tapped, like
+ * the other DSK Survival creatures. The payoff is [Patterns.Library.manifestDread].
+ */
+val DefiantSurvivor = card("Defiant Survivor") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Survivor"
+    power = 3
+    toughness = 2
+    oracleText = "Survival — At the beginning of your second main phase, if this creature is " +
+        "tapped, manifest dread. (Look at the top two cards of your library. Put one onto the " +
+        "battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face " +
+        "up any time for its mana cost if it's a creature card.)"
+
+    // Survival — At the beginning of your second main phase, if this creature is tapped, manifest dread.
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = Patterns.Library.manifestDread()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Jessica Fong"
+        flavorText = "\"The dark should be scared of me!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg?1726286512"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -244,6 +244,64 @@
     ]
 }
 
+// Attack-in-the-Box
+{
+    "name": "Attack-in-the-Box",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Toy",
+    "oracleText": "Whenever this creature attacks, you may have it get +4/+0 until end of turn. If you do, sacrifice it at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "CreateDelayedTrigger",
+                                "step": "END",
+                                "effect": {
+                                    "type": "SacrificeTarget",
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Have Attack-in-the-Box get +4/+0 until end of turn? (If you do, sacrifice it at the beginning of the next end step.)"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "UNCOMMON",
+        "artist": "Domenico Cava",
+        "flavorText": "Pop goes the evil.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg?1726286774"
+    },
+    "colorIdentityOverride": []
+}
+
 // Balemurk Leech
 {
     "name": "Balemurk Leech",
@@ -1512,6 +1570,94 @@
     "colorIdentityOverride": []
 }
 
+// Coordinated Clobbering
+{
+    "name": "Coordinated Clobbering",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Tap one or two target untapped creatures you control. They each deal damage equal to their power to target creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "allTargets"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "allTargets",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "creature ctrl:you"
+                    },
+                    "storeMatching": "clobberers"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "clobberers"
+                    },
+                    "body": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "clobberers"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "IterationEntity",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature an opponent controls"
+            },
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature untapped ctrl:you"
+                },
+                "id": "untapped creatures you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "Zimone's theory was that the fractalization of atmospheric aether would increase kinetic energy. Tyvar's theory was that if you hit cultists in the face really hard, they would fall down. They were both right.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg?1726286504"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cracked Skull
 {
     "name": "Cracked Skull",
@@ -1704,6 +1850,182 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Dashing Bloodsucker
+{
+    "name": "Dashing Bloodsucker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Vampire Warrior",
+    "oracleText": "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, this creature gets +2/+0 and gains lifelink until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, Dashing Bloodsucker gets +2/+0 and gains lifelink until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, Dashing Bloodsucker gets +2/+0 and gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"There are worse things here than vampires.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg?1726286186"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Defiant Survivor
+{
+    "name": "Defiant Survivor",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if this creature is tapped, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Jessica Fong",
+        "flavorText": "\"The dark should be scared of me!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg?1726286512"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -1328,6 +1328,29 @@ internal fun EmitCtx.mayCostIfYouDoEffect(may: JsonObject, ifAct: JsonObject, tv
     if (cost == "DrawACard" && thenActions.singleOrNull()?.strField("_Action") == "DiscardACard") {
         return call("MayEffect", arg(call("Patterns.Hand.loot")))
     }
+    // "Whenever this creature attacks, you may have it get +X/+0 until end of turn. If you do, <then>."
+    // (Attack-in-the-Box). Here the MayCost wraps a *layer effect* (the pump) rather than a real cost:
+    // the optional action is the pump itself, and "if you do" gates <then> to the same yes. Faithful
+    // shape is MayEffect(Composite(<pump>, <then>)) — both run iff the player chooses to. Only the
+    // until-end-of-turn AdjustPT pump on a self-reference renders; anything else falls through.
+    if (cost == "CreatePermanentLayerEffectUntil") {
+        val pumpNode = (may["args"] as? JsonObject)
+        if (pumpNode != null) {
+            val pump = renderAction(
+                buildJsonObject {
+                    put("_Action", JsonPrimitive("CreatePermanentLayerEffectUntil"))
+                    pumpNode["args"]?.let { put("args", it) }
+                },
+                tvar,
+            )
+            val then = renderEffectList(thenActions, tvar)
+            if (pump != null && then != null) {
+                val body = if (then is Composite) Composite(listOf(pump) + then.parts)
+                else Composite(listOf(pump, then))
+                return call("MayEffect", arg(body))
+            }
+        }
+    }
     // Render the paid cost as the IfYouDo's `action`. Only the self-discard cost is modeled today; any
     // other cost (sacrifice, pay life, exile, mana) declines -> the pair stays uncollapsed.
     val costAction = when (cost) {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -316,7 +316,10 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     }
 
     on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
-        if (jsonContains(args, "_Permanent", "ThisPermanent")) Lit("SacrificeSelfEffect") else null
+        // The subject is a self-reference: `ThisPermanent`, or the trigger-bound `Trigger_ThatCreature`
+        // ("sacrifice it" on a SELF attack trigger — Attack-in-the-Box). Both denote the source, so both
+        // render to the source sacrifice; any non-self permanent declines (-> SCAFFOLD).
+        if (findRef(args) in SELF_REFS) Lit("SacrificeSelfEffect") else null
     }
     on("SacrificeAPermanent") { _, args, _ ->
         // "sacrifice a <filter>" by the resolving player (Accursed Centaur's ETB "sacrifice a creature").

--- a/mtgish-tooling/src/test/resources/fixtures/chk.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/chk.emitted.golden.txt
@@ -3960,7 +3960,7 @@ val JunkyoBell = card("Junkyo Bell") {
     colorIdentity = ""
     typeLine = "Artifact"
     oracleText = "At the beginning of your upkeep, you may have target creature you control get +X/+X until end of turn, where X is the number of creatures you control. If you do, sacrifice that creature at the beginning of the next end step."
-    // STRUCTURE needs human wiring: MayCost
+    // STRUCTURE needs human wiring: CreateFutureTrigger, MayCost, SacrificePermanent
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "258"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttackInTheBoxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttackInTheBoxScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Attack-in-the-Box (DSK #242) — {3} 2/4 Artifact Creature — Toy.
+ *
+ * "Whenever this creature attacks, you may have it get +4/+0 until end of turn. If you do,
+ *  sacrifice it at the beginning of the next end step."
+ *
+ * The attack trigger's whole body is gated by one "you may"; choosing yes pumps it +4/+0 and arms
+ * a delayed trigger that sacrifices it at the next end step. Declining does neither.
+ */
+class AttackInTheBoxScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Attack-in-the-Box — attack may-pump with delayed sacrifice") {
+
+            test("choosing to pump grants +4/+0 and sacrifices it at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Attack-in-the-Box", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val box = game.findPermanent("Attack-in-the-Box")!!
+                withClue("Base power before the attack trigger") {
+                    game.state.projectedState.getPower(box) shouldBe 2
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Attack-in-the-Box" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("The 'you may' decision should be pending after attacking") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                withClue("It got +4/+0 until end of turn") {
+                    game.state.projectedState.getPower(box) shouldBe 6
+                    game.state.projectedState.getToughness(box) shouldBe 4
+                }
+
+                // Advance to the end step; the delayed sacrifice fires.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Sacrificed at the beginning of the next end step") {
+                    game.isOnBattlefield("Attack-in-the-Box") shouldBe false
+                    game.isInGraveyard(1, "Attack-in-the-Box") shouldBe true
+                }
+            }
+
+            test("declining leaves it unpumped and on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Attack-in-the-Box", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val box = game.findPermanent("Attack-in-the-Box")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Attack-in-the-Box" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("No pump when declining") {
+                    game.state.projectedState.getPower(box) shouldBe 2
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Not sacrificed — the 'if you do' never armed the delayed trigger") {
+                    game.isOnBattlefield("Attack-in-the-Box") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoordinatedClobberingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoordinatedClobberingScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Coordinated Clobbering (DSK #173) — {G} Sorcery.
+ *
+ * "Tap one or two target untapped creatures you control. They each deal damage equal to their
+ *  power to target creature an opponent controls."
+ *
+ * Verifies the 1-or-2 your-creature target group gets tapped and each deals damage equal to its
+ * own power to the single opponent's creature; and the single-creature mode. Targets are supplied
+ * at cast time in requirement order: the opponent's creature (declared first), then the clobberers.
+ */
+class CoordinatedClobberingScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Coordinated Clobbering") {
+
+            test("two clobberers tap and each deals its power to the opponent's creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Coordinated Clobbering")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardOnBattlefield(2, "Air Elemental") // 4/4 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val victim = game.findPermanent("Air Elemental")!!
+                val spell = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Coordinated Clobbering"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(
+                            ChosenTarget.Permanent(victim),
+                            ChosenTarget.Permanent(giant),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                    ),
+                )
+                withClue("Casting Coordinated Clobbering should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both clobberers are tapped") {
+                    (game.state.getEntity(giant)?.get<TappedComponent>() == TappedComponent) shouldBe true
+                    (game.state.getEntity(bears)?.get<TappedComponent>() == TappedComponent) shouldBe true
+                }
+                withClue("3 + 2 = 5 damage kills the 4/4 Air Elemental") {
+                    game.isOnBattlefield("Air Elemental") shouldBe false
+                    game.isInGraveyard(2, "Air Elemental") shouldBe true
+                }
+            }
+
+            test("single clobberer taps and deals its power to the opponent's creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Coordinated Clobbering")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val victim = game.findPermanents("Grizzly Bears").first {
+                    game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId == game.player2Id
+                }
+                val spell = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Coordinated Clobbering"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(
+                            ChosenTarget.Permanent(victim),
+                            ChosenTarget.Permanent(giant),
+                        ),
+                    ),
+                )
+                cast.error shouldBe null
+                game.resolveStack()
+
+                withClue("The single clobberer is tapped") {
+                    (game.state.getEntity(giant)?.get<TappedComponent>() == TappedComponent) shouldBe true
+                }
+                withClue("3 damage kills the 2/2 victim") {
+                    val victimZone = game.state.getZone(com.wingedsheep.engine.state.ZoneKey(game.player2Id, Zone.GRAVEYARD))
+                    (victim in victimZone) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DashingBloodsuckerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DashingBloodsuckerScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dashing Bloodsucker (DSK #90) — {3}{B} 2/5 Creature — Vampire Warrior.
+ *
+ * "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, this
+ *  creature gets +2/+0 and gains lifelink until end of turn."
+ *
+ * Eerie is two triggered abilities; the enchantment-enters half is exercised here. Each fire
+ * pumps the source +2/+0 and grants lifelink until end of turn.
+ */
+class DashingBloodsuckerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dashing Bloodsucker — Eerie (enchantment enters)") {
+
+            test("an enchantment you control entering pumps it +2/+0 and grants lifelink") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dashing Bloodsucker")
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bloodsucker = game.findPermanent("Dashing Bloodsucker")!!
+                withClue("Base stats before any Eerie trigger") {
+                    game.state.projectedState.getPower(bloodsucker) shouldBe 2
+                    game.state.projectedState.getToughness(bloodsucker) shouldBe 5
+                    game.state.projectedState.hasKeyword(bloodsucker, Keyword.LIFELINK) shouldBe false
+                }
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Eerie pumped Dashing Bloodsucker +2/+0 and granted lifelink") {
+                    game.state.projectedState.getPower(bloodsucker) shouldBe 4
+                    game.state.projectedState.getToughness(bloodsucker) shouldBe 5
+                    game.state.projectedState.hasKeyword(bloodsucker, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("an opponent's enchantment entering does NOT trigger Eerie") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dashing Bloodsucker")
+                    .withCardInHand(2, "Test Enchantment") // controlled by the opponent
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bloodsucker = game.findPermanent("Dashing Bloodsucker")!!
+
+                val cast = game.castSpell(2, "Test Enchantment")
+                withClue("Opponent casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("No Eerie trigger — the enchantment isn't the Bloodsucker controller's") {
+                    game.hasPendingDecision() shouldBe false
+                    game.state.projectedState.getPower(bloodsucker) shouldBe 2
+                    game.state.projectedState.hasKeyword(bloodsucker, Keyword.LIFELINK) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefiantSurvivorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefiantSurvivorScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Defiant Survivor (DSK #175) — {2}{G} 3/2 Creature — Human Survivor.
+ *
+ * "Survival — At the beginning of your second main phase, if this creature is tapped, manifest
+ *  dread."
+ *
+ * Survival is an intervening-if postcombat-main trigger gated on the source being tapped; the
+ * payoff is manifest dread (look at top two, manifest one as a face-down 2/2, the other to the
+ * graveyard).
+ */
+class DefiantSurvivorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Defiant Survivor — Survival manifest dread") {
+
+            test("tapped at second main phase manifests dread: a face-down 2/2 enters, other card milled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Defiant Survivor", tapped = true)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val battlefieldBefore = game.findPermanents("Grizzly Bears").size +
+                    game.findPermanents("Hill Giant").size
+                val graveBefore = game.graveyardSize(1)
+
+                // Advance to the controller's second main phase; the Survival trigger goes on the
+                // stack. Resolve until the manifest-dread card-selection decision surfaces.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for manifest dread; got ${game.getPendingDecision()}")
+                // Manifest the first option.
+                val manifestPick = decision.options.first()
+                game.submitDecision(CardsSelectedResponse(decisionId = decision.id, selectedCards = listOf(manifestPick)))
+                game.resolveStack()
+
+                withClue("A face-down 2/2 was manifested onto the battlefield") {
+                    val faceDown = game.state.getEntity(manifestPick)?.get<FaceDownComponent>()
+                    faceDown shouldBe FaceDownComponent
+                    game.state.projectedState.getPower(manifestPick) shouldBe 2
+                    game.state.projectedState.getToughness(manifestPick) shouldBe 2
+                    game.state.projectedState.isCreature(manifestPick) shouldBe true
+                }
+                withClue("The other looked-at card was put into the graveyard") {
+                    game.graveyardSize(1) shouldBe graveBefore + 1
+                }
+            }
+
+            test("untapped at second main phase does not manifest dread") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Defiant Survivor", tapped = false)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val graveBefore = game.graveyardSize(1)
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Intervening-if (this creature is tapped) is false — no manifest dread") {
+                    game.hasPendingDecision() shouldBe false
+                    game.graveyardSize(1) shouldBe graveBefore
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Duskmourn: House of Horror cards — all canonical DSK printings, each with a passing rules-engine scenario test.

## Cards

| Card | Cost / Type | Mechanic |
|------|-------------|----------|
| **Attack-in-the-Box** | {3} 2/4 Artifact Creature — Toy | Attack trigger whose whole body is gated by one "you may": `MayEffect(Composite(ModifyStats +4/+0, CreateDelayedTrigger(END, SacrificeSelf)))`. Declining does neither (the "if you do" binds the sacrifice to the same yes). |
| **Dashing Bloodsucker** | {3}{B} 2/5 Vampire Warrior | Eerie as two triggers (enchantment-you-control enters / fully unlock a Room); each pumps +2/+0 and grants lifelink until end of turn on `Self`. |
| **Coordinated Clobbering** | {G} Sorcery | One-or-two untapped creatures you control (`TargetCreature count=2 minCount=1`) + one opponent creature. Gather chosen targets → filter to your creatures → tap them → `ForEachInCollection` deals each one's own power (`EntityReference.IterationEntity`) to the opponent's creature. |
| **Defiant Survivor** | {2}{G} 3/2 Human Survivor | Survival intervening-if postcombat-main trigger gated on `SourceIsTapped`; payoff `Patterns.Library.manifestDread`. |

No new SDK building blocks — all four compose existing effects / triggers / conditions / patterns.

## mtgish-tooling (fix the emitter, not the cards)

- `SacrificePermanent` now renders **any** `SELF_REF` subject (`Trigger_ThatCreature`, …), not just `ThisPermanent`, to `SacrificeSelfEffect` — both denote the source.
- `mayCostIfYouDoEffect` recognizes the "you may have it get +X/+0 until end of turn. If you do, &lt;then&gt;." shape where `MayCost` wraps a `CreatePermanentLayerEffectUntil` pump, rendering `MayEffect(Composite(<pump>, <then>))`. This promotes **Attack-in-the-Box** SCAFFOLD → AUTO; the render is structurally identical to the hand-authored card.
- **Coordinated Clobbering stays SCAFFOLD** — its 1-or-2-target / each-deals-its-power composition is genuinely card-specific, so the emitter declines rather than emit a lossy approximation (per the fix-the-generator policy).

## Verification

- 8 new scenario tests pass (2 per card, covering happy path + decline / no-trigger / single-target edge cases).
- `CardDefinitionSnapshotTest` re-blessed (only the 4 new cards added to `DSK.json`; no other card moved).
- `CardLintTest` passes.
- `EmitterGoldenTest` re-blessed: the **only** golden change is CHK Junkyo Bell's SCAFFOLD reason annotation (it stays SCAFFOLD — its X-pump-on-target shape remains unrenderable).
- **POR `coverage-verify` stays 0-mismatch (158/158 GATE PASS)** — the emitter regression gate.
- Pre-existing CHK/ONS gameplay-tree mismatches (Sachi, Uncontrollable Anger, et al.) are unrelated to these changes — they render through different code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)