### PR TITLE
Add 4 DSK manifest-dread / face-up cards + mtgish emitter support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CryptidInspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CryptidInspector.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cryptid Inspector
+ * {2}{G}
+ * Creature — Elf Warrior
+ * 2/3
+ * Vigilance
+ * Whenever a face-down permanent you control enters and whenever this creature or another
+ * permanent you control is turned face up, put a +1/+1 counter on this creature.
+ *
+ * The "X and whenever Y" templating is two distinct triggered abilities sharing one payoff
+ * (CR has no "or" trigger combiner), so it's modelled as two `triggeredAbility` blocks, both
+ * putting a +1/+1 counter on this creature ([EffectTarget.Self]):
+ *  - a face-down permanent you control entering ([Triggers.entersBattlefield] filtered to
+ *    face-down permanents you control); and
+ *  - any permanent you control (including this creature) being turned face up
+ *    ([Triggers.CreatureTurnedFaceUp] — in DSK every face-up turn is a manifested creature).
+ */
+val CryptidInspector = card("Cryptid Inspector") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\nWhenever a face-down permanent you control enters and whenever this " +
+        "creature or another permanent you control is turned face up, put a +1/+1 counter on " +
+        "this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.faceDown().youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CreatureTurnedFaceUp()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Kim Sokol"
+        flavorText = "\"Please be dead, please be dead, please be dead.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg?1726286509"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DisturbingMirth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DisturbingMirth.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Disturbing Mirth
+ * {B}{R}
+ * Enchantment
+ * When this enchantment enters, you may sacrifice another enchantment or creature. If you do,
+ * draw two cards.
+ * When you sacrifice this enchantment, manifest dread. (Look at the top two cards of your library.
+ * Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn
+ * it face up any time for its mana cost if it's a creature card.)
+ *
+ * First ability: "sacrifice another enchantment or creature" is a resolution-time choice, not a
+ * target — the player accepts the optional first, then chooses which permanent, so declining never
+ * commits anything. Only when a permanent is actually sacrificed does the "If you do, draw two
+ * cards" payoff run. Modelled with [ReflexiveTriggerEffect] (optional sacrifice action, untargeted
+ * draw payoff) — the same shape as Treetop Sentries / Unscrupulous Contractor.
+ *
+ * Second ability: the standard [Triggers.Sacrificed] SELF trigger ("when you sacrifice this"),
+ * reusing the shared [Patterns.Library.manifestDread] recipe (CR 701.62b).
+ */
+val DisturbingMirth = card("Disturbing Mirth") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, you may sacrifice another enchantment or " +
+        "creature. If you do, draw two cards.\nWhen you sacrifice this enchantment, manifest " +
+        "dread. (Look at the top two cards of your library. Put one onto the battlefield face " +
+        "down as a 2/2 creature and the other into your graveyard. Turn it face up any time for " +
+        "its mana cost if it's a creature card.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Composite(
+                listOf(
+                    SelectTargetEffect(
+                        requirement = TargetObject(
+                            filter = TargetFilter.CreatureOrEnchantment.youControl().other()
+                        ),
+                        storeAs = "permanentToSacrifice"
+                    ),
+                    Effects.SacrificeTarget(EffectTarget.PipelineTarget("permanentToSacrifice"))
+                )
+            ),
+            optional = true,
+            reflexiveEffect = Effects.DrawCards(2),
+            descriptionOverride = "You may sacrifice another enchantment or creature. If you do, draw two cards."
+        )
+        description = "When this enchantment enters, you may sacrifice another enchantment or " +
+            "creature. If you do, draw two cards."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Sacrificed
+        effect = Patterns.Library.manifestDread()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "212"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg?1726286660"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DragToTheRoots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DragToTheRoots.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Drag to the Roots
+ * {2}{B}{G}
+ * Instant
+ * Delirium — This spell costs {2} less to cast as long as there are four or more card types among
+ * cards in your graveyard.
+ * Destroy target nonland permanent.
+ *
+ * Delirium is an ability word (no rules meaning of its own). The fixed {2} reduction is a
+ * [CostModification.ReduceGeneric] gated by [CostGating.OnlyIf] on the standard four-card-type
+ * graveyard [Conditions.Delirium] threshold — the same pattern as Mental Modulation's
+ * conditional reduction, just with a delirium condition instead of "during your turn".
+ */
+val DragToTheRoots = card("Drag to the Roots") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Delirium — This spell costs {2} less to cast as long as there are four or more " +
+        "card types among cards in your graveyard.\nDestroy target nonland permanent."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.Delirium()),
+        )
+    }
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.Destroy(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"Valgavoth commands us to feed the trees. Let our blood be their mulch, " +
+            "our flesh their soil.\"\n—Victor, Valgavoth's seneschal"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg?1726286661"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrowingDread.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrowingDread.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Growing Dread
+ * {G}{U}
+ * Enchantment
+ * Flash
+ * When this enchantment enters, manifest dread. (Look at the top two cards of your library. Put
+ * one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it
+ * face up any time for its mana cost if it's a creature card.)
+ * Whenever you turn a permanent face up, put a +1/+1 counter on it.
+ *
+ * The enters trigger reuses the shared [Patterns.Library.manifestDread] recipe. The face-up
+ * payoff is the standard [Triggers.CreatureTurnedFaceUp] (any face-up turn you control — in DSK
+ * every face-up permanent is a manifested creature) putting a +1/+1 counter on the triggering
+ * permanent via [EffectTarget.TriggeringEntity].
+ */
+val GrowingDread = card("Growing Dread") {
+    manaCost = "{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Enchantment"
+    oracleText = "Flash\nWhen this enchantment enters, manifest dread. (Look at the top two cards " +
+        "of your library. Put one onto the battlefield face down as a 2/2 creature and the other " +
+        "into your graveyard. Turn it face up any time for its mana cost if it's a creature " +
+        "card.)\nWhenever you turn a permanent face up, put a +1/+1 counter on it."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.manifestDread()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CreatureTurnedFaceUp()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg?1726286675"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1614,6 +1614,60 @@
     ]
 }
 
+// Cryptid Inspector
+{
+    "name": "Cryptid Inspector",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Vigilance\nWhenever a face-down permanent you control enters and whenever this creature or another permanent you control is turned face up, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent facedown ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CreatureTurnedFaceUpEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Kim Sokol",
+        "flavorText": "\"Please be dead, please be dead, please be dead.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg?1726286509"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cult Healer
 {
     "name": "Cult Healer",
@@ -1817,6 +1871,122 @@
     ]
 }
 
+// Disturbing Mirth
+{
+    "name": "Disturbing Mirth",
+    "manaCost": "{B}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, you may sacrifice another enchantment or creature. If you do, draw two cards.\nWhen you sacrifice this enchantment, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature|enchantment ctrl:you",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "storeAs": "permanentToSacrifice"
+                            },
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "permanentToSacrifice"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "descriptionOverride": "You may sacrifice another enchantment or creature. If you do, draw two cards."
+                },
+                "descriptionOverride": "When this enchantment enters, you may sacrifice another enchantment or creature. If you do, draw two cards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "PermanentsSacrificedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg?1726286660"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Diversion Specialist
 {
     "name": "Diversion Specialist",
@@ -1934,6 +2104,72 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Drag to the Roots
+{
+    "name": "Drag to the Roots",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Delirium — This spell costs {2} less to cast as long as there are four or more card types among cards in your graveyard.\nDestroy target nonland permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "AggregateZone",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "aggregation": "DISTINCT_TYPES"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"Valgavoth commands us to feed the trees. Let our blood be their mulch, our flesh their soil.\"\n—Victor, Valgavoth's seneschal",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg?1726286661"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -3884,6 +4120,97 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Growing Dread
+{
+    "name": "Growing Dread",
+    "manaCost": "{G}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash\nWhen this enchantment enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you turn a permanent face up, put a +1/+1 counter on it.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CreatureTurnedFaceUpEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg?1726286675"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -56,6 +56,8 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("AtTheBeginningOfAPlayersSecondMainPhase", "trigger: your second (postcombat) main phase (Triggers.YourPostcombatMain — Survival ability word)")
     supported("WhenAPlayerGainsLife", "trigger: you gain life (Triggers.YouGainLife — Pest Mascot, Essence Channeler)")
     supported("WhenAPlayerGainsLifeForTheFirstTimeEachTurn", "trigger: you gain life for the first time each turn (Triggers.YouGainLifeFirstTimeEachTurn — Leech Collector)")
+    supported("WhenAPlayerTurnsAPermanentFaceUp", "trigger: you turn a permanent face up (Triggers.CreatureTurnedFaceUp — Growing Dread)")
+    supported("WhenAPermanentIsTurnedFaceUp", "trigger: this or another permanent you control is turned face up (Triggers.CreatureTurnedFaceUp — Cryptid Inspector)")
     // OTJ Plot (CR 718) — "When this card becomes plotted, …" (Triggers.BecomesPlotted, Aloe Alchemist).
     supported("WhenACardBecomesPlotted", "trigger: this card becomes plotted (Triggers.BecomesPlotted)")
     supported("WhenAPermanentBecomesTheTargetOfASpellOrAbility", "trigger: becomes target (Triggers.BecomesTargetByOpponent / BecomesTarget / CreatureYouControlBecomesTargetByOpponent)")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -367,6 +367,19 @@ private fun EmitCtx.targetPermanentCostReductionLines(rule: JsonObject): List<St
  *
  * Any other condition, or a colored/dynamic reduction, declines -> SCAFFOLD rather than widening.
  */
+/**
+ * Extract the delirium threshold M from a `NumCardTypesInGraveyardIs` predicate's
+ * `Comparison(GreaterThanOrEqualTo, Integer M)` argument. Only a plain `>= M` renders the
+ * standard delirium gate ([Conditions.Delirium]); any other comparison returns null (decline).
+ */
+private fun deliriumThreshold(args: JsonElement?): Int? {
+    val cmp = args as? JsonObject ?: return null
+    if (cmp.strField("_Comparison") != "GreaterThanOrEqualTo") return null
+    val number = cmp["args"] as? JsonObject ?: return null
+    if (number.strField("_GameNumber") != "Integer") return null
+    return number["args"].asInt()
+}
+
 private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
     val node = rule["args"] as? JsonObject ?: return null
     if (node.strField("_CastEffect") != "ReduceCastingCostIf") return null
@@ -399,6 +412,18 @@ private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
             arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
             arg("gating", call("CostGating.OnlyIf", arg("Conditions.YouCommittedCrimeThisTurn"))),
         )
+        // Delirium — "costs {N} less if there are M or more card types among cards in your graveyard"
+        // (Drag to the Roots). The threshold M lives in a GTE comparison; render the standard
+        // delirium-gated fixed reduction. Only a plain `>= M` renders; any other comparison declines.
+        "NumCardTypesInGraveyardIs" -> {
+            val threshold = deliriumThreshold(predicate["args"]) ?: return null
+            call(
+                "ModifySpellCost",
+                arg("target", Lit("SpellCostTarget.SelfCast")),
+                arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+                arg("gating", call("CostGating.OnlyIf", arg(call("Conditions.Delirium", arg("$threshold"))))),
+            )
+        }
         else -> return null
     }
     return renderBlock(Block("staticAbility", listOf(Assign("ability", ability))), "    ")
@@ -1965,7 +1990,15 @@ internal fun EmitCtx.triggerBlock(
     // (ControllerOfTriggeringEntity), not the triggering player — see [EmitCtx.triggeringEntityIsSpell].
     val prevTriggeringSpell = triggeringEntityIsSpell
     triggeringEntityIsSpell = jsonContains(effRule["args"].asArr?.firstOrNull(), "_Trigger", "WhenAPlayerCastsASpell")
-    val edsl = renderEffectList(lifted?.second ?: effectActions, tvar).also { triggeringEntityIsSpell = prevTriggeringSpell } ?: return null
+    // In a "whenever you turn a permanent face up" trigger, "that permanent" is the triggering entity
+    // (the turned-up permanent), so a counter effect targets EffectTarget.TriggeringEntity, not Self.
+    val prevTurnedUp = triggeringEntityIsTurnedUpPermanent
+    triggeringEntityIsTurnedUpPermanent =
+        jsonContains(effRule["args"].asArr?.firstOrNull(), "_Trigger", "WhenAPlayerTurnsAPermanentFaceUp")
+    val edsl = renderEffectList(lifted?.second ?: effectActions, tvar).also {
+        triggeringEntityIsSpell = prevTriggeringSpell
+        triggeringEntityIsTurnedUpPermanent = prevTurnedUp
+    } ?: return null
 
     val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
     val triggerCond = effTriggerCondition ?: condFromIf
@@ -2743,6 +2776,36 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     // in the once-per-turn semantics. Only the You scope renders.
     if (jsonContains(trig, "_Trigger", "WhenAPlayerGainsLifeForTheFirstTimeEachTurn") && jsonContains(trig, "_Player", "You"))
         return "Triggers.YouGainLifeFirstTimeEachTurn"
+
+    // "Whenever you turn a permanent face up" (You, AnyPermanent) — Growing Dread. The IR scopes the
+    // turner to a player and the permanent to a group; only the You scope over an unfiltered
+    // AnyPermanent maps to Triggers.CreatureTurnedFaceUp() (in Duskmourn every face-up turn is a
+    // manifested creature). A non-You turner or a filtered permanent group has no calibrated card yet,
+    // so it declines -> SCAFFOLD. The "that permanent" subject of the effect is the turned-up permanent
+    // (the triggering entity) — see [EmitCtx.triggeringEntityIsTurnedUpPermanent], set in triggerBlock.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerTurnsAPermanentFaceUp")) {
+        val targs = trig["args"].asArr ?: return null
+        val player = targs.getOrNull(0) as? JsonObject
+        val perms = targs.getOrNull(1) as? JsonObject
+        val youScoped = player?.strField("_Players") == "SinglePlayer" &&
+            jsonContains(player["args"], "_Player", "You")
+        if (youScoped && perms?.strField("_Permanents") == "AnyPermanent")
+            return "Triggers.CreatureTurnedFaceUp()"
+    }
+
+    // "Whenever this creature or another permanent you control is turned face up" — the permanent-
+    // scoped face-up trigger (Cryptid Inspector, an arm of its Or-union). The subject is
+    // `Or(ThisPermanent, And(Other(ThisPermanent), ControlledByAPlayer(You)))` = any permanent you
+    // control (self included) turned face up, which is exactly Triggers.CreatureTurnedFaceUp(You).
+    // Only that self-or-other-you-control shape renders; a foreign or filtered subject declines.
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentIsTurnedFaceUp")) {
+        val subj = trig["args"] as? JsonObject
+        val selfOrYours = subj?.strField("_Permanents") == "Or" &&
+            jsonContains(subj["args"], "_Permanent", "ThisPermanent") &&
+            jsonContains(subj["args"], "_Permanents", "ControlledByAPlayer") &&
+            jsonContains(subj["args"], "_Player", "You")
+        if (selfOrYours) return "Triggers.CreatureTurnedFaceUp()"
+    }
 
     // "Whenever this creature becomes the target of a spell or ability an opponent controls"
     // (Cactarantula). The trigger's args is a 2-tuple [subject, spell/ability-filter]; the subject must

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -111,6 +111,18 @@ class EmitCtx(val keywords: Set<String>, val oracleText: String? = null) {
     var triggeringEntityIsSpell: Boolean = false
 
     /**
+     * True while rendering the effect of a "whenever you turn a permanent face up" trigger
+     * (`WhenAPlayerTurnsAPermanentFaceUp`). In that context the IR's "that permanent"
+     * (`Trigger_ThatPermanent`) is the permanent that was turned face up — the *triggering* entity,
+     * not the source — so a "put a +1/+1 counter on it" effect must resolve to
+     * `EffectTarget.TriggeringEntity` (Growing Dread), overriding the default [SELF_REFS] mapping of
+     * `Trigger_ThatPermanent` to `EffectTarget.Self` (which is calibrated for dies-triggers, where
+     * "that permanent" is the source itself via last-known information). Set/cleared only by
+     * [triggerBlock]; default false on every other path.
+     */
+    var triggeringEntityIsTurnedUpPermanent: Boolean = false
+
+    /**
      * True while rendering the effect of an activated ability whose cost sacrifices or exiles the
      * source itself. In that context the source's counters are wiped at cost-payment time
      * (CR 122.2), so "for each counter on this creature" must read the pre-cost count as last-known
@@ -795,6 +807,10 @@ internal fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
         // means the first target of that kind. A genuinely ambiguous case (no first-of-kind) declines.
         return targetRefVars[ref] ?: targetRefVarsByKind[ref]?.firstOrNull()
     }
+    // In a "whenever you turn a permanent face up" trigger, "that permanent" is the turned-up
+    // permanent (the triggering entity), not the source — override the SELF_REFS default below.
+    if (ref == "Trigger_ThatPermanent" && triggeringEntityIsTurnedUpPermanent)
+        return "EffectTarget.TriggeringEntity"
     if (ref in SELF_REFS) return "EffectTarget.Self"
     // "the tokens created this way" / "the created tokens" — the tokens a preceding CreateTokens action
     // in this same action list just made (Fractal Tender: "create a 0/0 Fractal … and put three +1/+1

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -1173,6 +1173,10 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
     // GameObjectFilter.Creature.blocking(), the same helper TargetFilter.BlockingCreature uses).
     FilterPredicates.blocking(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.nontoken(filterNode)?.let { node = node.dot(it) }
+    // "a face-down permanent you control" (IsFaceDown) — Cryptid Inspector's "whenever a face-down
+    // permanent you control enters". Backed by GameObjectFilter.faceDown(); dropping it would widen
+    // the trigger to every permanent entering, so it's a real predicate here.
+    if ("IsFaceDown" in blob) node = node.dot("faceDown")
     // "creatures that saddled/crewed it this turn" (SaddledPermanentThisTurn / CrewedPermanentThisTurn,
     // bound to the trigger's permanent — Rambling Possum's "return any number of creatures that saddled
     // it this turn"). Source-relative; composes via .crewedOrSaddledSourceThisTurn() onto the creature

--- a/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
@@ -7102,7 +7102,11 @@ val IxidorRealitySculptor = card("Ixidor, Reality Sculptor") {
     power = 3
     toughness = 4
     staticAbility {
-        ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter(GameObjectFilter.Creature))
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.faceDown())
+        )
     }
     // STRUCTURE needs human wiring: TurnPermanentFaceUp
     metadata {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptidInspectorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptidInspectorScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Cryptid Inspector (DSK #174) — {2}{G} Elf Warrior 2/3 with Vigilance.
+ *
+ * "Whenever a face-down permanent you control enters and whenever this creature or another
+ *  permanent you control is turned face up, put a +1/+1 counter on this creature."
+ *
+ * Two distinct triggers, both adding a +1/+1 counter to the Inspector itself: one when a
+ * face-down permanent you control enters, one when a permanent you control is turned face up.
+ */
+class CryptidInspectorScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    fun GameTestDriver.counterOn(id: com.wingedsheep.sdk.model.EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("a face-down permanent entering and a face-up turn each add a +1/+1 counter to the Inspector") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val inspector = d.putCreatureOnBattlefield(you, "Cryptid Inspector")
+        d.counterOn(inspector) shouldBe 0
+
+        // Cast Manifest Dread: a face-down 2/2 enters → first trigger adds a counter.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val manifested = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+        val md = d.putCardInHand(you, "Manifest Dread")
+        d.giveMana(you, Color.GREEN, 2)
+        d.castSpell(you, md)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(manifested)))
+        // Drain the face-down-enters trigger.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.counterOn(inspector) shouldBe 1
+        d.state.projectedState.getPower(inspector) shouldBe 3 // base 2 +1
+
+        // Turn that manifested creature face up → the turn-face-up trigger adds another counter.
+        d.giveMana(you, Color.GREEN, 3)
+        d.submit(TurnFaceUp(playerId = you, sourceId = manifested, paymentStrategy = PaymentStrategy.FromPool))
+            .error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.counterOn(inspector) shouldBe 2
+        d.state.projectedState.getPower(inspector) shouldBe 4
+        d.state.projectedState.getToughness(inspector) shouldBe 5
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbingMirthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbingMirthScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Disturbing Mirth (DSK #212) — {B}{R} Enchantment.
+ *
+ *  - When this enchantment enters, you may sacrifice another enchantment or creature. If you do,
+ *    draw two cards.
+ *  - When you sacrifice this enchantment, manifest dread.
+ *
+ * The ETB is the standard optional-sacrifice reflexive flow (Boilerbilges Ripper shape) with an
+ * untargeted "draw two" payoff. The sacrifice-self trigger reuses the shared manifest-dread recipe.
+ */
+class DisturbingMirthScenarioTest : FunSpec({
+
+    // Inline sac outlet so we can sacrifice Disturbing Mirth itself and observe its sacrifice trigger.
+    val sacOutlet = card("Sac Outlet") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            target("target permanent you control", TargetPermanent(filter = TargetFilter.PermanentYouControl))
+            effect = Effects.SacrificeTarget(EffectTarget.ContextTarget(0))
+        }
+    }
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + sacOutlet)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("ETB: sacrificing another creature draws two cards") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val fodder = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val handBefore = d.getHand(you).size
+
+        val mirth = d.putCardInHand(you, "Disturbing Mirth")
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.RED, 1)
+        d.castSpell(you, mirth)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // "You may sacrifice another enchantment or creature." — accept, then pick the fodder.
+        (d.pendingDecision as? YesNoDecision)?.let {
+            d.submitDecision(you, YesNoResponse(decisionId = it.id, choice = true))
+        }
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        (d.pendingDecision as? SelectCardsDecision)?.let {
+            d.submitDecision(you, CardsSelectedResponse(decisionId = it.id, selectedCards = listOf(fodder)))
+        }
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The fodder was sacrificed and we drew two cards.
+        d.getPermanents(you).contains(fodder) shouldBe false
+        d.getHand(you).size shouldBe handBefore + 2
+    }
+
+    test("sacrificing Disturbing Mirth itself manifests dread") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Put Disturbing Mirth onto the battlefield directly (skip its ETB for this case).
+        val mirth = d.putPermanentOnBattlefield(you, "Disturbing Mirth")
+
+        // Library top two for the manifest-dread look.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        // Cast the sac outlet targeting Disturbing Mirth — sacrificing it triggers manifest dread.
+        val outlet = d.putCardInHand(you, "Sac Outlet")
+        d.giveColorlessMana(you, 1)
+        d.castSpellWithTargets(you, outlet, listOf(entityIdToChosenTarget(d.state, mirth)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getPermanents(you).contains(mirth) shouldBe false
+
+        // Manifest dread pauses on the pick.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+
+        d.getPermanents(you).contains(creature) shouldBe true
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragToTheRootsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragToTheRootsScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Drag to the Roots (DSK #213) — {2}{B}{G} Instant.
+ *
+ *  - Delirium — This spell costs {2} less to cast as long as there are four or more card types
+ *    among cards in your graveyard.
+ *  - Destroy target nonland permanent.
+ *
+ * The reduction is a fixed {2} generic reduction gated by the four-card-type delirium condition,
+ * so the effective cost is the full {2}{B}{G} (CMC 4) without delirium and {B}{G} (CMC 2) with it.
+ */
+class DragToTheRootsScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("costs full {2}{B}{G} without delirium and {B}{G} with four card types in graveyard") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val calculator = CostCalculator(d.cardRegistry)
+        val card = d.cardRegistry.requireCard("Drag to the Roots")
+
+        // No delirium yet — full cost.
+        val full = calculator.calculateEffectiveCost(d.state, card, you)
+        full.genericAmount shouldBe 2
+        full.cmc shouldBe 4
+
+        // Three card types only (creature, instant, sorcery) — still no reduction.
+        d.putCardInGraveyard(you, "Centaur Courser") // creature
+        d.putCardInGraveyard(you, "Lightning Bolt")  // instant
+        d.putCardInGraveyard(you, "Doom Blade")      // (instant) — keep at three distinct types
+        val threeTypes = calculator.calculateEffectiveCost(d.state, card, you)
+        threeTypes.genericAmount shouldBe 2
+        threeTypes.cmc shouldBe 4
+
+        // Add an enchantment and a land → four+ card types → {2} reduction.
+        d.putCardInGraveyard(you, "Test Enchantment")
+        d.putCardInGraveyard(you, "Forest")
+        val withDelirium = calculator.calculateEffectiveCost(d.state, card, you)
+        withDelirium.genericAmount shouldBe 0
+        withDelirium.cmc shouldBe 2
+    }
+
+    test("destroys target nonland permanent") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opp = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val spell = d.putCardInHand(you, "Drag to the Roots")
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveMana(you, Color.GREEN, 1)
+        d.giveColorlessMana(you, 2)
+        d.castSpellWithTargets(you, spell, listOf(entityIdToChosenTarget(d.state, victim)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.getZone(com.wingedsheep.engine.state.ZoneKey(opp, Zone.GRAVEYARD)).contains(victim) shouldBe true
+        d.getPermanents(opp).contains(victim) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrowingDreadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrowingDreadScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Growing Dread (DSK #216) — {G}{U} Enchantment with Flash.
+ *
+ *  - When this enchantment enters, manifest dread.
+ *  - Whenever you turn a permanent face up, put a +1/+1 counter on it.
+ *
+ * Exercises the enters trigger (shared manifest-dread recipe) and the face-up payoff: turning a
+ * manifested creature face up puts a +1/+1 counter on that creature (the triggering permanent),
+ * so it ends up as its printed P/T plus one.
+ */
+class GrowingDreadScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("entering manifests dread, then turning the manifest face up adds a +1/+1 counter") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two: a creature on top (to manifest), a land beneath.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser") // {2}{G} 3/3
+
+        // Cast Growing Dread; its ETB manifest-dread trigger resolves and pauses on the pick.
+        val gd = d.putCardInHand(you, "Growing Dread")
+        d.giveMana(you, Color.GREEN, 1)
+        d.giveMana(you, Color.BLUE, 1)
+        d.castSpell(you, gd)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+
+        // Turn the manifested Centaur Courser face up for its {2}{G} cost.
+        d.giveMana(you, Color.GREEN, 3)
+        d.submit(TurnFaceUp(playerId = you, sourceId = creature, paymentStrategy = PaymentStrategy.FromPool))
+            .error shouldBe null
+        // Drain the "you turn a permanent face up" trigger.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Growing Dread's trigger put a +1/+1 counter on it — now a 4/4.
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe null
+        val counters = d.state.getEntity(creature)?.get<CountersComponent>()?.counters ?: emptyMap()
+        counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 1
+        d.state.projectedState.getPower(creature) shouldBe 4
+        d.state.projectedState.getToughness(creature) shouldBe 4
+    }
+})


### PR DESCRIPTION
## Summary

Implements four **Duskmourn: House of Horror** cards, all composing existing SDK primitives (no new engine/SDK types), and teaches the mtgish-tooling emitter to auto-draft three of them.

### Cards

| Card | Cost | What it does |
|------|------|--------------|
| **Drag to the Roots** | {2}{B}{G} Instant | Delirium-gated {2} cost reduction (`ModifySpellCost` + `CostGating.OnlyIf(Conditions.Delirium())`) + destroy target nonland permanent |
| **Disturbing Mirth** | {B}{R} Enchantment | ETB optional-sacrifice → draw 2 (untargeted `ReflexiveTriggerEffect`) + "when you sacrifice this" → manifest dread (`Triggers.Sacrificed`) |
| **Growing Dread** | {G}{U} Enchantment (Flash) | ETB manifest dread + "whenever you turn a permanent face up, put a +1/+1 counter on it" (`CreatureTurnedFaceUp` → counter on `EffectTarget.TriggeringEntity`) |
| **Cryptid Inspector** | {2}{G} Elf Warrior 2/3 (Vigilance) | Two triggers (face-down permanent you control enters; this/another permanent you control turned face up) each add a +1/+1 counter to itself |

Each card has a passing rules-engine scenario test. DSK card snapshot re-blessed (only the four new cards added).

### mtgish-tooling (fix the emitter, never hand-patch generated cards)

Drag to the Roots, Growing Dread, and Cryptid Inspector now render at **fidelity tier AUTO** and gameplay-match the hand-authored cards:

- **Delirium cost reduction** — render `ReduceCastingCostIf` over `NumCardTypesInGraveyardIs(>= M)` as `ModifySpellCost(ReduceGeneric(N), OnlyIf(Conditions.Delirium(M)))`.
- **Turn-face-up triggers** — `WhenAPlayerTurnsAPermanentFaceUp` (You) and `WhenAPermanentIsTurnedFaceUp` (this-or-another-you-control) → `Triggers.CreatureTurnedFaceUp()`. A new `triggeringEntityIsTurnedUpPermanent` context flag resolves "that permanent" to `EffectTarget.TriggeringEntity` (overriding the `SELF_REFS` default that's calibrated for dies-triggers).
- **Face-down filter** — compose `.faceDown()` from an `IsFaceDown` predicate in `gameObjectFilterExpr`. This also fixes a **latent constraint-drop on Ixidor, Reality Sculptor**: "face-down creatures get +1/+1" now renders `GameObjectFilter.Creature.faceDown()` instead of the over-broad `GameObjectFilter.Creature`. ONS golden re-blessed for that one card.
- Bridge entries added for the two turn-face-up trigger tags.
- **Disturbing Mirth deliberately left at SCAFFOLD**: its `MayCost(SacrificeAPermanent) + If(CostWasPaid) → draw` shape has no faithful AUTO rendering (the `IfYouDo` form with a sacrifice action isn't a calibrated idiom), so it declines rather than emitting a lossy approximation.

### Verification

- `:rules-engine` scenario tests for all four cards — PASS
- `:mtg-sets` `CardDefinitionSnapshotTest` (DSK re-blessed) + `CardLintTest` — PASS
- `:mtgish-tooling` `EmitterGoldenTest` (only Ixidor changed, a correctness fix) — PASS
- `coverage-verify POR` — 158/158, **0-mismatch** (unchanged)
- DSK gate's remaining mismatches are **pre-existing** (Survival / Impending / modal-punctuation / target-recovery) and unrelated to any path changed here.

No new SDK types → no `card-sdk-language-reference.md` change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)