### PR TITLE
Town land // spell DFC support (inverse-Adventure layout) + 5 FIN lands

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -155,17 +155,22 @@ All six cards implemented and covered by `TieredScenarioTest` (per-tier cost cha
 affordability gating, scaled effects, targeting, double/triple P/T, Vincent's dies→return-tapped).
 → Fire Magic, Ice Magic, Thunder Magic, Restoration Magic, Tifa's Limit Break, Vincent's Limit Break.
 
-### 5. Town land // spell DFC — "play the land from exile later" (≈6) — ❌ **GAP** (new layout)
+### 5. Town land // spell DFC — "play the land from exile later" (5) — ✅ **DONE** (reused ADVENTURE layout)
 
 Several Town lands are double-faced: front = `Land — Town` (enters tapped, taps for mana), back = a one-shot
-sorcery, with reminder *"(Then exile this card. You may play the land later from exile.)"* You either play the land
-**or** cast the spell; casting the spell exiles the card and lets you **play the land half from exile** later. This
-is the **inverse of Adventure** (Adventure exiles after the spell and lets you cast the *creature*; here the
-permanent half is a *land*). No `CardLayout` variant models "spell-then-exile, replay the land from exile"
-(`CardDefinition.kt` `CardLayout`). Adventure's machinery (`CastSpell.faceIndex`, exile-with-play-permission) is the
-structural template; needs a sibling layout + loader so the land becomes the playable-from-exile half.
+instant/sorcery, with reminder *"(Then exile this card. You may play the land later from exile.)"* You either play
+the land **or** cast the spell; casting the spell exiles the card and lets you **play the land half from exile**
+later. These cards are literally typed `— Adventure` (CR 715) on Scryfall, and it turned out **no new `CardLayout`
+was needed**: `CardLayout.ADVENTURE` already models "spell resolves → exile → replay the main face from exile", and
+the resolution grant (`StackResolver` `adventureFaceExile` → generic `MayPlayPermission`) plus the exile-replay
+(`CastFromZoneEnumerator` / `PlayLandHandler`) are blind to whether the primary face is a creature or a land. The
+only engine gap was `CastSpellEnumerator` skipping land-primary cards before its secondary-face enumeration — fixed
+so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) and "cast the Adventure spell"
+(`CastSpell.faceIndex = 0`). All five lands implemented + `TownLandSpellAdventureEnumerationTest` /
+`TownLandSpellAdventureScenarioTest` (play-from-hand, cast → exile → replay-from-exile, land-drop gating).
 → Ishgard the Holy See, Jidoor Aristocratic Capital, Lindblum Industrial Regency, Midgar City of Mako, Zanarkand
-  Ancient Metropolis (and Balamb Garden, which is a land→Vehicle *transform* land — closer to a DFC land that flips).
+  Ancient Metropolis. (Balamb Garden is a land→Vehicle *transform* land — a separate "DFC land that flips" mechanic,
+  still a gap.)
 
 ---
 
@@ -249,7 +254,8 @@ structural template; needs a sibling layout + loader so the land becomes the pla
    Equipment at once; isolated and high-yield.
 3. ✅ **Tiered (§4) — DONE:** the modal/Spree cast pipeline already charged the chosen mode's additional cost on the
    choose-1 path (no engine change); shipped the `tiered { }` builder + all 6 spells.
-4. **Town land // spell DFC (§5)** — new inverse-Adventure layout. ~6 lands.
+4. ✅ **Town land // spell DFC (§5) — DONE:** reused `CardLayout.ADVENTURE` (these cards are typed `— Adventure`);
+   the only engine change was enumerating the Adventure spell face for a land-primary card. 5 lands shipped.
 5. **Summon Sagas (§1)** — the headline `add-feature`: make Sagas co-exist with creatures + an opt-out-of-sacrifice
    flag + self-referential chapter resolution. Largest lift; gates ~15 cards.
 6. **Dominant / Eikon transform (§2)** — depends on §1; add exile-and-return-transformed (new object). ~8 cards.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -84,8 +84,12 @@ section; do not let SDK additions land without a corresponding doc update.
   cast independently via `CastSpell.faceIndex`; only the chosen half goes on the stack (CR 709.4). A non-permanent half
   carries its effect in a `face("Name") { spell { … } }` block (with its own `target(...)` requirements); a permanent
   half (Room) carries triggered/activated/static abilities instead.
-- `ADVENTURE` — primary face is a creature, `cardFaces[0]` is an instant/sorcery Adventure (CR 715). Resolving the
-  Adventure exiles the card and grants permission to cast the creature from exile.
+- `ADVENTURE` — primary face is a permanent (usually a creature; **may also be a land** — FIN Towns), `cardFaces[0]`
+  is an instant/sorcery Adventure (CR 715). Resolving the Adventure exiles the card and grants permission to play
+  the primary face from exile — *cast* the creature, or *play* the land for a **land // spell** Adventure
+  (`Land — Town // Sorcery — Adventure`, e.g. Ishgard, the Holy See // Faith & Grief). The generic may-play
+  permission covers both; from hand a land-primary Adventure offers *play the land* (PlayLandEnumerator) **and**
+  *cast the Adventure spell* (`CastSpell.faceIndex = 0`).
 - `OMEN` — primary face is a permanent (creature), `cardFaces[0]` is an instant/sorcery Omen (Tarkir: Dragonstorm).
   Casts exactly like an Adventure (creature face, or Omen via `CastSpell.faceIndex = 0`), but resolving the Omen
   **shuffles the card into its owner's library** instead of exiling it — no cast-from-exile linkage. DSL:
@@ -4923,7 +4927,13 @@ Card authors rarely reference these directly; they are created/updated by the ma
   The cast-from-exile path is the standard `MayPlayPermission` flow in `CastFromZoneEnumerator` — `permanent = true`
   keeps the grant alive across end-of-turn cleanup. Emits `CardPlottedEvent` / `ClientEvent.CardPlotted`.
 - **Adventure (CR 715)** — `layout = ADVENTURE` + `cardFaces[0]` Adventure spell; DSL:
-  `card { adventure("Name") { spell { … } } }`.
+  `card { adventure("Name") { spell { … } } }`. The primary face may be a **land** (`Land — Town`) instead of a
+  creature — FIN's "Town land // spell" DFCs (Ishgard, the Holy See // Faith & Grief, …). No new layout: resolving
+  the Adventure exiles the card with the same generic `MayPlayPermission`, which `CastFromZoneEnumerator` /
+  `PlayLandHandler` already honor as a *play-the-land-from-exile* permission. The only seam beyond the creature case
+  is `CastSpellEnumerator` — it now enumerates the Adventure spell face for a land-primary card (the land itself is
+  played via `PlayLandEnumerator`). First land users: Ishgard, the Holy See; Jidoor, Aristocratic Capital; Lindblum,
+  Industrial Regency; Midgar, City of Mako; Zanarkand, Ancient Metropolis.
 - **Omen (Tarkir: Dragonstorm)** — `layout = OMEN` + `cardFaces[0]` Omen spell; DSL:
   `card { omen("Name") { spell { … } } }`. Reuses the Adventure cast/enumeration path (`enumerateSecondaryFace`,
   cast via `CastSpell.faceIndex = 0`), but `StackResolver` routes the resolving Omen to `Zone.LIBRARY` and shuffles

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IshgardTheHolySee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IshgardTheHolySee.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ishgard, the Holy See // Faith & Grief
+ * Land — Town // Sorcery — Adventure
+ *
+ * Ishgard, the Holy See:
+ *   This land enters tapped.
+ *   {T}: Add {W}.
+ *
+ * Faith & Grief — {3}{W}{W}, Sorcery — Adventure:
+ *   Return up to two target artifact and/or enchantment cards from your graveyard to your hand.
+ *   (Then exile this card. You may play the land later from exile.)
+ *
+ * Town land // spell Adventure (CR 715, modeled on the [com.wingedsheep.sdk.model.CardLayout.ADVENTURE]
+ * layout): the land is the *primary* face. You either play the land or cast Faith & Grief; casting
+ * the Adventure resolves its graveyard recursion, exiles the card, and grants permission to *play
+ * the land* from exile later (CR 715.3d — the engine's generic may-play permission covers playing a
+ * land, not just casting a creature).
+ */
+val IshgardTheHolySee = card("Ishgard, the Holy See") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n{T}: Add {W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    adventure("Faith & Grief") {
+        manaCost = "{3}{W}{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Return up to two target artifact and/or enchantment cards from your graveyard " +
+            "to your hand. (Then exile this card. You may play the land later from exile.)"
+        spell {
+            target = TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.ArtifactOrEnchantment.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+            effect = ForEachTargetEffect(
+                effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND))
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "283"
+        artist = "Kohei Yamada"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/068bc755-9d3d-430b-abc5-c775a5415bf9.jpg?1748706839"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JidoorAristocraticCapital.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JidoorAristocraticCapital.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Jidoor, Aristocratic Capital // Overture
+ * Land — Town // Sorcery — Adventure
+ *
+ * Jidoor, Aristocratic Capital:
+ *   This land enters tapped.
+ *   {T}: Add {U}.
+ *
+ * Overture — {4}{U}{U}, Sorcery — Adventure:
+ *   Target opponent mills half their library, rounded down.
+ *   (Then exile this card. You may play the land later from exile.)
+ *
+ * Town land // spell Adventure — see [IshgardTheHolySee] for the layout rationale. "Half their
+ * library, rounded down" is `Divide(AggregateZone(ContextPlayer(0), LIBRARY), 2, roundUp = false)`
+ * read off the chosen opponent (mirrors Rush of Dread's half-of-a-chosen-player counts).
+ */
+val JidoorAristocraticCapital = card("Jidoor, Aristocratic Capital") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n{T}: Add {U}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    adventure("Overture") {
+        manaCost = "{4}{U}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target opponent mills half their library, rounded down. " +
+            "(Then exile this card. You may play the land later from exile.)"
+        spell {
+            target = Targets.Opponent
+            effect = Patterns.Library.mill(
+                count = DynamicAmount.Divide(
+                    numerator = DynamicAmount.AggregateZone(Player.ContextPlayer(0), Zone.LIBRARY),
+                    denominator = DynamicAmount.Fixed(2),
+                    roundUp = false
+                ),
+                target = EffectTarget.ContextTarget(0)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "284"
+        artist = "Erikas Perl"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98b2d5b5-f85b-4c42-a0f5-a76f6af304ba.jpg?1748962589"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LindblumIndustrialRegency.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LindblumIndustrialRegency.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lindblum, Industrial Regency // Mage Siege
+ * Land — Town // Instant — Adventure
+ *
+ * Lindblum, Industrial Regency:
+ *   This land enters tapped.
+ *   {T}: Add {R}.
+ *
+ * Mage Siege — {2}{R}, Instant — Adventure:
+ *   Create a 0/1 black Wizard creature token with "Whenever you cast a noncreature spell, this
+ *   token deals 1 damage to each opponent."
+ *   (Then exile this card. You may play the land later from exile.)
+ *
+ * Town land // spell Adventure — see [IshgardTheHolySee]. The Adventure half is an *instant*, so it
+ * may be cast at instant speed; the token-with-embedded-trigger shape mirrors Cornered by Black Mages.
+ */
+val LindblumIndustrialRegency = card("Lindblum, Industrial Regency") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n{T}: Add {R}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    adventure("Mage Siege") {
+        manaCost = "{2}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a 0/1 black Wizard creature token with \"Whenever you cast a noncreature " +
+            "spell, this token deals 1 damage to each opponent.\" " +
+            "(Then exile this card. You may play the land later from exile.)"
+        spell {
+            effect = CreateTokenEffect(
+                power = 0,
+                toughness = 1,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Wizard"),
+                triggeredAbilities = listOf(
+                    TriggeredAbility.create(
+                        trigger = Triggers.YouCastNoncreature.event,
+                        binding = Triggers.YouCastNoncreature.binding,
+                        effect = DealDamageEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "285"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/548dd152-f0b6-4e8f-9afc-a4ec1671b648.jpg?1748706846"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MidgarCityOfMako.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MidgarCityOfMako.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Midgar, City of Mako // Reactor Raid
+ * Land — Town // Sorcery — Adventure
+ *
+ * Midgar, City of Mako:
+ *   This land enters tapped.
+ *   {T}: Add {B}.
+ *
+ * Reactor Raid — {2}{B}, Sorcery — Adventure:
+ *   You may sacrifice an artifact or creature. If you do, draw two cards.
+ *   (Then exile this card. You may play the land later from exile.)
+ *
+ * Town land // spell Adventure — see [IshgardTheHolySee]. The optional sacrifice is a
+ * gather → choose-up-to-one → sacrifice pipeline wrapped in [Effects.IfYouDo]: choosing nothing
+ * (the "you may" no) performs no sacrifice, so `SuccessCriterion.Auto` reports no success and the
+ * draw doesn't happen (mirrors Highway Robbery's "sacrifice a land. If you do, draw two cards").
+ */
+val MidgarCityOfMako = card("Midgar, City of Mako") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n{T}: Add {B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    adventure("Reactor Raid") {
+        manaCost = "{2}{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "You may sacrifice an artifact or creature. If you do, draw two cards. " +
+            "(Then exile this card. You may play the land later from exile.)"
+        spell {
+            effect = Effects.IfYouDo(
+                action = Effects.Pipeline {
+                    val fodder = gather(GameObjectFilter.CreatureOrArtifact, player = Player.You)
+                    val chosen = chooseUpTo(
+                        1,
+                        from = fodder,
+                        useTargetingUI = true,
+                        prompt = "Choose an artifact or creature to sacrifice"
+                    )
+                    sacrifice(chosen)
+                },
+                ifYouDo = Effects.DrawCards(2)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "286"
+        artist = "Anthony Devine"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a837256-6bb4-4a60-962d-d2793548d26c.jpg?1748706848"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZanarkandAncientMetropolis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZanarkandAncientMetropolis.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zanarkand, Ancient Metropolis // Lasting Fayth
+ * Land — Town // Sorcery — Adventure
+ *
+ * Zanarkand, Ancient Metropolis:
+ *   This land enters tapped.
+ *   {T}: Add {G}.
+ *
+ * Lasting Fayth — {4}{G}{G}, Sorcery — Adventure:
+ *   Create a 1/1 colorless Hero creature token. Put a +1/+1 counter on it for each land you control.
+ *   (Then exile this card. You may play the land later from exile.)
+ *
+ * Town land // spell Adventure — see [IshgardTheHolySee]. The counters target the freshly created
+ * token via the [CREATED_TOKENS] pipeline collection ([Effects.AddCountersToCollection]); the count
+ * is "lands you control" read through projected control.
+ */
+val ZanarkandAncientMetropolis = card("Zanarkand, Ancient Metropolis") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n{T}: Add {G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    adventure("Lasting Fayth") {
+        manaCost = "{4}{G}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create a 1/1 colorless Hero creature token. Put a +1/+1 counter on it for each " +
+            "land you control. (Then exile this card. You may play the land later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Hero")
+                ),
+                Effects.AddCountersToCollection(
+                    CREATED_TOKENS,
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land)
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "293"
+        artist = "Erikas Perl"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/881e4c00-3b9a-47a1-bf66-1badda994c88.jpg?1748706876"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2757,6 +2757,166 @@
     "colorIdentityOverride": []
 }
 
+// Ishgard, the Holy See
+{
+    "name": "Ishgard, the Holy See",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "283",
+        "rarity": "RARE",
+        "artist": "Kohei Yamada",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/068bc755-9d3d-430b-abc5-c775a5415bf9.jpg?1748706839"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Faith & Grief",
+            "manaCost": "{3}{W}{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Return up to two target artifact and/or enchantment cards from your graveyard to your hand. (Then exile this card. You may play the land later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "artifact|enchantment own:you",
+                            "zone": "Graveyard"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+// Jidoor, Aristocratic Capital
+{
+    "name": "Jidoor, Aristocratic Capital",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "284",
+        "rarity": "RARE",
+        "artist": "Erikas Perl",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98b2d5b5-f85b-4c42-a0f5-a76f6af304ba.jpg?1748962589"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Overture",
+            "manaCost": "{4}{U}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target opponent mills half their library, rounded down. (Then exile this card. You may play the land later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Divide",
+                                    "numerator": {
+                                        "type": "AggregateZone",
+                                        "player": {
+                                            "type": "ContextPlayer",
+                                            "index": 0
+                                        },
+                                        "zone": "Library"
+                                    },
+                                    "denominator": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "roundUp": false
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    "TargetOpponent"
+                ]
+            }
+        }
+    ]
+}
+
 // Jumbo Cactuar
 {
     "name": "Jumbo Cactuar",
@@ -2796,6 +2956,87 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lindblum, Industrial Regency
+{
+    "name": "Lindblum, Industrial Regency",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "285",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/548dd152-f0b6-4e8f-9afc-a4ec1671b648.jpg?1748706846"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Mage Siege",
+            "manaCost": "{2}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a 0/1 black Wizard creature token with \"Whenever you cast a noncreature spell, this token deals 1 damage to each opponent.\" (Then exile this card. You may play the land later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Wizard"
+                    ],
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_2",
+                            "trigger": {
+                                "type": "SpellCastEvent",
+                                "spellFilter": {
+                                    "cardPredicates": [
+                                        "IsNoncreature"
+                                    ]
+                                }
+                            },
+                            "binding": "ANY",
+                            "effect": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 
@@ -3268,6 +3509,101 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Midgar, City of Mako
+{
+    "name": "Midgar, City of Mako",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "286",
+        "rarity": "RARE",
+        "artist": "Anthony Devine",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a837256-6bb4-4a60-962d-d2793548d26c.jpg?1748706848"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Reactor Raid",
+            "manaCost": "{2}{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "You may sacrifice an artifact or creature. If you do, draw two cards. (Then exile this card. You may play the land later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": "creature|artifact",
+                                        "player": "You"
+                                    },
+                                    "storeAs": "gathered0"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "gathered0",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "selected1",
+                                    "prompt": "Choose an artifact or creature to sacrifice",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "selected1",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Sacrifice"
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            }
+        }
     ]
 }
 
@@ -5596,4 +5932,73 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/0/70d9ab99-ec8a-402e-ba1d-ffa6c4c84a3f.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Zanarkand, Ancient Metropolis
+{
+    "name": "Zanarkand, Ancient Metropolis",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "293",
+        "rarity": "RARE",
+        "artist": "Erikas Perl",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/881e4c00-3b9a-47a1-bf66-1badda994c88.jpg?1748706876"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Lasting Fayth",
+            "manaCost": "{4}{G}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create a 1/1 colorless Hero creature token. Put a +1/+1 counter on it for each land you control. (Then exile this card. You may play the land later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ]
+                        },
+                        {
+                            "type": "AddCountersToCollection",
+                            "collectionName": "createdTokens",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -54,7 +54,33 @@ class CastSpellEnumerator : ActionEnumerator {
         // --- Normal spell casting ---
         for (cardId in hand) {
             val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-            if (cardComponent.typeLine.isLand) continue
+            if (cardComponent.typeLine.isLand) {
+                // A land's primary characteristics are *played*, not cast (PlayLandEnumerator
+                // handles that). But a land//spell Adventure (FIN Towns — "Land — Town //
+                // Sorcery — Adventure", CR 715) still exposes a castable Adventure spell face
+                // from hand. Enumerate that face, then skip the normal cast path below, which
+                // never applies to a land. When the Adventure resolves it exiles itself and
+                // grants permission to *play the land* from exile (StackResolver / CR 715.3d).
+                if (!context.cantCastSpell(cardId)) {
+                    val landCardDef = context.cardRegistry.getCard(cardComponent.name)
+                    if (landCardDef != null &&
+                        (landCardDef.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE ||
+                            landCardDef.layout == com.wingedsheep.sdk.model.CardLayout.OMEN ||
+                            landCardDef.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) &&
+                        landCardDef.cardFaces.isNotEmpty() &&
+                        context.castPermissionUtils.checkCastRestrictions(
+                            state, playerId, landCardDef.script.castRestrictions
+                        )
+                    ) {
+                        // The land primary is always an available alternative, so surface the
+                        // spell face even when unaffordable (grayed out in the drag-to-play menu).
+                        enumerateSecondaryFace(
+                            context, cardId, landCardDef, result, primaryFaceAffordable = true
+                        )
+                    }
+                }
+                continue
+            }
 
             // Skip this spell if the player can't cast it — a blanket lock, Mana Maze color
             // sharing, or a PlayersCantCastSpells restriction (all routed through one chokepoint).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TownLandSpellAdventureEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/TownLandSpellAdventureEnumerationTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.mtg.sets.definitions.fin.cards.IshgardTheHolySee
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * A Town land // spell Adventure (FIN — "Land — Town // Sorcery — Adventure") is a land-primary
+ * Adventure card. From hand the player may either *play the land* or *cast the Adventure spell*.
+ *
+ * Regression guard for the engine fix: `CastSpellEnumerator` previously skipped every land in hand
+ * before reaching its secondary-face enumeration, so a land-primary Adventure's spell face was never
+ * offered. The fix enumerates the spell face for land-primary Adventure/Omen/modal-DFC cards while
+ * still leaving the land itself to `PlayLandEnumerator`.
+ *
+ * Ishgard, the Holy See // Faith & Grief — land face `Land — Town`, Adventure face `{3}{W}{W}`.
+ */
+class TownLandSpellAdventureEnumerationTest : FunSpec({
+
+    test("a land//spell Adventure in hand offers BOTH playing the land and casting the Adventure spell") {
+        val driver = setupP1(
+            hand = listOf("Ishgard, the Holy See"),
+            // Five Plains affords the {3}{W}{W} Adventure face.
+            battlefield = listOf("Plains", "Plains", "Plains", "Plains", "Plains"),
+            extraSetCards = listOf(IshgardTheHolySee),
+        )
+
+        val view = driver.enumerateFor(driver.player1)
+
+        // The land primary is playable from hand (PlayLandEnumerator).
+        view.playLandActionsFor("Ishgard, the Holy See") shouldHaveSize 1
+
+        // The Adventure spell face is castable from hand (the fix). It is the only cast option —
+        // a land has no normal "cast the primary face" action.
+        val casts = view.castActionsFor("Ishgard, the Holy See")
+        casts shouldHaveSize 1
+        (casts.single().action as CastSpell).faceIndex shouldBe 0
+        casts.single().affordable shouldBe true
+    }
+
+    test("when the Adventure spell is unaffordable, the land can still be played and the spell shows grayed-out") {
+        val driver = setupP1(
+            hand = listOf("Ishgard, the Holy See"),
+            battlefield = listOf("Plains"), // 1 mana — cannot pay {3}{W}{W}
+            extraSetCards = listOf(IshgardTheHolySee),
+        )
+
+        val view = driver.enumerateFor(driver.player1)
+
+        // Playing the land is always an alternative, so the spell face is still surfaced (grayed out)
+        // rather than the menu silently offering only the land.
+        view.playLandActionsFor("Ishgard, the Holy See") shouldHaveSize 1
+        val casts = view.castActionsFor("Ishgard, the Holy See")
+        casts shouldHaveSize 1
+        casts.single().affordable shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TownLandSpellAdventureScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TownLandSpellAdventureScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.IshgardTheHolySee
+import com.wingedsheep.mtg.sets.definitions.fin.cards.LindblumIndustrialRegency
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Town land // spell DFC (FIN) — the inverse-Adventure layout (CR 715).
+ *
+ * These cards are land-primary Adventure cards: front = `Land — Town`, back = an instant/sorcery
+ * `— Adventure`. From hand you either **play the land** or **cast the Adventure spell**; casting the
+ * Adventure resolves its effect, exiles the card, and grants permission to **play the land** from
+ * exile later (CR 715.3d — the engine's generic may-play permission covers playing a land, not just
+ * casting a creature).
+ *
+ * No new layout was needed: `CardLayout.ADVENTURE` already models "spell resolves → exile → replay
+ * the main face from exile"; the only seams that needed work were (a) enumerating the spell face for
+ * a land-primary card (covered by `TownLandSpellAdventureEnumerationTest`) and (b) the existing
+ * `CastFromZoneEnumerator` / `PlayLandHandler` exile-land path, exercised here end to end.
+ *
+ * Lindblum, Industrial Regency // Mage Siege — land face `Land — Town` ({T}: Add {R}); Adventure
+ * face Mage Siege {2}{R}, Instant, "Create a 0/1 black Wizard creature token ...".
+ */
+class TownLandSpellAdventureScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(LindblumIndustrialRegency)
+        driver.registerCard(IshgardTheHolySee)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): com.wingedsheep.sdk.model.EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40, "Plains" to 20), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("the land primary can be played from hand and enters tapped") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val ishgard = driver.putCardInHand(player, "Ishgard, the Holy See")
+        driver.playLand(player, ishgard).isSuccess shouldBe true
+
+        driver.getPermanents(player) shouldContain ishgard
+        driver.isTapped(ishgard) shouldBe true // "This land enters tapped."
+    }
+
+    test("casting the Adventure spell resolves its effect, exiles the card, then the land is playable from exile") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val lindblum = driver.putCardInHand(player, "Lindblum, Industrial Regency")
+        driver.giveMana(player, Color.RED, 3) // {2}{R}
+
+        val permanentsBefore = driver.getPermanents(player).size
+
+        // Cast Mage Siege (the Adventure spell face, faceIndex = 0) — not the land.
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = lindblum,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // The spell effect happened: a 0/1 Wizard token was created.
+        val tokenWizard = driver.getPermanents(player).firstOrNull { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.typeLine?.toString()?.contains("Wizard") == true
+        }
+        (tokenWizard != null) shouldBe true
+        driver.getPermanents(player).size shouldBe permanentsBefore + 1 // the token, not the land
+
+        // The card was exiled by its own resolution (CR 715.3d), not put in the graveyard.
+        driver.getExile(player) shouldContain lindblum
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldNotContain lindblum
+
+        // A may-play permission for the exiled card was granted to its caster.
+        driver.state.mayPlayPermissions.any { lindblum in it.cardIds && it.controllerId == player } shouldBe true
+
+        // Now play the land half from exile.
+        driver.playLand(player, lindblum).isSuccess shouldBe true
+
+        driver.getPermanents(player) shouldContain lindblum
+        driver.getExile(player) shouldNotContain lindblum
+        driver.isTapped(lindblum) shouldBe true // the land still "enters tapped" from exile
+
+        // The permission is cleaned up so the land can't be re-authorized if it returns to exile.
+        driver.state.mayPlayPermissions.any { lindblum in it.cardIds } shouldBe false
+    }
+
+    test("playing the land from exile consumes the turn's land drop") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val lindblum = driver.putCardInHand(player, "Lindblum, Industrial Regency")
+        val mountain = driver.putCardInHand(player, "Mountain")
+        driver.giveMana(player, Color.RED, 3)
+
+        // Cast Mage Siege → Lindblum is exiled with play permission.
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = lindblum,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Play the land from exile — this is a normal land play and uses the land drop.
+        driver.playLand(player, lindblum).isSuccess shouldBe true
+
+        // A second land play this turn is now illegal.
+        driver.submit(PlayLand(player, mountain)).isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
## What

Implements **§5 "Town land // spell DFC"** from `backlog/fin-engine-gaps.md` — FIN's double-faced Town lands where front = `Land — Town` and back = a one-shot instant/sorcery, with reminder *"(Then exile this card. You may play the land later from exile.)"* You either **play the land** or **cast the spell**; casting the spell exiles the card and lets you **play the land half from exile** later.

## Key insight: no new layout needed

These cards are literally typed `— Adventure` (CR 715) on Scryfall, and the engine's `CardLayout.ADVENTURE` already models *"spell resolves → exile → replay the main face from exile"*. The resolution grant (`StackResolver` `adventureFaceExile` → a generic `MayPlayPermission`) and the exile-replay path (`CastFromZoneEnumerator` / `PlayLandHandler`) are **already blind to whether the primary face is a creature or a land** — a land in exile with a may-play permission is enumerated as a `PlayLand`, and the permission is cleaned up on play.

The only engine gap was in `CastSpellEnumerator`: it skipped every land in hand *before* reaching its secondary-face enumeration, so a land-primary Adventure never offered its spell face. Fixed so a land-primary Adventure/Omen/modal-DFC card enumerates its spell face (`CastSpell.faceIndex = 0`) from hand, while the land itself is still played via `PlayLandEnumerator`.

## Cards (5)

| Card | Adventure spell |
|------|-----------------|
| Ishgard, the Holy See | Faith & Grief — `{3}{W}{W}` return up to two artifact/enchantment cards from your graveyard |
| Jidoor, Aristocratic Capital | Overture — `{4}{U}{U}` target opponent mills half their library, rounded down |
| Lindblum, Industrial Regency | Mage Siege — `{2}{R}` instant, create a 0/1 Wizard token w/ embedded trigger |
| Midgar, City of Mako | Reactor Raid — `{2}{B}` you may sacrifice an artifact or creature; if you do, draw two |
| Zanarkand, Ancient Metropolis | Lasting Fayth — `{4}{G}{G}` create a 1/1 Hero, +1/+1 counter per land you control |

*(Balamb Garden is a land→Vehicle **transform** land — a separate mechanic, left as a gap.)*

## Tests

- `TownLandSpellAdventureEnumerationTest` — from hand the card offers **both** "play the land" and "cast the Adventure spell"; the spell face surfaces grayed-out when unaffordable.
- `TownLandSpellAdventureScenarioTest` — land plays from hand and enters tapped; cast Adventure → effect resolves → card exiled with permission → land replayed from exile (permission cleaned up); playing the exiled land consumes the turn's land drop.
- Re-blessed FIN card snapshot golden; `CardLintTest` green. Full `:rules-engine` and `:mtg-sets` suites pass.

## Docs

- `docs/card-sdk-language-reference.md` — ADVENTURE layout now documents land-primary (land // spell) Adventures.
- `backlog/fin-engine-gaps.md` — §5 checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)