### PR TITLE
Add DSK Possessed Goat, Unable to Scream, Overgrown Zealot, Creeping Peeper

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -503,6 +503,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `LoseAllCreatureTypes(target, duration)` — remove all creature subtypes.
 - `SetCreatureSubtypes(subtypes, target, duration)` — replace subtypes outright.
 - `AddCreatureType(subtype, target, duration)` — additive subtype.
+- `AddColor(color | colors, target, duration?)` — add color(s) in addition to existing ones
+  (Layer 5; default duration Permanent). Ability-applied counterpart of the `GrantColor` static.
+  Pair with `AddCreatureType`/`AddCardType` for "becomes a [color] [type] in addition to its other
+  colors and types" (Possessed Goat).
 - `GrantHexproof(target, duration)` — temporary hexproof.
 - `GrantExileOnLeave(target)` — "if it would leave, exile instead".
 - `GrantKeywordToAttackersBlockedBy(keyword, target)` — grant keyword to creatures this blocks.
@@ -2621,6 +2625,11 @@ staticAbility {
   remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
 - `ConditionalStaticAbility` — static gated by a runtime `Condition`.
+- `CantBeTurnedFaceUp(filter)` — matching permanents can't be turned face up (Layer 6; projects a
+  `cantBeTurnedFaceUp` flag read by the turn-face-up handler/enumerator). Only meaningful while the
+  permanent is face down (a face-up permanent can't be "turned face up"), so it's applied
+  unconditionally. Unable to Scream: "As long as enchanted creature is face down, it can't be turned
+  face up."
 - `CantReceiveCounters(filter)` — matching permanents can't have counters put on them (projects the
   `AbilityFlag.CANT_RECEIVE_COUNTERS` flag).
 - `CantBeSacrificed(filter)` — matching permanents can't be sacrificed (projects the
@@ -4302,7 +4311,19 @@ restriction matches the spell context.
   granted artifact mana ability. Generalizes `CastFromExileOnly` by allowing all non-hand
   origins instead of exile alone; rejects ability activations.
 - `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?)` —
-  Steelswarm Operator shape.
+  Steelswarm Operator shape. Use `cardType = CardType.ENCHANTMENT, allowSpells = true` for
+  "spend only to cast an enchantment spell."
+- `ManaRestriction.TurnPermanentsFaceUpOnly` — only the turn-face-up special action (disguise/
+  morph face-up). Satisfied by `SpellPaymentContext.isTurnFaceUpAction`; the turn-face-up handler/
+  enumerator pass that context so restricted mana in the pool is consumed. Overgrown Zealot,
+  Creeping Peeper.
+- `ManaRestriction.UnlockDoorOnly` — only the unlock-a-door special action (CR 709.5e).
+  Satisfied by `SpellPaymentContext.isUnlockDoorAction`; the unlock-room handler/enumerator pass
+  that context. Creeping Peeper (inside `AnyOf`).
+- `ManaRestriction.AnyOf(restrictions)` — disjunction; the mana is spendable in any context that
+  satisfies *any* listed restriction. Compose atomic restrictions for multi-option mana — e.g.
+  Creeping Peeper's "cast an enchantment spell, unlock a door, or turn a permanent face up" is
+  `AnyOf(CardTypeSpellsOrAbilitiesOnly(ENCHANTMENT), UnlockDoorOnly, TurnPermanentsFaceUpOnly)`.
 
 ### `ManaSpellRider`
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -131,6 +131,7 @@ import com.wingedsheep.sdk.scripting.effects.NoteCreatureTypeEffect
 import com.wingedsheep.sdk.scripting.effects.ChangeColorToChosenEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseColorForTargetEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeChosenManaColorEffect
+import com.wingedsheep.sdk.scripting.effects.AddColorEffect
 import com.wingedsheep.sdk.scripting.effects.ChangeColorEffect
 import com.wingedsheep.sdk.scripting.effects.ChangeWordInTextEffect
 import com.wingedsheep.sdk.scripting.effects.OptionType
@@ -1290,6 +1291,25 @@ object Effects {
         colors: Set<Color>,
         duration: Duration = Duration.EndOfTurn
     ): Effect = ChangeColorEffect(target, colors.map { it.name }.toSet(), duration)
+
+    /**
+     * Add [colors] to a single target in addition to its existing colors (default duration:
+     * Permanent). Unlike [ChangeColor], the target keeps its other colors. Pair with
+     * [AddCreatureType] / [AddCardType] for "becomes a [color] [type] in addition to its other
+     * colors and types" (Possessed Goat).
+     */
+    fun AddColor(
+        colors: Set<Color>,
+        target: EffectTarget = EffectTarget.Self,
+        duration: Duration = Duration.Permanent
+    ): Effect = AddColorEffect(colors.map { it.name }.toSet(), target, duration)
+
+    /** Convenience overload adding a single color. */
+    fun AddColor(
+        color: Color,
+        target: EffectTarget = EffectTarget.Self,
+        duration: Duration = Duration.Permanent
+    ): Effect = AddColorEffect(setOf(color.name), target, duration)
 
     /**
      * Make a single target become all five colors until [duration] expires.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -205,6 +205,25 @@ data class LoseAllAbilities(
 }
 
 /**
+ * The affected permanent can't be turned face up.
+ * Used for Unable to Scream: "As long as enchanted creature is face down, it can't be turned
+ * face up." Only meaningful while the affected permanent is face down (a face-up permanent
+ * can't be "turned face up" anyway), so the static is applied unconditionally to the attached
+ * creature — the turn-face-up special action reads the projected flag and is rejected.
+ *
+ * This is a Layer 6 (ABILITY) continuous effect.
+ *
+ * @property filter What this ability applies to (typically AttachedCreature for auras)
+ */
+@SerialName("CantBeTurnedFaceUp")
+@Serializable
+data class CantBeTurnedFaceUp(
+    val filter: GroupFilter = GroupFilter.attachedCreature()
+) : StaticAbility {
+    override val description: String = "can't be turned face up"
+}
+
+/**
  * Enchanted land becomes a specific basic land type.
  * Used for auras like Sea's Claim: "Enchanted land is an Island."
  * This replaces all existing land subtypes with the specified type (Rule 305.7).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -122,6 +122,52 @@ sealed interface ManaRestriction {
     }
 
     /**
+     * "Spend this mana only to turn permanents face up."
+     *
+     * Satisfied by the turn-face-up special action (disguise/morph face-up, CR 707.9 / 702.37e),
+     * not by spell casts or ability activations. Used by Overgrown Zealot and Creeping Peeper.
+     */
+    @SerialName("TurnPermanentsFaceUpOnly")
+    @Serializable
+    data object TurnPermanentsFaceUpOnly : ManaRestriction {
+        override val description: String = "Spend this mana only to turn permanents face up"
+    }
+
+    /**
+     * "Spend this mana only to unlock a door."
+     *
+     * Satisfied by the unlock-a-door special action (CR 709.5e), not by spell casts or ability
+     * activations. Used inside [AnyOf] by Creeping Peeper.
+     */
+    @SerialName("UnlockDoorOnly")
+    @Serializable
+    data object UnlockDoorOnly : ManaRestriction {
+        override val description: String = "Spend this mana only to unlock a door"
+    }
+
+    /**
+     * "Spend this mana only to [A], [B], or [C]." Disjunction of restrictions — the mana is
+     * spendable in any context that satisfies *any* of the [restrictions]. Used by Creeping
+     * Peeper ("cast an enchantment spell, unlock a door, or turn a permanent face up"). Composing
+     * atomic restrictions this way keeps each spend-context check in one place and lets new
+     * multi-option mana reuse the existing atoms.
+     */
+    @SerialName("AnyOf")
+    @Serializable
+    data class AnyOf(
+        val restrictions: List<ManaRestriction>
+    ) : ManaRestriction {
+        init {
+            require(restrictions.isNotEmpty()) { "AnyOf must have at least one restriction" }
+        }
+
+        override val description: String = "Spend this mana only to " +
+            restrictions.joinToString(", or ") {
+                it.description.removePrefix("Spend this mana only to ")
+            }
+    }
+
+    /**
      * "Spend this mana only to cast a spell from anywhere other than your hand."
      *
      * Used by Mm'menon, the Right Hand's granted artifact ability. Generalizes

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
@@ -293,6 +293,36 @@ data class ChangeColorEffect(
 }
 
 /**
+ * Add one or more colors to a single target, in addition to its existing colors.
+ * "It becomes a black Demon in addition to its other colors and types." (Possessed Goat)
+ *
+ * Creates a Layer-5 (COLOR) floating effect with an additive `AddColor` modification — unlike
+ * [ChangeColorEffect], the target keeps its other colors. The one-shot, ability-applied
+ * counterpart to the [com.wingedsheep.sdk.scripting.GrantColor] static ability (used by auras
+ * like Deep Freeze). Pair with [AddCreatureTypeEffect] / [AddCardTypeEffect] to model
+ * "becomes a [color] [type] in addition to its other colors and types".
+ *
+ * @property target Which entity to add colors to
+ * @property colors The colors to add (use [com.wingedsheep.sdk.core.Color] entries' `.name`)
+ * @property duration How long the color addition lasts (default: Permanent)
+ */
+@SerialName("AddColor")
+@Serializable
+data class AddColorEffect(
+    val colors: Set<String>,
+    val target: EffectTarget = EffectTarget.Self,
+    val duration: Duration = Duration.Permanent
+) : Effect {
+    override val description: String = buildString {
+        append(target.description)
+        append(" becomes ")
+        append(colors.joinToString(", ") { it.lowercase() })
+        append(" in addition to its other colors")
+        if (duration.description.isNotEmpty()) append(" ${duration.description}")
+    }
+}
+
+/**
  * Choose a color and store that choice on a target permanent.
  *
  * Used by permanents that make a color choice during resolution, rather than as

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CreepingPeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CreepingPeeper.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Creeping Peeper
+ * {1}{U}
+ * Creature — Eye
+ * {T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a
+ * permanent face up.
+ * 2/1
+ *
+ * The triple spend restriction is a disjunction of three atomic restrictions via
+ * [ManaRestriction.AnyOf]: cast an enchantment spell ([ManaRestriction.CardTypeSpellsOrAbilitiesOnly]
+ * for ENCHANTMENT), unlock a door ([ManaRestriction.UnlockDoorOnly]), or turn a permanent face up
+ * ([ManaRestriction.TurnPermanentsFaceUpOnly]).
+ */
+val CreepingPeeper = card("Creeping Peeper") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Eye"
+    power = 2
+    toughness = 1
+    oracleText = "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, " +
+        "or turn a permanent face up."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(
+            Color.BLUE, 1,
+            restriction = ManaRestriction.AnyOf(
+                listOf(
+                    ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                        cardType = CardType.ENCHANTMENT,
+                        allowSpells = true,
+                        allowAbilities = false,
+                    ),
+                    ManaRestriction.UnlockDoorOnly,
+                    ManaRestriction.TurnPermanentsFaceUpOnly,
+                ),
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a " +
+            "door, or turn a permanent face up."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Maxime Minard"
+        flavorText = "\"Be on your guard. Valgavoth has eyes everywhere. And I don't mean that " +
+            "figuratively.\"\n—Winter"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg?1726286029"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OvergrownZealot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OvergrownZealot.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Overgrown Zealot
+ * {1}{G}
+ * Creature — Elf Druid
+ * {T}: Add one mana of any color.
+ * {T}: Add two mana of any one color. Spend this mana only to turn permanents face up.
+ * 0/4
+ */
+val OvergrownZealot = card("Overgrown Zealot") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 0
+    toughness = 4
+    oracleText = "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this " +
+        "mana only to turn permanents face up."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(2, restriction = ManaRestriction.TurnPermanentsFaceUpOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add two mana of any one color. Spend this mana only to turn permanents face up."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "Tyler Walpole"
+        flavorText = "Even as the roots twisted painfully into his flesh, he sang out in joy, for he " +
+            "could feel himself becoming one with the woods."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg?1726286585"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PossessedGoat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PossessedGoat.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Possessed Goat
+ * {W}
+ * Creature — Goat
+ * {3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon
+ * in addition to its other colors and types. Activate only once.
+ * 1/1
+ *
+ * "becomes a black Demon in addition to its other colors and types" is modeled additively:
+ * [Effects.AddColor] (Layer 5, keeps White) + [Effects.AddCreatureType] (Layer 4, keeps Goat),
+ * both Permanent. "Activate only once" maps to [ActivationRestriction.Once] (once for the
+ * lifetime of this permanent).
+ */
+val PossessedGoat = card("Possessed Goat") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Goat"
+    power = 1
+    toughness = 1
+    oracleText = "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a " +
+        "black Demon in addition to its other colors and types. Activate only once."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.DiscardCard)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self),
+            Effects.AddColor(Color.BLACK, EffectTarget.Self, Duration.Permanent),
+            Effects.AddCreatureType("Demon", EffectTarget.Self, Duration.Permanent),
+        )
+        restrictions = listOf(ActivationRestriction.Once)
+        description = "{3}, Discard a card: Put three +1/+1 counters on this creature and it " +
+            "becomes a black Demon in addition to its other colors and types. Activate only once."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "When their would-be sacrifice wandered back to their encampment, the survivors " +
+            "breathed a sigh of relief, assuming the demon had departed."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg?1726285949"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnableToScream.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnableToScream.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeTurnedFaceUp
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Unable to Scream
+ * {U}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature loses all abilities and is a Toy artifact creature with base power and
+ * toughness 0/2 in addition to its other types.
+ * As long as enchanted creature is face down, it can't be turned face up.
+ *
+ * Modeled as a stack of statics on the attached creature:
+ *  - [LoseAllAbilities] (Layer 6)
+ *  - "Toy artifact creature in addition to its other types": [GrantCardType] ARTIFACT +
+ *    [GrantSubtype] Toy (Layer 4; it's already a creature, so no need to add CREATURE)
+ *  - [SetBasePowerToughnessStatic] 0/2 (Layer 7b)
+ *  - [CantBeTurnedFaceUp] — only meaningful while face down (a face-up permanent can't be
+ *    "turned face up"), so applied unconditionally; the turn-face-up special action reads it.
+ */
+val UnableToScream = card("Unable to Scream") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature loses all abilities and is a Toy artifact " +
+        "creature with base power and toughness 0/2 in addition to its other types.\nAs long as " +
+        "enchanted creature is face down, it can't be turned face up."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    staticAbility {
+        ability = GrantCardType("ARTIFACT", filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = GrantSubtype("Toy", filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(0, 2)
+    }
+
+    staticAbility {
+        ability = CantBeTurnedFaceUp()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Fariba Khamseh"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg?1726286143"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1614,6 +1614,53 @@
     ]
 }
 
+// Creeping Peeper
+{
+    "name": "Creeping Peeper",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Eye",
+    "oracleText": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE",
+                    "restriction": {
+                        "type": "AnyOf",
+                        "restrictions": [
+                            {
+                                "type": "CardTypeSpellsOrAbilitiesOnly",
+                                "cardType": "ENCHANTMENT"
+                            },
+                            "UnlockDoorOnly",
+                            "TurnPermanentsFaceUpOnly"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Maxime Minard",
+        "flavorText": "\"Be on your guard. Valgavoth has eyes everywhere. And I don't mean that figuratively.\"\n—Winter",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg?1726286029"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cult Healer
 {
     "name": "Cult Healer",
@@ -5243,6 +5290,55 @@
     ]
 }
 
+// Overgrown Zealot
+{
+    "name": "Overgrown Zealot",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to turn permanents face up.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": "TurnPermanentsFaceUpOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add two mana of any one color. Spend this mana only to turn permanents face up."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Walpole",
+        "flavorText": "Even as the roots twisted painfully into his flesh, he sang out in joy, for he could feel himself becoming one with the woods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg?1726286585"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Overlord of the Balemurk
 {
     "name": "Overlord of the Balemurk",
@@ -6169,6 +6265,75 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Possessed Goat
+{
+    "name": "Possessed Goat",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Goat",
+    "oracleText": "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon in addition to its other colors and types. Activate only once.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "AddColor",
+                            "colors": [
+                                "BLACK"
+                            ]
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Demon"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon in addition to its other colors and types. Activate only once."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "When their would-be sacrifice wandered back to their encampment, the survivors breathed a sigh of relief, assuming the demon had departed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg?1726285949"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -8091,6 +8256,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Unable to Scream
+{
+    "name": "Unable to Scream",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature loses all abilities and is a Toy artifact creature with base power and toughness 0/2 in addition to its other types.\nAs long as enchanted creature is face down, it can't be turned face up.",
+    "script": {
+        "staticAbilities": [
+            "LoseAllAbilities",
+            {
+                "type": "GrantCardType",
+                "cardType": "ARTIFACT",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Toy",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 0,
+                "toughness": 2
+            },
+            "CantBeTurnedFaceUp"
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg?1726286143"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -80,13 +80,51 @@ internal fun manaProduceDsl(node: JsonElement?): Dsl? =
  */
 private fun manaUseModifierRestriction(modifiers: List<JsonElement>): String? {
     val modifier = modifiers.singleOrNull() as? JsonObject ?: return null
-    if (modifier.strField("_ManaUseModifier") != "CanOnlySpendOnSpells") return null
-    val spells = modifier["args"] as? JsonObject ?: return null
+    return singleManaUseModifierRestriction(modifier)
+}
 
-    // "Spend this mana only to cast a Mount spell" (Bucolic Ranch): a BARE single subtype check, not
-    // wrapped in an Or. Map the one subtype straight to SubtypeSpellsOnly(setOf("Mount")).
+/**
+ * Recover a single `_ManaUseModifier` node into a `ManaRestriction.*` token, or null to scaffold.
+ * Handles the spell-spend shapes ([spellSpendRestriction]), the two DSK special-action spend
+ * modifiers (turn a permanent face up / unlock a door), and an `Or` of any of these as
+ * [ManaRestriction.AnyOf] — so multi-option mana like Creeping Peeper's "cast an enchantment spell,
+ * unlock a door, or turn a permanent face up" renders faithfully. Declines (null) the moment any
+ * branch is unrenderable, so a restriction is never silently dropped.
+ */
+private fun singleManaUseModifierRestriction(modifier: JsonObject): String? =
+    when (modifier.strField("_ManaUseModifier")) {
+        // "Spend this mana only to turn a permanent face up." (Overgrown Zealot / Creeping Peeper)
+        "CanOnlySpendToTurnAPermanentFaceUp" -> "ManaRestriction.TurnPermanentsFaceUpOnly"
+        // "Spend this mana only to unlock a door." (Creeping Peeper)
+        "CanOnlySpendToUnlockDoors" -> "ManaRestriction.UnlockDoorOnly"
+        "CanOnlySpendOnSpells" -> (modifier["args"] as? JsonObject)?.let { spellSpendRestriction(it) }
+        // A disjunction of modifiers -> ManaRestriction.AnyOf. Every branch must itself render.
+        "Or" -> {
+            val branches = modifier["args"] as? JsonArray ?: return null
+            val tokens = branches.map { b ->
+                val obj = b as? JsonObject ?: return null
+                singleManaUseModifierRestriction(obj) ?: return null
+            }
+            if (tokens.isEmpty()) null
+            else "ManaRestriction.AnyOf(listOf(${tokens.joinToString(", ")}))"
+        }
+        else -> null
+    }
+
+/**
+ * Recover the `_Spells` predicate of a `CanOnlySpendOnSpells` modifier into a `ManaRestriction.*`
+ * token. Covers a bare subtype check (`SubtypeSpellsOnly`), a bare card-type check
+ * (`CardTypeSpellsOrAbilitiesOnly`, e.g. "cast an enchantment spell"), and an `Or` of those
+ * (`InstantOrSorceryOnly` for {Instant, Sorcery}, otherwise `SubtypeSpellsOnly`). Null to scaffold.
+ */
+private fun spellSpendRestriction(spells: JsonObject): String? {
+    // "Spend this mana only to cast a Mount spell" (Bucolic Ranch): a BARE single subtype check.
     subtypeOfSpellsCheck(spells)?.let { subtype ->
         return "ManaRestriction.SubtypeSpellsOnly(setOf(\"$subtype\"))"
+    }
+    // "Spend this mana only to cast an enchantment spell" (Creeping Peeper): a BARE card-type check.
+    cardtypeOfSpellsCheck(spells)?.let { cardType ->
+        return "ManaRestriction.CardTypeSpellsOrAbilitiesOnly(CardType.$cardType, allowSpells = true, allowAbilities = false)"
     }
 
     if (spells.strField("_Spells") != "Or") return null
@@ -105,6 +143,21 @@ private fun manaUseModifierRestriction(modifiers: List<JsonElement>): String? {
     }
     if (subtypes.isEmpty()) return null
     return "ManaRestriction.SubtypeSpellsOnly(setOf(${subtypes.joinToString(", ") { "\"$it\"" }}))"
+}
+
+/**
+ * A single `IsCardtype` spells check carrying a bare string card type -> that type's `CardType.*`
+ * enum name (uppercased), for the card types the engine's `CardTypeSpellsOrAbilitiesOnly` accepts;
+ * else null. Only enchantment is wired here so far (Creeping Peeper); other card types decline
+ * rather than render an unsupported restriction.
+ */
+private fun cardtypeOfSpellsCheck(node: JsonObject): String? {
+    if (node.strField("_Spells") != "IsCardtype") return null
+    val type = (node["args"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: return null
+    return when (type) {
+        "Enchantment" -> "ENCHANTMENT"
+        else -> null
+    }
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -58,6 +59,10 @@ class TurnFaceUpHandler(
 ) : ActionHandler<TurnFaceUp> {
     override val actionType: KClass<TurnFaceUp> = TurnFaceUp::class
 
+    // Lets restricted mana tagged "spend only to turn permanents face up" (Overgrown Zealot,
+    // Creeping Peeper) be recognized when paying a turn-face-up cost from the pool.
+    private val faceUpContext = SpellPaymentContext(isTurnFaceUpAction = true)
+
     override fun validate(state: GameState, action: TurnFaceUp): String? {
         if (state.priorityPlayerId != action.playerId) {
             return "You don't have priority"
@@ -79,6 +84,11 @@ class TurnFaceUpHandler(
             return "This creature is not face-down"
         }
 
+        // "It can't be turned face up" (e.g. Unable to Scream enchanting a face-down creature).
+        if (state.projectedState.cantBeTurnedFaceUp(action.sourceId)) {
+            return "This creature can't be turned face up"
+        }
+
         val morphData = container.get<MorphDataComponent>()
             ?: return "This creature cannot be turned face up (no morph cost)"
 
@@ -96,7 +106,7 @@ class TurnFaceUpHandler(
                 val xValue = action.xValue ?: 0
                 when (action.paymentStrategy) {
                     is PaymentStrategy.AutoPay -> {
-                        if (!manaSolver.canPay(state, action.playerId, manaCost, xValue)) {
+                        if (!manaSolver.canPay(state, action.playerId, manaCost, xValue, spellContext = faceUpContext)) {
                             return "Not enough mana to turn this creature face up"
                         }
                     }
@@ -109,9 +119,10 @@ class TurnFaceUpHandler(
                             black = poolComponent.black,
                             red = poolComponent.red,
                             green = poolComponent.green,
-                            colorless = poolComponent.colorless
+                            colorless = poolComponent.colorless,
+                            restrictedMana = poolComponent.restrictedMana
                         )
-                        if (!costHandler.canPayManaCost(pool, manaCost)) {
+                        if (!costHandler.canPayManaCost(pool, manaCost, faceUpContext)) {
                             return "Insufficient mana in pool to turn this creature face up"
                         }
                     }
@@ -131,7 +142,7 @@ class TurnFaceUpHandler(
                             .map { it.entityId }
                             .filter { it !in chosen }
                             .toSet()
-                        if (manaSolver.solve(state, action.playerId, manaCost, xValue, excludeSources = excluded) == null) {
+                        if (manaSolver.solve(state, action.playerId, manaCost, xValue, excludeSources = excluded, spellContext = faceUpContext) == null) {
                             return "Selected mana sources cannot pay the morph cost"
                         }
                     }
@@ -183,10 +194,11 @@ class TurnFaceUpHandler(
                             black = poolComponent.black,
                             red = poolComponent.red,
                             green = poolComponent.green,
-                            colorless = poolComponent.colorless
+                            colorless = poolComponent.colorless,
+                            restrictedMana = poolComponent.restrictedMana
                         )
 
-                        val newPool = costHandler.payManaCost(pool, manaCost)
+                        val newPool = costHandler.payManaCost(pool, manaCost, faceUpContext)
                             ?: return ExecutionResult.error(currentState, "Insufficient mana in pool")
 
                         currentState = currentState.updateEntity(action.playerId) { c ->
@@ -197,7 +209,8 @@ class TurnFaceUpHandler(
                                     black = newPool.black,
                                     red = newPool.red,
                                     green = newPool.green,
-                                    colorless = newPool.colorless
+                                    colorless = newPool.colorless,
+                                    restrictedMana = newPool.restrictedMana
                                 )
                             )
                         }
@@ -226,10 +239,11 @@ class TurnFaceUpHandler(
                             black = poolComponent.black,
                             red = poolComponent.red,
                             green = poolComponent.green,
-                            colorless = poolComponent.colorless
+                            colorless = poolComponent.colorless,
+                            restrictedMana = poolComponent.restrictedMana
                         )
 
-                        val partialResult = pool.payPartial(manaCost)
+                        val partialResult = pool.payPartial(manaCost, faceUpContext)
                         var poolAfterPayment = partialResult.newPool
                         val remainingCost = partialResult.remainingCost
                         val manaSpentFromPool = partialResult.manaSpent
@@ -278,14 +292,15 @@ class TurnFaceUpHandler(
                                     black = poolAfterPayment.black,
                                     red = poolAfterPayment.red,
                                     green = poolAfterPayment.green,
-                                    colorless = poolAfterPayment.colorless
+                                    colorless = poolAfterPayment.colorless,
+                                    restrictedMana = poolAfterPayment.restrictedMana
                                 )
                             )
                         }
 
                         // Tap lands for remaining cost (using xRemainingToPay instead of full xValue)
                         if (!remainingCost.isEmpty() || xRemainingToPay > 0) {
-                            val solution = manaSolver.solve(currentState, action.playerId, remainingCost, xRemainingToPay)
+                            val solution = manaSolver.solve(currentState, action.playerId, remainingCost, xRemainingToPay, spellContext = faceUpContext)
                                 ?: return ExecutionResult.error(currentState, "Not enough mana to turn face up")
 
                             val (stateAfterTaps, tapEvents) = manaAbilitySideEffectExecutor

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.mechanics.mana.UnlockCostReducer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -51,6 +52,10 @@ class UnlockRoomDoorHandler(
     // Inquisitive-Glimmer-style "Unlock costs you pay cost {N} less" reductions. The enumerator
     // applies the same reducer so affordability and payment agree (CR 709.5e).
     private val unlockCostReducer = UnlockCostReducer(cardRegistry)
+
+    // Lets restricted mana tagged "spend only to ... unlock a door" (Creeping Peeper) be
+    // recognized when paying an unlock cost.
+    private val unlockContext = SpellPaymentContext(isUnlockDoorAction = true)
 
     override fun validate(state: GameState, action: UnlockRoomDoor): String? {
         if (state.priorityPlayerId != action.playerId) {
@@ -91,7 +96,7 @@ class UnlockRoomDoorHandler(
         val cost = unlockCostReducer.effectiveUnlockCost(state, action.playerId, face.manaCost)
         when (action.paymentStrategy) {
             is PaymentStrategy.AutoPay -> {
-                if (!manaSolver.canPay(state, action.playerId, cost, 0)) {
+                if (!manaSolver.canPay(state, action.playerId, cost, 0, spellContext = unlockContext)) {
                     return "Not enough mana to unlock ${face.name}"
                 }
             }
@@ -104,9 +109,10 @@ class UnlockRoomDoorHandler(
                     black = poolComponent.black,
                     red = poolComponent.red,
                     green = poolComponent.green,
-                    colorless = poolComponent.colorless
+                    colorless = poolComponent.colorless,
+                    restrictedMana = poolComponent.restrictedMana
                 )
-                if (!costHandler.canPayManaCost(pool, cost)) {
+                if (!costHandler.canPayManaCost(pool, cost, unlockContext)) {
                     return "Insufficient mana in pool to unlock ${face.name}"
                 }
             }
@@ -123,7 +129,7 @@ class UnlockRoomDoorHandler(
                     .map { it.entityId }
                     .filter { it !in chosen }
                     .toSet()
-                if (manaSolver.solve(state, action.playerId, cost, 0, excludeSources = excluded) == null) {
+                if (manaSolver.solve(state, action.playerId, cost, 0, excludeSources = excluded, spellContext = unlockContext) == null) {
                     return "Selected mana sources cannot pay the unlock cost"
                 }
             }
@@ -156,9 +162,10 @@ class UnlockRoomDoorHandler(
                     black = poolComponent.black,
                     red = poolComponent.red,
                     green = poolComponent.green,
-                    colorless = poolComponent.colorless
+                    colorless = poolComponent.colorless,
+                    restrictedMana = poolComponent.restrictedMana
                 )
-                val newPool = costHandler.payManaCost(pool, cost)
+                val newPool = costHandler.payManaCost(pool, cost, unlockContext)
                     ?: return ExecutionResult.error(currentState, "Insufficient mana in pool")
                 currentState = currentState.updateEntity(action.playerId) { c ->
                     c.with(
@@ -168,7 +175,8 @@ class UnlockRoomDoorHandler(
                             black = newPool.black,
                             red = newPool.red,
                             green = newPool.green,
-                            colorless = newPool.colorless
+                            colorless = newPool.colorless,
+                            restrictedMana = newPool.restrictedMana
                         )
                     )
                 }
@@ -194,9 +202,10 @@ class UnlockRoomDoorHandler(
                     black = poolComponent.black,
                     red = poolComponent.red,
                     green = poolComponent.green,
-                    colorless = poolComponent.colorless
+                    colorless = poolComponent.colorless,
+                    restrictedMana = poolComponent.restrictedMana
                 )
-                val partialResult = pool.payPartial(cost)
+                val partialResult = pool.payPartial(cost, unlockContext)
                 val poolAfterPayment = partialResult.newPool
                 val remainingCost = partialResult.remainingCost
                 val manaSpentFromPool = partialResult.manaSpent
@@ -216,13 +225,14 @@ class UnlockRoomDoorHandler(
                             black = poolAfterPayment.black,
                             red = poolAfterPayment.red,
                             green = poolAfterPayment.green,
-                            colorless = poolAfterPayment.colorless
+                            colorless = poolAfterPayment.colorless,
+                            restrictedMana = poolAfterPayment.restrictedMana
                         )
                     )
                 }
 
                 if (!remainingCost.isEmpty()) {
-                    val solution = manaSolver.solve(currentState, action.playerId, remainingCost, 0)
+                    val solution = manaSolver.solve(currentState, action.playerId, remainingCost, 0, spellContext = unlockContext)
                         ?: return ExecutionResult.error(currentState, "Not enough mana to unlock ${face.name}")
 
                     val (stateAfterTaps, tapEvents) = manaAbilitySideEffectExecutor

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -55,6 +55,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.phasing.PhaseInLinkedTo
 import com.wingedsheep.engine.handlers.effects.permanent.tapping.TapUntapCollectionExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.tapping.TapUntapExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AddCardTypeExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.AddColorExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AddCreatureTypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AddSubtypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AnimateLandExecutor
@@ -129,6 +130,7 @@ class PermanentExecutors(
         GiveControlToTargetPlayerExecutor(),
         // types
         AddCardTypeExecutor(),
+        AddColorExecutor(),
         AddCreatureTypeExecutor(),
         AddSubtypeExecutor(),
         SetLandTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/AddColorExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/AddColorExecutor.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.handlers.effects.permanent.types
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.effects.AddColorEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [AddColorEffect].
+ * "It becomes black in addition to its other colors." — adds one or more colors to a single
+ * target via a Layer 5 (COLOR) additive floating effect, keeping the target's existing colors.
+ */
+class AddColorExecutor : EffectExecutor<AddColorEffect> {
+
+    override val effectType: KClass<AddColorEffect> = AddColorEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: AddColorEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target)
+            ?: return EffectResult.success(state)
+
+        if (targetId !in state.getBattlefield()) {
+            return EffectResult.success(state)
+        }
+
+        val newState = state.addFloatingEffect(
+            layer = Layer.COLOR,
+            modification = SerializableModification.AddColor(effect.colors),
+            affectedEntities = setOf(targetId),
+            duration = effect.duration,
+            context = context
+        )
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -24,6 +25,10 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
  */
 class TurnFaceUpEnumerator : ActionEnumerator {
 
+    // Lets restricted mana tagged "spend only to turn permanents face up" count toward
+    // affordability of the turn-face-up special action (Overgrown Zealot, Creeping Peeper).
+    private val faceUpContext = SpellPaymentContext(isTurnFaceUpAction = true)
+
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
         val result = mutableListOf<LegalAction>()
         val state = context.state
@@ -34,6 +39,9 @@ class TurnFaceUpEnumerator : ActionEnumerator {
 
             // Must be face-down
             if (!container.has<FaceDownComponent>()) continue
+
+            // "It can't be turned face up" (Unable to Scream) suppresses the special action.
+            if (state.projectedState.cantBeTurnedFaceUp(entityId)) continue
 
             // Must have morph data (to get the morph cost)
             val morphData = container.get<MorphDataComponent>() ?: continue
@@ -62,9 +70,9 @@ class TurnFaceUpEnumerator : ActionEnumerator {
                                 maxAffordableX = maxX
                             )
                         )
-                    } else if (context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)) {
+                    } else if (context.manaSolver.canPay(state, playerId, effectiveCost, spellContext = faceUpContext, precomputedSources = context.availableManaSources)) {
                         val autoTapPreview = if (context.skipAutoTapPreview) null else {
-                            context.manaSolver.solve(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
+                            context.manaSolver.solve(state, playerId, effectiveCost, spellContext = faceUpContext, precomputedSources = context.availableManaSources)
                                 ?.sources?.map { it.entityId }
                         }
                         result.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/UnlockRoomDoorEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/UnlockRoomDoorEnumerator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.UnlockRoomDoor
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 
 /**
@@ -13,6 +14,10 @@ import com.wingedsheep.engine.state.components.identity.RoomComponent
  * Timing: sorcery speed — controller's main phase, stack empty.
  */
 class UnlockRoomDoorEnumerator : ActionEnumerator {
+
+    // Lets restricted mana tagged "spend only to ... unlock a door" count toward affordability
+    // of the unlock special action (Creeping Peeper).
+    private val unlockContext = SpellPaymentContext(isUnlockDoorAction = true)
 
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
         if (!context.canPlaySorcerySpeed) return emptyList()
@@ -27,11 +32,11 @@ class UnlockRoomDoorEnumerator : ActionEnumerator {
 
             for (face in room.lockedFaces) {
                 val cost = context.unlockCostReducer.effectiveUnlockCost(state, playerId, face.manaCost)
-                if (!context.manaSolver.canPay(state, playerId, cost, precomputedSources = context.availableManaSources)) {
+                if (!context.manaSolver.canPay(state, playerId, cost, spellContext = unlockContext, precomputedSources = context.availableManaSources)) {
                     continue
                 }
                 val autoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, cost, precomputedSources = context.availableManaSources)
+                    context.manaSolver.solve(state, playerId, cost, spellContext = unlockContext, precomputedSources = context.availableManaSources)
                         ?.sources?.map { it.entityId }
                 }
                 result.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -328,6 +328,13 @@ sealed interface SerializableModification {
     data object SetCantBlock : SerializableModification
 
     /**
+     * "It can't be turned face up." Used by Unable to Scream while it enchants a face-down
+     * creature. Projected onto the affected permanent; [TurnFaceUpHandler] reads it.
+     */
+    @Serializable
+    data object SetCantBeTurnedFaceUp : SerializableModification
+
+    /**
      * Suspect status: marks a permanent as suspected.
      * Applied atomically with GrantKeyword(MENACE) and SetCantBlock by SuspectEffectHandler.
      * Stored as a distinct modification so future cards can query the status independently.
@@ -572,6 +579,7 @@ fun SerializableModification.toModification(): Modification = when (this) {
     is SerializableModification.AddAllCreatureTypes -> Modification.AddAllCreatureTypes
     // SetCantAttack maps to the layer modification for "can't attack" projection
     is SerializableModification.SetCantAttack -> Modification.SetCantAttack
+    is SerializableModification.SetCantBeTurnedFaceUp -> Modification.SetCantBeTurnedFaceUp
     // SetCantBlock maps to the layer modification for "can't block" projection
     is SerializableModification.SetCantBlock -> Modification.SetCantBlock
     // SetSuspected maps to the layer modification for the "suspected" status projection

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -233,6 +233,9 @@ internal class EffectApplicator(
                 is Modification.SetCantBlock -> {
                     values.cantBlock = true
                 }
+                is Modification.SetCantBeTurnedFaceUp -> {
+                    values.cantBeTurnedFaceUp = true
+                }
                 is Modification.SetMustAttack -> {
                     values.mustAttack = true
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
@@ -20,6 +20,7 @@ data class ProjectedValues(
     val isSuspected: Boolean = false,
     val cantAttack: Boolean = false,
     val cantBlock: Boolean = false,
+    val cantBeTurnedFaceUp: Boolean = false,
     val mustAttack: Boolean = false,
     val mustBlock: Boolean = false,
     val cantBeBlockedExceptByFilters: List<com.wingedsheep.sdk.scripting.GameObjectFilter> = emptyList(),
@@ -98,6 +99,9 @@ class ProjectedState(
 
     fun cantBlock(entityId: EntityId): Boolean = projectedValues[entityId]?.cantBlock == true
 
+    fun cantBeTurnedFaceUp(entityId: EntityId): Boolean =
+        projectedValues[entityId]?.cantBeTurnedFaceUp == true
+
     fun mustAttack(entityId: EntityId): Boolean = projectedValues[entityId]?.mustAttack == true
 
     fun mustBlock(entityId: EntityId): Boolean = projectedValues[entityId]?.mustBlock == true
@@ -149,6 +153,7 @@ internal fun buildIntermediateProjectedState(
             isSuspected = v.isSuspected,
             cantAttack = v.cantAttack,
             cantBlock = v.cantBlock,
+            cantBeTurnedFaceUp = v.cantBeTurnedFaceUp,
             mustAttack = v.mustAttack,
             mustBlock = v.mustBlock,
             cantBeBlockedExceptByFilters = v.cantBeBlockedExceptByFilters.toList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -461,6 +461,17 @@ sealed interface Modification {
         override val layer get() = Layer.ABILITY
     }
 
+    /**
+     * Prevents the affected permanent from being turned face up (CR-style "it can't be turned
+     * face up"). Used by Unable to Scream: "As long as enchanted creature is face down, it can't
+     * be turned face up." Only meaningful while the permanent is face down; [TurnFaceUpHandler]
+     * rejects the special action when this flag is projected onto the source.
+     */
+    @Serializable
+    data object SetCantBeTurnedFaceUp : Modification {
+        override val layer get() = Layer.ABILITY
+    }
+
     @Serializable
     data object SetMustAttack : Modification {
         override val layer get() = Layer.ABILITY
@@ -578,6 +589,7 @@ internal data class MutableProjectedValues(
     var isSuspected: Boolean = false,
     var cantAttack: Boolean = false,
     var cantBlock: Boolean = false,
+    var cantBeTurnedFaceUp: Boolean = false,
     var mustAttack: Boolean = false,
     var mustBlock: Boolean = false,
     val cantBeBlockedExceptByFilters: MutableList<GameObjectFilter> = mutableListOf(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -306,6 +306,7 @@ class StateProjector(
                 isSuspected = v.isSuspected,
                 cantAttack = v.cantAttack,
                 cantBlock = v.cantBlock,
+                cantBeTurnedFaceUp = v.cantBeTurnedFaceUp,
                 mustAttack = v.mustAttack,
                 mustBlock = v.mustBlock,
                 cantBeBlockedExceptByFilters = v.cantBeBlockedExceptByFilters.toList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -53,6 +53,7 @@ import com.wingedsheep.sdk.scripting.AnimateLandGroup
 import com.wingedsheep.sdk.scripting.GrantAdditionalTypesToGroup
 import com.wingedsheep.sdk.scripting.GrantColor
 import com.wingedsheep.sdk.scripting.GrantChosenColor
+import com.wingedsheep.sdk.scripting.CantBeTurnedFaceUp
 import com.wingedsheep.sdk.scripting.LoseAllAbilities
 import com.wingedsheep.sdk.scripting.TransformPermanent
 import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
@@ -651,6 +652,12 @@ class StaticAbilityHandler(
             is LoseAllAbilities -> {
                 ContinuousEffectData(
                     modification = Modification.RemoveAllAbilities,
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is CantBeTurnedFaceUp -> {
+                ContinuousEffectData(
+                    modification = Modification.SetCantBeTurnedFaceUp,
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -47,6 +47,18 @@ data class SpellPaymentContext(
      * also requires `!isAbilityActivation`.
      */
     val isFromHand: Boolean = true,
+    /**
+     * True when the payment is for the turn-face-up special action (CR 707.9 / disguise's
+     * turn-up). Lets restrictions like [ManaRestriction.TurnPermanentsFaceUpOnly] recognize
+     * "spend this mana only to turn permanents face up" (Overgrown Zealot, Creeping Peeper).
+     */
+    val isTurnFaceUpAction: Boolean = false,
+    /**
+     * True when the payment is for the unlock-a-door special action (CR 709.5e). Lets
+     * [ManaRestriction.UnlockDoorOnly] recognize "spend this mana only to ... unlock a door"
+     * (Creeping Peeper).
+     */
+    val isUnlockDoorAction: Boolean = false,
 )
 
 /**
@@ -66,6 +78,9 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
             context.subtypes.any { it.equals(subtype, ignoreCase = true) }
     is ManaRestriction.CastFromExileOnly -> !context.isAbilityActivation && context.isFromExile
     is ManaRestriction.CastFromNonHandOnly -> !context.isAbilityActivation && !context.isFromHand
+    is ManaRestriction.TurnPermanentsFaceUpOnly -> context.isTurnFaceUpAction
+    is ManaRestriction.UnlockDoorOnly -> context.isUnlockDoorAction
+    is ManaRestriction.AnyOf -> restrictions.any { it.isSatisfiedBy(context) }
     is ManaRestriction.SubtypeSpellsOnly ->
         !context.isAbilityActivation &&
             subtypes.any { sub -> context.subtypes.any { it.equals(sub, ignoreCase = true) } }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepingPeeperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepingPeeperScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.mechanics.mana.isSatisfiedBy
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.CreepingPeeper
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Creeping Peeper's mana ability — "Add {U}. Spend this mana only to cast an enchantment
+ * spell, unlock a door, or turn a permanent face up." Modeled as a [ManaRestriction.AnyOf] of three
+ * atomic restrictions.
+ */
+class CreepingPeeperScenarioTest : FunSpec({
+
+    val peeperRestriction = ManaRestriction.AnyOf(
+        listOf(
+            ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ENCHANTMENT,
+                allowSpells = true,
+                allowAbilities = false,
+            ),
+            ManaRestriction.UnlockDoorOnly,
+            ManaRestriction.TurnPermanentsFaceUpOnly,
+        ),
+    )
+
+    // A morph creature whose turn-face-up cost is the mana {2}{B}.
+    val manaMorphTester = card("Mana Morph Tester") {
+        manaCost = "{3}{B}"
+        typeLine = "Creature — Zombie"
+        power = 2
+        toughness = 2
+        morph = "{2}{B}"
+    }
+
+    val allCards = TestCards.all + listOf(CreepingPeeper, manaMorphTester)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(state.updateEntity(creatureId) { container ->
+            var c = container.with(FaceDownComponent)
+            if (morphAbility != null) {
+                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+            }
+            c
+        })
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    test("the AnyOf restriction satisfies enchantment spells, unlock, and turn-face-up — but not creatures") {
+        val enchantmentSpell = SpellPaymentContext(cardTypes = setOf(CardType.ENCHANTMENT))
+        val unlock = SpellPaymentContext(isUnlockDoorAction = true)
+        val faceUp = SpellPaymentContext(isTurnFaceUpAction = true)
+        val creatureSpell = SpellPaymentContext(isCreature = true, cardTypes = setOf(CardType.CREATURE))
+        val artifactSpell = SpellPaymentContext(cardTypes = setOf(CardType.ARTIFACT))
+
+        peeperRestriction.isSatisfiedBy(enchantmentSpell) shouldBe true
+        peeperRestriction.isSatisfiedBy(unlock) shouldBe true
+        peeperRestriction.isSatisfiedBy(faceUp) shouldBe true
+        peeperRestriction.isSatisfiedBy(creatureSpell) shouldBe false
+        peeperRestriction.isSatisfiedBy(artifactSpell) shouldBe false
+    }
+
+    test("Creeping Peeper's restricted {U} can pay toward turning a permanent face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Morph cost is {2}{B}. Give 1 blue (Peeper) + the rest as the same multi-option
+        // restriction, all spendable on the turn-face-up action.
+        val cutthroat = driver.putFaceDownCreature(player, "Mana Morph Tester")
+        driver.giveRestrictedMana(player, Color.BLUE, 1, peeperRestriction)
+        driver.giveRestrictedMana(player, Color.BLACK, 1, peeperRestriction)
+        driver.giveRestrictedMana(player, null, 1, peeperRestriction)
+
+        val result = driver.submit(
+            TurnFaceUp(playerId = player, sourceId = cutthroat, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.error shouldBe null
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe null
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        pool.restrictedMana.size shouldBe 0
+    }
+
+    test("card definition exposes one mana ability") {
+        CreepingPeeper.activatedAbilities.size shouldBe 1
+        CreepingPeeper.activatedAbilities.single().isManaAbility shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OvergrownZealotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OvergrownZealotScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.mechanics.mana.isSatisfiedBy
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.OvergrownZealot
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Overgrown Zealot's second mana ability — "Add two mana of any one color. Spend this
+ * mana only to turn permanents face up." ([ManaRestriction.TurnPermanentsFaceUpOnly]).
+ */
+class OvergrownZealotScenarioTest : FunSpec({
+
+    // A morph creature whose turn-face-up cost is the mana {2}{B}.
+    val manaMorphTester = card("Mana Morph Tester") {
+        manaCost = "{3}{B}"
+        typeLine = "Creature — Zombie"
+        power = 2
+        toughness = 2
+        morph = "{2}{B}"
+    }
+
+    val allCards = TestCards.all + listOf(OvergrownZealot, manaMorphTester)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(state.updateEntity(creatureId) { container ->
+            var c = container.with(FaceDownComponent)
+            if (morphAbility != null) {
+                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+            }
+            c
+        })
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    test("TurnPermanentsFaceUpOnly mana satisfies only the turn-face-up context") {
+        val faceUp = SpellPaymentContext(isTurnFaceUpAction = true)
+        val unlock = SpellPaymentContext(isUnlockDoorAction = true)
+        val creatureSpell = SpellPaymentContext(isCreature = true, cardTypes = setOf(CardType.CREATURE))
+
+        ManaRestriction.TurnPermanentsFaceUpOnly.isSatisfiedBy(faceUp) shouldBe true
+        ManaRestriction.TurnPermanentsFaceUpOnly.isSatisfiedBy(unlock) shouldBe false
+        ManaRestriction.TurnPermanentsFaceUpOnly.isSatisfiedBy(creatureSpell) shouldBe false
+    }
+
+    test("restricted face-up mana in the pool pays a face-down creature's morph cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Morph cost is {2}{B}. Give exactly that as turn-face-up-only mana.
+        val cutthroat = driver.putFaceDownCreature(player, "Mana Morph Tester")
+        driver.giveRestrictedMana(player, Color.BLACK, 1, ManaRestriction.TurnPermanentsFaceUpOnly)
+        driver.giveRestrictedMana(player, null, 2, ManaRestriction.TurnPermanentsFaceUpOnly)
+
+        val result = driver.submit(
+            TurnFaceUp(playerId = player, sourceId = cutthroat, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.error shouldBe null
+
+        // Flipped face up, and all the restricted mana was consumed.
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe null
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        pool.restrictedMana.size shouldBe 0
+    }
+
+    test("card definition exposes two mana abilities, the second restricted to turn-face-up") {
+        OvergrownZealot.activatedAbilities.size shouldBe 2
+        OvergrownZealot.activatedAbilities.all { it.isManaAbility } shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PossessedGoatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PossessedGoatScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.PossessedGoat
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Possessed Goat — specifically the additive "becomes a black Demon in addition to its
+ * other colors and types" payoff. The activated ability puts three +1/+1 counters and applies an
+ * additive color ([com.wingedsheep.sdk.scripting.effects.AddColorEffect]) + an additive creature
+ * type, all permanent.
+ *
+ * The effect composition is exercised here via an inline instant (so we isolate the new
+ * AddColorEffect executor and projection); the card definition's once-only activation is pinned by
+ * a definition-level sanity check.
+ */
+class PossessedGoatScenarioTest : FunSpec({
+
+    // Mirrors Possessed Goat's resolved ability: three +1/+1 counters, become black, become a Demon.
+    val possess = card("Possess") {
+        manaCost = "{W}"
+        typeLine = "Instant"
+        oracleText = "Put three +1/+1 counters on target creature and it becomes a black Demon " +
+            "in addition to its other colors and types."
+        spell {
+            val target = target("target creature", Targets.Creature)
+            effect = CompositeEffect(
+                listOf(
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, target),
+                    Effects.AddColor(Color.BLACK, target, Duration.Permanent),
+                    Effects.AddCreatureType("Demon", target, Duration.Permanent),
+                )
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(possess, PossessedGoat))
+        return driver
+    }
+
+    test("becomes a black Demon with three +1/+1 counters, keeping its other colors and types") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Savannah Lions is a white Cat — used to prove colors/types are ADDED, not replaced.
+        val creature = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        val spell = driver.putCardInHand(player, "Possess")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.castSpell(player, spell, listOf(creature))
+        driver.bothPass()
+
+        // Three +1/+1 counters.
+        driver.state.getEntity(creature)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 3
+
+        val projected = driver.state.projectedState
+        // Black added, white kept (in addition to its other colors).
+        projected.hasColor(creature, Color.BLACK) shouldBe true
+        projected.hasColor(creature, Color.WHITE) shouldBe true
+        // Demon added, Cat kept (in addition to its other types).
+        projected.hasSubtype(creature, "Demon") shouldBe true
+        projected.hasSubtype(creature, "Cat") shouldBe true
+    }
+
+    test("card definition: once-only ability with a mana + discard cost") {
+        val ability = PossessedGoat.activatedAbilities.single()
+        ability.restrictions shouldBe listOf(ActivationRestriction.Once)
+        // The cost is the {3} + discard-a-card composite (no tap).
+        ability.isManaAbility shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnableToScreamScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnableToScreamScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnableToScream
+import com.wingedsheep.mtg.sets.definitions.scg.cards.ZombieCutthroat
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Unable to Scream
+ * {U} Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature loses all abilities and is a Toy artifact creature with base power and
+ * toughness 0/2 in addition to its other types.
+ * As long as enchanted creature is face down, it can't be turned face up.
+ */
+class UnableToScreamScenarioTest : FunSpec({
+
+    // A flying blue Bird with an activated ability — proves abilities are removed but the original
+    // color/creature type are kept (added to, not replaced).
+    val flyer = CardDefinition.creature(
+        name = "Test Flyer",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = setOf(Subtype("Bird")),
+        power = 3,
+        toughness = 3,
+        keywords = setOf(Keyword.FLYING),
+    )
+
+    val projector = StateProjector()
+
+    val allCards = TestCards.all + listOf(flyer, ZombieCutthroat, UnableToScream)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(state.updateEntity(creatureId) { container ->
+            var c = container.with(FaceDownComponent)
+            if (morphAbility != null) {
+                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+            }
+            c
+        })
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    test("enchanted creature is a 0/2 Toy artifact creature with no abilities, keeping its other types/colors") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(player, "Test Flyer")
+        val aura = driver.putCardInHand(player, "Unable to Scream")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.castSpell(player, aura, listOf(creature))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        // Base P/T 0/2.
+        projector.getProjectedPower(driver.state, creature) shouldBe 0
+        projector.getProjectedToughness(driver.state, creature) shouldBe 2
+        // Loses all abilities (flying gone).
+        projected.hasLostAllAbilities(creature) shouldBe true
+        projected.hasKeyword(creature, Keyword.FLYING) shouldBe false
+        // Toy artifact creature, in addition to its other types (still a Bird, still blue).
+        projected.hasType(creature, CardType.ARTIFACT.name) shouldBe true
+        projected.hasType(creature, CardType.CREATURE.name) shouldBe true
+        projected.hasSubtype(creature, "Toy") shouldBe true
+        projected.hasSubtype(creature, "Bird") shouldBe true
+        projected.hasColor(creature, Color.BLUE) shouldBe true
+    }
+
+    test("a face-down enchanted creature can't be turned face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40, "Swamp" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A face-down morph creature (Zombie Cutthroat) that could normally be turned face up.
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+
+        // Enchant it with Unable to Scream.
+        val aura = driver.putCardInHand(player, "Unable to Scream")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.castSpell(player, aura, listOf(cutthroat))
+        driver.bothPass()
+
+        // The flag is projected, and the turn-face-up special action is rejected.
+        driver.state.projectedState.cantBeTurnedFaceUp(cutthroat) shouldBe true
+        val result = driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat))
+        result.isSuccess shouldBe false
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+})


### PR DESCRIPTION
Implements four Duskmourn: House of Horror cards plus the SDK/engine support they require.

## Cards
- **Possessed Goat** `{W}` 1/1 Goat — `{3}, Discard a card:` (once-only) puts three +1/+1 counters and becomes **a black Demon in addition to its other colors and types**. Composes `AddCounters` + the new additive `AddColor` effect + `AddCreatureType`, all permanent, gated by `ActivationRestriction.Once`.
- **Unable to Scream** `{U}` Aura — enchanted creature **loses all abilities and is a Toy artifact creature with base 0/2 in addition to its other types**, and **can't be turned face up while face down**. Composes `LoseAllAbilities` + `SetBasePowerToughnessStatic(0,2)` + `GrantCardType(ARTIFACT)` + `GrantSubtype(Toy)` + a new `CantBeTurnedFaceUp` static.
- **Overgrown Zealot** `{1}{G}` 0/4 — two mana abilities; the second adds two mana of any one color **restricted to turning permanents face up**.
- **Creeping Peeper** `{1}{U}` 2/1 — adds `{U}` **restricted to casting an enchantment spell, unlocking a door, or turning a permanent face up**.

## SDK / engine additions
- `Effects.AddColor` / `AddColorEffect` — Layer-5 additive color (the ability-applied counterpart of the `GrantColor` static), with a new `AddColorExecutor`.
- `CantBeTurnedFaceUp` static ability + a `SetCantBeTurnedFaceUp` projected flag (`cantBeTurnedFaceUp`), honored by `TurnFaceUpHandler` (rejects the action) and `TurnFaceUpEnumerator` (suppresses the action).
- `ManaRestriction.TurnPermanentsFaceUpOnly`, `ManaRestriction.UnlockDoorOnly`, and `ManaRestriction.AnyOf` (disjunction). `SpellPaymentContext` gains `isTurnFaceUpAction` / `isUnlockDoorAction`, threaded through the turn-face-up and unlock-door special-action payment paths (handlers + enumerators) so restricted mana in the pool is actually consumed.
- `docs/card-sdk-language-reference.md` updated for every new building block.

## mtgish tooling
- Emitter (`ManaHandlers.kt`) now recovers `CanOnlySpendToTurnAPermanentFaceUp`, `CanOnlySpendToUnlockDoors`, the `IsCardtype Enchantment` spell-spend (→ `CardTypeSpellsOrAbilitiesOnly(ENCHANTMENT)`), and an `Or` of mana-use modifiers (→ `ManaRestriction.AnyOf`). **Overgrown Zealot** and **Creeping Peeper** now render at **AUTO** tier; the two layer-effect creatures stay **SCAFFOLD** by design (faithful rather than lossy).
- `coverage-verify POR` stays **0-mismatch (158/158)**. The pre-existing DSK golden-drift mismatches are unrelated (target filters / modal descriptions / Impending+Survival triggers) and use no mana-use modifiers; no existing emitter golden changed on rebless.

## Tests
Per-card scenario tests in `rules-engine` (counter/color/type projection, the can't-turn-face-up rejection, and restricted-mana payment of a morph cost via the new restrictions). DSK card snapshot re-blessed (only the four new cards added). `CardLintTest`, `EffectExecutorCoverageTest`, the touched morph/room/mana tests, and `just build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)