### PR TITLE
Add DSK cards: Cryptid Inspector, Defiant Survivor, Overgrown Zealot, Possessed Goat, Stalked Researcher

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StalkedResearcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StalkedResearcher.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Stalked Researcher
+ * {1}{U}
+ * Creature — Human Wizard
+ * 3/3
+ * Defender
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room,
+ * this creature can attack this turn as though it didn't have defender.
+ *
+ * The "X and whenever Y" Eerie templating is two distinct triggered abilities sharing one
+ * payoff (CR has no "or" trigger combiner), modelled like the other DSK Eerie creatures
+ * (e.g. Optimistic Scavenger): one block fires when an enchantment you control enters
+ * ([Triggers.entersBattlefield] filtered to enchantments you control), the other when you
+ * fully unlock a Room ([Triggers.RoomFullyUnlocked]). Both grant this creature
+ * [Effects.CanAttackDespiteDefenderThisTurn] (the turn-scoped counterpart to the static
+ * CanAttackDespiteDefender), which lets it attack as though it didn't have defender for the turn.
+ */
+val StalkedResearcher = card("Stalked Researcher") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Defender\nEerie — Whenever an enchantment you control enters and whenever you " +
+        "fully unlock a Room, this creature can attack this turn as though it didn't have defender."
+
+    keywords(Keyword.DEFENDER, Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CanAttackDespiteDefenderThisTurn()
+        description = "Eerie — Whenever an enchantment you control enters, this creature can " +
+            "attack this turn as though it didn't have defender."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.CanAttackDespiteDefenderThisTurn()
+        description = "Eerie — Whenever you fully unlock a Room, this creature can attack this " +
+            "turn as though it didn't have defender."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Marta Nael"
+        flavorText = "\"Just a shadow. It's only a shadow. Please let it be a shadow.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg?1726286124"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1760,6 +1760,53 @@
     ]
 }
 
+// Creeping Peeper
+{
+    "name": "Creeping Peeper",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Eye",
+    "oracleText": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE",
+                    "restriction": {
+                        "type": "AnyOf",
+                        "restrictions": [
+                            {
+                                "type": "CardTypeSpellsOrAbilitiesOnly",
+                                "cardType": "ENCHANTMENT"
+                            },
+                            "UnlockDoorOnly",
+                            "TurnPermanentsFaceUpOnly"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Maxime Minard",
+        "flavorText": "\"Be on your guard. Valgavoth has eyes everywhere. And I don't mean that figuratively.\"\n—Winter",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg?1726286029"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cryptid Inspector
 {
     "name": "Cryptid Inspector",
@@ -5892,6 +5939,55 @@
     ]
 }
 
+// Overgrown Zealot
+{
+    "name": "Overgrown Zealot",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to turn permanents face up.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": "TurnPermanentsFaceUpOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add two mana of any one color. Spend this mana only to turn permanents face up."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Walpole",
+        "flavorText": "Even as the roots twisted painfully into his flesh, he sang out in joy, for he could feel himself becoming one with the woods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg?1726286585"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Overlord of the Balemurk
 {
     "name": "Overlord of the Balemurk",
@@ -6818,6 +6914,75 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Possessed Goat
+{
+    "name": "Possessed Goat",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Goat",
+    "oracleText": "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon in addition to its other colors and types. Activate only once.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "AddColor",
+                            "colors": [
+                                "BLACK"
+                            ]
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Demon"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon in addition to its other colors and types. Activate only once."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "When their would-be sacrifice wandered back to their encampment, the survivors breathed a sigh of relief, assuming the demon had departed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg?1726285949"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -8257,6 +8422,53 @@
     ]
 }
 
+// Stalked Researcher
+{
+    "name": "Stalked Researcher",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Defender\nEerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, this creature can attack this turn as though it didn't have defender.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER",
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": "CanAttackDespiteDefenderThisTurn",
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, this creature can attack this turn as though it didn't have defender."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": "CanAttackDespiteDefenderThisTurn",
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, this creature can attack this turn as though it didn't have defender."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Marta Nael",
+        "flavorText": "\"Just a shadow. It's only a shadow. Please let it be a shadow.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg?1726286124"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // The Jolly Balloon Man
 {
     "name": "The Jolly Balloon Man",
@@ -8740,6 +8952,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Unable to Scream
+{
+    "name": "Unable to Scream",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature loses all abilities and is a Toy artifact creature with base power and toughness 0/2 in addition to its other types.\nAs long as enchanted creature is face down, it can't be turned face up.",
+    "script": {
+        "staticAbilities": [
+            "LoseAllAbilities",
+            {
+                "type": "GrantCardType",
+                "cardType": "ARTIFACT",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Toy",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 0,
+                "toughness": 2
+            },
+            "CantBeTurnedFaceUp"
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg?1726286143"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StalkedResearcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StalkedResearcherScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stalked Researcher (DSK #73) — {1}{U} 3/3 Creature — Human Wizard, Defender.
+ *
+ * "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room,
+ *  this creature can attack this turn as though it didn't have defender."
+ *
+ * Exercises the enchantment-enters half of the Eerie ability granting the temporary
+ * [com.wingedsheep.sdk.scripting.effects.CanAttackDespiteDefenderThisTurnEffect]: with Defender it
+ * cannot attack, but once an enchantment you control enters it gains the transient marker and
+ * can attack this turn.
+ */
+class StalkedResearcherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stalked Researcher — Eerie grants attack despite defender") {
+
+            test("cannot attack with Defender before any enchantment enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stalked Researcher", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Stalked Researcher" to 2))
+                withClue("Defender blocks the attack before Eerie fires") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("an enchantment you control entering lets it attack this turn despite Defender") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stalked Researcher", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val researcher = game.findPermanent("Stalked Researcher")!!
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Eerie fired — Researcher gains the can-attack-despite-defender marker") {
+                    game.state.getEntity(researcher)
+                        ?.get<CanAttackDespiteDefenderThisTurnComponent>().shouldNotBeNull()
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Stalked Researcher" to 2))
+                withClue("After Eerie fired the Researcher can attack despite Defender: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Stalked Researcher is now an attacker") {
+                    game.state.getEntity(researcher)?.get<AttackingComponent>().shouldNotBeNull()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the five requested **Duskmourn: House of Horror (DSK)** cards. Four were already authored on `main` (a parallel run landed Cryptid Inspector, Defiant Survivor, Overgrown Zealot, Possessed Goat); this PR adds the missing fifth — **Stalked Researcher** — and fixes a stale card snapshot golden that was already failing on `main`.

### Cards
| Card | Status | Notes |
|------|--------|-------|
| Cryptid Inspector | already implemented (main) | Vigilance + two face-down/face-up +1/+1 triggers — verified faithful, scenario test passing |
| Defiant Survivor | already implemented (main) | Survival → manifest dread — verified, scenario test passing |
| Overgrown Zealot | already implemented (main) | two mana abilities, 2nd restricted to turn-face-up — verified, scenario test passing |
| Possessed Goat | already implemented (main) | once-only "becomes a black Demon" — verified, scenario test passing |
| **Stalked Researcher** | **new in this PR** | Defender + Eerie → can attack despite defender this turn |

**Stalked Researcher** is modelled as two triggered abilities (CR has no "or" trigger combiner) sharing one payoff `Effects.CanAttackDespiteDefenderThisTurn`, mirroring the existing DSK Eerie creatures (e.g. Optimistic Scavenger). No new SDK surface — `Keyword.EERIE`, the enchantment-enters trigger, `Triggers.RoomFullyUnlocked`, and the turn-scoped `CanAttackDespiteDefender` effect all already exist.

### Snapshot rebless
`mtg-sets/.../snapshots/cards/DSK.json` was stale on `main`: commit `d1351d7d3` added Possessed Goat, Overgrown Zealot, Creeping Peeper, and Unable to Scream without blessing the golden, so `CardDefinitionSnapshotTest` was already red. The rebless picks up those four merged cards plus the new Stalked Researcher.

### mtgish tooling
- Cryptid Inspector, Defiant Survivor, Overgrown Zealot already **AUTO-emit** and match the golden tree (no emitter change needed).
- Possessed Goat (`CreatePermanentLayerEffect`) and Stalked Researcher (`CreatePermanentRuleEffectUntil` + trigger-shape) are engine-feature-complex; the emitter **correctly declines** them (NOT EMITTED / SCAFFOLD) rather than emitting a lossy approximation, per the "decline, don't widen" rule.
- Emitter source untouched. **POR stays GATE PASS (0-mismatch).**
- The 6 pre-existing DSK gameplay-tree mismatches (Attack-in-the-Box, Beastie Beatdown, Get Out, Glimmer Seeker, Overlord of the Boilerbilges, Razorkin Needlehead) are unrelated to these cards and predate this PR.

### Tests
- New `StalkedResearcherScenarioTest` (cannot attack with Defender; an enchantment entering grants attack-despite-defender) — passing.
- Existing scenario tests for the other four — passing.
- `CardDefinitionSnapshotTest` (reblessed), `CardLintTest`, full `:mtg-sets:test` — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)