### PR TITLE
Add DSK spells: Unnerving Grasp, Turn Inside Out (+ mtgish self-dies delayed trigger)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TurnInsideOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TurnInsideOut.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+
+/**
+ * Turn Inside Out
+ * {R}
+ * Instant
+ * Target creature gets +3/+0 until end of turn. When it dies this turn, manifest dread. (Look at
+ * the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and
+ * the other into your graveyard. Turn it face up any time for its mana cost if it's a creature
+ * card.)
+ *
+ * Modeled like Desperate Measures: a +3/+0 stat change until end of turn plus a watched-entity
+ * delayed [Triggers.Dies] trigger scoped to the buffed creature via `watchedTarget`, expiring at
+ * end of turn. When the creature dies this turn, the delayed trigger runs the shared
+ * [Patterns.Library.manifestDread] recipe for the spell's controller. The trigger is scoped by
+ * entity id, so it fires regardless of who controlled the creature when it died — matching the
+ * printed "When it dies this turn" (no controller restriction).
+ */
+val TurnInsideOut = card("Turn Inside Out") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 until end of turn. When it dies this turn, manifest " +
+        "dread. (Look at the top two cards of your library. Put one onto the battlefield face down " +
+        "as a 2/2 creature and the other into your graveyard. Turn it face up any time for its " +
+        "mana cost if it's a creature card.)"
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            ModifyStatsEffect(3, 0, t),
+            CreateDelayedTriggerEffect(
+                effect = Patterns.Library.manifestDread(),
+                trigger = Triggers.Dies,
+                watchedTarget = t,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Loïc Canavaggia"
+        flavorText = "\"Scared, are you? Need a hug?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg?1726286448"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnnervingGrasp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnnervingGrasp.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Unnerving Grasp
+ * {2}{U}
+ * Sorcery
+ * Return up to one target nonland permanent to its owner's hand. Manifest dread. (Look at the top
+ * two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other
+ * into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)
+ *
+ * "Up to one target nonland permanent" → an optional [TargetPermanent] over
+ * [TargetFilter.NonlandPermanent]; the bounce is skipped when no target is chosen and the manifest
+ * dread still happens. The two effects are an ordered [Effects.Composite] (bounce, then the shared
+ * [Patterns.Library.manifestDread] recipe), matching the printed sequence.
+ */
+val UnnervingGrasp = card("Unnerving Grasp") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target nonland permanent to its owner's hand. Manifest dread. " +
+        "(Look at the top two cards of your library. Put one onto the battlefield face down as a " +
+        "2/2 creature and the other into your graveyard. Turn it face up any time for its mana " +
+        "cost if it's a creature card.)"
+
+    spell {
+        val permanent = target(
+            "up to one target nonland permanent",
+            TargetPermanent(optional = true, filter = TargetFilter.NonlandPermanent),
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(permanent),
+            Patterns.Library.manifestDread(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Jeremy Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg?1726286150"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -8695,6 +8695,116 @@
     ]
 }
 
+// Turn Inside Out
+{
+    "name": "Turn Inside Out",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 until end of turn. When it dies this turn, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "manifestDreadLooked"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "manifestDreadLooked",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "manifestDreadManifested",
+                                "storeRemainder": "manifestDreadGraveyard",
+                                "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                "remainderLabel": "Put into your graveyard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadManifested",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "faceDown": "MANIFEST"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "ZoneChangeEvent",
+                            "from": "Battlefield",
+                            "to": "Graveyard"
+                        }
+                    },
+                    "watchedTarget": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "\"Scared, are you? Need a hug?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg?1726286448"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Twist Reality
 {
     "name": "Twist Reality",
@@ -9179,6 +9289,96 @@
                 ]
             }
         }
+    ]
+}
+
+// Unnerving Grasp
+{
+    "name": "Unnerving Grasp",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target nonland permanent to its owner's hand. Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target nonland permanent"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "up to one target nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Jeremy Wilson",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg?1726286150"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -100,14 +100,64 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
             else -> null
         }
     }
-    on("CreateTriggerUntil") { node, _, _ ->
+    on("CreateTriggerUntil") { node, _, tvar ->
         // Harsh Justice: reflect attackers' combat damage back to their controller.
         val blob = compact(node)
         if ("WhenACreatureDealsCombatDamageToAPlayer" in blob && "ControllerOfPermanent" in blob && "Trigger_ThatMuch" in blob) {
-            call("ReflectCombatDamageEffect")
-        } else null
+            return@on call("ReflectCombatDamageEffect")
+        }
+        // "When it dies this turn, <actions>." — a self-scoped delayed dies trigger watching the
+        // spell's bound target until end of turn (Turn Inside Out: +3/+0 then manifest dread on death;
+        // the Desperate Measures `CreateDelayedTriggerEffect(trigger = Triggers.Dies, watchedTarget =
+        // t)` shape). Renders only when the trigger is `WhenACreatureOrPlaneswalkerDies` scoped to the
+        // bound `Ref_TargetPermanent`, the expiry is UntilEndOfTurn, and the body renders whole.
+        whenThatPermanentDiesDelayedTrigger(node, tvar)
     }
     on("CreateEachPermanentRuleEffectUntil") { node, _, tvar -> renderGrantToGroup(node, tvar) }
+}
+
+/**
+ * `CreateTriggerUntil(WhenACreatureOrPlaneswalkerDies(SinglePermanent(Ref_TargetPermanent)),
+ * [actions], UntilEndOfTurn)` → a watched-entity delayed dies trigger on the spell's bound target:
+ * `CreateDelayedTriggerEffect(effect = <body>, trigger = Triggers.Dies, watchedTarget = <tvar>,
+ * expiry = DelayedTriggerExpiry.EndOfTurn)`.
+ *
+ * This is the "Target creature gets +X/+Y until end of turn. When it dies this turn, <do something>"
+ * shape (Turn Inside Out, Desperate Measures). Only renders when:
+ *  - the trigger is `WhenACreatureOrPlaneswalkerDies` scoped to `SinglePermanent(Ref_TargetPermanent)`
+ *    (i.e. "when *that* creature dies", the spell's bound target — not some other group),
+ *  - the expiry is `UntilEndOfTurn`,
+ *  - the body action list renders whole (sharing the ability's bound `tvar`).
+ * Any other trigger, subject, expiry, or an unrenderable body declines → SCAFFOLD.
+ */
+internal fun EmitCtx.whenThatPermanentDiesDelayedTrigger(node: JsonObject, tvar: String?): Dsl? {
+    if (tvar == null) return null
+    val args = node["args"].asArr ?: return null
+    val trigger = args.getOrNull(0) as? JsonObject ?: return null
+    val actionList = args.getOrNull(1) as? JsonObject ?: return null
+    val expiration = args.getOrNull(2) as? JsonObject ?: return null
+
+    if (trigger.strField("_Trigger") != "WhenACreatureOrPlaneswalkerDies") return null
+    if (expiration.strField("_Expiration") != "UntilEndOfTurn") return null
+
+    // The trigger must watch the bound target specifically: SinglePermanent(Ref_TargetPermanent).
+    val perms = trigger["args"] as? JsonObject ?: return null
+    if (perms.strField("_Permanents") != "SinglePermanent") return null
+    val single = perms["args"] as? JsonObject ?: return null
+    if (single.strField("_Permanent") != "Ref_TargetPermanent") return null
+
+    if (actionList.strField("_Actions") != "ActionList") return null
+    val inner = actionList["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+    if (inner.isEmpty()) return null
+    val body = renderEffectList(inner, tvar) ?: return null
+
+    return call(
+        "CreateDelayedTriggerEffect",
+        arg("effect", body),
+        arg("trigger", "Triggers.Dies"),
+        arg("watchedTarget", Lit(tvar)),
+        arg("expiry", "DelayedTriggerExpiry.EndOfTurn"),
+    )
 }
 
 /** A spell that grants a combat rule to a group / target (Alluring Scent, Taunt, Dread Charge). */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TurnInsideOutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TurnInsideOutScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Turn Inside Out (DSK #160) — {R} Instant.
+ *
+ *  - Target creature gets +3/+0 until end of turn.
+ *  - When it dies this turn, manifest dread.
+ *
+ * Exercises the +3/+0 buff and the watched-entity delayed dies trigger: killing the buffed
+ * creature later this turn fires the manifest dread. Also covers the case where the creature
+ * survives — no manifest dread.
+ */
+class TurnInsideOutScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("buffs +3/+0; when the creature dies this turn, manifest dread happens") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two for manifest dread later: a creature to manifest, a land beneath.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val toManifest = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val creature = d.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val spell = d.putCardInHand(you, "Turn Inside Out")
+        d.giveMana(you, Color.RED, 1)
+        d.castSpellWithTargets(you, spell, listOf(entityIdToChosenTarget(d.state, creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // +3/+0 applied → 6/3.
+        d.state.projectedState.getPower(creature) shouldBe 6
+        d.state.projectedState.getToughness(creature) shouldBe 3
+
+        // Now kill it with Doom Blade — the watched dies trigger fires manifest dread.
+        val doomBlade = d.putCardInHand(you, "Doom Blade")
+        d.giveMana(you, Color.BLACK, 1)
+        d.giveColorlessMana(you, 1)
+        d.castSpellWithTargets(you, doomBlade, listOf(entityIdToChosenTarget(d.state, creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Creature died.
+        d.state.getZone(com.wingedsheep.engine.state.ZoneKey(you, Zone.GRAVEYARD)).contains(creature) shouldBe true
+
+        // Delayed trigger paused on the manifest-dread pick.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(toManifest)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.getEntity(toManifest)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+
+    test("if the creature survives, no manifest dread") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardOnTopOfLibrary(you, "Forest")
+        d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val creature = d.putCreatureOnBattlefield(you, "Centaur Courser")
+        val spell = d.putCardInHand(you, "Turn Inside Out")
+        d.giveMana(you, Color.RED, 1)
+        d.castSpellWithTargets(you, spell, listOf(entityIdToChosenTarget(d.state, creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // No death this turn → no manifest dread decision is pending.
+        d.pendingDecision.shouldBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnnervingGraspScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnnervingGraspScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unnerving Grasp (DSK #80) — {2}{U} Sorcery.
+ *
+ *  - Return up to one target nonland permanent to its owner's hand.
+ *  - Manifest dread.
+ *
+ * Exercises both the bounce (with a chosen target) and the manifest dread that follows, plus the
+ * "up to one" optional path where no target is chosen and only the manifest dread happens.
+ */
+class UnnervingGraspScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("bounces a target nonland permanent, then manifests dread") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opp = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two: a creature to manifest, a land beneath.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val toManifest = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val victim = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val spell = d.putCardInHand(you, "Unnerving Grasp")
+        d.giveMana(you, Color.BLUE, 1)
+        d.giveColorlessMana(you, 2)
+        d.castSpellWithTargets(you, spell, listOf(entityIdToChosenTarget(d.state, victim)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Bounce resolved: victim is back in its owner's hand.
+        d.state.getZone(com.wingedsheep.engine.state.ZoneKey(opp, Zone.HAND)).contains(victim) shouldBe true
+        d.getPermanents(opp).contains(victim) shouldBe false
+
+        // Manifest dread paused on the pick — choose the creature to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(toManifest)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.getEntity(toManifest)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+
+    test("with no target chosen, only manifest dread happens") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val toManifest = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val spell = d.putCardInHand(you, "Unnerving Grasp")
+        d.giveMana(you, Color.BLUE, 1)
+        d.giveColorlessMana(you, 2)
+        // Cast with no targets (the bounce is "up to one").
+        d.castSpellWithTargets(you, spell, emptyList())
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(toManifest)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.getEntity(toManifest)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+})


### PR DESCRIPTION
Implements the remaining two of the four requested Duskmourn: House of Horror (DSK) cards. Both reuse existing SDK primitives — no new engine/SDK types.

> Note: **Drag to the Roots** ({2}{B}{G} Instant — Delirium-gated {2} cost reduction + destroy target nonland permanent) and **Growing Dread** ({G}{U} Enchantment, Flash — ETB manifest dread + "whenever you turn a permanent face up, put a +1/+1 counter on it") were already implemented and merged into `main` in an earlier commit, so they are not part of this diff. All four are now in the tree.

## Cards in this PR

- **Unnerving Grasp** ({2}{U} Sorcery) — "Return up to one target nonland permanent to its owner's hand. Manifest dread." Optional `TargetPermanent(NonlandPermanent)` + ordered `Composite(ReturnToHand, Patterns.Library.manifestDread())`. Scenario test covers both the bounce-then-manifest path and the up-to-zero path (no target chosen → only manifest dread).
- **Turn Inside Out** ({R} Instant) — "Target creature gets +3/+0 until end of turn. When it dies this turn, manifest dread." Modeled like Desperate Measures: `ModifyStats(3,0)` + a watched-entity delayed `Triggers.Dies` trigger scoped to the buffed creature via `watchedTarget`, expiring end of turn, running the shared manifest-dread recipe on death. Scenario test covers the dies-this-turn manifest and the survives → no-manifest case.

Each card has a passing rules-engine scenario test. The DSK card snapshot was re-blessed (only the two new cards added to the golden).

## mtgish-tooling

Fix the emitter, never hand-patch generated cards:

- Taught the `CreateTriggerUntil` handler the "when that permanent dies this turn, <actions>" shape: `WhenACreatureOrPlaneswalkerDies` scoped to `SinglePermanent(Ref_TargetPermanent)` with `UntilEndOfTurn` expiry now renders as `CreateDelayedTriggerEffect(trigger = Triggers.Dies, watchedTarget = <bound target>, expiry = DelayedTriggerExpiry.EndOfTurn, effect = <body>)`. Turn Inside Out now emits at fidelity tier **AUTO** and gameplay-matches the hand-authored card (previously declined to SCAFFOLD on the unrecovered `CreateTriggerUntil`). Any other trigger/subject/expiry, or an unrenderable body, still declines → SCAFFOLD.
- Unnerving Grasp already emitted at AUTO (bounce + manifest dread) and matches.

## Tests

- `UnnervingGraspScenarioTest`, `TurnInsideOutScenarioTest` — pass.
- Full `:rules-engine` suite — pass.
- `:mtgish-tooling` tests (incl. POR/ONS/CHK/INR/TMP golden fixtures) — pass.
- `coverage-verify POR` — **0 mismatch** (gate PASS).
- `CardDefinitionSnapshotTest` — green after re-bless.

### Note on the DSK coverage gate
`coverage-verify DSK` still reports 6 gameplay-tree mismatches, but these are **pre-existing and unrelated** to this change (Attack-in-the-Box, Beastie Beatdown, Get Out, Glimmer Seeker, Overlord of the Boilerbilges, Razorkin Needlehead — none use `CreateTriggerUntil`). This PR strictly improves the gate (one more AUTO match; Turn Inside Out moves from declined to matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)