### PR TITLE
Add DSK artifacts: Chainsaw, Killer's Mask, Dissection Tools, Patched Plaything + mtgish autogen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1937,6 +1937,12 @@ for any other (filter, binding, to/excludeTo) combination.
   "Whenever one or more creatures your opponents control die, …" (Spiteful Banditry). A per-creature
   `leavesBattlefield(binding = ANY)` would create a separate trigger per death, and simultaneous
   deaths each fire before the once-per-turn marker is set, so the batched form is required here.
+- `OneOrMoreCreaturesDie(filter = Creature)` — the unscoped variant: "Whenever one or more creatures
+  die, …" (any player's creatures, regardless of controller — Chainsaw). Sugar for
+  `OneOrMoreCreaturesYouControlDie(filter.anyController())`; same batched once-per-death-batch
+  semantics. The filter carries `ControllerPredicate.ControlledByAny`, which `TriggerDetector`
+  treats as "every controller's deaths count". Use `.anyController()` on a `GameObjectFilter` to
+  widen any controller-scoped filter the same way.
 - `PutIntoGraveyardFromBattlefield` — SELF, same event shape as `Dies`; rename
   clarifies non-creature intent (artifact / enchantment going to yard).
 - `leavesBattlefield(filter, to?, excludeTo?, binding)` — factory. `to = GRAVEYARD`
@@ -3426,7 +3432,12 @@ composite abilities).
   enumerator gates affordability on the cheapest reachable cost (largest reduction over the
   currently-legal targets) since the target isn't chosen until activation. The synthesized ability
   carries `ActivatedAbility.isEquipAbility = true`, which the engine keys off for the equip-timing
-  and free-first-equip permissions below.
+  and free-first-equip permissions below. For a **non-mana equip cost** ("Equip—Sacrifice a
+  creature" — Dissection Tools) the `equipAbility(cost)` helper doesn't apply (it only parses a mana
+  cost); author the ability by hand as `activatedAbility { cost = Costs.Sacrifice(...); isEquipAbility
+  = true; timing = TimingRule.SorcerySpeed; … }`. The `activatedAbility { }` builder exposes
+  `isEquipAbility` so a hand-rolled equip ability still participates in equip-specific rules
+  (sorcery-speed default, equip-cost reductions, instant-speed-equip permissions).
 - `Fortify(cost)` — Aura-like attach cost on lands.
 
 ```kotlin
@@ -4778,7 +4789,10 @@ substitution.
   and whose `{5},{T}: draw` ability reads the count via `genericCostReduction` to cost `{1}` less per counter.
   Pure passive counters with no inherent rule; the cards that use them accumulate/spend them via their own
   abilities and read the count via `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.X))` — or, when a
-  self-sacrifice/exile cost wipes them first, `DynamicAmounts.lastKnownSourceCounters(...)` (CR 112.7a; see §13).)
+  self-sacrifice/exile cost wipes them first, `DynamicAmounts.lastKnownSourceCounters(...)` (CR 112.7a; see §13).
+  `rev` (`Counters.REV`): DSK — Chainsaw, whose "whenever one or more creatures die" batched trigger accumulates one
+  per death batch and whose `+X/+0` static reads the count via `DynamicAmounts.countersOnSelf(...)` applied to the
+  equipped creature — another pure passive counter with no inherent rule.)
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -52,7 +52,8 @@ enum class CounterType {
     LOOT,
     WIND,
     NEST,
-    PAGE
+    PAGE,
+    REV
 }
 
 /**
@@ -158,6 +159,13 @@ object Counters {
      * count to reduce an activated ability's cost. No inherent rule.
      */
     const val PAGE = "page"
+
+    /**
+     * Rev counter (DSK — Chainsaw). Passive storage counter with no inherent rule; the card's own
+     * abilities accumulate it (a "whenever one or more creatures die" trigger adds one) and read
+     * the count to scale the equipped creature's power bonus (+X/+0). No inherent rule.
+     */
+    const val REV = "rev"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1315,6 +1315,14 @@ class ActivatedAbilityBuilder {
     var effect: Effect? = null
     var target: TargetRequirement? = null
     var manaAbility: Boolean = false
+    /**
+     * When true, this is an equip ability (CR 702.6): it attaches an Equipment to a creature and
+     * participates in equip-specific rules — sorcery-speed by default, eligible for equip-cost
+     * reductions, and able to be activated at instant speed when an effect allows it. Set this for
+     * an "Equip—<non-mana cost>" ability (e.g. "Equip—Sacrifice a creature"); the simple mana
+     * `equipAbility(cost)` helper already sets it.
+     */
+    var isEquipAbility: Boolean = false
     var timing: TimingRule = TimingRule.InstantSpeed
     var restrictions: List<ActivationRestriction> = emptyList()
     var activateFromZone: Zone = Zone.BATTLEFIELD
@@ -1363,6 +1371,7 @@ class ActivatedAbilityBuilder {
             effect = effect!!,
             targetRequirements = targetRequirements,
             isManaAbility = manaAbility,
+            isEquipAbility = isEquipAbility,
             timing = timing,
             restrictions = restrictions,
             activateFromZone = activateFromZone,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1535,6 +1535,21 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * Whenever one or more creatures die — any player's creatures, regardless of who controls them.
+     * Same batched death trigger as [OneOrMoreCreaturesYouControlDie] with the controller scope
+     * widened to every player ([ControllerPredicate.ControlledByAny]); fires at most once per death
+     * batch regardless of how many creatures died (CR 603.3b), so a board wipe fires it once, not
+     * once per creature. Example: "Whenever one or more creatures die, put a rev counter on this
+     * Equipment." (Chainsaw).
+     */
+    fun OneOrMoreCreaturesDie(
+        filter: GameObjectFilter = GameObjectFilter.Creature
+    ): TriggerSpec = TriggerSpec(
+        event = CreaturesYouControlDiedEvent(filter = filter.anyController()),
+        binding = TriggerBinding.ANY
+    )
+
     // =========================================================================
     // Enter Battlefield Batch Triggers
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1683,6 +1683,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
                 when (filter.controllerPredicate) {
                     com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByOpponent ->
                         " an opponent controls die"
+                    com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByAny ->
+                        " die"
                     else -> " you control die"
                 }
             )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -702,6 +702,9 @@ data class GameObjectFilter(
     /** Must be controlled by an opponent */
     fun opponentControls() = copy(controllerPredicate = ControllerPredicate.ControlledByOpponent)
 
+    /** Controlled by any player (no controller scope) */
+    fun anyController() = copy(controllerPredicate = ControllerPredicate.ControlledByAny)
+
     /** Must be controlled by the active player (the player whose turn it is) */
     fun controlledByActivePlayer() = copy(controllerPredicate = ControllerPredicate.ControlledByActivePlayer)
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Chainsaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Chainsaw.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Chainsaw
+ * {1}{R}
+ * Artifact — Equipment
+ * When this Equipment enters, it deals 3 damage to up to one target creature.
+ * Whenever one or more creatures die, put a rev counter on this Equipment.
+ * Equipped creature gets +X/+0, where X is the number of rev counters on this Equipment.
+ * Equip {3}
+ *
+ * The "whenever one or more creatures die" trigger is the batched death shape
+ * ([Triggers.OneOrMoreCreaturesDie]): it fires at most once per death batch regardless of how many
+ * creatures died simultaneously and regardless of who controlled them (CR 603.3b), so a board wipe
+ * adds exactly one rev counter, not one per creature.
+ *
+ * Rev counters are passive storage counters (no inherent rule); the +X/+0 static reads the count off
+ * the Equipment (the source) via [DynamicAmounts.countersOnSelf] and applies it to the equipped
+ * creature ([Filters.EquippedCreature]).
+ */
+val Chainsaw = card("Chainsaw") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, it deals 3 damage to up to one target creature.\n" +
+        "Whenever one or more creatures die, put a rev counter on this Equipment.\n" +
+        "Equipped creature gets +X/+0, where X is the number of rev counters on this Equipment.\n" +
+        "Equip {3}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("up to one target creature", TargetCreature(optional = true, filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(3, t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesDie()
+        effect = Effects.AddCounters(Counters.REV, 1, EffectTarget.Self)
+    }
+
+    staticAbility {
+        val revCount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.REV))
+        ability = GrantDynamicStatsEffect(
+            filter = Filters.EquippedCreature,
+            powerBonus = revCount,
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "128"
+        artist = "J.P. Targete"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg?1726286325"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DissectionTools.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DissectionTools.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dissection Tools
+ * {5}
+ * Artifact — Equipment
+ * When this Equipment enters, manifest dread, then attach this Equipment to that creature.
+ * Equipped creature gets +2/+2 and has deathtouch and lifelink.
+ * Equip—Sacrifice a creature.
+ *
+ * Manifest dread (CR 701.62) stores the manifested creature under the pipeline collection
+ * "manifestDreadManifested" (see [Patterns.Library.manifestDread]); the follow-up attach targets
+ * that creature via [EffectTarget.PipelineTarget]. If the library is empty (no creature is
+ * manifested), there is nothing to attach and the attach step is a no-op.
+ *
+ * The equip cost is a non-mana cost ("Equip—Sacrifice a creature"), so it is modeled as an equip
+ * activated ability (`isEquipAbility = true`) whose cost sacrifices any creature — including the
+ * equipped one (the oracle says "a creature", not "another"). Sorcery-speed, like every equip.
+ */
+val DissectionTools = card("Dissection Tools") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, manifest dread, then attach this Equipment to that creature.\n" +
+        "Equipped creature gets +2/+2 and has deathtouch and lifelink.\n" +
+        "Equip—Sacrifice a creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.manifestDread(),
+            Effects.AttachEquipment(EffectTarget.PipelineTarget("manifestDreadManifested"))
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEATHTOUCH)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        isEquipAbility = true
+        timing = TimingRule.SorcerySpeed
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Diana Franco"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg?1726301876"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/KillersMask.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/KillersMask.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Killer's Mask
+ * {2}{B}
+ * Artifact — Equipment
+ * When this Equipment enters, manifest dread, then attach this Equipment to that creature. (Look at
+ * the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the
+ * other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)
+ * Equipped creature has menace.
+ * Equip {2}
+ *
+ * Manifest dread (CR 701.62) stores the manifested creature under the pipeline collection
+ * "manifestDreadManifested" (see [Patterns.Library.manifestDread]); the follow-up attach targets
+ * that creature via [EffectTarget.PipelineTarget]. If the library is empty (no creature is
+ * manifested), there is nothing to attach and the attach step is a no-op.
+ */
+val KillersMask = card("Killer's Mask") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, manifest dread, then attach this Equipment to that " +
+        "creature. (Look at the top two cards of your library. Put one onto the battlefield face " +
+        "down as a 2/2 creature and the other into your graveyard. Turn it face up any time for " +
+        "its mana cost if it's a creature card.)\n" +
+        "Equipped creature has menace.\n" +
+        "Equip {2}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.manifestDread(),
+            Effects.AttachEquipment(EffectTarget.PipelineTarget("manifestDreadManifested"))
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.MENACE)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Wero Gallo"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg?1726286237"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PatchedPlaything.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PatchedPlaything.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Patched Plaything
+ * {2}{W}
+ * Artifact Creature — Toy
+ * 4/3
+ * Double strike
+ * This creature enters with two -1/-1 counters on it if you cast it from your hand.
+ *
+ * The conditional enter-with-counters is a replacement effect (CR 614.12) whose condition is
+ * evaluated as the permanent enters: [Conditions.WasCastFromHand] reads the cast-origin marker
+ * stamped on the resolving permanent, so the two -1/-1 counters appear only on a hand-cast (not when
+ * it enters via a token-copy, reanimation, or any effect that puts it onto the battlefield without
+ * casting it from hand).
+ */
+val PatchedPlaything = card("Patched Plaything") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Toy"
+    power = 4
+    toughness = 3
+    oracleText = "Double strike\n" +
+        "This creature enters with two -1/-1 counters on it if you cast it from your hand."
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.MinusOneMinusOne,
+            count = 2,
+            selfOnly = true,
+            condition = Conditions.WasCastFromHand
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "Domenico Cava"
+        flavorText = "When it ripped, its owner attempted to fix it. Something went... wrong."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg?1726285949"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1251,6 +1251,122 @@
     ]
 }
 
+// Chainsaw
+{
+    "name": "Chainsaw",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on this Equipment.\nEquipped creature gets +X/+0, where X is the number of rev counters on this Equipment.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CreaturesYouControlDiedEvent",
+                    "filter": "creature ctrl:any"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "rev",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "rev"
+                        }
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "RARE",
+        "artist": "J.P. Targete",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg?1726286325"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Clammy Prowler
 {
     "name": "Clammy Prowler",
@@ -2238,6 +2354,137 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Dissection Tools
+{
+    "name": "Dissection Tools",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, manifest dread, then attach this Equipment to that creature.\nEquipped creature gets +2/+2 and has deathtouch and lifelink.\nEquip—Sacrifice a creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "manifestDreadLooked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "manifestDreadLooked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "manifestDreadManifested",
+                                    "storeRemainder": "manifestDreadGraveyard",
+                                    "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                    "remainderLabel": "Put into your graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadManifested",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "faceDown": "MANIFEST"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadGraveyard",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "manifestDreadManifested"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "RARE",
+        "artist": "Diana Franco",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg?1726301876"
+    },
+    "colorIdentityOverride": []
 }
 
 // Disturbing Mirth
@@ -5294,6 +5541,131 @@
     ]
 }
 
+// Killer's Mask
+{
+    "name": "Killer's Mask",
+    "manaCost": "{2}{B}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, manifest dread, then attach this Equipment to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has menace.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "manifestDreadLooked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "manifestDreadLooked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "manifestDreadManifested",
+                                    "storeRemainder": "manifestDreadGraveyard",
+                                    "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                    "remainderLabel": "Put into your graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadManifested",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "faceDown": "MANIFEST"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadGraveyard",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "manifestDreadManifested"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "UNCOMMON",
+        "artist": "Wero Gallo",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg?1726286237"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Leyline of Hope
 {
     "name": "Leyline of Hope",
@@ -6748,6 +7120,42 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Patched Plaything
+{
+    "name": "Patched Plaything",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact Creature — Toy",
+    "oracleText": "Double strike\nThis creature enters with two -1/-1 counters on it if you cast it from your hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": "MinusOneMinusOne",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasCastFromHand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "Domenico Cava",
+        "flavorText": "When it ripped, its owner attempted to fix it. Something went... wrong.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg?1726285949"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2353,6 +2353,19 @@ internal fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
 
 /** One non-And intervening-if condition node -> its `Conditions.*` DSL, or null (-> SCAFFOLD). */
 private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
+    // "if you cast it from your hand" — EnteringPermanentPassesFilter(CastByPlayerFromHand(You, You)):
+    // the entering permanent was cast from its controller's hand (Patched Plaything's "enters with two
+    // -1/-1 counters on it if you cast it from your hand"). Maps to Conditions.WasCastFromHand. Only the
+    // You/You scope renders; any other player scope has no calibrated DSL, so it declines -> SCAFFOLD.
+    if (cond.strField("_Condition") == "EnteringPermanentPassesFilter") {
+        val filter = cond["args"] as? JsonObject
+        if (filter?.strField("_Permanents") == "CastByPlayerFromHand") {
+            val players = filter["args"].asArr
+            val p0 = (players?.getOrNull(0) as? JsonObject)?.strField("_Player")
+            val p1 = (players?.getOrNull(1) as? JsonObject)?.strField("_Player")
+            if (p0 == "You" && p1 == "You") return "Conditions.WasCastFromHand"
+        }
+    }
     // "if it had counters on it" — DeadPermanentPassesFilter(HasACounter): the just-died permanent
     // (the triggering entity of a dies trigger) had at least one counter of any kind on it (Scolding
     // Administrator's "When this creature dies, if it had counters on it, …"). Maps to
@@ -3383,23 +3396,36 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject, condition: String? = null):
                 Call("EntersWithCounters", ewArgs)
             }
             "EntersWithNumberCounters" -> {
-                // "enters with N +1/+1 counters". A FIXED count (Integer) renders the static
+                // "enters with N +1/+1 (or -1/-1) counters". A FIXED count (Integer) renders the static
                 // EntersWithCounters(count = N); a dynamic count (Stag Beetle: number of other creatures —
                 // as it enters, self isn't on the battlefield, so the plain count IS "other") renders
-                // EntersWithDynamicCounters. Only the ±1/±1 counter with a recoverable amount renders.
+                // EntersWithDynamicCounters. Only the +1/+1 or -1/-1 counter with a recoverable amount
+                // renders; any other PTCounter ratio declines -> SCAFFOLD.
                 val a = rep["args"].asArr ?: run { reasons.add("AsPermanentEnters"); return null }
                 val counter = a.getOrNull(1) as? JsonObject
                 val pt = counter?.get("args").asArr
-                if (counter?.strField("_CounterType") != "PTCounter" || pt?.getOrNull(0).asInt() != 1 || pt?.getOrNull(1).asInt() != 1) {
-                    reasons.add("AsPermanentEnters"); return null
+                val px = pt?.getOrNull(0).asInt()
+                val py = pt?.getOrNull(1).asInt()
+                val counterTypeArg: Arg? = when {
+                    counter?.strField("_CounterType") != "PTCounter" -> { reasons.add("AsPermanentEnters"); return null }
+                    // +1/+1 -> default-filter EntersWithCounters (the PlusOnePlusOne default), no explicit arg.
+                    px == 1 && py == 1 -> null
+                    // -1/-1 (Patched Plaything) -> explicit MinusOneMinusOne filter.
+                    px == -1 && py == -1 -> arg("counterType", "CounterTypeFilter.MinusOneMinusOne")
+                    else -> { reasons.add("AsPermanentEnters"); return null }
                 }
                 val countNode = a.getOrNull(0) as? JsonObject
                 if (countNode?.strField("_GameNumber") == "Integer") {
                     val n = countNode["args"].asInt() ?: run { reasons.add("AsPermanentEnters"); return null }
-                    val ewArgs = mutableListOf(arg("count", "$n"), arg("selfOnly", "true"))
+                    val ewArgs = mutableListOf<Arg>()
+                    if (counterTypeArg != null) ewArgs.add(counterTypeArg)
+                    ewArgs.add(arg("count", "$n"))
+                    ewArgs.add(arg("selfOnly", "true"))
                     if (condition != null) ewArgs.add(arg("condition", condition))
                     Call("EntersWithCounters", ewArgs)
                 } else {
+                    // Dynamic count: only the +1/+1 default renders (no counterType param on the dynamic form).
+                    if (counterTypeArg != null) { reasons.add("AsPermanentEnters"); return null }
                     if (condition != null) { reasons.add("AsPermanentEnters"); return null } // no condition param on dynamic form
                     val amt = dynamicAmountExpr(a.getOrNull(0)) ?: run { reasons.add("AsPermanentEnters"); return null }
                     call("EntersWithDynamicCounters", arg("count", amt))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2099,6 +2099,8 @@ class TriggerDetector(
                 deathControllerId == controllerId
             com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByOpponent ->
                 deathControllerId in state.getOpponents(controllerId)
+            // "whenever one or more creatures die" — any controller's creatures count (Chainsaw).
+            com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByAny -> true
             else -> controllerPredicate.evaluateWith { leaf ->
                 when (leaf) {
                     com.wingedsheep.sdk.scripting.predicates.ControllerPredicate.ControlledByYou ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChainsawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChainsawScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chainsaw (DSK #128) — {1}{R} Artifact — Equipment.
+ *
+ *  - "When this Equipment enters, it deals 3 damage to up to one target creature."
+ *  - "Whenever one or more creatures die, put a rev counter on this Equipment." (any controller,
+ *    once per death batch — [com.wingedsheep.sdk.dsl.Triggers.OneOrMoreCreaturesDie]).
+ *  - "Equipped creature gets +X/+0, where X is the number of rev counters on this Equipment."
+ *  - "Equip {3}".
+ */
+class ChainsawScenarioTest : ScenarioTestBase() {
+
+    private fun revCounters(game: TestGame): Int {
+        val id = game.findPermanent("Chainsaw")!!
+        return game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.REV) ?: 0
+    }
+
+    init {
+        context("Chainsaw") {
+            test("ETB deals 3 damage to up to one target creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Chainsaw")
+                    .withCardOnBattlefield(2, "Centaur Courser") // 3/3
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val cast = game.castSpell(1, "Chainsaw")
+                withClue("Casting Chainsaw should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The ETB "deals 3 damage to up to one target creature" trigger pauses for its target.
+                val targetDecision = game.getPendingDecision() as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the ETB damage; got ${game.getPendingDecision()}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(courser))))
+                game.resolveStack()
+
+                withClue("3 damage kills the 3/3 Centaur Courser") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+            }
+
+            test("a single creature dying adds one rev counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chainsaw")
+                    .withCardOnBattlefield(2, "Glory Seeker") // 2/2
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val seeker = game.findPermanent("Glory Seeker")!!
+                game.castSpell(1, "Doom Blade", targetId = seeker)
+                game.resolveStack()
+
+                withClue("One creature died → one rev counter") { revCounters(game) shouldBe 1 }
+            }
+
+            test("a board wipe killing several creatures adds exactly one rev counter (once per batch)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chainsaw")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2, yours
+                    .withCardOnBattlefield(2, "Glory Seeker") // 2/2, opponent's
+                    .withCardOnBattlefield(2, "Glory Seeker") // 2/2, opponent's
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pyroclasm")
+                game.resolveStack()
+
+                withClue("All three 2/2s die to 2 damage") {
+                    game.findPermanents("Glory Seeker").size shouldBe 0
+                }
+                withClue("Three simultaneous deaths form one batch → exactly one rev counter") {
+                    revCounters(game) shouldBe 1
+                }
+            }
+
+            test("equipped creature gets +X/+0 where X is the rev counter count") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chainsaw")
+                    .withCardOnBattlefield(1, "Centaur Courser", summoningSickness = false) // 3/3
+                    .withCardOnBattlefield(2, "Glory Seeker") // 2/2, dies to add a rev counter
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chainsaw = game.findPermanent("Chainsaw")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val equipId = cardRegistry.getCard("Chainsaw")!!.script.activatedAbilities
+                    .first { it.isEquipAbility }.id
+
+                // Equip {3} → attach to the Courser.
+                val equip = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chainsaw,
+                        abilityId = equipId,
+                        targets = listOf(ChosenTarget.Permanent(courser))
+                    )
+                )
+                withClue("Equip should succeed: ${equip.error}") { equip.error shouldBe null }
+                game.resolveStack()
+
+                game.state.getEntity(chainsaw)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+                // No rev counters yet → +0/+0, base 3/3.
+                withClue("With 0 rev counters the Courser is an unbuffed 3/3") {
+                    game.state.projectedState.getPower(courser) shouldBe 3
+                    game.state.projectedState.getToughness(courser) shouldBe 3
+                }
+
+                // Kill the opponent's Glory Seeker → one rev counter.
+                val seeker = game.findPermanent("Glory Seeker")!!
+                game.castSpell(1, "Doom Blade", targetId = seeker)
+                game.resolveStack()
+                withClue("One creature died → one rev counter") { revCounters(game) shouldBe 1 }
+
+                withClue("+1/+0 from one rev counter → 4/3") {
+                    game.state.projectedState.getPower(courser) shouldBe 4
+                    game.state.projectedState.getToughness(courser) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DissectionToolsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DissectionToolsScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dissection Tools (DSK #245) — {5} Artifact — Equipment.
+ *
+ * "When this Equipment enters, manifest dread, then attach this Equipment to that creature."
+ * "Equipped creature gets +2/+2 and has deathtouch and lifelink." Equip—Sacrifice a creature.
+ */
+class DissectionToolsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dissection Tools") {
+            test("ETB manifests dread, attaches, and grants +2/+2, deathtouch, lifelink") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dissection Tools")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Dissection Tools")
+                withClue("Casting Dissection Tools should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for manifest dread; got ${game.getPendingDecision()}")
+                val manifestPick = decision.options.first()
+                game.submitDecision(CardsSelectedResponse(decisionId = decision.id, selectedCards = listOf(manifestPick)))
+                game.resolveStack()
+
+                val toolsId = game.findPermanent("Dissection Tools")!!
+                val attachedTo = game.state.getEntity(toolsId)?.get<AttachedToComponent>()
+                attachedTo.shouldNotBeNull()
+                attachedTo.targetId shouldBe manifestPick
+
+                withClue("+2/+2 on a 2/2 manifest = 4/4, with deathtouch and lifelink") {
+                    game.state.projectedState.getPower(manifestPick) shouldBe 4
+                    game.state.projectedState.getToughness(manifestPick) shouldBe 4
+                    game.state.projectedState.hasKeyword(manifestPick, Keyword.DEATHTOUCH) shouldBe true
+                    game.state.projectedState.hasKeyword(manifestPick, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("Equip—Sacrifice a creature: paying the cost sacrifices a creature and re-attaches the Tools") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dissection Tools")
+                    .withCardOnBattlefield(1, "Centaur Courser", summoningSickness = false) // target to equip
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)   // fodder to sacrifice
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val toolsId = game.findPermanent("Dissection Tools")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val equipId = cardRegistry.getCard("Dissection Tools")!!.script.activatedAbilities
+                    .first { it.isEquipAbility }.id
+
+                val equip = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = toolsId,
+                        abilityId = equipId,
+                        targets = listOf(ChosenTarget.Permanent(courser)),
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears))
+                    )
+                )
+                withClue("Equip—Sacrifice should succeed: ${equip.error}") { equip.error shouldBe null }
+                game.resolveStack()
+
+                withClue("The sacrificed Grizzly Bears left the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                game.state.getEntity(toolsId)?.get<AttachedToComponent>()?.targetId shouldBe courser
+                withClue("+2/+2 on the equipped 3/3 Courser = 5/5") {
+                    game.state.projectedState.getPower(courser) shouldBe 5
+                    game.state.projectedState.getToughness(courser) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillersMaskScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillersMaskScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Killer's Mask (DSK #104) — {2}{B} Artifact — Equipment.
+ *
+ * "When this Equipment enters, manifest dread, then attach this Equipment to that creature."
+ * "Equipped creature has menace." Equip {2}.
+ *
+ * Same manifest-dread-then-attach shape as Conductive Machete; here we additionally assert the
+ * equipped (manifested) creature gains menace through the projector.
+ */
+class KillersMaskScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Killer's Mask") {
+            test("ETB manifests dread and attaches to the manifested creature, granting menace") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Killer's Mask")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Killer's Mask")
+                withClue("Casting Killer's Mask should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for manifest dread; got ${game.getPendingDecision()}")
+                val manifestPick = decision.options.first()
+                game.submitDecision(CardsSelectedResponse(decisionId = decision.id, selectedCards = listOf(manifestPick)))
+                game.resolveStack()
+
+                withClue("The chosen card is a manifested 2/2 on the battlefield") {
+                    game.state.getEntity(manifestPick)?.get<ManifestedComponent>() shouldBe ManifestedComponent
+                    game.state.projectedState.getPower(manifestPick) shouldBe 2
+                    game.state.projectedState.getToughness(manifestPick) shouldBe 2
+                }
+
+                val maskId = game.findPermanent("Killer's Mask")!!
+                val attachedTo = game.state.getEntity(maskId)?.get<AttachedToComponent>()
+                attachedTo.shouldNotBeNull()
+                attachedTo.targetId shouldBe manifestPick
+
+                withClue("Equipped creature has menace") {
+                    game.state.projectedState.hasKeyword(manifestPick, Keyword.MENACE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatchedPlaythingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatchedPlaythingScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Patched Plaything (DSK #24) — {2}{W} Artifact Creature — Toy, 4/3, double strike.
+ *
+ * "This creature enters with two -1/-1 counters on it if you cast it from your hand."
+ *
+ * The conditional enter-with-counters is a replacement effect gated on
+ * [com.wingedsheep.sdk.dsl.Conditions.WasCastFromHand]: a hand-cast enters with two -1/-1 counters
+ * (a 2/1), while a permanent put onto the battlefield without being cast from hand enters at full
+ * 4/3.
+ */
+class PatchedPlaythingScenarioTest : ScenarioTestBase() {
+
+    private fun minusCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.MINUS_ONE_MINUS_ONE) ?: 0
+
+    init {
+        context("Patched Plaything") {
+            test("cast from hand: enters with two -1/-1 counters (a 2/1) and has double strike") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Patched Plaything")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Patched Plaything")
+                withClue("Casting Patched Plaything should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val id = game.findPermanent("Patched Plaything")!!
+                withClue("Two -1/-1 counters from the hand-cast condition") {
+                    minusCounters(game, id) shouldBe 2
+                }
+                withClue("4/3 base minus two -1/-1 counters = 2/1") {
+                    game.state.projectedState.getPower(id) shouldBe 2
+                    game.state.projectedState.getToughness(id) shouldBe 1
+                }
+                withClue("Double strike is present") {
+                    game.state.projectedState.hasKeyword(id, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+            }
+
+            test("put onto the battlefield without being cast from hand: no counters (full 4/3)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Patched Plaything")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val id = game.findPermanent("Patched Plaything")!!
+                withClue("Not cast from hand → no -1/-1 counters") {
+                    minusCounters(game, id) shouldBe 0
+                }
+                withClue("Full base stats 4/3") {
+                    game.state.projectedState.getPower(id) shouldBe 4
+                    game.state.projectedState.getToughness(id) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -108,4 +108,5 @@ export const counterManaClass: Record<string, string> = {
   WIND: 'counter-vortex',
   NEST: 'counter-fungus',
   PAGE: 'counter-lore',
+  REV: 'counter-bolt',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -669,6 +669,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.WIND,
   CounterType.NEST,
   CounterType.PAGE,
+  CounterType.REV,
 ]
 
 /**

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1782,6 +1782,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   WIND: { bg: 'rgba(20, 60, 55, 0.95)', border: 'rgba(120, 220, 200, 0.6)', color: '#9ce0d0' },
   NEST: { bg: 'rgba(25, 55, 25, 0.95)', border: 'rgba(120, 200, 110, 0.65)', color: '#a8e090', glow: 'rgba(120, 200, 110, 0.55)' },
   PAGE: { bg: 'rgba(35, 30, 55, 0.95)', border: 'rgba(160, 150, 220, 0.65)', color: '#bcb4e8', glow: 'rgba(160, 150, 220, 0.5)' },
+  REV: { bg: 'rgba(60, 30, 15, 0.95)', border: 'rgba(230, 140, 70, 0.7)', color: '#f0b070', glow: 'rgba(230, 140, 70, 0.55)' },
 }
 
 const fallbackCounterPalette: CounterBadgePalette = { bg: 'rgba(40, 40, 40, 0.95)', border: 'rgba(180, 180, 180, 0.6)', color: '#e0e0e0' }

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -371,6 +371,7 @@ export enum CounterType {
   WIND = 'WIND',
   NEST = 'NEST',
   PAGE = 'PAGE',
+  REV = 'REV',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -418,6 +419,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.WIND]: 'Wind',
   [CounterType.NEST]: 'Nest',
   [CounterType.PAGE]: 'Page',
+  [CounterType.REV]: 'Rev',
 }
 
 /**


### PR DESCRIPTION
Implements four Duskmourn: House of Horror (DSK) artifacts, all canonical in DSK (their earliest real printing).

## Cards

- **Chainsaw** `{1}{R}` Artifact — Equipment. When it enters, deals 3 damage to up to one target creature; "whenever one or more creatures die" puts a rev counter on it; equipped creature gets +X/+0 where X is the number of rev counters. Equip {3}. Uses a new unscoped batched death trigger + a new passive `rev` counter; the +X/+0 is `GrantDynamicStatsEffect(EquippedCreature, countersOnSelf(REV))`.
- **Killer's Mask** `{2}{B}` Artifact — Equipment. ETB manifest dread then attach; equipped creature has menace; equip {2}. Composes the existing manifest-dread + `AttachEquipment` pipeline (same shape as Conductive Machete).
- **Dissection Tools** `{5}` Artifact — Equipment. ETB manifest dread then attach; equipped creature gets +2/+2 and has deathtouch and lifelink; **Equip—Sacrifice a creature** (non-mana equip cost).
- **Patched Plaything** `{2}{W}` 4/3 Artifact Creature — Toy, double strike. Enters with two -1/-1 counters if cast from hand, via `EntersWithCounters(MinusOneMinusOne, condition = WasCastFromHand)`.

## SDK additions

- `CounterType.REV` / `Counters.REV` — passive storage counter (no inherent rule), plus frontend wiring (enum, display name, icon class, passive-counter badge palette).
- `Triggers.OneOrMoreCreaturesDie(filter)` — unscoped batched "whenever one or more creatures die" trigger (any controller, once per death batch). Backed by `ControllerPredicate.ControlledByAny` handled in `CreaturesYouControlDiedEvent` description + `TriggerDetector`, and a new `GameObjectFilter.anyController()` helper.
- `ActivatedAbilityBuilder.isEquipAbility` — lets a hand-rolled "Equip—<non-mana cost>" ability participate in equip-specific rules (sorcery-speed default, equip-cost reductions, instant-speed-equip permissions).
- `docs/card-sdk-language-reference.md` updated for all of the above.

## mtgish-tooling

- Emitter now renders Patched Plaything's conditional enters-with-counters: widened `EntersWithNumberCounters` to -1/-1 (`CounterTypeFilter.MinusOneMinusOne`) and taught `singleInterveningIfDsl` the `EnteringPermanentPassesFilter(CastByPlayerFromHand(You, You))` → `Conditions.WasCastFromHand` condition. Patched Plaything now AUTO-emits and is gameplay-tree equivalent to the golden.
- Killer's Mask already AUTO-emits and matches the golden. Chainsaw and Dissection Tools correctly **decline to SCAFFOLD** (rev-counter mechanic / equip-sacrifice cost the emitter doesn't model — rendering wrong would be worse).
- **POR stays 0-mismatch** (GATE PASS). The 6 remaining DSK gate mismatches are pre-existing and unrelated to these cards. The hermetic `EmitterGoldenTest` is unchanged (the emitter change is purely additive — it only renders shapes that previously declined), so no golden rebless was needed.

## Tests

- 10 scenario tests across the four cards (rules-engine), all passing — covers ETB damage targeting, rev-counter accumulation (single death + board wipe once-per-batch), +X/+0 buff, manifest-dread-then-attach, granted keywords, the non-mana equip-sacrifice cost, and the cast-from-hand-conditional -1/-1 counters.
- Card snapshot re-blessed (`DSK.json`, only the four cards added; no other card moved).
- Full `:rules-engine:test` and `:mtgish-tooling:test` green; all main modules compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)