### PR TITLE
DSK batch 3: 4 Duskmourn cards + mtgish FindAGenericCard search recovery

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CynicalLoner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CynicalLoner.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cynical Loner
+ * {1}{B}
+ * Creature — Human Survivor
+ * 3/1
+ *
+ * This creature can't be blocked by Glimmers.
+ * Survival — At the beginning of your second main phase, if this creature is tapped, you may
+ * search your library for a card, put it into your graveyard, then shuffle.
+ *
+ * "Survival" is an ability word (no rules meaning) — modeled as a postcombat-main-phase trigger
+ * ([Triggers.YourPostcombatMain]) with an intervening-if ([Conditions.SourceIsTapped], CR 603.4 —
+ * checked both when it would trigger and on resolution). The search is "for a card" (any card,
+ * [GameObjectFilter.Any]) to the graveyard, and is optional ("you may"), so it's wrapped in a
+ * [MayEffect]; when you don't search, no shuffle happens. The unblockable-by clause is the unified
+ * [CantBeBlockedBy] static over the Glimmer subtype.
+ */
+val CynicalLoner = card("Cynical Loner") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Survivor"
+    power = 3
+    toughness = 1
+    oracleText = "This creature can't be blocked by Glimmers.\n" +
+        "Survival — At the beginning of your second main phase, if this creature is tapped, you " +
+        "may search your library for a card, put it into your graveyard, then shuffle."
+
+    staticAbility {
+        ability = CantBeBlockedBy(
+            blockerFilter = GameObjectFilter.Creature.withSubtype("Glimmer")
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = MayEffect(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                destination = SearchDestination.GRAVEYARD,
+                shuffleAfter = true,
+            )
+        )
+        description = "Survival — At the beginning of your second main phase, if this creature is " +
+            "tapped, you may search your library for a card, put it into your graveyard, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Miranda Meeks"
+        flavorText = "\"Thanks, but no thanks. I'm done with hope.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg?1726286181"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FanaticOfTheHarrowing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FanaticOfTheHarrowing.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fanatic of the Harrowing
+ * {3}{B}
+ * Creature — Human Cleric
+ * 2/2
+ *
+ * When this creature enters, each player discards a card. If you discarded a card this way, draw a card.
+ *
+ * Modeled as an enters trigger. Each player discards one card: opponents via
+ * [Patterns.Hand.eachOpponentDiscards], and the controller's discard is wrapped in an
+ * [Effects.IfYouDo] so the follow-up draw only happens when the controller actually had a card to
+ * discard (CR — "If you discarded a card this way"). [SuccessCriterion.Auto] infers the gate from
+ * the discard pipeline's terminal move to the graveyard, so an empty-handed controller draws
+ * nothing. A player with an empty hand simply doesn't discard.
+ */
+val FanaticOfTheHarrowing = card("Fanatic of the Harrowing") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, each player discards a card. If you discarded a card " +
+        "this way, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Hand.eachOpponentDiscards(1),
+            Effects.IfYouDo(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(1),
+            ),
+        )
+        description = "When this creature enters, each player discards a card. If you discarded a " +
+            "card this way, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"Valgavoth wants our pain, our terror! We cannot join him unless we suffer!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg?1726286207"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PopularEgotist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PopularEgotist.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Popular Egotist
+ * {2}{B}
+ * Creature — Human Rogue
+ * 3/2
+ *
+ * {1}{B}, Sacrifice another creature or enchantment: This creature gains indestructible until end
+ * of turn. Tap it.
+ * Whenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life.
+ *
+ * The activated ability's cost is mana + sacrifice another creature or enchantment
+ * ([Costs.SacrificeAnother] over [GameObjectFilter.CreatureOrEnchantment]). It grants this creature
+ * indestructible until end of turn ([Duration.EndOfTurn]) and taps it.
+ *
+ * The sacrifice trigger ([Triggers.YouSacrificeOneOrMore] over any permanent) is a batching trigger
+ * that fires once per sacrifice event — including the activated ability's own sacrifice cost — and
+ * drains a chosen opponent ([Targets.Opponent] loses 1 life, controller gains 1 life).
+ */
+val PopularEgotist = card("Popular Egotist") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 3
+    toughness = 2
+    oracleText = "{1}{B}, Sacrifice another creature or enchantment: This creature gains " +
+        "indestructible until end of turn. Tap it.\n" +
+        "Whenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.CreatureOrEnchantment)
+        )
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self, Duration.EndOfTurn),
+            Effects.Tap(EffectTarget.Self)
+        )
+        description = "This creature gains indestructible until end of turn. Tap it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeOneOrMore(GameObjectFilter.Permanent)
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, opponent),
+            GainLifeEffect(1)
+        )
+        description = "Whenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "114"
+        artist = "Julia Metzger"
+        flavorText = "\"I know you'd want me to live, bestie!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg?1726286273"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SilentHallcreeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SilentHallcreeper.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Silent Hallcreeper
+ * {1}{U}
+ * Enchantment Creature — Horror
+ * 1/1
+ *
+ * This creature can't be blocked.
+ * Whenever this creature deals combat damage to a player, choose one that hasn't been chosen —
+ * • Put two +1/+1 counters on this creature.
+ * • Draw a card.
+ * • This creature becomes a copy of another target creature you control.
+ *
+ * "Choose one that hasn't been chosen" is modeled with [ModalEffect.chooseOneNotYetChosen]: the
+ * engine remembers which modes this Hallcreeper has already chosen and never offers them again, so
+ * across multiple combat-damage triggers each mode is used at most once. Once all three have been
+ * chosen the ability does nothing.
+ *
+ * The copy mode targets "another target creature you control" ([Targets.OtherCreatureYouControl])
+ * and makes this creature ([EffectTarget.Self], `affected`) become a copy of that target until it
+ * leaves play (the copy is permanent per the card — no duration clause), copying copiable values
+ * only (Rule 707).
+ */
+val SilentHallcreeper = card("Silent Hallcreeper") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Horror"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked.\n" +
+        "Whenever this creature deals combat damage to a player, choose one that hasn't been chosen —\n" +
+        "• Put two +1/+1 counters on this creature.\n" +
+        "• Draw a card.\n" +
+        "• This creature becomes a copy of another target creature you control."
+
+    staticAbility {
+        ability = CantBeBlocked()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = ModalEffect.chooseOneNotYetChosen(
+            // • Put two +1/+1 counters on this creature.
+            Mode.noTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+                "Put two +1/+1 counters on this creature"
+            ),
+            // • Draw a card.
+            Mode.noTarget(
+                Effects.DrawCards(1),
+                "Draw a card"
+            ),
+            // • This creature becomes a copy of another target creature you control.
+            Mode.withTarget(
+                Effects.EachPermanentBecomesCopyOfTarget(
+                    target = EffectTarget.ContextTarget(0),
+                    duration = Duration.Permanent,
+                    affected = EffectTarget.Self,
+                ),
+                Targets.OtherCreatureYouControl,
+                "This creature becomes a copy of another target creature you control"
+            )
+        )
+        description = "Whenever this creature deals combat damage to a player, choose one that " +
+            "hasn't been chosen — Put two +1/+1 counters on this creature; or draw a card; or this " +
+            "creature becomes a copy of another target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "72"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg?1726286122"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2031,6 +2031,98 @@
     ]
 }
 
+// Cynical Loner
+{
+    "name": "Cynical Loner",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Survivor",
+    "oracleText": "This creature can't be blocked by Glimmers.\nSurvival — At the beginning of your second main phase, if this creature is tapped, you may search your library for a card, put it into your graveyard, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            "ShuffleLibrary"
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "descriptionOverride": "Survival — At the beginning of your second main phase, if this creature is tapped, you may search your library for a card, put it into your graveyard, then shuffle."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Glimmer"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Miranda Meeks",
+        "flavorText": "\"Thanks, but no thanks. I'm done with hope.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg?1726286181"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Daggermaw Megalodon
 {
     "name": "Daggermaw Megalodon",
@@ -3176,6 +3268,133 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Fanatic of the Harrowing
+{
+    "name": "Fanatic of the Harrowing",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature enters, each player discards a card. If you discarded a card this way, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "EachOpponent"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.DoAction",
+                                "action": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, each player discards a card. If you discarded a card this way, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "\"Valgavoth wants our pain, our terror! We cannot join him unless we suffer!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg?1726286207"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -7478,6 +7697,108 @@
     ]
 }
 
+// Popular Egotist
+{
+    "name": "Popular Egotist",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "{1}{B}, Sacrifice another creature or enchantment: This creature gains indestructible until end of turn. Tap it.\nWhenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "permanent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|enchantment",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "This creature gains indestructible until end of turn. Tap it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Metzger",
+        "flavorText": "\"I know you'd want me to live, bestie!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg?1726286273"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Possessed Goat
 {
     "name": "Possessed Goat",
@@ -8662,6 +8983,84 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Silent Hallcreeper
+{
+    "name": "Silent Hallcreeper",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment Creature — Horror",
+    "oracleText": "This creature can't be blocked.\nWhenever this creature deals combat damage to a player, choose one that hasn't been chosen —\n• Put two +1/+1 counters on this creature.\n• Draw a card.\n• This creature becomes a copy of another target creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 2,
+                                "target": "Self"
+                            },
+                            "description": "Put two +1/+1 counters on this creature"
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "EachPermanentBecomesCopyOfTarget",
+                                "affected": "Self"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you",
+                                        "excludeSelf": true
+                                    }
+                                }
+                            ],
+                            "description": "This creature becomes a copy of another target creature you control"
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, choose one that hasn't been chosen — Put two +1/+1 counters on this creature; or draw a card; or this creature becomes a copy of another target creature you control."
+            }
+        ],
+        "staticAbilities": [
+            "CantBeBlocked"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg?1726286122"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -739,6 +739,11 @@ internal fun EmitCtx.renderSearch(args: JsonElement?): Dsl? {
         searchSubtype != null -> "GameObjectFilter.Any.withSubtype(\"$searchSubtype\")"  // "an Elf card"
         enchSubtype != null -> "GameObjectFilter.Enchantment.withSubtype(\"$enchSubtype\")"  // "an Aura card"
         unionTypes != null -> cardTypeUnionFilter(unionTypes) ?: return null
+        // "search your library for a card" (Cynical Loner) — `FindAGenericCard` is the IR marker for an
+        // unrestricted search with NO type/subtype filter. Render `GameObjectFilter.Any` directly rather
+        // than falling through to `landSearchFilterDsl`, whose oracle-substring heuristics ("creature"
+        // appears in this card's unrelated "this creature" wording) would wrongly narrow the search.
+        "FindAGenericCard" in blob -> "GameObjectFilter.Any"
         else -> landSearchFilterDsl(args)
     }
     // "a legendary creature card" (Time of Need): a positive supertype the type search filter drops.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskBatch3CombatSacrificeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskBatch3CombatSacrificeScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.PopularEgotist
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * DSK batch 3 — combat-damage modal trigger and sacrifice payoff.
+ *
+ *  - Silent Hallcreeper (#72)  — {1}{U} 1/1 Enchantment Creature. Can't be blocked.
+ *      Whenever it deals combat damage to a player, choose one that hasn't been chosen —
+ *      put two +1/+1 counters; draw a card; or become a copy of another target creature you control.
+ *  - Popular Egotist (#114)    — {2}{B} 3/2 Human Rogue.
+ *      {1}{B}, Sacrifice another creature or enchantment: gains indestructible EOT, tap it.
+ *      Whenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life.
+ */
+class DskBatch3CombatSacrificeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.advanceToPlayer1DeclareAttackers() {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.DECLARE_ATTACKERS)
+            safety++
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("Silent Hallcreeper — combat damage offers the modal choice; +1/+1 mode adds two counters") {
+        val driver = createDriver()
+        driver.registerCard(PopularEgotist) // unused here; keeps registration symmetric
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val me = driver.player1
+        val opp = driver.player2
+        val creeper = driver.putCreatureOnBattlefield(me, "Silent Hallcreeper")
+        driver.removeSummoningSickness(creeper)
+
+        driver.advanceToPlayer1DeclareAttackers()
+        driver.declareAttackers(me, listOf(creeper), opp)
+        driver.bothPass() // to declare blockers
+        driver.declareNoBlockers(opp)
+        driver.bothPass() // into combat damage; trigger goes on the stack
+
+        // Resolve into the modal ChooseOptionDecision.
+        var guard = 0
+        while (driver.pendingDecision !is ChooseOptionDecision && guard < 20) {
+            driver.bothPass(); guard++
+        }
+        val choice = driver.pendingDecision as? ChooseOptionDecision
+            ?: error("expected ChooseOptionDecision for the modal trigger; got ${driver.pendingDecision}")
+        choice.options.size shouldBe 3
+
+        val counterMode = "Put two +1/+1 counters on this creature"
+        choice.options shouldContain counterMode
+        driver.submitDecision(me, OptionChosenResponse(choice.id, choice.options.indexOf(counterMode)))
+        driver.bothPass()
+
+        val counters = driver.state.getEntity(creeper)?.get<CountersComponent>()?.counters ?: emptyMap()
+        counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 2
+        // 1/1 base + two +1/+1 = 3/3
+        projector.getProjectedPower(driver.state, creeper) shouldBe 3
+        projector.getProjectedToughness(driver.state, creeper) shouldBe 3
+    }
+
+    test("Popular Egotist — sacrificing a permanent drains a target opponent for 1") {
+        val driver = createDriver()
+        driver.registerCard(PopularEgotist)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val egotist = driver.putCreatureOnBattlefield(me, "Popular Egotist")
+        driver.removeSummoningSickness(egotist)
+        // One fodder creature (NOT another Egotist, so only one drain trigger fires) to sacrifice
+        // for the activated ability's "Sacrifice another creature or enchantment" cost.
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(fodder)
+
+        val abilityId = PopularEgotist.activatedAbilities.first().id
+        driver.giveMana(me, Color.BLACK, 2)
+
+        // Activate {1}{B}, Sacrifice another creature: with one fodder the sacrifice is deterministic.
+        // The drain trigger ("whenever you sacrifice a permanent") targets the opponent.
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = egotist,
+                abilityId = abilityId,
+                targets = emptyList()
+            )
+        ).isSuccess shouldBe true
+
+        // Resolve until the drain trigger needs a target, then point it at the opponent.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() || driver.pendingDecision != null) {
+            if (driver.pendingDecision != null) {
+                driver.submitTargetSelection(me, listOf(opp))
+            } else {
+                driver.bothPass()
+            }
+            if (guard++ > 30) break
+        }
+
+        driver.getLifeTotal(opp) shouldBe 19
+        driver.getLifeTotal(me) shouldBe 21
+
+        // The Egotist itself is now tapped and indestructible (EOT); the fodder is gone.
+        driver.state.getBattlefield().contains(fodder) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskBatch3SurvivalEtbScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskBatch3SurvivalEtbScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * DSK batch 3 — Survival and enters-the-battlefield cards.
+ *
+ *  - Cynical Loner (#89)          — {1}{B} 3/1 Human Survivor. Can't be blocked by Glimmers.
+ *      Survival: if tapped at second main, may search library for a card to the graveyard, shuffle.
+ *  - Fanatic of the Harrowing (#96) — {3}{B} 2/2 Human Cleric. ETB: each player discards a card;
+ *      if you discarded a card this way, draw a card.
+ */
+class DskBatch3SurvivalEtbScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cynical Loner — Survival (mill self to graveyard)") {
+            test("a tapped Cynical Loner searches a card from library to graveyard at second main") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cynical Loner", tapped = true)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                val p1 = com.wingedsheep.sdk.model.EntityId.of("player-1")
+                // Drive: the Survival ability is a MayEffect → first a YesNo ("you may search"),
+                // then a SelectCards library search. Answer yes, then pick the Swamp.
+                var guard = 0
+                while (!game.isInGraveyard(1, "Swamp") && guard < 30) {
+                    val decision = game.state.pendingDecision
+                    when (decision) {
+                        is com.wingedsheep.engine.core.YesNoDecision -> game.answerYesNo(true)
+                        is com.wingedsheep.engine.core.SelectCardsDecision -> {
+                            val swampInLib = game.state.getLibrary(p1).first { id ->
+                                game.state.getEntity(id)
+                                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Swamp"
+                            }
+                            game.selectCards(listOf(swampInLib))
+                        }
+                        else -> game.resolveStack()
+                    }
+                    guard++
+                }
+
+                withClue("the chosen card is now in the graveyard") {
+                    game.isInGraveyard(1, "Swamp") shouldBe true
+                }
+            }
+
+            test("an untapped Cynical Loner does NOT fire Survival") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cynical Loner", tapped = false)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(5) { if (!game.hasPendingDecision()) game.resolveStack() }
+
+                withClue("no Survival selection — the Loner is untapped") {
+                    game.hasPendingDecision() shouldBe false
+                    game.isInGraveyard(1, "Swamp") shouldBe false
+                }
+            }
+        }
+
+        context("Fanatic of the Harrowing — ETB discard then draw") {
+            test("each player discards a card and the controller draws back when they discarded") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fanatic of the Harrowing")
+                    .withCardInHand(1, "Swamp")           // controller's discard fodder
+                    .withCardInHand(2, "Forest")          // opponent's discard fodder
+                    .withCardInLibrary(1, "Mountain")     // controller's replacement draw
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Fanatic of the Harrowing").error shouldBe null
+                game.resolveStack()
+
+                // Discards may pause for a card selection per player; auto-resolve single options.
+                var guard = 0
+                while (game.hasPendingDecision() && guard < 20) {
+                    val decision = game.state.pendingDecision
+                    if (decision is ChooseTargetsDecision) break
+                    // SelectCards decisions: each player has exactly one discardable card here,
+                    // so feeding it the only option is deterministic.
+                    val p1 = com.wingedsheep.sdk.model.EntityId.of("player-1")
+                    val p2 = com.wingedsheep.sdk.model.EntityId.of("player-2")
+                    val swamp = game.state.getHand(p1).firstOrNull { id ->
+                        game.state.getEntity(id)
+                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Swamp"
+                    }
+                    val forest = game.state.getHand(p2).firstOrNull { id ->
+                        game.state.getEntity(id)
+                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Forest"
+                    }
+                    when {
+                        swamp != null -> game.selectCards(listOf(swamp))
+                        forest != null -> game.selectCards(listOf(forest))
+                        else -> game.resolveStack()
+                    }
+                    game.resolveStack()
+                    guard++
+                }
+
+                withClue("controller discarded the Swamp") { game.isInGraveyard(1, "Swamp") shouldBe true }
+                withClue("opponent discarded the Forest") { game.isInGraveyard(2, "Forest") shouldBe true }
+                withClue("controller drew a replacement (the Mountain)") {
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards implemented (Duskmourn: House of Horror)

All four auto-register via the `dsk/cards` package scan (`CardDiscovery.findIn`), so no set-file edit was needed. Oracle text verified verbatim against Scryfall.

- **Cynical Loner** (#89, {1}{B} 3/1 Human Survivor) — can't be blocked by Glimmers (`CantBeBlockedBy`); Survival trigger at your second main, intervening-if `SourceIsTapped`, optional (`MayEffect`) search your library for any card to your graveyard, then shuffle.
- **Fanatic of the Harrowing** (#96, {3}{B} 2/2 Human Cleric) — ETB: each opponent discards a card; the controller's own discard is wrapped in `IfYouDo` so the follow-up draw only happens when they actually had a card to discard.
- **Popular Egotist** (#114, {2}{B} 3/2 Human Rogue) — `{1}{B}, Sacrifice another creature or enchantment`: gains indestructible until end of turn and taps itself; sacrifice-batch trigger (`YouSacrificeOneOrMore`) drains a target opponent for 1 and gains you 1.
- **Silent Hallcreeper** (#72, {1}{U} 1/1 Enchantment Creature) — can't be blocked; combat-damage `chooseOneNotYetChosen` modal (two +1/+1 counters / draw a card / become a copy of another target creature you control).

No new engine/SDK features were required — all four compose existing primitives.

## Tests

- `DskBatch3CombatSacrificeScenarioTest` — Silent Hallcreeper modal (+1/+1 mode) and Popular Egotist sacrifice → drain.
- `DskBatch3SurvivalEtbScenarioTest` — Cynical Loner Survival (fires tapped, no-op untapped) and Fanatic ETB discard-then-draw.
- All 5 scenario tests pass; `CardLintTest` green; DSK card snapshot golden re-blessed (only the 4 new cards added, no other diffs).

## mtgish auto-gen change

Emitter `renderSearch` now recognizes the `FindAGenericCard` IR marker and renders `GameObjectFilter.Any` directly, before the `landSearchFilterDsl` fallthrough. That fallthrough's oracle-substring heuristic was wrongly narrowing an unrestricted "search your library for a card" to `GameObjectFilter.Creature` because Cynical Loner's *unrelated* text contains the word "creature" ("this creature is tapped"). This is a faithful-render fix, not a widening.

- `just coverage-verify POR` → **158/158 GATE PASS** (0 mismatch).
- `EmitterGoldenTest` unchanged across all committed sets (10E/CHK/EOE/INR/ISD/ONS/POR/RAV/SOS/TMP) — no re-bless needed.
- With the fix, Cynical Loner emits faithfully at AUTO tier; Fanatic (`EachPlayerAction`), Popular Egotist (sacrifice-batch `trigger-shape`), and Silent Hallcreeper (`modal-trigger`) correctly decline to SCAFFOLD rather than emit lossy approximations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)