### PR TITLE
Add Floodpits Drowner + Wickerfolk Thresher (DSK) + mtgish recovery

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FloodpitsDrowner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FloodpitsDrowner.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Floodpits Drowner
+ * {1}{U}
+ * Creature — Merfolk
+ * 2/1
+ *
+ * Flash
+ * Vigilance
+ * When this creature enters, tap target creature an opponent controls and put a stun counter on it.
+ * {1}{U}, {T}: Shuffle this creature and target creature with a stun counter on it into their
+ * owners' libraries.
+ *
+ * The ETB is the shared "tap + stun" shape (a stun counter replaces the next untap — the Grappling
+ * Kraken / Kitnap idiom). The activated ability shuffles two permanents into their owners'
+ * libraries: the source itself ([EffectTarget.Self]) plus a target creature carrying a stun
+ * counter, modelled as two sequential [Effects.ShuffleIntoLibrary] moves (each goes to its own
+ * owner's library).
+ */
+val FloodpitsDrowner = card("Floodpits Drowner") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    power = 2
+    toughness = 1
+    oracleText = "Flash\nVigilance\nWhen this creature enters, tap target creature an opponent " +
+        "controls and put a stun counter on it.\n{1}{U}, {T}: Shuffle this creature and target " +
+        "creature with a stun counter on it into their owners' libraries."
+
+    keywords(Keyword.FLASH, Keyword.VIGILANCE)
+
+    // When this creature enters, tap target creature an opponent controls and put a stun counter on it.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            AddCountersEffect(counterType = Counters.STUN, count = 1, target = t)
+        )
+    }
+
+    // {1}{U}, {T}: Shuffle this creature and target creature with a stun counter on it into their
+    // owners' libraries.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withCounter(Counters.STUN)))
+        )
+        effect = Effects.ShuffleIntoLibrary(EffectTarget.Self)
+            .then(Effects.ShuffleIntoLibrary(t))
+        description = "{1}{U}, {T}: Shuffle this creature and target creature with a stun counter " +
+            "on it into their owners' libraries."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "John Tedrick"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg?1726286073"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WickerfolkThresher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WickerfolkThresher.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wickerfolk Thresher
+ * {3}{G}
+ * Artifact Creature — Scarecrow
+ * 5/4
+ *
+ * Delirium — Whenever this creature attacks, if there are four or more card types among cards in
+ * your graveyard, look at the top card of your library. If it's a land card, you may put it onto
+ * the battlefield. If you don't put the card onto the battlefield, put it into your hand.
+ *
+ * Delirium is an ability word (no rules meaning of its own); the attack trigger carries an
+ * intervening-"if" gate of [Conditions.Delirium] (four+ distinct card types in your graveyard).
+ * The payoff is the look-top / play-land-else-hand pipeline (Fecund Greenshell shape), except the
+ * land enters untapped ([ZonePlacement.Default]). Card types counted are artifact, battle,
+ * creature, enchantment, instant, kindred, land, planeswalker, sorcery — supertypes and subtypes
+ * don't count.
+ */
+val WickerfolkThresher = card("Wickerfolk Thresher") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 5
+    toughness = 4
+    oracleText = "Delirium — Whenever this creature attacks, if there are four or more card types " +
+        "among cards in your graveyard, look at the top card of your library. If it's a land card, " +
+        "you may put it onto the battlefield. If you don't put the card onto the battlefield, put " +
+        "it into your hand."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.Delirium()
+        effect = Effects.Composite(
+            listOf(
+                // Look at the top card of your library.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "looked",
+                ),
+                // Split into land and non-land.
+                FilterCollectionEffect(
+                    from = "looked",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
+                    storeMatching = "landCards",
+                    storeNonMatching = "nonLandCards"
+                ),
+                // If it's a land, you may put it onto the battlefield; else it stays for hand.
+                SelectFromCollectionEffect(
+                    from = "landCards",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "landToHand",
+                    selectedLabel = "Put onto the battlefield",
+                    remainderLabel = "Put into your hand"
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                ),
+                // If you don't put the card onto the battlefield, put it into your hand
+                // (both the declined land and any non-land top card).
+                MoveCollectionEffect(
+                    from = "landToHand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "nonLandCards",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "WolfSkullJack"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg?1726286638"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -4055,6 +4055,128 @@
     ]
 }
 
+// Floodpits Drowner
+{
+    "name": "Floodpits Drowner",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "Flash\nVigilance\nWhen this creature enters, tap target creature an opponent controls and put a stun counter on it.\n{1}{U}, {T}: Shuffle this creature and target creature with a stun counter on it into their owners' libraries.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Library",
+                            "placement": "Shuffled"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "destination": "Library",
+                            "placement": "Shuffled"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "HasCounter",
+                                        "counterType": "stun"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}{U}, {T}: Shuffle this creature and target creature with a stun counter on it into their owners' libraries."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "John Tedrick",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg?1726286073"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Frantic Strength
 {
     "name": "Frantic Strength",
@@ -10745,6 +10867,114 @@
         "artist": "Olivier Bernard",
         "flavorText": "Valgavoth harbors a special loathing for dogs, whose mere presence provides a powerful antidote to the fear he craves.",
         "imageUri": "https://cards.scryfall.io/normal/front/2/5/25ed97f2-b47e-49b7-9b1a-694c4bbeca3b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wickerfolk Thresher
+{
+    "name": "Wickerfolk Thresher",
+    "manaCost": "{3}{G}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "Delirium — Whenever this creature attacks, if there are four or more card types among cards in your graveyard, look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "landCards",
+                            "storeNonMatching": "nonLandCards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "landCards",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "landToHand",
+                            "selectedLabel": "Put onto the battlefield",
+                            "remainderLabel": "Put into your hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "landToHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "nonLandCards",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "WolfSkullJack",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg?1726286638"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -19,6 +19,10 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("PutGraveyardCardIntoHand", "MoveCollection graveyard->hand", composes = listOf("MoveToZone"))
     composed("PutGraveyardCardOntoBattlefield", "MoveCollection graveyard->battlefield (reanimate)", composes = listOf("MoveToZone"))
     composed("ShuffleGraveyardCardIntoLibrary", "MoveCollection + ShuffleLibrary", composes = listOf("MoveToZone", "ShuffleLibrary"))
+    // "Shuffle this creature and target creature ... into their owners' libraries" (Floodpits Drowner):
+    // two sequential Effects.ShuffleIntoLibrary moves (self + bound target), each into its own owner's
+    // library. The emitter renders only the self + one-bound-target `Or` shape; other groups scaffold.
+    composed("ShuffleEachPermanentIntoLibrary", "self + target ShuffleIntoLibrary (each to owner's library)", composes = listOf("MoveToZone", "ShuffleLibrary"))
     composed("ReturnDeadGraveyardCardToTopOfLibrary", "MoveCollection -> library top", composes = listOf("MoveToZone"))
     composed("PutGraveyardCardOnBottomOfLibrary", "MoveCollection -> library bottom (Tomb Trawler)", composes = listOf("MoveToZone"))
     composed("ReturnGraveyardCardToHand", UNIVERSAL, composes = listOf("MoveToZone"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -250,6 +250,33 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         }
         return Call("TargetFilter", listOf(arg(g)))
     }
+    // "target creature with a <kind> counter on it" (HasACounterOfType) — Floodpits Drowner's "target
+    // creature with a stun counter on it". The named state predicate lives on GameObjectFilter
+    // (.withCounter(Counters.X)), not on the TargetFilter surface, so render the GameObjectFilter form
+    // wrapped in TargetFilter — matching the hand-authored `TargetFilter(GameObjectFilter.Creature
+    // .withCounter(Counters.STUN))`. Guard strictly: only the bare Creature + counter shape (optionally a
+    // You/Opponent controller); any other predicate would be silently dropped, so decline -> SCAFFOLD.
+    // The counter kind must be one counterTypeDsl can name exactly, else decline rather than widen.
+    run {
+        val counterNodes = filterNode.nodesTagged("HasACounterOfType")
+        if (counterNodes.size == 1) {
+            val otherPredicates = listOf(
+                "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "PowerIs", "ToughnessIs", "ManaValueIs",
+                "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken", "IsCreatureType",
+                "IsNonCreatureType", "IsNonCardtype", "Other", "WasDealtDamageThisTurn",
+            )
+            if (otherPredicates.none { it in blob }) {
+                val counter = counterTypeDsl(counterNodes.first()["args"]) ?: return null
+                var g: Dsl = Lit("GameObjectFilter.Creature").dot("withCounter", arg(counter))
+                when {
+                    "\"You\"" in blob -> g = g.dot("youControl")
+                    "\"Opponent\"" in blob -> g = g.dot("opponentControls")
+                    "ControlledByAPlayer" in blob -> return null  // unrenderable controller ref -> SCAFFOLD
+                }
+                return Call("TargetFilter", listOf(arg(g)))
+            }
+        }
+    }
     // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
     // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
     val nonCardtypes = filterNode.argWordsTagged("IsNonCardtype")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.findRef
@@ -338,6 +339,29 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     on("ShuffleGraveyardCardIntoLibrary") { _, args, tvar ->  // e.g. Alabaster Dragon
         val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
         call("Effects.Move", arg(Lit(tgt)), arg("Zone.LIBRARY"), arg("ZonePlacement.Shuffled"))
+    }
+
+    // "Shuffle this creature and target creature with a stun counter on it into their owners'
+    // libraries" (Floodpits Drowner). The IR shuffles each permanent of an `Or` group; render ONLY the
+    // self + one-bound-target shape: an `Or` of exactly two `SinglePermanent`s, one a self-ref
+    // (ThisPermanent) and the other the bound `Ref_TargetPermanent`. Each is shuffled into its own
+    // owner's library, so it becomes two sequential `Effects.ShuffleIntoLibrary` moves — source first,
+    // then the target — matching the IR order. Any other group (more permanents, a filtered group, no
+    // bound target, no self member) declines -> SCAFFOLD rather than emit a lossy shuffle.
+    on("ShuffleEachPermanentIntoLibrary") { _, args, tvar ->
+        if (args.strField("_Permanents") != "Or") return@on null
+        val members = args.field("args").asArr ?: return@on null
+        if (members.size != 2) return@on null
+        val refs = members.map { m ->
+            if (m.strField("_Permanents") != "SinglePermanent") return@on null
+            findRef(m.field("args"))
+        }
+        val selfIdx = refs.indexOfFirst { it in SELF_REFS }
+        val targetIdx = refs.indexOfFirst { it == "Ref_TargetPermanent" }
+        if (selfIdx < 0 || targetIdx < 0 || selfIdx == targetIdx) return@on null
+        val targetDsl = refTarget(members[targetIdx].field("args"), tvar) ?: return@on null
+        call("Effects.ShuffleIntoLibrary", arg("EffectTarget.Self"))
+            .dot("then", arg(call("Effects.ShuffleIntoLibrary", arg(Lit(targetDsl)))))
     }
 
     on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -165,4 +165,29 @@ class EffectHandlerTest : StringSpec({
             "t",
         ).shouldBeNull()
     }
+
+    // --- ShuffleEachPermanentIntoLibrary (self + bound target, Floodpits Drowner) -----------------
+
+    "ShuffleEachPermanentIntoLibrary renders self + target as two ShuffleIntoLibrary moves" {
+        // "Shuffle this creature and target creature with a stun counter on it into their owners'
+        // libraries" — Or(SinglePermanent ThisPermanent, SinglePermanent Ref_TargetPermanent), each
+        // shuffled into its own owner's library, source first then the bound target.
+        layer(
+            """{"_Action":"ShuffleEachPermanentIntoLibrary","args":{"_Permanents":"Or","args":[""" +
+                """{"_Permanents":"SinglePermanent","args":{"_Permanent":"ThisPermanent"}},""" +
+                """{"_Permanents":"SinglePermanent","args":{"_Permanent":"Ref_TargetPermanent"}}]}}""",
+            "t",
+        ) shouldBe "Effects.ShuffleIntoLibrary(EffectTarget.Self).then(Effects.ShuffleIntoLibrary(t))"
+    }
+
+    "ShuffleEachPermanentIntoLibrary declines a group that isn't self + one bound target" {
+        // No self member (two bound targets) — not the modeled self + target shape, so decline rather
+        // than emit a shuffle that drops the source half.
+        layer(
+            """{"_Action":"ShuffleEachPermanentIntoLibrary","args":{"_Permanents":"Or","args":[""" +
+                """{"_Permanents":"SinglePermanent","args":{"_Permanent":"Ref_TargetPermanent1"}},""" +
+                """{"_Permanents":"SinglePermanent","args":{"_Permanent":"Ref_TargetPermanent2"}}]}}""",
+            "t",
+        ).shouldBeNull()
+    }
 })

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -232,6 +232,30 @@ class TargetRecoveryTest : StringSpec({
         ctx.creatureFilterDsl(nonMount) shouldBe "TargetFilter(GameObjectFilter.Creature.notSubtype(Subtype(\"Mount\")))"
     }
 
+    "creatureFilterDsl renders a 'with a stun counter on it' restriction (Floodpits Drowner)" {
+        // "target creature with a stun counter on it" — HasACounterOfType has no TargetFilter passthrough,
+        // so it must render the GameObjectFilter form wrapped in TargetFilter rather than dropping the
+        // counter constraint (which would let the ability shuffle away any creature).
+        val withStun = obj(
+            """{"_Permanents":"And","args":[""" +
+                """{"_Permanents":"IsCardtype","args":"Creature"},""" +
+                """{"_Permanents":"HasACounterOfType","args":{"_CounterType":"StunCounter"}}]}""",
+        )
+        ctx.creatureFilterDsl(withStun) shouldBe
+            "TargetFilter(GameObjectFilter.Creature.withCounter(Counters.STUN))"
+    }
+
+    "creatureFilterDsl declines a counter restriction whose kind it can't name exactly" {
+        // The counter constraint must never be silently dropped; an unnamed counter kind declines
+        // (-> SCAFFOLD) rather than widening the target to any creature.
+        val withUnknownCounter = obj(
+            """{"_Permanents":"And","args":[""" +
+                """{"_Permanents":"IsCardtype","args":"Creature"},""" +
+                """{"_Permanents":"HasACounterOfType","args":{"_CounterType":"OmenCounter"}}]}""",
+        )
+        ctx.creatureFilterDsl(withUnknownCounter).shouldBeNull()
+    }
+
     "creatureFilterDsl renders a 'dealt damage this turn' restriction (Rooftop Assassin)" {
         // "target creature an opponent controls that was dealt damage this turn" -> the
         // .dealtDamageThisTurn() state-predicate suffix composed with the controller suffix.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FloodpitsDrownerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FloodpitsDrownerScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Floodpits Drowner (DSK #59) — {1}{U} 2/1 Creature — Merfolk.
+ *
+ * Flash, Vigilance.
+ * "When this creature enters, tap target creature an opponent controls and put a stun counter on it."
+ * "{1}{U}, {T}: Shuffle this creature and target creature with a stun counter on it into their
+ *  owners' libraries."
+ *
+ * The ETB is the shared "tap + stun" idiom; the activated ability shuffles two permanents (the
+ * source plus a stun-countered target) into their owners' libraries.
+ */
+class FloodpitsDrownerScenarioTest : ScenarioTestBase() {
+
+    private val shuffleAbilityId =
+        cardRegistry.getCard("Floodpits Drowner")!!.activatedAbilities.first().id
+
+    init {
+        context("Floodpits Drowner — enters-the-battlefield tap + stun") {
+
+            test("ETB taps a target creature an opponent controls and gives it a stun counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Floodpits Drowner")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = false) // 2/2
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Floodpits Drowner").error shouldBe null
+                game.resolveStack() // creature enters → ETB asks for a target
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.selectTargets(listOf(bears))
+                withClue("Targeting the opponent's creature is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The opponent's creature is tapped") {
+                    game.isOnBattlefield("Floodpits Drowner") shouldBe true
+                    (game.state.getEntity(bears)?.has<TappedComponent>() == true) shouldBe true
+                }
+                withClue("The opponent's creature has a stun counter") {
+                    (game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.STUN) ?: 0) shouldBe 1
+                }
+            }
+        }
+
+        context("Floodpits Drowner — activated shuffle ability") {
+
+            test("shuffles itself and a stun-countered creature into their owners' libraries") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Floodpits Drowner", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true) // 2/2 with stun counter
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drowner = game.findPermanent("Floodpits Drowner")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Stamp a stun counter on the opposing creature so it is a legal target.
+                game.state = game.state.updateEntity(bears) {
+                    it.with(CountersComponent(mapOf(CounterType.STUN to 1)))
+                }
+
+                val libBeforeP1 = game.librarySize(1)
+                val libBeforeP2 = game.librarySize(2)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = drowner,
+                        abilityId = shuffleAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activating the shuffle ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Floodpits Drowner left the battlefield (shuffled into its owner's library)") {
+                    game.isOnBattlefield("Floodpits Drowner") shouldBe false
+                    game.librarySize(1) shouldBe libBeforeP1 + 1
+                }
+                withClue("The stun-countered creature left the battlefield (shuffled into its owner's library)") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 0
+                    game.librarySize(2) shouldBe libBeforeP2 + 1
+                }
+            }
+
+            test("cannot target a creature without a stun counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Floodpits Drowner", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = false) // no stun counter
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drowner = game.findPermanent("Floodpits Drowner")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = drowner,
+                        abilityId = shuffleAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("A creature without a stun counter is not a legal target") {
+                    (activation.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickerfolkThresherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickerfolkThresherScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wickerfolk Thresher (DSK #207) — {3}{G} 5/4 Artifact Creature — Scarecrow.
+ *
+ * "Delirium — Whenever this creature attacks, if there are four or more card types among cards in
+ *  your graveyard, look at the top card of your library. If it's a land card, you may put it onto
+ *  the battlefield. If you don't put the card onto the battlefield, put it into your hand."
+ *
+ * Delirium gates the attack trigger as an intervening-"if" (four+ distinct card types in the
+ * controller's graveyard). The payoff is the look-top / play-land-else-hand pipeline.
+ */
+class WickerfolkThresherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wickerfolk Thresher — delirium attack trigger") {
+
+            // Four card types in graveyard: artifact, creature, instant, sorcery, land → ≥ 4.
+            fun deliriumGraveyard(builder: ScenarioBuilder): ScenarioBuilder = builder
+                .withCardInGraveyard(1, "Ornithopter")     // Artifact
+                .withCardInGraveyard(1, "Grizzly Bears")   // Creature
+                .withCardInGraveyard(1, "Lightning Bolt")  // Instant
+                .withCardInGraveyard(1, "Forest")          // Land
+
+            test("with delirium and a land on top, may put it onto the battlefield") {
+                val game = deliriumGraveyard(
+                    scenario()
+                        .withPlayers("Player1", "Player2")
+                        .withCardOnBattlefield(1, "Wickerfolk Thresher", tapped = false, summoningSickness = false)
+                        .withCardInLibrary(1, "Mountain") // top of library is a land
+                        .withCardInLibrary(2, "Island")
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                )
+                    .build()
+
+                val landsBefore = game.findPermanents("Mountain").size
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wickerfolk Thresher" to 2))
+
+                // Attack trigger goes on the stack; resolve until the look-top selection surfaces.
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for the land choice; got ${game.getPendingDecision()}")
+
+                // Choose to put the land onto the battlefield.
+                game.selectCards(listOf(decision.options.first()))
+                game.resolveStack()
+
+                withClue("The land entered the battlefield") {
+                    game.findPermanents("Mountain").size shouldBe landsBefore + 1
+                }
+                withClue("Nothing went to hand") {
+                    game.isInHand(1, "Mountain") shouldBe false
+                }
+            }
+
+            test("with delirium and a land on top, declining puts it into your hand") {
+                val game = deliriumGraveyard(
+                    scenario()
+                        .withPlayers("Player1", "Player2")
+                        .withCardOnBattlefield(1, "Wickerfolk Thresher", tapped = false, summoningSickness = false)
+                        .withCardInLibrary(1, "Mountain")
+                        .withCardInLibrary(2, "Island")
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                )
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wickerfolk Thresher" to 2))
+
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision; got ${game.getPendingDecision()}")
+
+                // Decline (select none) — the land goes to hand.
+                game.selectCards(emptyList())
+                game.resolveStack()
+
+                withClue("Declining puts the land into hand") {
+                    game.findPermanents("Mountain").size shouldBe 0
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+            }
+
+            test("without delirium, the attack trigger does nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wickerfolk Thresher", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears") // only one card type
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wickerfolk Thresher" to 2))
+                game.resolveStack()
+
+                withClue("No delirium → no look-top, no decision") {
+                    (game.getPendingDecision() is SelectCardsDecision) shouldBe false
+                    game.findPermanents("Mountain").size shouldBe 0
+                    game.isInHand(1, "Mountain") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards implemented (canonical in DSK)

- **Floodpits Drowner** — `{1}{U}` Creature — Merfolk, 2/1, Flash, Vigilance.
  ETB taps a target creature an opponent controls and puts a stun counter on it;
  `{1}{U}, {T}` shuffles itself and a target creature with a stun counter into
  their owners' libraries.
- **Wickerfolk Thresher** — `{3}{G}` Artifact Creature — Scarecrow, 5/4.
  Delirium attack trigger: with 4+ card types in your graveyard, look at the top
  card; if it's a land you may put it onto the battlefield, otherwise put it into
  your hand.

Each card has a passing scenario test in `rules-engine`. Card lint, the DSK card
snapshot, and the canonical-printing checks all pass.

## mtgish auto-gen changes

Taught the emitter + capability bridge two new renderable shapes so **Floodpits
Drowner now emits as a complete `AUTO` card** that gameplay-tree matches its golden:

- **`ShuffleEachPermanentIntoLibrary` handler** (`ZoneHandlers.kt`) — renders the
  self + one-bound-target `Or` shape as two sequential `Effects.ShuffleIntoLibrary`
  moves (source first, then the bound target), each into its own owner's library.
  Any other group (more permanents, no self/target member) declines → `SCAFFOLD`.
  Capability added to the `ZoneMovement` bridge.
- **TargetFilter counter recovery** (`TargetRecovery.kt`) — "target creature with a
  `<kind>` counter on it" (`HasACounterOfType`) now renders
  `TargetFilter(GameObjectFilter.Creature.withCounter(Counters.STUN))` instead of
  silently dropping the counter constraint. An unnamed counter kind declines →
  `SCAFFOLD`.
- New `EffectHandlerTest` + `TargetRecoveryTest` cases pin both recoveries (render +
  decline).

### Regression gates

- `coverage-verify POR` → **158/158 GATE PASS, 0 mismatch** (unchanged).
- `EmitterGoldenTest` → all 10 calibrated fixtures pass (no rebless needed; my
  changes only add recovery for shapes none of the golden cards use).
- DSK card snapshot reblessed for the two new cards only (`DSK.json` diff adds
  exactly Floodpits Drowner + Wickerfolk Thresher).
- DSK is *not* a 0-mismatch calibrated set; its 6 pre-existing emitter mismatches
  (Attack-in-the-Box, Beastie Beatdown, Get Out, Glimmer Seeker, Overlord of the
  Boilerbilges, Razorkin Needlehead) are unrelated to this change — none use the
  shapes touched here.

## Skipped (require `add-feature`, not single-card authoring)

- **Oblivious Bookworm** — needs new turn-tracker conditions ("a permanent entered
  the battlefield face down under your control this turn" / "you turned a permanent
  face up this turn"); no such `Condition`/`TurnTracker` exists.
- **Paranormal Analyst** — needs a "whenever you manifest dread" trigger plus a
  reference to the card put into the graveyard by that manifest dread; no such
  trigger/event or trigger-linked graveyard payload exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)