### PR TITLE
Add exile-and-return-transformed effect (FIN Dominant / eikon transform §2)

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -110,7 +110,7 @@ Two sub-gaps surface inside this cycle:
   Cerberus II/III copy-next-spell) — the "next spell you cast" one-shot rider pattern exists (next-spell-uncounterable,
   pending copy); verify the copy-next-instant variant composes, else extend.
 
-### 2. Dominant / Eikon transform — creature front → **Saga-creature** back via exile-and-return (≈8) — ❌ **GAP**
+### 2. Dominant / Eikon transform — creature front → **Saga-creature** back via exile-and-return (≈8) — ✅ **ENGINE DONE** (cards in progress)
 
 The Dominants (Clive→Ifrit, Jill→Shiva, Dion→Bahamut, Joshua→Phoenix, Terra→Esper Terra, Jecht, Crystal Fragments,
 Esper Origins) are double-faced cards whose **back face is a Summon Saga (§1)** and whose front transforms via an
@@ -119,12 +119,30 @@ a **leave-and-re-enter** transform (a new object), not an in-place `TransformEff
 ticks its chapters as a creature and, on its final chapter, *"exile it, then return it to the battlefield (front face
 up)"* — re-entering as the original front-face legend.
 
-**Needs:** (a) §1 (saga-creature back faces) as a hard prerequisite; (b) an **exile-and-return-transformed** effect
-that re-enters the permanent as a *new object* on the chosen face (resetting the saga), as opposed to the in-place
-`TransformEffect`. No `ExileAndReturnTransformed` effect exists today (grep: none). Compose from
-exile + return-to-battlefield-transformed, or add a dedicated effect.
-→ Clive, Jill, Dion, Joshua (5-color dominants); Terra, Magical Adept; Jecht; Crystal Fragments (Equipment→Saga);
-  Esper Origins (sorcery cast-from-graveyard → enters transformed as a Saga).
+**Shipped:** the engine gap is closed by `Effects.ExileAndReturnTransformed(target, returnAs)` +
+`ExileAndReturnTransformedExecutor` (`ReturnFace.TRANSFORMED` for front→back, `FRONT` for the eikon final
+chapter's "front face up"). It exiles a DFC and re-enters it as a *new object* via the standard
+`ZoneTransitionService.moveToZone` path, so a Saga back re-enters with one lore counter (CR 714.2b) and ETB/LTB
+triggers fire (not transform triggers) — distinct from in-place `TransformEffect`. The Craft return
+(`ReturnSelfFromExileTransformed`) was refactored to share the same flip-and-return-from-exile helper. The eikon
+backs need **no** sacrifice opt-out flag: their final chapter exile-returns them front face up *before* the
+CR 714.4 sacrifice SBA applies (chapter on the stack → no sac; resolves → no longer a Saga). Covered by
+`DominantEikonTransformScenarioTest` (front→back new object + fresh lore, eikon final-chapter return-to-front
+instead of sacrifice, sorcery-speed gating, second card).
+→ ✅ Clive // Ifrit, Jill // Shiva, Jecht // Braska's Final Aeon (front = "may" combat-damage trigger; back = a
+  plain sacrifice-after-III Summon Saga, no return). The remaining cards reuse the **same** transform effect; they
+  are blocked only on **unrelated chapter/effect primitives**, not on §2:
+  - Dion // Bahamut — needs the "during your turn, Knights you control have flying" conditional static grant.
+  - Joshua // Phoenix — needs "return any number of target creature cards with total mana value ≤ 6 from your
+    graveyard to the battlefield" (any-number-with-total-MV-budget reanimation).
+  - Terra // Esper Terra — needs "create a token copy of target nonlegendary enchantment, if it's a Saga put up
+    to three lore counters on it, sacrifice at the next end step".
+  - Crystal Fragments // Summon: Alexander — Equipment front works via `CardDefinition.doubleFacedPermanent`, but
+    the Alexander back needs a **group damage-prevention shield** ("prevent all damage that would be dealt to
+    creatures you control this turn" — `PreventDamageEffect` only targets a single entity today).
+  - Esper Origins — a different template (a *sorcery* that, when cast from a graveyard, exiles itself off the stack
+    and *puts itself onto the battlefield transformed with a finality counter*) — a spell-becomes-permanent shape,
+    not the permanent exile-and-return this effect models.
 
 ### 3. Job select (≈16 Equipment) — ❌ **GAP** (create-token-then-attach-self)
 
@@ -258,7 +276,10 @@ so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) 
    the only engine change was enumerating the Adventure spell face for a land-primary card. 5 lands shipped.
 5. **Summon Sagas (§1)** — the headline `add-feature`: make Sagas co-exist with creatures + an opt-out-of-sacrifice
    flag + self-referential chapter resolution. Largest lift; gates ~15 cards.
-6. **Dominant / Eikon transform (§2)** — depends on §1; add exile-and-return-transformed (new object). ~8 cards.
+6. ✅ **Dominant / Eikon transform (§2) — ENGINE DONE:** `Effects.ExileAndReturnTransformed(target, returnAs)`
+   (new object, both directions) + shared flip-and-return helper with the Craft return. Clive//Ifrit, Jill//Shiva,
+   Jecht//Braska shipped; the remaining ~5 reuse the same effect and are blocked only on unrelated chapter
+   primitives (see §2).
 7. **Tier-2 turn-structure + Tier-3 one-offs** (additional end step §9, first-combat condition §8, coin-flip-win §10,
    meld, ×2 replacements, ability-copy) as the relevant legendaries/rares come up.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -447,6 +447,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   battlefield as its back face, under its owner's control, and re-attaches the source's
   `CraftedFromExiledComponent` recording the exiled materials. Pair with `AbilityCost.Craft`; see the `Craft`
   keyword helper in the keyword catalog.
+- `ExileAndReturnTransformed(target = Self, returnAs = ReturnFace.TRANSFORMED)` — "Exile [this], then return it
+  to the battlefield transformed under its owner's control" (FIN Dominant / eikon transform). Exiles a
+  double-faced permanent and re-enters it as a **new object** on the chosen face — unlike `Transform`, which
+  flips a permanent in place. Because it is a new object: counters/damage drop, attachments fall off, leaves-
+  and enters-the-battlefield triggers fire (not transform triggers), and a Saga face re-enters with one lore
+  counter (CR 714.2b). The exile and return are atomic (no priority/SBAs between). `returnAs`: `TRANSFORMED`
+  (the opposite face — front→back), `FRONT` ("return it front face up" — the eikon Saga's final chapter flips
+  back to the legend), or `BACK`. The front face's activated ability is sorcery-speed
+  (`timing = TimingRule.SorcerySpeed`); Jecht uses it from a "may" combat-damage trigger instead.
 - `ReturnCreaturesPutInGraveyardThisTurn(player)` — Patriarch's Bidding shape.
 
 ### Hand reveal

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -119,6 +119,8 @@ import com.wingedsheep.sdk.scripting.effects.ExileAndGrantOwnerPlayPermissionEff
 import com.wingedsheep.sdk.scripting.effects.CreateGlobalTriggeredAbilityEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnCreaturesPutInGraveyardThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnOneFromLinkedExileEffect
+import com.wingedsheep.sdk.scripting.effects.ExileAndReturnTransformedEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfToBattlefieldAttachedEffect
 import com.wingedsheep.sdk.scripting.effects.DrawUpToEffect
@@ -647,6 +649,18 @@ object Effects {
      * as the activated ability's effect; see CR 702.167a.
      */
     val ReturnSelfFromExileTransformed: Effect = ReturnSelfFromExileTransformedEffect
+
+    /**
+     * Exile a double-faced permanent, then return it to the battlefield as a new object on the
+     * chosen face (FIN "Dominant" / eikon transform — "Exile this, then return it transformed").
+     * Distinct from [Transform], which flips a permanent in place; this re-enters a fresh object,
+     * so counters/auras drop, ETB/LTB triggers fire, and a Saga face re-enters with one lore
+     * counter. Defaults to the source returning [ReturnFace.TRANSFORMED] (opposite face).
+     */
+    fun ExileAndReturnTransformed(
+        target: EffectTarget = EffectTarget.Self,
+        returnAs: ReturnFace = ReturnFace.TRANSFORMED
+    ): Effect = ExileAndReturnTransformedEffect(target, returnAs)
 
     /**
      * Return to hand all creature cards in a player's graveyard that were put there this turn.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
@@ -23,6 +23,46 @@ data class TransformEffect(
 }
 
 /**
+ * Which face a permanent re-enters on after an [ExileAndReturnTransformedEffect].
+ *
+ * - [TRANSFORMED] — the opposite of the face it had on the battlefield (oracle: "return it to
+ *   the battlefield transformed"). A front-face creature comes back as its back face; a back-face
+ *   Saga comes back as its front face.
+ * - [FRONT] — its front face, regardless of the face it left on (oracle: "return it to the
+ *   battlefield front face up"). Used by the eikon Saga backs on their final chapter.
+ * - [BACK] — its back face, regardless of the face it left on.
+ */
+enum class ReturnFace { TRANSFORMED, FRONT, BACK }
+
+/**
+ * Exile a double-faced permanent, then return it to the battlefield as a **new object** on the
+ * chosen face under its owner's control (FIN "Dominant" / eikon transform).
+ *
+ * Unlike [TransformEffect] (CR 701.27 — turning a permanent already on the battlefield over in
+ * place, preserving counters/damage/attachments and firing transform triggers), this models the
+ * "Exile [this], then return it to the battlefield transformed" templating: the permanent leaves
+ * and a brand-new object enters. Counters/damage/auras do **not** carry over, leaves-the-battlefield
+ * and enters-the-battlefield triggers fire (not transform triggers), and a Saga face re-enters with
+ * a fresh lore counter (CR 714.2b). The exile and return happen atomically in one resolution — no
+ * priority or state-based actions in between.
+ *
+ * Used by both directions of the cycle: the front face's activated/triggered ability returns it
+ * [TRANSFORMED] (front → back Saga), and the back Saga's final chapter returns it [FRONT].
+ */
+@SerialName("ExileAndReturnTransformed")
+@Serializable
+data class ExileAndReturnTransformedEffect(
+    val target: EffectTarget = EffectTarget.Self,
+    val returnAs: ReturnFace = ReturnFace.TRANSFORMED
+) : Effect {
+    override val description: String = when (returnAs) {
+        ReturnFace.TRANSFORMED -> "Exile ${target.description}, then return it to the battlefield transformed"
+        ReturnFace.FRONT -> "Exile ${target.description}, then return it to the battlefield front face up"
+        ReturnFace.BACK -> "Exile ${target.description}, then return it to the battlefield back face up"
+    }
+}
+
+/**
  * Return the source of a Craft activated ability (CR 702.167a) from exile to the battlefield
  * transformed under its owner's control.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CliveIfritsDominant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CliveIfritsDominant.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Clive, Ifrit's Dominant // Ifrit, Warden of Inferno
+ * {4}{R}{R} — Legendary Creature — Human Noble Warrior 5/5
+ * //  — Legendary Enchantment Creature — Saga Demon 9/9
+ *
+ * Front — Clive, Ifrit's Dominant:
+ *   When Clive enters, you may discard your hand, then draw cards equal to your devotion to red.
+ *   {4}{R}{R}, {T}: Exile Clive, then return it to the battlefield transformed under its owner's
+ *   control. Activate only as a sorcery.
+ *
+ * Back — Ifrit, Warden of Inferno (eikon Saga):
+ *   (As this Saga enters and after your draw step, add a lore counter.)
+ *   I — Lunge — Ifrit fights up to one other target creature.
+ *   II, III — Brimstone — Add {R}{R}{R}{R}. If Ifrit has three or more lore counters on it, exile
+ *   it, then return it to the battlefield (front face up).
+ */
+private val IfritWardenOfInferno = card("Ifrit, Warden of Inferno") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Legendary Enchantment Creature — Saga Demon"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter.)\n" +
+        "I — Lunge — Ifrit fights up to one other target creature.\n" +
+        "II, III — Brimstone — Add {R}{R}{R}{R}. If Ifrit has three or more lore counters on it, " +
+        "exile it, then return it to the battlefield (front face up)."
+    power = 9
+    toughness = 9
+
+    // I — Lunge — Ifrit fights up to one other target creature.
+    sagaChapter(1) {
+        val foe = target("creature", TargetObject(optional = true, filter = TargetFilter.OtherCreature))
+        effect = Effects.Fight(EffectTarget.Self, foe)
+    }
+
+    // II, III — Brimstone — Add {R}{R}{R}{R}. If Ifrit has three or more lore counters on it,
+    // exile it, then return it to the battlefield front face up. Only chapter III meets the
+    // lore threshold, so it is the chapter that flips Ifrit back to Clive.
+    val brimstone = Effects.Composite(
+        Effects.AddMana(Color.RED, 4),
+        ConditionalEffect(
+            condition = Conditions.SourceCounterCountAtLeast("LORE", 3),
+            effect = Effects.ExileAndReturnTransformed(EffectTarget.Self, ReturnFace.FRONT),
+        ),
+    )
+    sagaChapter(2) { effect = brimstone }
+    sagaChapter(3) { effect = brimstone }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "133"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/back/9/a/9a069e96-2786-493d-aca8-f70611435dbe.jpg?1748707817"
+    }
+}
+
+private val CliveIfritsDominantFront = card("Clive, Ifrit's Dominant") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Noble Warrior"
+    oracleText = "When Clive enters, you may discard your hand, then draw cards equal to your " +
+        "devotion to red. (Each {R} in the mana costs of permanents you control counts toward " +
+        "your devotion to red.)\n" +
+        "{4}{R}{R}, {T}: Exile Clive, then return it to the battlefield transformed under its " +
+        "owner's control. Activate only as a sorcery."
+    power = 5
+    toughness = 5
+
+    // When Clive enters, you may discard your hand, then draw cards equal to your devotion to red.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.Composite(
+                Patterns.Hand.discardHand(),
+                Effects.DrawCards(DynamicAmounts.devotionTo(Color.RED)),
+            ),
+        )
+    }
+
+    // {4}{R}{R}, {T}: Exile Clive, then return it transformed. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}{R}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ExileAndReturnTransformed()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "133"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a069e96-2786-493d-aca8-f70611435dbe.jpg?1748707817"
+    }
+}
+
+val CliveIfritsDominant: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = CliveIfritsDominantFront,
+    backFace = IfritWardenOfInferno,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JechtReluctantGuardian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JechtReluctantGuardian.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jecht, Reluctant Guardian // Braska's Final Aeon
+ * {3}{B} — Legendary Creature — Human Warrior 4/3
+ * //  — Legendary Enchantment Creature — Saga Nightmare 7/7
+ *
+ * Front — Jecht, Reluctant Guardian:
+ *   Menace
+ *   Whenever Jecht deals combat damage to a player, you may exile it, then return it to the
+ *   battlefield transformed under its owner's control.
+ *
+ * Back — Braska's Final Aeon (Summon Saga that stays as a creature, then is sacrificed):
+ *   (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ *   I, II — Jecht Beam — Each opponent discards a card and you draw a card.
+ *   III — Ultimate Jecht Shot — Each opponent sacrifices two creatures of their choice.
+ *   Menace
+ */
+private val BraskasFinalAeon = card("Braska's Final Aeon") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Legendary Enchantment Creature — Saga Nightmare"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I, II — Jecht Beam — Each opponent discards a card and you draw a card.\n" +
+        "III — Ultimate Jecht Shot — Each opponent sacrifices two creatures of their choice.\n" +
+        "Menace"
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.MENACE)
+
+    // I, II — Jecht Beam — Each opponent discards a card and you draw a card.
+    val jechtBeam = Effects.Composite(
+        Effects.Discard(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+        Effects.DrawCards(1),
+    )
+    sagaChapter(1) { effect = jechtBeam }
+    sagaChapter(2) { effect = jechtBeam }
+
+    // III — Ultimate Jecht Shot — Each opponent sacrifices two creatures of their choice.
+    sagaChapter(3) {
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            2,
+            EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Michael MacRae"
+        imageUri = "https://cards.scryfall.io/normal/back/4/e/4ec91fe8-b3da-47fa-b45e-94b62a260aba.jpg?1748707810"
+    }
+}
+
+private val JechtReluctantGuardianFront = card("Jecht, Reluctant Guardian") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "Menace\n" +
+        "Whenever Jecht deals combat damage to a player, you may exile it, then return it to the " +
+        "battlefield transformed under its owner's control."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    // Whenever Jecht deals combat damage to a player, you may exile-and-return-transformed.
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayEffect(Effects.ExileAndReturnTransformed())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Michael MacRae"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ec91fe8-b3da-47fa-b45e-94b62a260aba.jpg?1748707810"
+    }
+}
+
+val JechtReluctantGuardian: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = JechtReluctantGuardianFront,
+    backFace = BraskasFinalAeon,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JillShivasDominant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JillShivasDominant.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Jill, Shiva's Dominant // Shiva, Warden of Ice
+ * {2}{U} — Legendary Creature — Human Noble Warrior 2/2
+ * //  — Legendary Enchantment Creature — Saga Elemental 4/5
+ *
+ * Front — Jill, Shiva's Dominant:
+ *   When Jill enters, return up to one other target nonland permanent to its owner's hand.
+ *   {3}{U}{U}, {T}: Exile Jill, then return it to the battlefield transformed under its owner's
+ *   control. Activate only as a sorcery.
+ *
+ * Back — Shiva, Warden of Ice (eikon Saga):
+ *   (As this Saga enters and after your draw step, add a lore counter.)
+ *   I, II — Mesmerize — Target creature can't be blocked this turn.
+ *   III — Cold Snap — Tap all lands your opponents control. Exile Shiva, then return it to the
+ *   battlefield (front face up).
+ */
+private val ShivaWardenOfIce = card("Shiva, Warden of Ice") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Legendary Enchantment Creature — Saga Elemental"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter.)\n" +
+        "I, II — Mesmerize — Target creature can't be blocked this turn.\n" +
+        "III — Cold Snap — Tap all lands your opponents control. Exile Shiva, then return it to " +
+        "the battlefield (front face up)."
+    power = 4
+    toughness = 5
+
+    // I, II — Mesmerize — Target creature can't be blocked this turn.
+    sagaChapter(1) {
+        val t = target("creature", TargetObject(filter = TargetFilter.Creature))
+        effect = GrantKeywordEffect(AbilityFlag.CANT_BE_BLOCKED.name, t)
+    }
+    sagaChapter(2) {
+        val t = target("creature", TargetObject(filter = TargetFilter.Creature))
+        effect = GrantKeywordEffect(AbilityFlag.CANT_BE_BLOCKED.name, t)
+    }
+
+    // III — Cold Snap — Tap all lands your opponents control, then flip Shiva back to Jill.
+    sagaChapter(3) {
+        effect = Effects.Composite(
+            Patterns.Group.tapAll(GroupFilter(GameObjectFilter.Land.opponentControls())),
+            Effects.ExileAndReturnTransformed(EffectTarget.Self, ReturnFace.FRONT),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "58"
+        artist = "Arif Wijaya"
+        imageUri = "https://cards.scryfall.io/normal/back/1/f/1f163763-4802-4a96-a5bc-f3c381db7b5c.jpg?1748707805"
+    }
+}
+
+private val JillShivasDominantFront = card("Jill, Shiva's Dominant") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Noble Warrior"
+    oracleText = "When Jill enters, return up to one other target nonland permanent to its " +
+        "owner's hand.\n" +
+        "{3}{U}{U}, {T}: Exile Jill, then return it to the battlefield transformed under its " +
+        "owner's control. Activate only as a sorcery."
+    power = 2
+    toughness = 2
+
+    // When Jill enters, return up to one other target nonland permanent to its owner's hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "nonland permanent",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.NonlandPermanent, excludeSelf = true),
+            ),
+        )
+        effect = Effects.ReturnToHand(t)
+    }
+
+    // {3}{U}{U}, {T}: Exile Jill, then return it transformed. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}{U}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ExileAndReturnTransformed()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "58"
+        artist = "Arif Wijaya"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f163763-4802-4a96-a5bc-f3c381db7b5c.jpg?1748707805"
+    }
+}
+
+val JillShivasDominant: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = JillShivasDominantFront,
+    backFace = ShivaWardenOfIce,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1251,6 +1251,231 @@
     ]
 }
 
+// Clive, Ifrit's Dominant
+{
+    "name": "Clive, Ifrit's Dominant",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Legendary Creature — Human Noble Warrior",
+    "oracleText": "When Clive enters, you may discard your hand, then draw cards equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)\n{4}{R}{R}, {T}: Exile Clive, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "discardedHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discardedHand",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "DevotionTo",
+                                    "colors": [
+                                        "RED"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "ExileAndReturnTransformed",
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Ifrit, Warden of Inferno",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment Creature — Saga Demon",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter.)\nI — Lunge — Ifrit fights up to one other target creature.\nII, III — Brimstone — Add {R}{R}{R}{R}. If Ifrit has three or more lore counters on it, exile it, then return it to the battlefield (front face up).",
+        "creatureStats": {
+            "power": 9,
+            "toughness": 9
+        },
+        "script": {
+            "sagaChapters": [
+                {
+                    "chapter": 1,
+                    "effect": {
+                        "type": "Fight",
+                        "target1": "Self",
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature",
+                            "excludeSelf": true
+                        },
+                        "id": "creature"
+                    }
+                },
+                {
+                    "chapter": 2,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddMana",
+                                "color": "RED",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "LORE"
+                                                }
+                                            }
+                                        },
+                                        "operator": "GTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "type": "ExileAndReturnTransformed",
+                                    "returnAs": "FRONT"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "chapter": 3,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddMana",
+                                "color": "RED",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "LORE"
+                                                }
+                                            }
+                                        },
+                                        "operator": "GTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "type": "ExileAndReturnTransformed",
+                                    "returnAs": "FRONT"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "133",
+            "rarity": "MYTHIC",
+            "artist": "Nino Is",
+            "imageUri": "https://cards.scryfall.io/normal/back/9/a/9a069e96-2786-493d-aca8-f70611435dbe.jpg?1748707817"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "MYTHIC",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a069e96-2786-493d-aca8-f70611435dbe.jpg?1748707817"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cloud of Darkness
 {
     "name": "Cloud of Darkness",
@@ -2825,6 +3050,191 @@
     ]
 }
 
+// Jecht, Reluctant Guardian
+{
+    "name": "Jecht, Reluctant Guardian",
+    "manaCost": "{3}{B}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Menace\nWhenever Jecht deals combat damage to a player, you may exile it, then return it to the battlefield transformed under its owner's control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "ExileAndReturnTransformed"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Braska's Final Aeon",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment Creature — Saga Nightmare",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II — Jecht Beam — Each opponent discards a card and you draw a card.\nIII — Ultimate Jecht Shot — Each opponent sacrifices two creatures of their choice.\nMenace",
+        "creatureStats": {
+            "power": 7,
+            "toughness": 7
+        },
+        "keywords": [
+            "MENACE"
+        ],
+        "script": {
+            "sagaChapters": [
+                {
+                    "chapter": 1,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": "EachOpponent"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "chooser": "Opponent",
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": "EachOpponent"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "chapter": 2,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": "EachOpponent"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "chooser": "Opponent",
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": "EachOpponent"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "chapter": 3,
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "count": 2,
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "104",
+            "rarity": "RARE",
+            "artist": "Michael MacRae",
+            "imageUri": "https://cards.scryfall.io/normal/back/4/e/4ec91fe8-b3da-47fa-b45e-94b62a260aba.jpg?1748707810"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Michael MacRae",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ec91fe8-b3da-47fa-b45e-94b62a260aba.jpg?1748707810"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Jidoor, Aristocratic Capital
 {
     "name": "Jidoor, Aristocratic Capital",
@@ -2914,6 +3324,159 @@
                 ]
             }
         }
+    ]
+}
+
+// Jill, Shiva's Dominant
+{
+    "name": "Jill, Shiva's Dominant",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Noble Warrior",
+    "oracleText": "When Jill enters, return up to one other target nonland permanent to its owner's hand.\n{3}{U}{U}, {T}: Exile Jill, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "nonland permanent"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent",
+                        "excludeSelf": true
+                    },
+                    "id": "nonland permanent"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "ExileAndReturnTransformed",
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Shiva, Warden of Ice",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment Creature — Saga Elemental",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II — Mesmerize — Target creature can't be blocked this turn.\nIII — Cold Snap — Tap all lands your opponents control. Exile Shiva, then return it to the battlefield (front face up).",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 5
+        },
+        "script": {
+            "sagaChapters": [
+                {
+                    "chapter": 1,
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "CANT_BE_BLOCKED",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                },
+                {
+                    "chapter": 2,
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "CANT_BE_BLOCKED",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                },
+                {
+                    "chapter": 3,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "land ctrl:opponent"
+                                    }
+                                },
+                                "body": {
+                                    "type": "TapUntap",
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "ExileAndReturnTransformed",
+                                "returnAs": "FRONT"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "58",
+            "rarity": "RARE",
+            "artist": "Arif Wijaya",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/f/1f163763-4802-4a96-a5bc-f3c381db7b5c.jpg?1748707805"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "RARE",
+        "artist": "Arif Wijaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f163763-4802-4a96-a5bc-f3c381db7b5c.jpg?1748707805"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -78,6 +78,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.types.EachPermanentBeco
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetCreatureSubtypesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetGroupCreatureSubtypesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetLandTypeExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.ExileAndReturnTransformedExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.ReturnSelfFromExileTransformedExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TransformEffectExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceDownExecutor
@@ -155,6 +156,7 @@ class PermanentExecutors(
         SetGroupCreatureSubtypesExecutor(),
         TransformEffectExecutor(cardRegistry),
         ReturnSelfFromExileTransformedExecutor(cardRegistry),
+        ExileAndReturnTransformedExecutor(cardRegistry),
         TurnFaceDownExecutor(),
         TurnFaceUpExecutor(cardRegistry),
         // attachments

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ExileAndReturnTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ExileAndReturnTransformedExecutor.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.handlers.effects.permanent.types
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.effects.ExileAndReturnTransformedEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ExileAndReturnTransformedEffect] (FIN "Dominant" / eikon transform).
+ *
+ * Models the "Exile [this], then return it to the battlefield transformed under its owner's
+ * control" templating: the target double-faced permanent leaves the battlefield and a brand-new
+ * object enters on the requested face. Two zone changes happen atomically inside this single
+ * resolution — no priority or state-based actions in between — so the permanent is only momentarily
+ * in exile, matching the single-instruction oracle wording.
+ *
+ * Distinct from [TransformEffectExecutor]: that flips a permanent in place (CR 701.27), preserving
+ * counters/damage/attachments and emitting a `TransformedEvent`. This produces a *new object*, so:
+ *  - counters/damage drop and attachments fall off (Rule 400.7 "new object" cleanup),
+ *  - leaves-the-battlefield triggers fire on the exile and enters-the-battlefield triggers fire on
+ *    the return (not transform triggers), and
+ *  - a Saga face re-enters with a fresh lore counter via the standard battlefield-entry Saga setup
+ *    (CR 714.2b) — see [ZoneTransitionService.moveToZone].
+ *
+ * The destination face is computed from the on-battlefield face *before* exiling, because a DFC
+ * reverts to its front face when it leaves the battlefield (Rule 712.8a).
+ */
+class ExileAndReturnTransformedExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<ExileAndReturnTransformedEffect> {
+
+    override val effectType: KClass<ExileAndReturnTransformedEffect> =
+        ExileAndReturnTransformedEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ExileAndReturnTransformedEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid target for exile-and-return-transformed")
+
+        val container = state.getEntity(targetId)
+            ?: return EffectResult.error(state, "Target entity not found")
+
+        // Not a double-faced permanent: there is nothing to transform, so the effect does nothing.
+        val dfc = container.get<DoubleFacedComponent>()
+            ?: return EffectResult.success(state)
+
+        // Resolve the destination face from the current on-battlefield face up front — the entity
+        // reverts to its front face once it leaves the battlefield (Rule 712.8a).
+        val destinationFace = when (effect.returnAs) {
+            ReturnFace.TRANSFORMED -> when (dfc.currentFace) {
+                DoubleFacedComponent.Face.FRONT -> DoubleFacedComponent.Face.BACK
+                DoubleFacedComponent.Face.BACK -> DoubleFacedComponent.Face.FRONT
+            }
+            ReturnFace.FRONT -> DoubleFacedComponent.Face.FRONT
+            ReturnFace.BACK -> DoubleFacedComponent.Face.BACK
+        }
+
+        // 1. Exile from the battlefield. The permanent ceases to exist as its current object;
+        //    leaves-the-battlefield triggers fire and attachments come off via standard cleanup.
+        val exileTransition = ZoneTransitionService.moveToZone(state, targetId, Zone.EXILE)
+        var newState = exileTransition.state
+        val events = exileTransition.events.toMutableList()
+
+        // A replacement effect may have redirected the exile elsewhere; if the entity is no longer
+        // reachable, stop after the move rather than fabricating a return.
+        if (newState.getEntity(targetId) == null) {
+            return EffectResult.success(newState, events)
+        }
+
+        // 2. Flip to the destination face and return it to the battlefield as a new object.
+        val returnTransition = returnDfcFaceFromExile(newState, cardRegistry, targetId, destinationFace)
+        newState = returnTransition.state
+        events.addAll(returnTransition.events)
+
+        return EffectResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
@@ -3,15 +3,10 @@ package com.wingedsheep.engine.handlers.effects.permanent.types
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
-import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
-import com.wingedsheep.engine.state.components.identity.OwnerComponent
-import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
 import kotlin.reflect.KClass
 
@@ -51,49 +46,18 @@ class ReturnSelfFromExileTransformedExecutor(
             ?: return EffectResult.error(state, "Craft effect has no source")
         val container = state.getEntity(sourceId)
             ?: return EffectResult.error(state, "Craft source not found")
-
-        val dfc = container.get<DoubleFacedComponent>()
+        container.get<DoubleFacedComponent>()
             ?: return EffectResult.error(state, "Craft source is not a double-faced permanent")
-
-        val backDef = cardRegistry.getCard(dfc.backCardDefinitionId)
-            ?: return EffectResult.error(state, "Back face not registered: ${dfc.backCardDefinitionId}")
-
-        val ownerId = container.get<OwnerComponent>()?.playerId
-            ?: return EffectResult.error(state, "Craft source has no owner")
 
         val materials = container.get<CraftedFromExiledComponent>()
 
-        // Snapshot the front-face CardComponent (the entity is currently in exile, so per
-        // CR 712.8a the component on it is the front face's). Stashing it on the DFC lets
-        // ZoneTransitionService restore Saheeli's Lattice when Mastercraft Raptor later
-        // leaves the battlefield to a non-battlefield/non-stack zone — same path
-        // TransformEffectExecutor uses for transforming DFCs.
-        val frontFaceCard = container.get<CardComponent>()
-            ?: return EffectResult.error(state, "Craft source has no CardComponent")
-
-        // Build the back face's CardComponent via the same helper TransformEffectExecutor uses.
-        val backCard = buildCardComponentForDfcFace(frontFaceCard, backDef)
-
-        // Flip the DFC face + swap CardComponent while the entity is still in exile so the
-        // zone transition picks up the back face's static abilities cleanly. Save the front
-        // face on the DFC so Rule 712.8a's restore-on-leave path can swap back to it.
-        var newState = state.updateEntity(sourceId) { c ->
-            c.with(backCard).with(
-                dfc.copy(
-                    currentFace = DoubleFacedComponent.Face.BACK,
-                    frontFaceCard = frontFaceCard
-                )
-            )
-        }
-
-        // Move EXILE → BATTLEFIELD under owner's control.
-        val transition = ZoneTransitionService.moveToZone(
-            newState,
-            sourceId,
-            Zone.BATTLEFIELD,
-            options = ZoneEntryOptions(controllerId = ownerId)
+        // Flip to the back face (CR 702.167a always returns transformed) and move EXILE →
+        // BATTLEFIELD under owner's control. The shared helper handles the face swap + zone move
+        // (it is also used by the FIN Dominant exile-and-return-transformed effect).
+        val transition = returnDfcFaceFromExile(
+            state, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK
         )
-        newState = transition.state
+        var newState = transition.state
 
         // Re-attach CraftedFromExiledComponent: ZoneTransitionService.applyBattlefieldEntry
         // strips it as part of the Rule 400.7 "new object" cleanup (alongside

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -4,6 +4,9 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.TransformedEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionResult
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -12,7 +15,10 @@ import com.wingedsheep.engine.mechanics.layers.ContinuousEffectSourceComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
 import kotlin.reflect.KClass
 
@@ -135,3 +141,56 @@ internal fun buildCardComponentForDfcFace(
     spellEffect = face.spellEffect,
     imageUri = face.metadata.imageUri ?: current.imageUri
 )
+
+/**
+ * Flip a double-faced entity that is currently **in exile** to [destinationFace] and return it to
+ * the battlefield as a new object under its owner's control.
+ *
+ * The face swap is applied while the entity is still in exile so the EXILE → BATTLEFIELD move
+ * registers the destination face's static abilities and (for a Saga face) the lore-counter entry
+ * setup cleanly. Per Rule 712.8a the front face's [CardComponent] is stashed on the
+ * [DoubleFacedComponent] when going to the back face, so the restore-on-leave path can swap back
+ * without a registry lookup.
+ *
+ * Shared by [ReturnSelfFromExileTransformedExecutor] (CR 702.167a Craft return — always to the
+ * back face) and [ExileAndReturnTransformedExecutor] (FIN Dominant / eikon — either direction).
+ * The caller is responsible for having already moved the entity into exile.
+ */
+internal fun returnDfcFaceFromExile(
+    state: GameState,
+    cardRegistry: CardRegistry,
+    entityId: EntityId,
+    destinationFace: DoubleFacedComponent.Face
+): ZoneTransitionResult {
+    val container = state.getEntity(entityId)
+        ?: return ZoneTransitionResult(state, emptyList())
+    val dfc = container.get<DoubleFacedComponent>()
+        ?: return ZoneTransitionResult(state, emptyList())
+    val currentCard = container.get<CardComponent>()
+        ?: return ZoneTransitionResult(state, emptyList())
+    val ownerId = container.get<OwnerComponent>()?.playerId ?: currentCard.ownerId
+        ?: return ZoneTransitionResult(state, emptyList())
+
+    val destinationDefinitionId = when (destinationFace) {
+        DoubleFacedComponent.Face.FRONT -> dfc.frontCardDefinitionId
+        DoubleFacedComponent.Face.BACK -> dfc.backCardDefinitionId
+    }
+    val destinationDef = cardRegistry.getCard(destinationDefinitionId)
+        ?: return ZoneTransitionResult(state, emptyList())
+
+    val destinationCard = buildCardComponentForDfcFace(currentCard, destinationDef)
+    val updatedDfc = when (destinationFace) {
+        // currentCard is the front face here (the entity reverts to its front face on leaving the
+        // battlefield, Rule 712.8a) — stash it so the back face can restore it on its next exit.
+        DoubleFacedComponent.Face.BACK -> dfc.copy(currentFace = destinationFace, frontFaceCard = currentCard)
+        DoubleFacedComponent.Face.FRONT -> dfc.copy(currentFace = destinationFace, frontFaceCard = null)
+    }
+
+    val prepared = state.updateEntity(entityId) { c -> c.with(destinationCard).with(updatedDfc) }
+    return ZoneTransitionService.moveToZone(
+        prepared,
+        entityId,
+        Zone.BATTLEFIELD,
+        options = ZoneEntryOptions(controllerId = ownerId)
+    )
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DominantEikonTransformScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DominantEikonTransformScenarioTest.kt
@@ -1,0 +1,188 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CliveIfritsDominant
+import com.wingedsheep.mtg.sets.definitions.fin.cards.JillShivasDominant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Dominant / eikon transform (FIN §2): the front face's "Exile this, then return it transformed"
+ * activated/triggered ability flips the legend into its Summon-Saga back face as a *new object*,
+ * and the eikon Saga's final chapter exiles and returns it *front face up* — never the in-place
+ * [com.wingedsheep.sdk.scripting.effects.TransformEffect]. Exercises
+ * [com.wingedsheep.sdk.scripting.effects.ExileAndReturnTransformedEffect] in both directions.
+ */
+class DominantEikonTransformScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    /**
+     * Clear any decision that pauses the game by taking the minimal legal choice: decline "may"
+     * yes/no prompts, and pick exactly each target requirement's minimum number of legal targets
+     * (none for an optional "up to one", the sole legal target for a mandatory "target creature").
+     */
+    fun declineOptionalDecisions(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 12 && driver.isPaused) {
+            when (val decision = driver.pendingDecision) {
+                is YesNoDecision ->
+                    driver.submitDecision(decision.playerId, YesNoResponse(decision.id, false))
+                is ChooseTargetsDecision -> {
+                    val chosen = decision.targetRequirements.associate { req ->
+                        req.index to decision.legalTargets[req.index].orEmpty().take(req.minTargets)
+                    }
+                    driver.submitDecision(decision.playerId, TargetsResponse(decision.id, chosen))
+                }
+                else -> driver.autoResolveDecision()
+            }
+        }
+    }
+
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+        declineOptionalDecisions(driver)
+        resolveStack(driver)
+        declineOptionalDecisions(driver)
+    }
+
+    fun newDriver(card: com.wingedsheep.sdk.model.CardDefinition, land: String): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(card))
+        driver.initMirrorMatch(deck = Deck.of(land to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castAndResolve(driver: GameTestDriver, player: EntityId, name: String): EntityId {
+        val spell = driver.putCardInHand(player, name)
+        driver.giveMana(player, Color.RED, 2)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.giveColorlessMana(player, 8)
+        driver.castSpell(player, spell)
+        driver.bothPass()
+        resolveStack(driver)
+        declineOptionalDecisions(driver) // decline the ETB "may"
+        resolveStack(driver)
+        return driver.findPermanent(player, name)!!
+    }
+
+    test("the front-face transform ability is sorcery-speed (CR: 'activate only as a sorcery')") {
+        CliveIfritsDominant.activatedAbilities.first().timing shouldBe TimingRule.SorcerySpeed
+        JillShivasDominant.activatedAbilities.first().timing shouldBe TimingRule.SorcerySpeed
+    }
+
+    test("Clive's activated ability exiles and returns it as the Ifrit Saga back — a new object") {
+        val driver = newDriver(CliveIfritsDominant, "Mountain")
+        val active = driver.activePlayer!!
+
+        val clive = castAndResolve(driver, active, "Clive, Ifrit's Dominant")
+        projector.project(driver.state).getPower(clive) shouldBe 5
+
+        // {T} cost: bypass summoning sickness so the sorcery-speed ability can fire this turn.
+        driver.removeSummoningSickness(clive)
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 4)
+        val abilityId = CliveIfritsDominant.activatedAbilities.first().id
+        driver.submit(ActivateAbility(playerId = active, sourceId = clive, abilityId = abilityId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        declineOptionalDecisions(driver) // chapter I "fight up to one" — no other creature, none chosen
+        resolveStack(driver)
+        declineOptionalDecisions(driver)
+
+        // Same entity id, now the back face: Ifrit, a 9/9 Enchantment-Creature Saga with a fresh
+        // lore counter (it re-entered as a brand-new object, not flipped in place).
+        val container = driver.state.getEntity(clive)!!
+        container.get<com.wingedsheep.engine.state.components.identity.CardComponent>()!!.name shouldBe
+            "Ifrit, Warden of Inferno"
+        val projected = projector.project(driver.state)
+        projected.isCreature(clive) shouldBe true
+        projected.hasType(clive, "Saga") shouldBe true
+        projected.getPower(clive) shouldBe 9
+        projected.getToughness(clive) shouldBe 9
+        container.get<SagaComponent>() shouldNotBe null
+        container.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 1
+    }
+
+    test("Ifrit's final chapter returns it front face up as Clive, rather than being sacrificed") {
+        val driver = newDriver(CliveIfritsDominant, "Mountain")
+        val active = driver.activePlayer!!
+
+        val clive = castAndResolve(driver, active, "Clive, Ifrit's Dominant")
+        driver.removeSummoningSickness(clive)
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 4)
+        val abilityId = CliveIfritsDominant.activatedAbilities.first().id
+        driver.submit(ActivateAbility(playerId = active, sourceId = clive, abilityId = abilityId))
+        driver.bothPass()
+        declineOptionalDecisions(driver)
+        resolveStack(driver)
+        declineOptionalDecisions(driver)
+
+        // Ifrit entered with lore 1. Accrue to lore 3 (chapter III "Brimstone" meets the
+        // three-or-more-lore clause and flips Ifrit back to Clive, front face up).
+        advanceToNextTurnMain(driver) // opp turn 2
+        advanceToNextTurnMain(driver) // active turn 3 -> lore 2 (chapter II, condition false)
+        driver.state.getEntity(clive)!!.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 2
+        advanceToNextTurnMain(driver) // opp turn 4
+        advanceToNextTurnMain(driver) // active turn 5 -> lore 3 (chapter III -> return front)
+
+        // Still on the battlefield (it returned itself instead of being sacrificed by CR 714.4),
+        // now Clive again: front face, 5/5, no Saga machinery, no lore counter (a new object).
+        val container = driver.state.getEntity(clive)!!
+        container.get<com.wingedsheep.engine.state.components.identity.CardComponent>()!!.name shouldBe
+            "Clive, Ifrit's Dominant"
+        projector.project(driver.state).getPower(clive) shouldBe 5
+        container.get<SagaComponent>() shouldBe null
+        (container.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0) shouldBe 0
+    }
+
+    test("Jill's activated ability returns it as the Shiva Saga back (4/5, fresh lore)") {
+        val driver = newDriver(JillShivasDominant, "Island")
+        val active = driver.activePlayer!!
+
+        val jill = castAndResolve(driver, active, "Jill, Shiva's Dominant")
+        driver.removeSummoningSickness(jill)
+        driver.giveMana(active, Color.BLUE, 2)
+        driver.giveColorlessMana(active, 3)
+        val abilityId = JillShivasDominant.activatedAbilities.first().id
+        driver.submit(ActivateAbility(playerId = active, sourceId = jill, abilityId = abilityId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        declineOptionalDecisions(driver)
+        resolveStack(driver)
+        declineOptionalDecisions(driver)
+
+        val container = driver.state.getEntity(jill)!!
+        container.get<com.wingedsheep.engine.state.components.identity.CardComponent>()!!.name shouldBe
+            "Shiva, Warden of Ice"
+        val projected = projector.project(driver.state)
+        projected.getPower(jill) shouldBe 4
+        projected.getToughness(jill) shouldBe 5
+        container.get<SagaComponent>() shouldNotBe null
+        container.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 1
+    }
+})


### PR DESCRIPTION
## Summary

Closes the **§2 Dominant / Eikon transform** engine gap in `backlog/fin-engine-gaps.md`. The FIN Dominants flip their legend front into a Summon-Saga back (and the eikon flips back) via *"Exile [this], then return it to the battlefield transformed under its owner's control"* — a **leave-and-re-enter** transform that produces a **new object**, distinct from the in-place `TransformEffect` (Cecil).

## Engine

- **`Effects.ExileAndReturnTransformed(target = Self, returnAs = ReturnFace.TRANSFORMED)`** + `ExileAndReturnTransformedExecutor`. Exiles a double-faced permanent and re-enters it as a *new object* on the chosen face through the standard `ZoneTransitionService.moveToZone` path, so:
  - a Saga back re-enters with one lore counter (CR 714.2b),
  - counters/damage drop, attachments fall off, and **ETB/LTB triggers fire** (not transform triggers),
  - the exile and return are atomic (no priority/SBAs between).
  - `returnAs`: `TRANSFORMED` (front→back), `FRONT` (the eikon final chapter's "front face up"), or `BACK`.
  - Reuses existing `ZoneChangeEvent` plumbing — **no new GameEvent, DTO, or client change**.
- Extracted a shared **`returnDfcFaceFromExile`** helper (flip face while in exile + return to battlefield) and **refactored the Craft return** (`ReturnSelfFromExileTransformed`) to use it — one code path for both mechanics.
- The eikon backs need **no sacrifice opt-out flag**: their final chapter exile-returns them front face up *before* the CR 714.4 sacrifice SBA applies (chapter on the stack → no sac; once it resolves the permanent is no longer a Saga).

## Cards (front + Summon-Saga back)

- **Clive, Ifrit's Dominant // Ifrit, Warden of Inferno** — sorcery-speed activated transform; eikon final chapter returns front face up. (devotion-to-red ETB)
- **Jill, Shiva's Dominant // Shiva, Warden of Ice**.
- **Jecht, Reluctant Guardian // Braska's Final Aeon** — front uses the effect from a *"may" combat-damage trigger*; back is a plain sacrifice-after-III Summon Saga (no return), proving the sacrifice and return paths coexist.

The remaining §2 cards (Dion//Bahamut, Joshua//Phoenix, Terra//Esper Terra, Crystal Fragments, Esper Origins) **reuse this same effect** and are blocked only on *unrelated* chapter/effect primitives (conditional flying static, total-MV-budget reanimation, token-copy-enchantment-with-lore, group damage-prevention, spell-becomes-permanent) — each documented in the backlog.

## Tests

- New **`DominantEikonTransformScenarioTest`**: front→back as a new object with fresh lore, eikon final-chapter return-to-front *instead of* being sacrificed, sorcery-speed gating, and a second card.
- Existing **`SaheelisLatticeCraftScenarioTest`** still green after the shared-helper refactor.
- Full `:rules-engine` and `:mtg-sets` suites pass; FIN snapshot golden re-blessed; SDK reference updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)