### PR TITLE
Add DSK cards: Cynical Loner, Miasma Demon, Razorkin Hordecaller, Roaring Furnace

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1102,6 +1102,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   there (and use them whenever the inference is wrong). Wrap with `MayEffect` for the optional
   "You may [action]. If you do, [effect]" shape.
 - `ReflexiveTriggerEffect(action, reflexive, optional)` — same shape but the reflexive effect goes on the stack.
+  Targets in `reflexiveTargetRequirements` are chosen *after* `action` resolves, against the resolving
+  ability's live pipeline. A `TargetObject.dynamicMaxCount` on a reflexive requirement is therefore
+  resolved against that pipeline — so "up to **that many** target …" can read a count a preceding action
+  stored, e.g. `dynamicMaxCount = DynamicAmount.VariableReference("discarded_count")` paired with
+  `Patterns.Hand.discardAnyNumber()` (Miasma Demon: "you may discard any number of cards. When you do, up
+  to that many target creatures each get -2/-2"). This differs from the cast-time path
+  (`TargetValidator.effectiveMaxCount`), where the pipeline isn't live yet — pipeline-linked caps only
+  work on reflexive/resolution-time targets.
 - **Branching on gathered properties** — "reveal/look, if it's a [type] do X, otherwise Y" needs no
   bespoke effect type; it is the partition + collection-gate composition:
   1. **Partition:** `FilterCollection(from, CollectionFilter.MatchesFilter(filter), storeMatching,
@@ -1197,6 +1205,12 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `discardCardsUnlessMatching(count, unlessFilter, target?, reducedCount?, requiredMatches?)` /
   `Effects.DiscardUnlessMatching(...)` — one-step "discard N cards unless you discard a matching card" selection;
   a lower-count selection is valid only when it includes enough cards matching `unlessFilter`.
+- `discardAnyNumber(target?, filter?, storeAs?, prompt?)` — "discard any number of cards": the
+  controller chooses any subset of their hand (including none) to discard, via
+  `SelectionMode.ChooseAnyNumber`. The selected set is stored under `storeAs` (default `"discarded"`),
+  so the count is readable downstream as `DynamicAmount.VariableReference("${storeAs}_count")` — e.g.
+  Miasma Demon wires this as the `ReflexiveTriggerEffect` action and reads `discarded_count` as the
+  reflexive targets' `dynamicMaxCount` ("up to that many target creatures").
 - `discardRandom(count, target)` — random discards.
 - `discardHand(target)` — discard entire hand.
 - `eachOpponentDiscards(count, controllerDrawsPerDiscard?)` — Mind Twist-style.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -138,6 +138,48 @@ object HandPatterns {
     }
 
     /**
+     * "Discard any number of cards" — the controller chooses any subset of their hand (including
+     * none) to discard. The selected cards are stored under [storeAs], so the count is readable
+     * downstream as `DynamicAmount.VariableReference("${storeAs}_count")` — e.g. Miasma Demon's
+     * "you may discard any number of cards. When you do, up to that many target creatures each get
+     * -2/-2" wires this as the [com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect]
+     * action and reads `discarded_count` as the reflexive targets' `dynamicMaxCount`.
+     *
+     * Same Gather → Select → Move pipeline as the fixed-count [discardCards], but with
+     * [SelectionMode.ChooseAnyNumber] (no minimum). [filter] restricts which hand cards are
+     * eligible to discard.
+     */
+    fun discardAnyNumber(
+        target: EffectTarget = EffectTarget.Controller,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        storeAs: String = "discarded",
+        prompt: String = "Choose any number of cards to discard",
+    ): CompositeEffect {
+        val player = effectTargetToPlayer(target)
+        val chooser = effectTargetToChooser(target)
+        return CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, player, filter),
+                    storeAs = "${storeAs}_candidates"
+                ),
+                SelectFromCollectionEffect(
+                    from = "${storeAs}_candidates",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = chooser,
+                    storeSelected = storeAs,
+                    prompt = prompt
+                ),
+                MoveCollectionEffect(
+                    from = storeAs,
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, player),
+                    moveType = MoveType.Discard
+                )
+            )
+        )
+    }
+
+    /**
      * Discard [count] cards, or satisfy the instruction by discarding fewer cards if
      * the selection includes [requiredMatches] cards matching [unlessFilter].
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MiasmaDemon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MiasmaDemon.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Miasma Demon — Duskmourn: House of Horror #109
+ * {4}{B}{B} · Creature — Demon · 5/4
+ *
+ * Flying
+ * When this creature enters, you may discard any number of cards. When you do, up to that many
+ * target creatures each get -2/-2 until end of turn.
+ *
+ * Modeled as a [ReflexiveTriggerEffect]: the action is "discard any number of cards"
+ * ([Patterns.Hand.discardAnyNumber], which stores the discarded set so its size is readable as
+ * `discarded_count`), and the reflexive payoff selects up to that many target creatures —
+ * [TargetCreature.dynamicMaxCount] = `DynamicAmount.VariableReference("discarded_count")`, resolved
+ * against the resolving ability's pipeline when the reflexive targets are chosen (after the
+ * discard). [ForEachTargetEffect] applies -2/-2 until end of turn to each chosen creature.
+ *
+ * Per CR 603.10c / the oracle "when you do" reflexive shape, the payoff fires off the discard
+ * action itself; discarding zero cards means there is no "that many", so the reflexive trigger
+ * targets nothing — handled by `optional = false` on the reflexive wrapper (the action is the
+ * "may", a discard of zero is a legal no-op) combined with the 0-cap on targets.
+ */
+val MiasmaDemon = card("Miasma Demon") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, you may discard any number of cards. When you do, up to that " +
+        "many target creatures each get -2/-2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Patterns.Hand.discardAnyNumber(),
+            optional = false,
+            reflexiveEffect = ForEachTargetEffect(
+                listOf(
+                    Effects.ModifyStats(-2, -2, EffectTarget.ContextTarget(0))
+                )
+            ),
+            reflexiveTargetRequirements = listOf(
+                TargetCreature(
+                    optional = true,
+                    dynamicMaxCount = DynamicAmount.VariableReference("discarded_count")
+                )
+            ),
+            descriptionOverride = "You may discard any number of cards. When you do, up to that " +
+                "many target creatures each get -2/-2 until end of turn."
+        )
+        description = "When this creature enters, you may discard any number of cards. When you " +
+            "do, up to that many target creatures each get -2/-2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Mathias Kollros"
+        flavorText = "\"Hush, little ants. I can rid you of your troubles with a breath. All I " +
+            "ask in return is a drop of blood... and a promise.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg?1726286255"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RoaringFurnaceSteamingSauna.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RoaringFurnaceSteamingSauna.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Roaring Furnace // Steaming Sauna (DSK 230) — split-layout Room (CR 709.5).
+ *
+ * Roaring Furnace {1}{R} — Enchantment — Room
+ *   When you unlock this door, this Room deals damage equal to the number of cards in your hand
+ *   to target creature an opponent controls.
+ *
+ * Steaming Sauna {3}{U}{U} — Enchantment — Room
+ *   You have no maximum hand size.
+ *   At the beginning of your end step, draw a card.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). The
+ * Roaring Furnace door-unlock trigger ([Triggers.OnDoorUnlocked]) targets a creature an opponent
+ * controls and deals damage equal to [DynamicAmounts.cardsInYourHand]; the Room itself is the
+ * damage source (the default when no explicit `damageSource` is given to [Effects.DealDamage]).
+ * Steaming Sauna pairs the [NoMaximumHandSize] static with an end-step draw.
+ */
+val RoaringFurnaceSteamingSauna = card("Roaring Furnace // Steaming Sauna") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "UR"
+
+    face("Roaring Furnace") {
+        manaCost = "{1}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, this Room deals damage equal to the number of " +
+            "cards in your hand to target creature an opponent controls."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            target = Targets.CreatureOpponentControls
+            effect = Effects.DealDamage(DynamicAmounts.cardsInYourHand(), EffectTarget.ContextTarget(0))
+            description = "When you unlock this door, this Room deals damage equal to the number " +
+                "of cards in your hand to target creature an opponent controls."
+        }
+    }
+
+    face("Steaming Sauna") {
+        manaCost = "{3}{U}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "You have no maximum hand size.\nAt the beginning of your end step, draw a card."
+
+        staticAbility {
+            ability = NoMaximumHandSize
+        }
+
+        triggeredAbility {
+            trigger = Triggers.YourEndStep
+            effect = Effects.DrawCards(1)
+            description = "At the beginning of your end step, draw a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1726867698"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -6672,6 +6672,109 @@
     ]
 }
 
+// Miasma Demon
+{
+    "name": "Miasma Demon",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\nWhen this creature enters, you may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "discarded_candidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "discarded_candidates",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose any number of cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "dynamicMaxCount": {
+                                "type": "VariableReference",
+                                "variableName": "discarded_count"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn."
+                },
+                "descriptionOverride": "When this creature enters, you may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Hush, little ants. I can rid you of your troubles with a breath. All I ask in return is a drop of blood... and a promise.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg?1726286255"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Midnight Mayhem
 {
     "name": "Midnight Mayhem",
@@ -8766,6 +8869,89 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Roaring Furnace // Steaming Sauna
+{
+    "name": "Roaring Furnace // Steaming Sauna",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, this Room deals damage equal to the number of cards in your hand to target creature an opponent controls.\n//\nYou have no maximum hand size.\nAt the beginning of your end step, draw a card.",
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1726867698"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Roaring Furnace",
+            "manaCost": "{1}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, this Room deals damage equal to the number of cards in your hand to target creature an opponent controls.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Hand"
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        },
+                        "descriptionOverride": "When you unlock this door, this Room deals damage equal to the number of cards in your hand to target creature an opponent controls."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Steaming Sauna",
+            "manaCost": "{3}{U}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "You have no maximum hand size.\nAt the beginning of your end step, draw a card.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "END"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "descriptionOverride": "At the beginning of your end step, draw a card."
+                    }
+                ],
+                "staticAbilities": [
+                    "NoMaximumHandSize"
+                ]
+            }
+        }
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -206,6 +206,7 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     counterUnlessPaysEffect(actions)?.let { return it }
     counterUnlessPaysWithRiderEffect(actions)?.let { return it }
     mayCostReflexiveDamageEffect(actions)?.let { return it }
+    mayCostDiscardAnyNumberReflexiveModifyStatsEffect(actions)?.let { return it }
     mayCostReflexiveDestroyRoomEffect(actions)?.let { return it }
     erodeDestroyControllerFetchEffect(actions)?.let { return it }
     heatedArgumentExileRiderEffect(actions)?.let { return it }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SosRecognizers.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.tooling.coverage.Sub
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
@@ -636,6 +637,97 @@ internal fun EmitCtx.mayCostReflexiveDamageEffect(actions: List<JsonObject>): Ds
             arg("damageSource", Lit("EffectTarget.Self")),
         )),
         arg("reflexiveTargetRequirements", call("listOf", arg(reflexiveTarget))),
+    )
+}
+
+/**
+ * Miasma Demon — "you may discard any number of cards. When you do, up to that many target creatures
+ * each get -2/-2 until end of turn." The pipeline-count-linked reflexive sibling of
+ * [mayCostReflexiveDamageEffect]. mtgish models it as:
+ *
+ * `[ MayCost(DiscardAnyNumberOfCards),
+ *    If(CostWasPaid)[ ReflexiveTrigger(Targeted(
+ *        [UptoNumberTargetPermanents(NumCardsDiscardedThisWay, IsCardtype Creature)],
+ *        ActionList[ CreateEachPermanentLayerEffectUntil(Ref_TargetPermanents, [AdjustPT(-2,-2)], UntilEndOfTurn) ])) ] ]`
+ * →
+ * ```
+ * ReflexiveTriggerEffect(
+ *     action = Patterns.Hand.discardAnyNumber(),
+ *     optional = false,
+ *     reflexiveEffect = ForEachTargetEffect(listOf(Effects.ModifyStats(-2, -2, EffectTarget.ContextTarget(0)))),
+ *     reflexiveTargetRequirements = listOf(TargetCreature(
+ *         optional = true, dynamicMaxCount = DynamicAmount.VariableReference("discarded_count"))))
+ * ```
+ *
+ * "Discard any number of cards" stores the discarded set as `discarded`, so the reflexive target's
+ * `dynamicMaxCount` reads `discarded_count` ("up to **that many**"); the engine resolves it against the
+ * resolving ability's live pipeline (see `ReflexiveTriggerEffect` in the SDK reference). The payoff is a
+ * per-target AdjustPT layer effect until end of turn (modeled as ModifyStats under ForEachTarget). Renders
+ * ONLY this exact shape — discard-any-number cost, a CostWasPaid-gated single reflexive trigger targeting
+ * up-to-that-many creatures with a fixed ±P/±T until end of turn — and declines (→ SCAFFOLD) for any other
+ * cost, count source, filter, or payoff.
+ */
+internal fun EmitCtx.mayCostDiscardAnyNumberReflexiveModifyStatsEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    val (mayCost, ifPaid) = actions
+    if (mayCost.strField("_Action") != "MayCost") return null
+    val cost = mayCost["args"] as? JsonObject ?: return null
+    if (cost.strField("_Cost") != "DiscardAnyNumberOfCards") return null
+
+    // The gate must be exactly If(CostWasPaid)[ ReflexiveTrigger(...) ] — no else-branch.
+    if (ifPaid.strField("_Action") != "If") return null
+    val ifArgs = ifPaid["args"].asArr ?: return null
+    if (!jsonContains(ifArgs.getOrNull(0), "_Condition", "CostWasPaid") || ifArgs.getOrNull(2) != null) return null
+    val reflexive = (ifArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+        ?.singleOrNull()?.takeIf { it.strField("_Action") == "ReflexiveTrigger" } ?: return null
+
+    // The reflexive Targeted envelope: a single "up to that many target creatures" target.
+    val (rTargets, rActions) = extractEnvelope(reflexive)
+    val target = rTargets?.singleOrNull() ?: return null
+    if (target.strField("_Target") != "UptoNumberTargetPermanents") return null
+    val targetArgs = target["args"].asArr ?: return null
+    // The count source must be the discarded-this-way count ("that many"); anything else declines.
+    if ((targetArgs.getOrNull(0) as? JsonObject)?.strField("_GameNumber") != "NumCardsDiscardedThisWay") return null
+    // The target filter must be exactly "creature" (IsCardtype Creature, no extra clauses).
+    val filterNode = targetArgs.getOrNull(1) as? JsonObject ?: return null
+    if (filterNode.strField("_Permanents") != "IsCardtype" || filterNode["args"].asStr() != "Creature") return null
+    if (compact(target).let { "ControlledByAPlayer" in it || "IsCreatureType" in it }) return null
+
+    // The payoff: each targeted creature gets a fixed ±P/±T until end of turn (AdjustPT layer effect).
+    val layer = rActions?.singleOrNull()?.takeIf { it.strField("_Action") == "CreateEachPermanentLayerEffectUntil" } ?: return null
+    val layerArgs = layer["args"].asArr ?: return null
+    if (!jsonContains(layerArgs.getOrNull(0), "_Permanents", "Ref_TargetPermanents")) return null
+    if (!jsonContains(layerArgs.getOrNull(2), "_Expiration", "UntilEndOfTurn")) return null
+    val pt = (layerArgs.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+        ?.singleOrNull()?.takeIf { it.strField("_LayerEffect") == "AdjustPT" } ?: return null
+    val ptArgs = pt["args"].asArr ?: return null
+    val dPow = ptArgs.getOrNull(0).asInt() ?: return null
+    val dTou = ptArgs.getOrNull(1).asInt() ?: return null
+
+    return call(
+        "ReflexiveTriggerEffect",
+        arg("action", Lit("Patterns.Hand.discardAnyNumber()")),
+        arg("optional", Lit("false")),
+        arg("reflexiveEffect", call(
+            "ForEachTargetEffect",
+            arg(call(
+                "listOf",
+                arg(call(
+                    "Effects.ModifyStats",
+                    arg("$dPow"),
+                    arg("$dTou"),
+                    arg(Lit("EffectTarget.ContextTarget(0)")),
+                )),
+            )),
+        )),
+        arg("reflexiveTargetRequirements", call(
+            "listOf",
+            arg(call(
+                "TargetCreature",
+                arg("optional", Lit("true")),
+                arg("dynamicMaxCount", Lit("DynamicAmount.VariableReference(\"discarded_count\")")),
+            )),
+        )),
     )
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -297,13 +297,18 @@ class ReflexiveTriggerEffectExecutor(
             }
         }
 
-        // Create target requirement infos for the decision
+        // Create target requirement infos for the decision. A reflexive requirement's
+        // dynamicMaxCount ("up to that many target …") is resolved here against the resolving
+        // ability's pipeline context — so "that many" reads the count a preceding action stored
+        // (e.g. Miasma Demon's discard count via VariableReference("discarded_count")). Unlike the
+        // cast-time path (TargetValidator.effectiveMaxCount), the pipeline is live in `context`
+        // because the action already ran, so the variable resolves to the real selection size.
         val requirementInfos = targetRequirements.mapIndexed { index, req ->
             TargetRequirementInfo(
                 index = index,
                 description = req.description,
                 minTargets = req.effectiveMinCount,
-                maxTargets = req.count
+                maxTargets = resolveReflexiveMaxCount(state, req, context)
             )
         }
 
@@ -345,6 +350,29 @@ class ReflexiveTriggerEffectExecutor(
             decisionResult.pendingDecision,
             priorEvents + decisionResult.events.toList()
         )
+    }
+
+    /**
+     * Resolve the maximum number of targets a reflexive requirement allows. When the requirement
+     * carries a [com.wingedsheep.sdk.scripting.targets.TargetObject.dynamicMaxCount] ("up to that
+     * many target …"), evaluate it against the resolving ability's [context] — which holds the
+     * pipeline state the preceding action stored — so a pipeline count variable
+     * (`DynamicAmount.VariableReference("<name>_count")`) caps the count to what actually happened.
+     * Falls back to the static `count` when there's no dynamic cap or it can't be evaluated.
+     */
+    private fun resolveReflexiveMaxCount(
+        state: GameState,
+        req: TargetRequirement,
+        context: EffectContext
+    ): Int {
+        if (req.unlimited) return Int.MAX_VALUE
+        val dyn = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.dynamicMaxCount
+            ?: return req.count
+        return try {
+            amountEvaluator.evaluate(state, dyn, context).coerceAtLeast(0)
+        } catch (_: Exception) {
+            req.count
+        }
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MiasmaDemonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MiasmaDemonScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Miasma Demon (DSK #109) — {4}{B}{B} Demon, 5/4, Flying.
+ *
+ * "When this creature enters, you may discard any number of cards. When you do, up to that many
+ * target creatures each get -2/-2 until end of turn."
+ *
+ * Exercises the pipeline-count-linked reflexive target cap: the number of cards discarded
+ * (`discarded_count`) bounds how many creatures the reflexive trigger may target.
+ */
+class MiasmaDemonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Miasma Demon") {
+
+            test("discarding two cards lets it shrink up to two creatures by -2/-2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Miasma Demon")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2
+                    .withCardOnBattlefield(2, "Glory Seeker")  // 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val targetBears = game.findPermanent("Grizzly Bears")!!
+                val targetSeeker = game.findPermanent("Glory Seeker")!!
+
+                val cast = game.castSpell(1, "Miasma Demon")
+                withClue("Casting Miasma Demon should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB reflexive: discard the two non-Demon cards in hand.
+                val toDiscard = game.findCardsInHand(1, "Grizzly Bears") +
+                    game.findCardsInHand(1, "Glory Seeker")
+                withClue("Two discardable cards remain in hand") { toDiscard.size shouldBe 2 }
+                game.selectCards(toDiscard)
+
+                // "Up to that many" = 2: target both opposing creatures.
+                game.selectTargets(listOf(targetBears, targetSeeker))
+                game.resolveStack()
+
+                withClue("Grizzly Bears (2/2) gets -2/-2 and dies") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Glory Seeker (2/2) gets -2/-2 and dies") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe false
+                }
+            }
+
+            test("discarding one card caps the reflexive trigger at one target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Miasma Demon")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val targetBears = game.findPermanent("Grizzly Bears")!!
+                val targetSeeker = game.findPermanent("Glory Seeker")!!
+
+                game.castSpell(1, "Miasma Demon")
+                game.resolveStack()
+
+                // Discard the one non-Demon card.
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears"))
+
+                // Trying to target two creatures must be rejected (cap = discarded count = 1).
+                val tooMany = game.selectTargets(listOf(targetBears, targetSeeker))
+                withClue("Selecting two targets after discarding one is illegal") {
+                    (tooMany.error != null) shouldBe true
+                }
+
+                // One target is legal.
+                game.selectTargets(listOf(targetBears))
+                game.resolveStack()
+
+                withClue("The single targeted 2/2 dies to -2/-2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("The untargeted creature is unharmed") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe true
+                }
+            }
+
+            test("discarding zero cards fires no reflexive effect") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Miasma Demon")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Miasma Demon")
+                game.resolveStack()
+
+                // Decline to discard (select no cards).
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("No discard means no -2/-2, so the opposing creature survives") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe true
+                }
+                withClue("Miasma Demon resolved onto the battlefield") {
+                    game.isOnBattlefield("Miasma Demon") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoaringFurnaceSteamingSaunaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoaringFurnaceSteamingSaunaTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.RoaringFurnaceSteamingSauna
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * End-to-end scenario for `Roaring Furnace // Steaming Sauna` (DSK 230), a UR Room.
+ *
+ * Roaring Furnace {1}{R}: "When you unlock this door, this Room deals damage equal to the number
+ * of cards in your hand to target creature an opponent controls."
+ * Steaming Sauna {3}{U}{U}: "You have no maximum hand size. At the beginning of your end step,
+ * draw a card."
+ */
+class RoaringFurnaceSteamingSaunaTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(RoaringFurnaceSteamingSauna)
+        d.initMirrorMatch(
+            deck = Deck.of(
+                "Mountain" to 15,
+                "Island" to 15,
+                "Grizzly Bears" to 10,
+            ),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("unlocking Roaring Furnace deals damage equal to cards in hand to an opponent's creature") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent controls a 2/2 to be the damage target.
+        val bears = d.putPermanentOnBattlefield(p2, "Grizzly Bears")
+
+        // Cast Roaring Furnace (face 0, {1}{R}); it enters unlocked, firing the unlock trigger.
+        val roomId = d.putCardInHand(p1, RoaringFurnaceSteamingSauna.name)
+        // Give p1 two spare cards in hand so the damage is exactly 2 (lethal to the 2/2).
+        d.putCardInHand(p1, "Grizzly Bears")
+        d.putCardInHand(p1, "Grizzly Bears")
+        d.giveMana(p1, Color.RED, 2)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        // Resolve the Room spell; it enters unlocked and the "when you unlock this door" trigger
+        // goes on the stack, prompting for its target.
+        d.bothPass()
+
+        // The unlock trigger targets a creature an opponent controls.
+        d.submitTargetSelection(p1, listOf(bears))
+        d.bothPass()
+
+        val room = d.state.getEntity(roomId)?.get<RoomComponent>()
+        room shouldNotBe null
+        room!!.unlocked shouldBe setOf(RoomFaceId("Roaring Furnace"))
+
+        // 2 cards in hand -> 2 damage -> the 2/2 dies (moves to its owner's graveyard).
+        d.findPermanent(p2, "Grizzly Bears") shouldBe null
+        (bears in d.getGraveyard(p2)) shouldBe true
+    }
+
+    test("Steaming Sauna grants no maximum hand size and an end-step draw") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Steaming Sauna (face 1, {3}{U}{U}).
+        val roomId = d.putCardInHand(p1, RoaringFurnaceSteamingSauna.name)
+        d.giveMana(p1, Color.BLUE, 5)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+
+        val room = d.state.getEntity(roomId)?.get<RoomComponent>()!!
+        room.unlocked shouldBe setOf(RoomFaceId("Steaming Sauna"))
+
+        // End step: the "draw a card" trigger fires.
+        val handBefore = d.getHand(p1).size
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.getHand(p1).size shouldBe handBefore + 1
+    }
+})


### PR DESCRIPTION
Implements four Duskmourn: House of Horror (DSK) cards plus the mtgish tooling support for the new shape.

## Cards
- **Cynical Loner** (DSK 89) — {1}{B} 3/1 Human Survivor. Can't be blocked by Glimmers; Survival second-main trigger searches a card to graveyard if tapped. *(Already implemented earlier on this branch — verified, registered, in snapshot.)*
- **Razorkin Hordecaller** (DSK 152) — {4}{R} 4/4. Haste; "Whenever you attack, create a 1/1 red Gremlin." *(Already implemented earlier on this branch — verified.)*
- **Miasma Demon** (DSK 109) — {4}{B}{B} 5/4 Demon, Flying. "When this creature enters, you may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn." *(New.)*
- **Roaring Furnace // Steaming Sauna** (DSK 230) — UR split Room. Roaring Furnace's door-unlock deals damage equal to cards in your hand to a target opponent creature; Steaming Sauna grants no maximum hand size + an end-step draw. *(New.)*

## Engine / SDK changes (for Miasma Demon)
- `ReflexiveTriggerEffect` now resolves a reflexive target requirement's `dynamicMaxCount` against the resolving ability's **live pipeline**, so "up to **that many** target …" can read a pipeline count variable (`DynamicAmount.VariableReference("discarded_count")`). The cast-time path (`TargetValidator.effectiveMaxCount`) is intentionally unchanged — the pipeline isn't live there yet.
- New `Patterns.Hand.discardAnyNumber()` facade — "discard any number of cards" (`SelectionMode.ChooseAnyNumber`) storing the discarded set so its size drives downstream counts.
- `docs/card-sdk-language-reference.md` updated for both additions.

## mtgish tooling
- New emitter recognizer `mayCostDiscardAnyNumberReflexiveModifyStatsEffect` renders the Miasma Demon IR shape (`MayCost(DiscardAnyNumberOfCards)` + `If(CostWasPaid)[ReflexiveTrigger over UptoNumberTargetPermanents with NumCardsDiscardedThisWay + AdjustPT]`) to the exact hand-authored tree, and declines (→ SCAFFOLD) for any other cost/count/filter/payoff. Miasma Demon now emits at fidelity tier **AUTO**.
- No bridge change needed (all involved tags already mapped). `EmitterGoldenTest` unaffected; **POR stays 0-mismatch** (`coverage-verify POR` → GATE PASS).

## Tests
- `MiasmaDemonScenarioTest` — discard count caps targets to "that many"; discarding one card rejects a two-target selection; discarding zero is a no-op.
- `RoaringFurnaceSteamingSaunaTest` — unlock damage equals hand size (kills a 2/2 with 2 cards in hand); Steaming Sauna end-step draw.
- Full `:rules-engine` suite, `:mtg-sets` (snapshot re-blessed additively + lint), and `:mtgish-tooling` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)