### PR TITLE
Add DSK Golgari cards: Omnivorous Flytrap, Hauntwoods Shrieker, Wickerfolk Thresher, Ghost Vacuum

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostVacuum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostVacuum.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ghost Vacuum
+ * {1}
+ * Artifact
+ *
+ * {T}: Exile target card from a graveyard.
+ * {6}, {T}, Sacrifice this artifact: Put each creature card exiled with this artifact onto the
+ * battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in
+ * addition to its other types. Activate only as a sorcery.
+ *
+ * First ability: exiles a target card from any graveyard, linked to this artifact
+ * ([MoveToZoneEffect.linkToSource]) so the second ability can find the pile it built up.
+ *
+ * Second ability follows the proven [com.wingedsheep.mtg.sets.definitions.eoe.cards.PinnacleStarcage]
+ * shape: the linked-exile pile is gathered (filtered to creature cards via the move's [filter]) and
+ * the artifact is sacrificed *within the resolving effect* via [Effects.SacrificeTarget] rather than
+ * as a paid cost. This is functionally identical to "Sacrifice this artifact" as a cost — nothing
+ * references the artifact after the gather, and gathering before the sacrifice keeps the
+ * `LinkedExileComponent` available (CR 400.7) — while reusing the battle-tested pattern.
+ *
+ * The returned creatures enter under your control with a flying counter ([MoveCollectionEffect.addCounterType]
+ * = [CounterType.FLYING], which the projector maps to the flying keyword), then a per-permanent
+ * iteration over the moved collection ([IterationSpace.Collection]) sets each one's base power and
+ * toughness to 1/1 and adds the Spirit creature type, both for [Duration.Permanent] (the lasting
+ * "is a 1/1 Spirit in addition to its other types" effect, which persists after the artifact is gone).
+ */
+val GhostVacuum = card("Ghost Vacuum") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Exile target card from a graveyard.\n" +
+        "{6}, {T}, Sacrifice this artifact: Put each creature card exiled with this artifact onto " +
+        "the battlefield under your control with a flying counter on it. Each of them is a 1/1 " +
+        "Spirit in addition to its other types. Activate only as a sorcery."
+
+    // {T}: Exile target card from a graveyard (linked to this artifact).
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target(
+            "target card in a graveyard",
+            TargetObject(filter = TargetFilter.CardInGraveyard),
+        )
+        effect = Effects.Move(t, Zone.EXILE, linkToSource = true)
+        description = "Exile target card from a graveyard."
+    }
+
+    // {6}, {T}, Sacrifice this artifact: Put each creature card exiled with this artifact onto the
+    // battlefield under your control with a flying counter; each becomes a 1/1 Spirit in addition
+    // to its other types. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            // Gather the linked-exile pile before the sacrifice (CR 400.7).
+            GatherCardsEffect(
+                source = CardSource.FromLinkedExile(),
+                storeAs = "exiledPile",
+            ),
+            // Put each creature card from the pile onto the battlefield under your control with a
+            // flying counter; non-creature cards stay exiled (filter).
+            MoveCollectionEffect(
+                from = "exiledPile",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                filter = GameObjectFilter.Creature,
+                addCounterType = CounterType.FLYING,
+                storeMovedAs = "spirits",
+            ),
+            // Each of them is a 1/1 Spirit in addition to its other types (lasting).
+            ForEachEffect(
+                space = IterationSpace.Collection("spirits"),
+                body = Effects.Composite(
+                    Effects.SetBasePowerAndToughness(
+                        power = 1,
+                        toughness = 1,
+                        target = EffectTarget.Self,
+                        duration = com.wingedsheep.sdk.scripting.Duration.Permanent,
+                    ),
+                    Effects.AddCreatureType("Spirit", EffectTarget.Self),
+                ),
+            ),
+            // Sacrifice this artifact (modeled in-effect; see KDoc).
+            Effects.SacrificeTarget(EffectTarget.Self),
+        )
+        description = "Put each creature card exiled with this artifact onto the battlefield under " +
+            "your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to " +
+            "its other types. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "248"
+        artist = "David Szabo"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg?1726286797"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OmnivorousFlytrap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OmnivorousFlytrap.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Omnivorous Flytrap
+ * {2}{G}
+ * Creature — Plant
+ * 2/4
+ *
+ * Delirium — Whenever this creature enters or attacks, if there are four or more card types among
+ * cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if
+ * there are six or more card types among cards in your graveyard, double the number of +1/+1
+ * counters on those creatures.
+ *
+ * Delirium is an ability word (no rules meaning); both the enters trigger and the attacks trigger
+ * carry an intervening-"if" gate of [Conditions.Delirium] (four+ distinct card types in your
+ * graveyard) — modeled as two separate triggered abilities (Sentinel of the Nameless City shape).
+ *
+ * The payoff distributes two +1/+1 counters across one or two *target* creatures
+ * (`TargetCreature(count = 2, minCount = 1)` + [Effects.DistributeCountersAmongTargets]). The
+ * second clause is a separate check at resolution: gated on six+ card types ([Conditions.Delirium]
+ * with count = 6), it doubles the +1/+1 counters on **those same creatures** — iterating the chosen
+ * targets via [IterationSpace.Targets] so [Effects.DoubleCounters] applies to each (one or two).
+ * Each target received at least one counter from the distribution, so doubling is always meaningful;
+ * a target that became illegal before resolution is simply skipped by the iteration.
+ */
+val OmnivorousFlytrap = card("Omnivorous Flytrap") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    power = 2
+    toughness = 4
+    oracleText = "Delirium — Whenever this creature enters or attacks, if there are four or more " +
+        "card types among cards in your graveyard, distribute two +1/+1 counters among one or two " +
+        "target creatures. Then if there are six or more card types among cards in your graveyard, " +
+        "double the number of +1/+1 counters on those creatures."
+
+    // Distribute two +1/+1 counters among one or two target creatures, then (delirium ≥ 6) double
+    // the +1/+1 counters on those same creatures.
+    val payoff = Effects.Composite(
+        Effects.DistributeCountersAmongTargets(totalCounters = 2),
+        ConditionalEffect(
+            condition = Conditions.Delirium(count = 6),
+            effect = ForEachEffect(
+                space = IterationSpace.Targets,
+                body = Effects.DoubleCounters(target = EffectTarget.ContextTarget(0)),
+            ),
+        ),
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.Delirium()
+        target = TargetCreature(count = 2, minCount = 1)
+        effect = payoff
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.Delirium()
+        target = TargetCreature(count = 2, minCount = 1)
+        effect = payoff
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "192"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg?1726286582"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -4597,6 +4597,114 @@
     ]
 }
 
+// Ghost Vacuum
+{
+    "name": "Ghost Vacuum",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Exile target card from a graveyard.\n{6}, {T}, Sacrifice this artifact: Put each creature card exiled with this artifact onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card in a graveyard"
+                    },
+                    "destination": "Exile",
+                    "linkToSource": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card in a graveyard"
+                    }
+                ],
+                "descriptionOverride": "Exile target card from a graveyard."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "exiledPile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledPile",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "storeMovedAs": "spirits",
+                            "addCounterType": "FLYING",
+                            "filter": "creature"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "spirits"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SetBasePowerToughness",
+                                        "target": "Self",
+                                        "power": 1,
+                                        "toughness": 1
+                                    },
+                                    {
+                                        "type": "AddCreatureType",
+                                        "subtype": "Spirit"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "SacrificeTarget",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put each creature card exiled with this artifact onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "RARE",
+        "artist": "David Szabo",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg?1726286797"
+    },
+    "colorIdentityOverride": []
+}
+
 // Give In to Violence
 {
     "name": "Give In to Violence",
@@ -6923,6 +7031,154 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Omnivorous Flytrap
+{
+    "name": "Omnivorous Flytrap",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "Delirium — Whenever this creature enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DistributeCountersAmongTargets",
+                            "totalCounters": 2
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateZone",
+                                        "player": "You",
+                                        "zone": "Graveyard",
+                                        "aggregation": "DISTINCT_TYPES"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 6
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": "IterationSpace.Targets",
+                                "body": "DoubleCounters"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "minCount": 1,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DistributeCountersAmongTargets",
+                            "totalCounters": 2
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateZone",
+                                        "player": "You",
+                                        "zone": "Graveyard",
+                                        "aggregation": "DISTINCT_TYPES"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 6
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": "IterationSpace.Targets",
+                                "body": "DoubleCounters"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "minCount": 1,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "RARE",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg?1726286582"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -31,6 +31,13 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // "becomes the creature type of your choice" — a ChooseACreatureType + an AddCreatureTypeVariable
     // layer effect collapse to one BecomeCreatureTypeEffect (Mistform cycle, Imagecrafter).
     effect("AddCreatureTypeVariable", "BecomeCreatureType", UNIVERSAL)
+    // Layer effects carried by an enters-with rider (Ghost Vacuum's "each of them is a 1/1 Spirit in
+    // addition to its other types"): set base power/toughness (Layer 7b) and add a creature subtype
+    // (Layer 4). Both map to standing SDK effects with Duration.Permanent. Capability-only — the
+    // EntersWithLayerEffect/PutEachExiledCardOntoTheBattlefield host shape is card-specific, so the
+    // emitter declines -> SCAFFOLD.
+    effect("SetPT", "SetBasePowerToughness", "set base power/toughness via an enters-with layer effect (Ghost Vacuum)")
+    effect("AddCreatureType", "AddCreatureType", "add a creature subtype in addition to other types (Ghost Vacuum)")
     effects("PutACounterOfTypeOnPermanent", "PutNumberCountersOfTypeOnPermanent", tag = "AddCounters", note = UNIVERSAL)
     // "put those counters on <permanent>" — the counters a just-died permanent had move to the target
     // (Scolding Administrator's dies trigger). Maps to MoveAllLastKnownCounters, which moves every
@@ -40,6 +47,19 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // recovered group filter (Bounding Felidar's "each other creature you control").
     composed("PutACounterOfTypeOnEachPermanent", "ForEachInGroup(AddCounters) over a group filter",
         composes = listOf("AddCounters"))
+    // "Distribute N +1/+1 counters among one or two target creatures" — the counter analogue of
+    // distributed damage; the `TargetedDistributed` envelope's `DistributeNumberAmongTargets`
+    // distribution drives a DistributeDecision over the chosen targets, then this action places the
+    // counters (Omnivorous Flytrap, Abzan Charm shape). The emitter declines whole-card rendering of
+    // the distributed *triggered* shape (the distribution/double-on-each tail is card-specific), so
+    // this is capability-only -> SCAFFOLD.
+    effect("PutDistributedCounters", "DistributeCountersAmongTargets",
+        "distribute N +1/+1 counters among one or two target creatures (Omnivorous Flytrap)")
+    // "Double the number of +1/+1 counters on each of those creatures" — applied to the just-targeted
+    // permanents. Lowered to ForEach(IterationSpace.Targets) over Effects.DoubleCounters; capability-only
+    // (the per-target iteration + the ≥6-types intervening-if tail is card-specific) -> SCAFFOLD.
+    effect("DoubleCountersOfTypeOnEachPermanent", "DoubleCounters",
+        "double the +1/+1 counters on the chosen creatures (Omnivorous Flytrap)")
     // "Until end of turn, if you would put one or more +1/+1 counters on a creature you control, put
     // that many plus N +1/+1 counters on it instead." (Prairie Dog) — the duration-/controller-scoped
     // analogue of Hardened Scales' static ModifyCounterPlacement, lowered to

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -48,6 +48,16 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("PutACardFromHandOnBattlefield", "Patterns.Hand.putFromHand -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
     composed("PutTopOfLibraryInHand", "look-top pipeline -> MoveCollection (library->hand)", composes = listOf("MoveCollection", "MoveToZone"))
     composed("PutTopOfLibraryInGraveyard", "look-top pipeline -> MoveCollection (library->graveyard)", composes = listOf("MoveCollection", "MoveToZone"))
+    // "Look at the top card of your library" — the leading reveal of a look-top pipeline (Wickerfolk
+    // Thresher's delirium attack trigger). It's a GatherCards(TopOfLibrary) that the rest of the
+    // pipeline consumes; on its own it's a no-op informational peek, so capability-only.
+    composed("LookAtTopOfLibrary", "look-top pipeline -> GatherCards(TopOfLibrary)", composes = listOf("MoveCollection"))
+    // "(If it's a land card,) you may put it onto the battlefield" — the optional play-the-revealed-land
+    // half of Wickerfolk Thresher's look-top pipeline, a MayCost whose payment is the put-onto-battlefield.
+    // Expressed as FilterCollection(Land) -> SelectFromCollection(ChooseUpTo) -> MoveCollection(->battlefield);
+    // capability-only (the surrounding look-top/else-hand shape is card-specific) -> SCAFFOLD.
+    composed("PutTopCardOfLibraryOfTypeOnBattlefield", "look-top pipeline -> FilterCollection + SelectFromCollection + MoveCollection (library->battlefield)",
+        composes = listOf("MoveCollection", "MoveToZone"))
 
     composed("PutPermanentIntoItsOwnersHand", "bounce: MoveToZone / Gather-Select-MoveCollection pipeline", composes = listOf("MoveToZone"))
     // "Return a <filter> you control to its owner's hand" — the controller CHOOSES the permanent (not a

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostVacuumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostVacuumScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ghost Vacuum (DSK #248) — {1} Artifact.
+ *
+ * "{T}: Exile target card from a graveyard.
+ *  {6}, {T}, Sacrifice this artifact: Put each creature card exiled with this artifact onto the
+ *  battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in
+ *  addition to its other types. Activate only as a sorcery."
+ *
+ * Exercises:
+ *  - the first ability exiling a graveyard card linked to the artifact;
+ *  - the second ability returning the creature cards exiled this way under your control;
+ *  - each returned creature being a 1/1 Spirit (base P/T set, Spirit type added) with a flying
+ *    counter (and thus flying);
+ *  - non-creature cards exiled this way staying exiled.
+ */
+class GhostVacuumScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Ghost Vacuum") {
+
+            test("exiles a graveyard creature, then returns it as a 1/1 flying Spirit") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ghost Vacuum", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(2, "Centaur Courser") // opponent's graveyard creature
+                    .withLandsOnBattlefield(1, "Forest", 6)     // pay {6}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vacuum = game.findPermanent("Ghost Vacuum")!!
+                val cardDef = cardRegistry.getCard("Ghost Vacuum")!!.script
+                val exileAbility = cardDef.activatedAbilities[0]
+                val returnAbility = cardDef.activatedAbilities[1]
+
+                val gyCard = game.findCardsInGraveyard(2, "Centaur Courser").single()
+
+                // {T}: exile the graveyard creature (linked to Ghost Vacuum).
+                val exile = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = vacuum,
+                        abilityId = exileAbility.id,
+                        targets = listOf(ChosenTarget.Card(gyCard, game.player2Id, Zone.GRAVEYARD)),
+                    )
+                )
+                withClue("Exiling the graveyard card should succeed: ${exile.error}") {
+                    exile.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The card is no longer in the graveyard") {
+                    game.isInGraveyard(2, "Centaur Courser") shouldBe false
+                }
+
+                // Untap the artifact (the second ability would normally be activated on a later
+                // turn after the {T} of the first ability has worn off).
+                game.state = game.state.updateEntity(vacuum) { it.without<TappedComponent>() }
+
+                // {6}, {T}, Sacrifice: return creature cards as 1/1 flying Spirits.
+                val ret = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = vacuum,
+                        abilityId = returnAbility.id,
+                    )
+                )
+                withClue("Activating the return ability should succeed: ${ret.error}") {
+                    ret.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Ghost Vacuum was sacrificed") {
+                    game.isOnBattlefield("Ghost Vacuum") shouldBe false
+                }
+
+                val spirit = game.findPermanent("Centaur Courser")
+                withClue("The creature card returned to the battlefield under your control") {
+                    spirit shouldBe game.findPermanents("Centaur Courser").single()
+                }
+                val id = spirit!!
+                val projected = stateProjector.project(game.state)
+                withClue("It is a 1/1") {
+                    projected.getPower(id) shouldBe 1
+                    projected.getToughness(id) shouldBe 1
+                }
+                withClue("It has a flying counter and therefore flying") {
+                    game.state.getEntity(id)?.get<CountersComponent>()
+                        ?.getCount(CounterType.FLYING) shouldBe 1
+                    projected.hasKeyword(id, Keyword.FLYING) shouldBe true
+                }
+                withClue("It is a Spirit in addition to its other types") {
+                    projected.getSubtypes(id).contains("Spirit") shouldBe true
+                }
+            }
+
+            test("non-creature cards exiled this way are not returned") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ghost Vacuum", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Lightning Bolt") // an instant, not a creature
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vacuum = game.findPermanent("Ghost Vacuum")!!
+                val cardDef = cardRegistry.getCard("Ghost Vacuum")!!.script
+                val gyCard = game.findCardsInGraveyard(1, "Lightning Bolt").single()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = vacuum,
+                        abilityId = cardDef.activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Card(gyCard, game.player1Id, Zone.GRAVEYARD)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.state = game.state.updateEntity(vacuum) { it.without<TappedComponent>() }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = vacuum,
+                        abilityId = cardDef.activatedAbilities[1].id,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("The instant stays exiled (not a creature card)") {
+                    game.isOnBattlefield("Lightning Bolt") shouldBe false
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmnivorousFlytrapScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmnivorousFlytrapScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.DistributionResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Omnivorous Flytrap (DSK #192) — {2}{G} 2/4 Creature — Plant.
+ *
+ * "Delirium — Whenever this creature enters or attacks, if there are four or more card types among
+ *  cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if
+ *  there are six or more card types among cards in your graveyard, double the number of +1/+1
+ *  counters on those creatures."
+ *
+ * Exercises:
+ *  - the attack trigger gated by delirium (≥ 4 card types) distributing two +1/+1 counters;
+ *  - the ≥ 6 card-types clause doubling the counters on the chosen targets;
+ *  - the ≥ 4-but-< 6 case (distribute, no doubling);
+ *  - the no-delirium case (trigger does nothing).
+ */
+class OmnivorousFlytrapScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioBuilder.withFourTypes(): ScenarioBuilder = this
+        .withCardInGraveyard(1, "Ornithopter")    // Artifact
+        .withCardInGraveyard(1, "Grizzly Bears")  // Creature
+        .withCardInGraveyard(1, "Lightning Bolt") // Instant
+        .withCardInGraveyard(1, "Forest")         // Land
+
+    private fun ScenarioBuilder.withSixTypes(): ScenarioBuilder = withFourTypes()
+        .withCardInGraveyard(1, "Pacifism")       // Enchantment
+        .withCardInGraveyard(1, "Divination")     // Sorcery
+
+    init {
+        context("Omnivorous Flytrap — delirium attack trigger") {
+
+            test("with four card types, distributes two +1/+1 counters (no doubling)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Omnivorous Flytrap", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Centaur Courser") // distribute target
+                    .withFourTypes()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Centaur Courser")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Omnivorous Flytrap" to 2))
+
+                // Choose the single target, then distribute both counters onto it.
+                var guard = 0
+                while (game.getPendingDecision() == null && guard++ < 20) game.resolveStack()
+                game.selectTargets(listOf(bear)).error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as DistributeDecision
+                    game.submitDecision(DistributionResponse(decision.id, mapOf(bear to decision.totalAmount)))
+                    game.resolveStack()
+                }
+
+                withClue("Two +1/+1 counters on the target, not doubled (< 6 types)") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+            }
+
+            test("with six card types, doubles the counters on those creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Omnivorous Flytrap", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withSixTypes()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Centaur Courser")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Omnivorous Flytrap" to 2))
+
+                var guard = 0
+                while (game.getPendingDecision() == null && guard++ < 20) game.resolveStack()
+                game.selectTargets(listOf(bear)).error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as DistributeDecision
+                    game.submitDecision(DistributionResponse(decision.id, mapOf(bear to decision.totalAmount)))
+                    game.resolveStack()
+                }
+
+                withClue("Two counters distributed then doubled to four (≥ 6 types)") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 4
+                }
+            }
+
+            test("without delirium, the attack trigger does nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Omnivorous Flytrap", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardInGraveyard(1, "Grizzly Bears") // only one card type
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Centaur Courser")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Omnivorous Flytrap" to 2))
+                game.resolveStack()
+
+                withClue("No delirium → no target/distribute decision and no counters") {
+                    (game.getPendingDecision() is DistributeDecision) shouldBe false
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0 shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Duskmourn: House of Horror (DSK) cards. Hauntwoods Shrieker and Wickerfolk Thresher were already implemented and registered (auto-discovered) on this branch by earlier DSK batches; this PR adds the two remaining cards and the mtgish tooling support for all four.

## Cards

- **Omnivorous Flytrap** ({2}{G} 2/4 Creature — Plant) — Delirium "enters or attacks" trigger (two `triggeredAbility` blocks sharing one effect, the Sentinel of the Nameless City shape) gated on `Conditions.Delirium()`. Distributes two +1/+1 counters among one or two target creatures (`TargetCreature(count = 2, minCount = 1)` + `Effects.DistributeCountersAmongTargets`), then — on delirium ≥ 6 — doubles the +1/+1 counters on those same creatures via `ForEach(IterationSpace.Targets)` + `Effects.DoubleCounters`.
- **Ghost Vacuum** ({1} Artifact) — `{T}: Exile target card from a graveyard` linked to the artifact; `{6}, {T}, Sacrifice: put each creature card exiled this way onto the battlefield under your control with a flying counter; each is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.` Follows the proven Pinnacle Starcage pattern (gather the linked-exile pile before sacrificing — CR 400.7), `MoveCollection` with a `Creature` filter + `addCounterType = FLYING` + `storeMovedAs`, then a per-permanent `ForEach(IterationSpace.Collection)` applying `SetBasePowerAndToughness(1/1)` + `AddCreatureType("Spirit")` for `Duration.Permanent`, then `SacrificeTarget(Self)`.
- **Hauntwoods Shrieker** ({1}{G}{G} 3/3) — attack-trigger manifest dread + `{1}{G}: reveal target face-down permanent; if it's a creature card, you may turn it face up`. (already implemented; verified)
- **Wickerfolk Thresher** ({3}{G} 5/4 Artifact Creature — Scarecrow) — Delirium attack trigger look-top / play-land-else-hand pipeline. (already implemented; verified)

No new SDK surface — both new cards compose existing effects/facades, so `docs/card-sdk-language-reference.md` needs no change.

## Tests

- `OmnivorousFlytrapScenarioTest` — delirium 4 (distribute, no doubling), delirium 6 (doubled to four), no-delirium no-op.
- `GhostVacuumScenarioTest` — exile a graveyard creature then return it as a 1/1 flying Spirit; a non-creature card exiled this way stays exiled.
- Existing `HauntwoodsShriekerScenarioTest` and `WickerfolkThresherScenarioTest` re-run green.
- Card-definition snapshot golden (`DSK.json`) re-blessed (adds only the two new card trees); `CardLintTest` clean.

## mtgish auto-gen tooling

Capability **bridge** entries only — the emitter still declines these card-specific shapes → SCAFFOLD, per the conservative fidelity policy ("a confidently-wrong generated card is worse than none"):

- `PutDistributedCounters` → `DistributeCountersAmongTargets`, `DoubleCountersOfTypeOnEachPermanent` → `DoubleCounters` (Omnivorous Flytrap).
- `SetPT` → `SetBasePowerToughness`, `AddCreatureType` → `AddCreatureType` layer effects (Ghost Vacuum's enters-with rider).
- `LookAtTopOfLibrary` and `PutTopCardOfLibraryOfTypeOnBattlefield` composed look-top pipeline entries (Wickerfolk Thresher).

All four cards now probe **COVERABLE-NOW**. The change is emitter-output-neutral: `coverage-verify POR` and `coverage-verify ISD` (the two converged gates) stay **GATE PASS**, and the hermetic `EmitterGoldenTest` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)