### PR TITLE
Antiquities batch: artifact tap/activate triggers + untap-control family

### DIFF
--- a/backlog/sets/antiquities/TODO.md
+++ b/backlog/sets/antiquities/TODO.md
@@ -114,13 +114,17 @@ confirm the noted clause during `add-card`; if it surprises you, move it to List
 
 Each group is a candidate single feature PR. Confirm with `add-card` before building.
 
-### Artifact-tapped / artifact-ability-activated trigger
+### Artifact-tapped / artifact-ability-activated trigger ✅ DONE
 *Trigger: "whenever an artifact becomes tapped, or a player activates an artifact's ability
-without `{T}` in its cost."* No such trigger today (`becomesTapped` exists but not typed to
-artifacts, and there's no ability-activated-without-tap event).
-- **Haunting Wind** — global; 1 damage to the artifact's controller.
-- **Powerleech** — opponents' artifacts only; you gain 1 life.
-- **Artifact Possession** — single enchanted artifact; 2 damage to its controller.
+without `{T}` in its cost."* Implemented: the tap half reuses `Triggers.becomesTapped(filter)`;
+the ability half is `Triggers.activatesAbilityWithoutTap(player, sourceFilter, binding)`, backed by
+`EventPattern.AbilityActivatedEvent(sourceFilter, requireNoTapInCost)`. The engine now emits
+`AbilityActivatedEvent` (carrying `costsTap`/`isManaAbility`) for every activated ability whose cost
+lacks `{T}` — mana abilities included — so the literal "{T}-in-cost" wording is honored, distinct
+from the existing "isn't a mana ability" wording.
+- [x] **Haunting Wind** — global; 1 damage to the artifact's controller.
+- [x] **Powerleech** — opponents' artifacts only; you gain 1 life.
+- [x] **Artifact Possession** — single enchanted artifact (ATTACHED); 2 damage to its controller.
 
 ### "Doesn't untap" control family (untap restrictions / pay-to-untap / tap-locked buffs)
 No "you may choose not to untap", "doesn't untap during your untap step", per-permanent untap

--- a/backlog/sets/antiquities/cards.md
+++ b/backlog/sets/antiquities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 85 cards
 **Release Date:** March 4, 1994
-**Implemented:** 48 / 85
+**Implemented:** 51 / 85
 | Color       | Count |
 |-------------|-------|
 | White       | 7     |
@@ -39,9 +39,9 @@
 - [ ] Transmute Artifact
 
 ### Black
-- [ ] Artifact Possession
+- [x] Artifact Possession
 - [x] Gate to Phyrexia
-- [ ] Haunting Wind
+- [x] Haunting Wind
 - [ ] Phyrexian Gremlins
 - [ ] Priest of Yawgmoth
 - [ ] Xenic Poltergeist
@@ -62,7 +62,7 @@
 - [x] Citanul Druid
 - [x] Crumble
 - [x] Gaea's Avenger
-- [ ] Powerleech
+- [x] Powerleech
 - [ ] Titania's Song
 
 ### Artifacts

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2204,6 +2204,20 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   Mentor, whose payoff is `Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)` (for an
   `AbilityActivatedEvent` the triggering entity is the activated ability on the stack; the copy executor reprompts for
   new targets, CR 707.10/707.10c).
+- `activatesAbilityWithoutTap(player?, sourceFilter?, binding?)` — the Antiquities "tap / activate an artifact"
+  punisher half: a permanent matching `sourceFilter` has an activated ability used **without `{T}` in its activation
+  cost** (Haunting Wind, Powerleech, Artifact Possession). Backed by
+  `EventPattern.AbilityActivatedEvent(player, sourceFilter, requireNoTapInCost = true)`. This differs from
+  `OpponentActivatesAbility` / `YouActivateAbility` in two ways: it keys on the literal `{T}`-in-cost wording rather
+  than "isn't a mana ability", so **a non-`{T}` mana ability also fires it** (the engine emits an
+  `AbilityActivatedEvent` for every activated ability whose cost lacks `{T}`, mana or not, and `costsTap`/`isManaAbility`
+  on the event let the matcher pick the right wording); and `sourceFilter` restricts which permanent's ability counts
+  (`GameObjectFilter.Artifact`, `Artifact.opponentControls()`, or null with `TriggerBinding.ATTACHED` for "enchanted
+  artifact"). Pair with `becomesTapped(...)` to cover the full "becomes tapped or has a non-`{T}` ability activated"
+  clause. For "that artifact's controller": the **global** form uses
+  `EffectTarget.PlayerRef(Player.TriggeringPlayer)` (the activator); the **ATTACHED** form uses
+  `EffectTarget.ControllerOfTriggeringEntity` (the enchanted artifact's controller, exposed by
+  `AttachmentTriggerDetector`).
 
 **Other casters.** The same shape, scoped to a different caster via the runtime
 `Player.Each` / `Player.EachOpponent` matching on `SpellCastEvent`. Bind the payoff to the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -506,7 +506,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Stats & keywords
 
-- `ModifyStats(power, toughness, target?)` — `±P/±T` until end of turn (default scope).
+- `ModifyStats(power, toughness, target?, duration?)` — `±P/±T` for `duration` (default: until end of
+  turn). Pass `Duration.WhileSourceTapped("…")` for the Antiquities "tap-locked" buffs (Ashnod's Battle
+  Gear `+2/-2`, Tawnos's Weaponry `+1/+1`): the bonus persists for as long as the source artifact remains
+  tapped and the one-way latch drops it when it untaps.
 - `SetBasePower(target, power: DynamicAmount, duration)` — set base power to a dynamic value (Layer 7b).
 - `SetBasePowerAndToughness(power, toughness, target?, duration)` — set base power AND toughness to
   fixed values (Layer 7b, set values), e.g. "Target creature has base power and toughness 5/5 until end
@@ -2737,8 +2740,16 @@ staticAbility {
 - **Untap-step restriction flags** — granted via `GrantKeyword(AbilityFlag.X.name)` and read by the untap
   step (`BeginningPhaseManager`) off projected keywords, so they vanish when the granting source leaves play:
   - `AbilityFlag.DOESNT_UNTAP` — "doesn't untap during its controller's untap step" (Charmed Sleep,
-    Temporal Distortion's hourglass-counter form).
-  - `AbilityFlag.MAY_NOT_UNTAP` — controller may choose not to untap it (Everglove Courier).
+    Temporal Distortion's hourglass-counter form). `Effects.GrantKeyword(AbilityFlag.DOESNT_UNTAP, target,
+    duration)` works on **any** battlefield permanent, not only creatures (the grant executor no longer
+    requires a creature target), so it covers noncreature-artifact targets. For **imposed untap
+    suppression that lasts only while the source stays tapped** — Phyrexian Gremlins, "{T}: Tap target
+    artifact. It doesn't untap during its controller's untap step for as long as Phyrexian Gremlins
+    remains tapped" — compose `Effects.Tap(target) then Effects.GrantKeyword(AbilityFlag.DOESNT_UNTAP,
+    target, Duration.WhileSourceTapped("…"))`: the one-way `WhileSourceTapped` latch drops the grant the
+    instant the source untaps.
+  - `AbilityFlag.MAY_NOT_UNTAP` — controller may choose not to untap it (Everglove Courier, and the
+    Antiquities self-optional untap-skip on Phyrexian Gremlins / Ashnod's Battle Gear / Tawnos's Weaponry).
   - `AbilityFlag.REMOVE_COUNTER_TO_UNTAP` — "If this would untap during your untap step, remove a +1/+1
     counter from it instead. If you do, untap it." (Bewitching Leechcraft). During the controller's untap
     step the engine tries to remove a +1/+1 counter; the permanent untaps **only if** one was removed,
@@ -2747,6 +2758,14 @@ staticAbility {
     the natural untap step (callers pass projected state); explicit "untap target permanent" effects and
     other players' untap steps (Seedborn Muse) pass `projected = null` and never apply it — matching the
     "during **your** untap step" wording. Stacks after the stun-counter replacement (CR 122.1d, checked first).
+- `UntapLimitPerStep(filter, max)` — global untap-count cap, "Players can't untap more than `max` `filter`
+  during their untap steps" (Damping Field — `filter = GameObjectFilter.Artifact`, `max = 1`). Read by
+  `BeginningPhaseManager` for **every** player's untap step regardless of who controls the source: when a
+  player has more matching permanents that would untap than the cap allows, the engine raises the same
+  keep-tapped decision used by `MAY_NOT_UNTAP` with `minSelections = (matching − max)`, so the player keeps
+  the excess tapped and chooses which one untaps. Multiple copies do not stack to a stricter cap unless one
+  names a smaller `max` (most restrictive per filter wins). Inert when the player has `≤ max` matching
+  permanents tapped.
 - `MustBlock(filter = source())` — matching creatures must block each combat if able (Grand Melee).
 - `MustBeBlocked(allCreatures = false)` — static: the source creature must be blocked while active —
   "if able" (≥1 blocker, default) or by **all** able blockers (`allCreatures = true`, Lure-style).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -993,10 +993,18 @@ object Effects {
     // =========================================================================
 
     /**
-     * Modify power and toughness.
+     * Modify power and toughness for the given [duration] (default: until end of turn).
+     * Pass [com.wingedsheep.sdk.scripting.Duration.WhileSourceTapped] for the Antiquities
+     * "tap-locked" buffs (Ashnod's Battle Gear, Tawnos's Weaponry) — the bonus persists for as
+     * long as the source artifact remains tapped and ends when it untaps.
      */
-    fun ModifyStats(power: Int, toughness: Int, target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
-        ModifyStatsEffect(power, toughness, target)
+    fun ModifyStats(
+        power: Int,
+        toughness: Int,
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        duration: Duration = Duration.EndOfTurn
+    ): Effect =
+        ModifyStatsEffect(power, toughness, target, duration)
 
     /**
      * Modify power and toughness by dynamic amounts.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1006,6 +1006,34 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * Whenever [player] activates the ability of a permanent matching [sourceFilter] **without
+     * {T} in its activation cost** (the Antiquities "tap/activate an artifact" punisher template —
+     * Haunting Wind, Powerleech, Artifact Possession).
+     *
+     * Unlike [OpponentActivatesAbility] / [YouActivateAbility] (which key on "isn't a mana
+     * ability"), this keys on the literal {T}-in-cost wording: an ability without {T} fires it
+     * regardless of whether it's a mana ability, and an ability *with* {T} never does. Pair it
+     * with a [becomesTapped] trigger to cover the full "becomes tapped or has a non-{T} ability
+     * activated" clause.
+     *
+     * [sourceFilter] = null matches any permanent's non-{T} ability; pass
+     * [GameObjectFilter.Artifact] (Haunting Wind), `Artifact.opponentControls()` (Powerleech),
+     * or null with [TriggerBinding.ATTACHED] (Artifact Possession — enchanted artifact only).
+     */
+    fun activatesAbilityWithoutTap(
+        player: Player = Player.Each,
+        sourceFilter: GameObjectFilter? = null,
+        binding: TriggerBinding = TriggerBinding.ANY
+    ): TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(
+            player = player,
+            sourceFilter = sourceFilter,
+            requireNoTapInCost = true
+        ),
+        binding = binding
+    )
+
     // =========================================================================
     // Counter Triggers
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1020,6 +1020,15 @@ object Triggers {
      * [sourceFilter] = null matches any permanent's non-{T} ability; pass
      * [GameObjectFilter.Artifact] (Haunting Wind), `Artifact.opponentControls()` (Powerleech),
      * or null with [TriggerBinding.ATTACHED] (Artifact Possession — enchanted artifact only).
+     *
+     * For "that artifact's controller" in the payoff: the [TriggerBinding.ATTACHED] form exposes
+     * the activated ability's source permanent as the triggering entity, so use
+     * `EffectTarget.ControllerOfTriggeringEntity` (resolves to that permanent's controller). The
+     * global ([TriggerBinding.ANY]) form has only the *ability* as the triggering entity — and that
+     * entity is absent for mana abilities — so use `EffectTarget.PlayerRef(Player.TriggeringPlayer)`,
+     * i.e. the activating player. These coincide for every normal activation (you may only activate
+     * abilities of permanents you control); they would diverge only if a player somehow activated an
+     * artifact ability they don't control, which none of these cards permit.
      */
     fun activatesAbilityWithoutTap(
         player: Player = Player.Each,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1333,13 +1333,13 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * When a player activates an activated ability that isn't a mana ability.
+     * When a player activates an activated ability.
      *
-     * Mana abilities resolve without using the stack (CR 605.3), so the engine only emits its
-     * `AbilityActivatedEvent` for non-mana activated abilities — including planeswalker loyalty
-     * abilities (CR 606), which are activated abilities. This template therefore matches exactly
-     * "activates an ability that isn't a mana ability"; [player] scopes whose activations count
-     * ([Player.EachOpponent] for "an opponent activates …", [Player.You] for your own, etc.).
+     * By default this matches "activates an ability that isn't a mana ability": mana abilities
+     * resolve without using the stack (CR 605.3), so the engine emits its `AbilityActivatedEvent`
+     * for non-mana activated abilities — including planeswalker loyalty abilities (CR 606), which
+     * are activated abilities. [player] scopes whose activations count ([Player.EachOpponent] for
+     * "an opponent activates …", [Player.You] for your own, etc.).
      *
      * Used by Flamescroll Celebrant: "Whenever an opponent activates an ability that isn't a mana
      * ability, this creature deals 1 damage to that player."
@@ -1349,22 +1349,48 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * satisfying it — a non-targeting ability never fires. Ertha Jo, Frontier Mentor uses
      * [com.wingedsheep.sdk.scripting.events.AbilityTargetMatch.CreatureOrPlayer] for
      * "Whenever you activate an ability that targets a creature or player".
+     *
+     * [sourceFilter] optionally restricts which permanent the activated ability must belong to
+     * (e.g. [GameObjectFilter.Artifact], or `Artifact.opponentControls()`). Null = any source.
+     *
+     * [requireNoTapInCost] switches the trigger from the "isn't a mana ability" semantic to the
+     * Antiquities "without {T} in its activation cost" semantic (Haunting Wind, Powerleech,
+     * Artifact Possession). When true, the ability matches iff its activation cost does **not**
+     * include the {T} symbol — and mana abilities without {T} *do* count, unlike the default
+     * semantic. The engine emits an `AbilityActivatedEvent` for every activated ability whose cost
+     * lacks {T} (mana or not); this flag is what tells the matcher to accept the mana-ability ones.
      */
     @SerialName("AbilityActivatedEvent")
     @Serializable
     data class AbilityActivatedEvent(
         val player: Player = Player.You,
-        val targetMatch: com.wingedsheep.sdk.scripting.events.AbilityTargetMatch? = null
+        val targetMatch: com.wingedsheep.sdk.scripting.events.AbilityTargetMatch? = null,
+        val sourceFilter: GameObjectFilter? = null,
+        val requireNoTapInCost: Boolean = false
     ) : EventPattern {
         override val description: String = buildString {
             append(player.description)
-            append(" activates an ability that ")
-            if (targetMatch != null) {
-                append("targets a ")
-                append(targetMatch.description)
+            append(" activates ")
+            if (sourceFilter != null) {
+                append("a ")
+                append(sourceFilter.description)
+                append("'s ability that ")
             } else {
-                append("isn't a mana ability")
+                append("an ability that ")
             }
+            when {
+                targetMatch != null -> {
+                    append("targets a ")
+                    append(targetMatch.description)
+                }
+                requireNoTapInCost -> append("doesn't have {T} in its activation cost")
+                else -> append("isn't a mana ability")
+            }
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val newFilter = sourceFilter?.applyTextReplacement(replacer)
+            return if (newFilter !== sourceFilter) copy(sourceFilter = newFilter) else this
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -718,6 +718,30 @@ data class UntapFilteredDuringOtherUntapSteps(
 }
 
 /**
+ * Caps how many permanents matching [filter] a player may untap during their own untap step
+ * (CR 502.3 — "effects can keep one or more of a player's permanents from untapping"). A global
+ * restriction: it applies to every player's untap step, regardless of who controls the source.
+ *
+ * The active player still chooses *which* of the matching permanents untap: during the untap step
+ * the engine lets the player keep at least `(matching that would untap − max)` of them tapped, so
+ * no more than [max] ever untap. With fewer than [max] matching permanents tapped, the cap is
+ * inert. Multiple copies do not stack to a lower cap unless they name a smaller [max]; the most
+ * restrictive applies per filter.
+ *
+ * Used by Damping Field — "Players can't untap more than one artifact during their untap steps"
+ * (`filter = GameObjectFilter.Artifact`, `max = 1`).
+ */
+@SerialName("UntapLimitPerStep")
+@Serializable
+data class UntapLimitPerStep(
+    val filter: GameObjectFilter,
+    val max: Int
+) : StaticAbility {
+    override val description: String =
+        "Players can't untap more than $max ${filter.description} during their untap steps"
+}
+
+/**
  * You may activate loyalty abilities of planeswalkers you control an extra time each turn.
  * Used for Oath of Teferi: "You may activate the loyalty abilities of planeswalkers you control
  * twice each turn rather than only once."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ColossusOfSardia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ColossusOfSardia.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossus of Sardia reprint in 10E.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * ATQ's `cards/` package (the card's earliest real printing). This file contributes only
+ * the 10E-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ColossusOfSardiaReprint = Printing(
+    oracleId = "9be9625e-b98b-416b-aac4-9f7b2dfbd39d",
+    name = "Colossus of Sardia",
+    setCode = "10E",
+    collectorNumber = "317",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fd164011-7a8e-44a2-8599-0a1c0878b5b5.jpg",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/ArtifactPossession.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/ArtifactPossession.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Artifact Possession
+ * {2}{B}
+ * Enchantment — Aura
+ * Enchant artifact
+ * Whenever enchanted artifact becomes tapped or a player activates an ability of enchanted
+ * artifact without {T} in its activation cost, this Aura deals 2 damage to that artifact's
+ * controller.
+ *
+ * The single-target ([TriggerBinding.ATTACHED]) member of the Antiquities "tap / activate an
+ * artifact" punisher template (cf. Haunting Wind, Powerleech): both triggers fire only off the
+ * enchanted artifact. Routed through `AttachmentTriggerDetector`, which exposes the enchanted
+ * artifact as the triggering entity, so "that artifact's controller" resolves via
+ * [EffectTarget.ControllerOfTriggeringEntity] for both halves.
+ */
+val ArtifactPossession = card("Artifact Possession") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact\n" +
+        "Whenever enchanted artifact becomes tapped or a player activates an ability of enchanted " +
+        "artifact without {T} in its activation cost, this Aura deals 2 damage to that artifact's " +
+        "controller."
+    auraTarget = Targets.Artifact
+
+    triggeredAbility {
+        trigger = Triggers.becomesTapped(binding = TriggerBinding.ATTACHED)
+        effect = Effects.DealDamage(2, EffectTarget.ControllerOfTriggeringEntity)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.activatesAbilityWithoutTap(
+            player = Player.Each,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.DealDamage(2, EffectTarget.ControllerOfTriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Christopher Rush"
+        flavorText = "Any black mage could coax a Thraxodemon to inhabit a magical device."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg?1562913472"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/AshnodsBattleGear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/AshnodsBattleGear.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Ashnod's Battle Gear
+ * {2}
+ * Artifact
+ * You may choose not to untap this artifact during your untap step.
+ * {2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped.
+ *
+ * A "tap-locked" buff (cf. Tawnos's Weaponry, Everglove Courier): the +2/-2 is a
+ * [Effects.ModifyStats] with [Duration.WhileSourceTapped], lasting only while Battle Gear stays
+ * tapped and ending when it untaps. The optional self untap-skip is [AbilityFlag.MAY_NOT_UNTAP].
+ * Note the modern oracle restricts the target to a creature you control.
+ */
+val AshnodsBattleGear = card("Ashnod's Battle Gear") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "You may choose not to untap this artifact during your untap step.\n" +
+        "{2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped."
+
+    flags(AbilityFlag.MAY_NOT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, -2, creature, Duration.WhileSourceTapped("Ashnod's Battle Gear"))
+        description = "{2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Mark Poole"
+        flavorText = "This horrid invention clearly illustrates why Mishra's lieutenant was feared as much by her troops as by her foes."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg?1562931933"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/ColossusOfSardia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/ColossusOfSardia.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Colossus of Sardia
+ * {9}
+ * Artifact Creature — Golem
+ * 9/9
+ * Trample
+ * This creature doesn't untap during your untap step.
+ * {9}: Untap this creature. Activate only during your upkeep.
+ *
+ * "Doesn't untap" is the mandatory self-suppression flag [AbilityFlag.DOESNT_UNTAP] (cf. Goblin
+ * Sharpshooter) — the untap step filters it out, so it stays tapped after attacking. The pay-to-untap
+ * ability is a plain [Effects.Untap] on itself, gated to the controller's upkeep via
+ * [ActivationRestriction.OnlyDuringYourTurn] + [ActivationRestriction.DuringStep] UPKEEP (cf.
+ * Dwarven Weaponsmith).
+ */
+val ColossusOfSardia = card("Colossus of Sardia") {
+    manaCost = "{9}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 9
+    toughness = 9
+    oracleText = "Trample\nThis creature doesn't untap during your untap step.\n" +
+        "{9}: Untap this creature. Activate only during your upkeep."
+
+    keywords(Keyword.TRAMPLE)
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Mana("{9}")
+        effect = Effects.Untap(EffectTarget.Self)
+        restrictions = listOf(
+            ActivationRestriction.All(
+                ActivationRestriction.OnlyDuringYourTurn,
+                ActivationRestriction.DuringStep(Step.UPKEEP)
+            )
+        )
+        description = "{9}: Untap this creature. Activate only during your upkeep."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Jesper Myrfors"
+        flavorText = "From the Sardian mountains wakes ancient doom: Warrior born from a rocky womb."
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg?1562896386"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/DampingField.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/DampingField.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.UntapLimitPerStep
+
+/**
+ * Damping Field
+ * {2}{W}
+ * Enchantment
+ * Players can't untap more than one artifact during their untap steps.
+ *
+ * A global untap-count cap modeled by [UntapLimitPerStep] (filter = artifacts, max = 1). It applies
+ * to every player's untap step regardless of who controls Damping Field: when a player has more than
+ * one tapped artifact that would untap, the untap step makes them keep the excess tapped, choosing
+ * which single artifact untaps. (Originally an Artifact in 1994; the modern Oracle printing is an
+ * Enchantment.)
+ */
+val DampingField = card("Damping Field") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Players can't untap more than one artifact during their untap steps."
+
+    staticAbility {
+        ability = UntapLimitPerStep(GameObjectFilter.Artifact, 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Justin Hampton"
+        flavorText = "Eventually, mages learned to harness the power of natural damping fields and use it for their own ends."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg?1562898915"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/HauntingWind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/HauntingWind.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Haunting Wind
+ * {3}{B}
+ * Enchantment
+ * Whenever an artifact becomes tapped or a player activates an artifact's ability without {T} in
+ * its activation cost, this enchantment deals 1 damage to that artifact's controller.
+ *
+ * The Antiquities "tap / activate an artifact" punisher template (cf. Powerleech, Artifact
+ * Possession). It is two triggers:
+ *  - the tap half ([Triggers.becomesTapped] over [GameObjectFilter.Artifact]) — "that artifact's
+ *    controller" is the controller of the just-tapped artifact, reached via
+ *    [EffectTarget.ControllerOfTriggeringEntity].
+ *  - the ability half ([Triggers.activatesAbilityWithoutTap]) — keys on the literal "without {T}
+ *    in its activation cost" wording (not "isn't a mana ability"), so a non-{T} mana ability also
+ *    fires it. "That artifact's controller" is the activating player ([Player.TriggeringPlayer]).
+ */
+val HauntingWind = card("Haunting Wind") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Whenever an artifact becomes tapped or a player activates an artifact's ability " +
+        "without {T} in its activation cost, this enchantment deals 1 damage to that artifact's " +
+        "controller."
+
+    triggeredAbility {
+        trigger = Triggers.becomesTapped(
+            binding = TriggerBinding.ANY,
+            filter = GameObjectFilter.Artifact
+        )
+        effect = Effects.DealDamage(1, EffectTarget.ControllerOfTriggeringEntity)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.activatesAbilityWithoutTap(
+            player = Player.Each,
+            sourceFilter = GameObjectFilter.Artifact
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Jeff A. Menges"
+        flavorText = "These devices lured so many spirits that sometimes entire battlefields would " +
+            "become haunted at once."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg?1562929345"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/PhyrexianGremlins.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/PhyrexianGremlins.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Phyrexian Gremlins
+ * {2}{B}
+ * Creature — Phyrexian Gremlin
+ * 1/1
+ * You may choose not to untap this creature during your untap step.
+ * {T}: Tap target artifact. It doesn't untap during its controller's untap step for as long as
+ * this creature remains tapped.
+ *
+ * Imposed untap suppression. The {T} ability taps a target artifact ([Effects.Tap]) and grants it
+ * [AbilityFlag.DOESNT_UNTAP] via [Effects.GrantKeyword] with the [Duration.WhileSourceTapped]
+ * duration: while Phyrexian Gremlins remains tapped the artifact carries "doesn't untap", so it is
+ * filtered out of *its own controller's* untap step (the untap step honors DOESNT_UNTAP for whoever
+ * is untapping). The instant Gremlins untaps, the one-way `WhileSourceTapped` latch removes the
+ * grant and the artifact untaps normally on its controller's next untap step. Holding Gremlins
+ * tapped through your untap step ([AbilityFlag.MAY_NOT_UNTAP]) keeps the lock alive.
+ */
+val PhyrexianGremlins = card("Phyrexian Gremlins") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Gremlin"
+    power = 1
+    toughness = 1
+    oracleText = "You may choose not to untap this creature during your untap step.\n" +
+        "{T}: Tap target artifact. It doesn't untap during its controller's untap step for as long " +
+        "as this creature remains tapped."
+
+    flags(AbilityFlag.MAY_NOT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val artifact = target("target artifact", Targets.Artifact)
+        effect = Effects.Tap(artifact) then
+            Effects.GrantKeyword(AbilityFlag.DOESNT_UNTAP, artifact, Duration.WhileSourceTapped("Phyrexian Gremlins"))
+        description = "{T}: Tap target artifact. It doesn't untap during its controller's untap step " +
+            "for as long as this creature remains tapped."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Amy Weber"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg?1562902131"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/Powerleech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/Powerleech.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Powerleech
+ * {G}{G}
+ * Enchantment
+ * Whenever an artifact an opponent controls becomes tapped or an opponent activates an artifact's
+ * ability without {T} in its activation cost, you gain 1 life.
+ *
+ * Same "tap / activate an artifact" punisher template as Haunting Wind, but scoped to opponents'
+ * artifacts and rewarding the enchantment's controller with life instead of dealing damage:
+ *  - tap half: [Triggers.becomesTapped] over `Artifact.opponentControls()`.
+ *  - ability half: [Triggers.activatesAbilityWithoutTap] with [Player.EachOpponent] and the same
+ *    opponent-controlled artifact filter ("an opponent activates an artifact's ability").
+ *
+ * The reward is [Effects.GainLife] for the controller (default target), so no triggering-entity
+ * reference is needed.
+ */
+val Powerleech = card("Powerleech") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever an artifact an opponent controls becomes tapped or an opponent " +
+        "activates an artifact's ability without {T} in its activation cost, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.becomesTapped(
+            binding = TriggerBinding.ANY,
+            filter = GameObjectFilter.Artifact.opponentControls()
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.activatesAbilityWithoutTap(
+            player = Player.EachOpponent,
+            sourceFilter = GameObjectFilter.Artifact.opponentControls()
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Christopher Rush"
+        flavorText = "The Forest of Argoth has developed a resistance to mechanical intrusion."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg?1562931798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/TawnossWeaponry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/TawnossWeaponry.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.atq.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Tawnos's Weaponry
+ * {2}
+ * Artifact
+ * You may choose not to untap this artifact during your untap step.
+ * {2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped.
+ *
+ * A "tap-locked" buff (cf. Everglove Courier): the +1/+1 is a [Effects.ModifyStats] with the
+ * [Duration.WhileSourceTapped] duration, so it lasts only while Tawnos's Weaponry stays tapped and
+ * drops the instant it untaps. The optional self untap-skip is the [AbilityFlag.MAY_NOT_UNTAP]
+ * flag, letting the controller hold it tapped through their untap step to keep the bonus alive.
+ */
+val TawnossWeaponry = card("Tawnos's Weaponry") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "You may choose not to untap this artifact during your untap step.\n" +
+        "{2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped."
+
+    flags(AbilityFlag.MAY_NOT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(1, 1, creature, Duration.WhileSourceTapped("Tawnos's Weaponry"))
+        description = "{2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "70"
+        artist = "Dan Frazier"
+        flavorText = "When Urza's war machines became too costly, Tawnos's weaponry replaced them."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg?1562905158"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -370,6 +370,74 @@
     "colorIdentityOverride": []
 }
 
+// Ashnod's Battle Gear
+{
+    "name": "Ashnod's Battle Gear",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "You may choose not to untap this artifact during your untap step.\n{2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped.",
+    "flags": [
+        "MAY_NOT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    },
+                    "duration": {
+                        "type": "WhileSourceTapped",
+                        "sourceDescription": "Ashnod's Battle Gear"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "This horrid invention clearly illustrates why Mishra's lieutenant was feared as much by her troops as by her foes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg?1562931933"
+    },
+    "colorIdentityOverride": []
+}
+
 // Ashnod's Transmogrant
 {
     "name": "Ashnod's Transmogrant",
@@ -619,6 +687,64 @@
     "colorIdentityOverride": []
 }
 
+// Colossus of Sardia
+{
+    "name": "Colossus of Sardia",
+    "manaCost": "{9}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Trample\nThis creature doesn't untap during your untap step.\n{9}: Untap this creature. Activate only during your upkeep.",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{9}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationAll",
+                        "restrictions": [
+                            "OnlyDuringYourTurn",
+                            {
+                                "type": "DuringStep",
+                                "step": "UPKEEP"
+                            }
+                        ]
+                    }
+                ],
+                "descriptionOverride": "{9}: Untap this creature. Activate only during your upkeep."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Jesper Myrfors",
+        "flavorText": "From the Sardian mountains wakes ancient doom: Warrior born from a rocky womb.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg?1562896386"
+    },
+    "colorIdentityOverride": []
+}
+
 // Coral Helm
 {
     "name": "Coral Helm",
@@ -745,6 +871,33 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Damping Field
+{
+    "name": "Damping Field",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Players can't untap more than one artifact during their untap steps.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "UntapLimitPerStep",
+                "filter": "artifact",
+                "max": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Hampton",
+        "flavorText": "Eventually, mages learned to harness the power of natural damping fields and use it for their own ends.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg?1562898915"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1643,6 +1796,71 @@
     "colorIdentityOverride": []
 }
 
+// Phyrexian Gremlins
+{
+    "name": "Phyrexian Gremlins",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Phyrexian Gremlin",
+    "oracleText": "You may choose not to untap this creature during your untap step.\n{T}: Tap target artifact. It doesn't untap during its controller's untap step for as long as this creature remains tapped.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "flags": [
+        "MAY_NOT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DOESNT_UNTAP",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact"
+                            },
+                            "duration": {
+                                "type": "WhileSourceTapped",
+                                "sourceDescription": "Phyrexian Gremlins"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target artifact"
+                    }
+                ],
+                "descriptionOverride": "{T}: Tap target artifact. It doesn't untap during its controller's untap step for as long as this creature remains tapped."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Amy Weber",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg?1562902131"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Powerleech
 {
     "name": "Powerleech",
@@ -2143,6 +2361,74 @@
         "rarity": "UNCOMMON",
         "artist": "Douglas Shuler",
         "imageUri": "https://cards.scryfall.io/normal/front/9/7/978f09dd-121a-4da5-ba16-5c03fbdce084.jpg?1562927106"
+    },
+    "colorIdentityOverride": []
+}
+
+// Tawnos's Weaponry
+{
+    "name": "Tawnos's Weaponry",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "You may choose not to untap this artifact during your untap step.\n{2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped.",
+    "flags": [
+        "MAY_NOT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": {
+                        "type": "WhileSourceTapped",
+                        "sourceDescription": "Tawnos's Weaponry"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "flavorText": "When Urza's war machines became too costly, Tawnos's weaponry replaced them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg?1562905158"
     },
     "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -275,6 +275,63 @@
     ]
 }
 
+// Artifact Possession
+{
+    "name": "Artifact Possession",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact\nWhenever enchanted artifact becomes tapped or a player activates an ability of enchanted artifact without {T} in its activation cost, this Aura deals 2 damage to that artifact's controller.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TapEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "ControllerOfTriggeringEntity"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "player": "Each",
+                    "requireNoTapInCost": true
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "ControllerOfTriggeringEntity"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Christopher Rush",
+        "flavorText": "Any black mage could coax a Thraxodemon to inhabit a magical device.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg?1562913472"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ashnod's Altar
 {
     "name": "Ashnod's Altar",
@@ -1072,6 +1129,65 @@
     "colorIdentityOverride": []
 }
 
+// Haunting Wind
+{
+    "name": "Haunting Wind",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever an artifact becomes tapped or a player activates an artifact's ability without {T} in its activation cost, this enchantment deals 1 damage to that artifact's controller.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "artifact"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "ControllerOfTriggeringEntity"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "player": "Each",
+                    "sourceFilter": "artifact",
+                    "requireNoTapInCost": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff A. Menges",
+        "flavorText": "These devices lured so many spirits that sometimes entire battlefields would become haunted at once.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg?1562929345"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ivory Tower
 {
     "name": "Ivory Tower",
@@ -1525,6 +1641,60 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/9/59cc9bdb-7cf2-4795-bac7-ffff605c9eb0.jpg?1562913725"
     },
     "colorIdentityOverride": []
+}
+
+// Powerleech
+{
+    "name": "Powerleech",
+    "manaCost": "{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever an artifact an opponent controls becomes tapped or an opponent activates an artifact's ability without {T} in its activation cost, you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "artifact ctrl:opponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "player": "EachOpponent",
+                    "sourceFilter": "artifact ctrl:opponent",
+                    "requireNoTapInCost": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "The Forest of Argoth has developed a resistance to mechanical intrusion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg?1562931798"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Rakalite

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.UntapDuringOtherUntapSteps
 import com.wingedsheep.sdk.scripting.UntapFilteredDuringOtherUntapSteps
+import com.wingedsheep.sdk.scripting.UntapLimitPerStep
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
@@ -108,7 +109,25 @@ class BeginningPhaseManager(
             projected.hasKeyword(entityId, AbilityFlag.MAY_NOT_UNTAP)
         }
 
-        if (mayNotUntapPermanents.isNotEmpty()) {
+        // Untap-count restrictions (Damping Field — "can't untap more than one artifact"). A
+        // global restriction: gather every active UntapLimitPerStep regardless of controller, and
+        // for each work out which would-untap permanents match its filter. When more match than the
+        // cap allows, the active player must keep the excess tapped (their choice which).
+        val untapLimits = activeUntapLimits(newState).mapNotNull { (filter, max) ->
+            val matching = permanentsAfterCantUntap.filter { entityId ->
+                val container = newState.getEntity(entityId) ?: return@filter false
+                matchesFilterForUntap(newState, projected, entityId, container, filter)
+            }
+            if (matching.size > max) UntapLimitChoice(matching, max) else null
+        }
+        val forcedKeepCount = untapLimits.sumOf { it.matchingPermanents.size - it.max }
+
+        // Raise a single "keep tapped" decision when the player has any choice to make: optional
+        // MAY_NOT_UNTAP permanents and/or a forced keep from an untap-count cap. The option pool is
+        // the union of the optional permanents and every limit-constrained permanent.
+        val choosablePermanents = (mayNotUntapPermanents + untapLimits.flatMap { it.matchingPermanents })
+            .distinct()
+        if (mayNotUntapPermanents.isNotEmpty() || forcedKeepCount > 0) {
             // Ask the player which permanents to keep tapped
             val decisionResult = decisionHandler.createCardSelectionDecision(
                 state = newState,
@@ -116,9 +135,9 @@ class BeginningPhaseManager(
                 sourceId = null,
                 sourceName = null,
                 prompt = "Select permanents to keep tapped",
-                options = mayNotUntapPermanents,
-                minSelections = 0,
-                maxSelections = mayNotUntapPermanents.size,
+                options = choosablePermanents,
+                minSelections = forcedKeepCount,
+                maxSelections = choosablePermanents.size,
                 ordered = false,
                 phase = DecisionPhase.STATE_BASED,
                 useTargetingUI = true
@@ -127,7 +146,8 @@ class BeginningPhaseManager(
             val continuation = UntapChoiceContinuation(
                 decisionId = decisionResult.pendingDecision!!.id,
                 playerId = activePlayer,
-                allPermanentsToUntap = permanentsAfterCantUntap
+                allPermanentsToUntap = permanentsAfterCantUntap,
+                untapLimits = untapLimits
             )
 
             val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -332,6 +352,28 @@ class BeginningPhaseManager(
      * Check if an entity matches a GameObjectFilter for untap-during-other-untap-step abilities.
      * Uses projected state for type checks and base state for counters.
      */
+    /**
+     * Collect the active untap-count caps (`UntapLimitPerStep`, e.g. Damping Field) as
+     * `(filter, max)` pairs. The restriction is global, so every battlefield permanent's static
+     * abilities are scanned regardless of controller. When two restrictions share a filter the
+     * most restrictive (smallest [UntapLimitPerStep.max]) wins; distinct filters are kept separate.
+     */
+    private fun activeUntapLimits(
+        state: GameState
+    ): List<Pair<GameObjectFilter, Int>> {
+        val byFilter = LinkedHashMap<GameObjectFilter, Int>()
+        for (permanentId in state.getBattlefield()) {
+            val card = state.getEntity(permanentId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is UntapLimitPerStep) {
+                    byFilter.merge(ability.filter, ability.max, ::minOf)
+                }
+            }
+        }
+        return byFilter.map { (filter, max) -> filter to max }
+    }
+
     private fun matchesFilterForUntap(
         state: GameState,
         projected: ProjectedState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -422,6 +422,12 @@ data class SpellCastEvent(
 
 /**
  * An ability was activated.
+ *
+ * [costsTap] is true iff the activation cost includes the {T} symbol; [isManaAbility] is true for
+ * mana abilities (CR 605.1). These let triggers distinguish the two "activates an ability" wordings:
+ * "isn't a mana ability" (Flamescroll Celebrant — fired only for non-mana abilities, which use the
+ * stack) versus "without {T} in its activation cost" (Antiquities Haunting Wind / Powerleech /
+ * Artifact Possession — fired for any ability, mana or not, whose cost lacks {T}).
  */
 @Serializable
 @SerialName("AbilityActivatedEvent")
@@ -429,7 +435,9 @@ data class AbilityActivatedEvent(
     val sourceId: EntityId,
     val sourceName: String,
     val controllerId: EntityId,
-    val abilityEntityId: EntityId? = null
+    val abilityEntityId: EntityId? = null,
+    val costsTap: Boolean = false,
+    val isManaAbility: Boolean = false
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -172,18 +172,34 @@ data class AnyPlayerMayPayContinuation(
 /**
  * Resume after player selects which permanents to keep tapped during untap step.
  *
- * Used for permanents with "You may choose not to untap" keyword (MAY_NOT_UNTAP).
- * The player selects which permanents to keep tapped; everything else untaps normally.
+ * Used for permanents with "You may choose not to untap" keyword (MAY_NOT_UNTAP) and for
+ * untap-count restrictions such as Damping Field ("can't untap more than one artifact"). The
+ * player selects which permanents to keep tapped; everything else untaps normally.
  *
  * @property playerId The active player making the choice
  * @property allPermanentsToUntap All permanents that would normally untap
+ * @property untapLimits Active untap-count caps (Damping Field). Each pair is the set of would-untap
+ *   permanents matching the restriction's filter and the maximum of them allowed to untap. The
+ *   resumer enforces that no more than `max` of each set untaps (defence in depth — the raised
+ *   decision's `minSelections` already prevents an under-keep when the matching pool is homogeneous).
  */
 @Serializable
 data class UntapChoiceContinuation(
     override val decisionId: String,
     val playerId: EntityId,
-    val allPermanentsToUntap: List<EntityId>
+    val allPermanentsToUntap: List<EntityId>,
+    val untapLimits: List<UntapLimitChoice> = emptyList()
 ) : ContinuationFrame
+
+/**
+ * One active untap-count cap during a player's untap step: at most [max] of [matchingPermanents]
+ * (the would-untap permanents matching the restriction's filter) may untap.
+ */
+@Serializable
+data class UntapLimitChoice(
+    val matchingPermanents: List<EntityId>,
+    val max: Int
+)
 
 /**
  * Resume after player selects a card from their graveyard.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.event
 
+import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
 import com.wingedsheep.engine.core.TappedEvent
@@ -45,7 +46,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                     // aura's own ZoneChangeEvent. Only equipment stays on the battlefield.
                     if (isZoneChange && ability.trigger is EventPattern.ZoneChangeEvent &&
                         !entry.cardComponent.typeLine.isEquipment) continue
-                    if (matchesAttachedTrigger(ability.trigger, event, entityId, state)) {
+                    if (matchesAttachedTrigger(ability.trigger, event, entityId, entry.controllerId, state)) {
                         triggers.add(
                             PendingTrigger(
                                 ability = ability,
@@ -81,6 +82,9 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             is AttackersDeclaredEvent -> event.attackers
             is TurnFaceUpEvent -> listOf(event.entityId)
             is TappedEvent -> listOf(event.entityId)
+            // "an ability of enchanted artifact … was activated" (Artifact Possession) — the
+            // activated ability's source is the enchanted permanent.
+            is AbilityActivatedEvent -> listOf(event.sourceId)
             is ZoneChangeEvent -> {
                 if (event.fromZone == Zone.BATTLEFIELD) listOf(event.entityId) else emptyList()
             }
@@ -96,6 +100,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
         trigger: EventPattern,
         event: EngineGameEvent,
         attachedEntityId: com.wingedsheep.sdk.model.EntityId,
+        auraControllerId: com.wingedsheep.sdk.model.EntityId,
         state: GameState
     ): Boolean {
         return when (trigger) {
@@ -116,6 +121,14 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             }
             is EventPattern.TapEvent -> {
                 event is TappedEvent && event.entityId == attachedEntityId
+            }
+            is EventPattern.AbilityActivatedEvent -> {
+                if (event !is AbilityActivatedEvent) return false
+                if (event.sourceId != attachedEntityId) return false
+                if (!matcher.matchesPlayer(trigger.player, event.controllerId, auraControllerId)) return false
+                // Mirror the main matcher's two wordings (see TriggerMatcher.AbilityActivatedEvent):
+                // "without {T} in its activation cost" vs. "isn't a mana ability".
+                if (trigger.requireNoTapInCost) !event.costsTap else !event.isManaAbility
             }
             is EventPattern.TurnFaceUpEvent -> {
                 event is TurnFaceUpEvent && event.entityId == attachedEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -257,11 +257,39 @@ class TriggerMatcher(
                 targets != null && targets.size == 1
             }
             is EventPattern.AbilityActivatedEvent -> {
-                // The engine only emits AbilityActivatedEvent for non-mana activated abilities
-                // (mana abilities resolve without the stack), so this naturally matches
-                // "activates an ability that isn't a mana ability". Loyalty abilities qualify.
                 if (event !is AbilityActivatedEvent) return false
                 if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                if (trigger.requireNoTapInCost) {
+                    // Antiquities "activates an ability without {T} in its activation cost"
+                    // (Haunting Wind / Powerleech / Artifact Possession). Match any activated
+                    // ability whose cost lacks {T} — mana abilities without {T} count too.
+                    if (event.costsTap) return false
+                } else {
+                    // Default "activates an ability that isn't a mana ability" (Flamescroll
+                    // Celebrant): the engine emits AbilityActivatedEvent for non-mana abilities
+                    // (which use the stack) and, for the {T}-cost template above, for non-{T} mana
+                    // abilities — so explicitly reject the mana-ability ones here. Loyalty
+                    // abilities qualify (they aren't mana abilities).
+                    if (event.isManaAbility) return false
+                }
+                // SELF/ATTACHED binding: the ability's source must be this permanent (Artifact
+                // Possession — "enchanted artifact"); the source is exposed via TriggerContext as
+                // the triggering entity for the ATTACHED check upstream, but the source-id match
+                // here keys directly off event.sourceId.
+                if (binding == TriggerBinding.SELF && event.sourceId != sourceId) return false
+                // sourceFilter: the permanent whose ability was activated must match (e.g. an
+                // artifact, or an artifact an opponent controls).
+                val sourceFilter = trigger.sourceFilter
+                if (sourceFilter != null) {
+                    val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
+                        controllerId = controllerId,
+                        sourceId = sourceId
+                    )
+                    if (!PredicateEvaluator().matches(
+                            state, state.projectedState, event.sourceId, sourceFilter, predicateContext
+                        )
+                    ) return false
+                }
                 val targetMatch = trigger.targetMatch
                 if (targetMatch != null) {
                     // "...that targets a creature or player": the activated ability on the stack

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.actions.ability
 import com.wingedsheep.engine.state.components.battlefield.chosenColor
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.LoyaltyChangedEvent
@@ -936,6 +937,13 @@ class ActivateAbilityHandler(
             events.add(LoyaltyChangedEvent(action.sourceId, cardComponent.name, abilityCost.change))
         }
 
+        // Snapshot of the activation's cost-side events (cost payment + the {T}/tap/loyalty events
+        // emitted just above) before any mana-production event is appended. The mana-ability path
+        // resolves off the stack and returns early, so it must run trigger detection over this set
+        // — including the {T} TappedEvent — so an ANY-binding "whenever an artifact becomes tapped"
+        // trigger (Powerleech, Tap Watcher) fires when a {T} mana ability is activated.
+        val activationCostEvents = events.toList()
+
         // Track per-turn activation if the ability has an OncePerTurn or MaxPerTurn restriction
         fun isPerTurnTracked(r: ActivationRestriction): Boolean =
             r is ActivationRestriction.OncePerTurn || r is ActivationRestriction.MaxPerTurn ||
@@ -1227,26 +1235,49 @@ class ActivateAbilityHandler(
             val bonusResult = tappedForManaBonusResolver.drive(currentState, anyColorBonuses, allManaEvents)
             if (bonusResult.isPaused) return bonusResult
 
-            // Detect and queue any triggered abilities from the cost payment — e.g. the
-            // dies/leaves-the-battlefield trigger of a source sacrificed to pay a mana ability.
-            // Such triggered abilities still use the stack even though the mana ability itself
-            // resolves off it (mirrors the non-mana path below).
-            val costTriggers = triggerDetector.detectTriggers(bonusResult.newState, costPaymentEvents)
+            // A mana ability whose cost lacks {T} (e.g. Ashnod's Altar's "Sacrifice a creature: Add
+            // {C}{C}") still satisfies the Antiquities "activates an ability without {T} in its
+            // activation cost" template (Haunting Wind / Powerleech / Artifact Possession). Mana
+            // abilities resolve off the stack, so StackResolver never emits AbilityActivatedEvent
+            // for them — emit it here. The common tap-for-mana case (cost has {T}) is skipped, so
+            // there's no behavior change or client-log noise for ordinary mana sources.
+            val manaAbilityActivatedEvents: List<GameEvent> =
+                if (!hasTapCost(effectiveCost)) {
+                    listOf(
+                        AbilityActivatedEvent(
+                            sourceId = action.sourceId,
+                            sourceName = cardComponent.name,
+                            controllerId = action.playerId,
+                            abilityEntityId = null,
+                            costsTap = false,
+                            isManaAbility = true
+                        )
+                    )
+                } else emptyList()
+
+            // Detect and queue any triggered abilities from the activation — the cost-side events
+            // (a sacrificed source's dies trigger, the {T} TappedEvent for an artifact-tap trigger)
+            // plus the non-{T} mana-ability activation event above. Such triggered abilities still
+            // use the stack even though the mana ability itself resolves off it.
+            val activationTriggerEvents = activationCostEvents + manaAbilityActivatedEvents
+            val resultEvents = bonusResult.events + manaAbilityActivatedEvents
+            val costTriggers = triggerDetector.detectTriggers(bonusResult.newState, activationTriggerEvents)
             if (costTriggers.isNotEmpty()) {
                 val triggerResult = triggerProcessor.processTriggers(bonusResult.newState, costTriggers)
                 if (triggerResult.isPaused) {
                     return ExecutionResult.paused(
                         triggerResult.state.withPriority(action.playerId),
                         triggerResult.pendingDecision!!,
-                        bonusResult.events + triggerResult.events
+                        resultEvents + triggerResult.events
                     )
                 }
                 return ExecutionResult.success(
                     triggerResult.newState.withPriority(action.playerId),
-                    bonusResult.events + triggerResult.events
+                    resultEvents + triggerResult.events
                 )
             }
-            return bonusResult
+            return if (manaAbilityActivatedEvents.isEmpty()) bonusResult
+            else ExecutionResult.success(bonusResult.newState, resultEvents)
         }
 
         // Non-mana abilities go on the stack
@@ -1275,7 +1306,8 @@ class ActivateAbilityHandler(
 
         var stackResult = stackResolver.putActivatedAbility(
             currentState, abilityOnStack, action.targets,
-            targetRequirements = effectiveTargetReqs
+            targetRequirements = effectiveTargetReqs,
+            costsTap = hasTapCost(effectiveCost)
         )
         currentState = stackResult.newState
         events.addAll(stackResult.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -783,13 +783,18 @@ class SacrificeAndPayContinuationResumer(
 
         // Enforce any untap-count caps (Damping Field). The decision's minSelections already forces
         // the player to keep enough tapped when the matching pool is homogeneous; this is defence in
-        // depth against a selection that satisfies the count but leaves a filter over its cap.
+        // depth against a selection that satisfies the count but leaves a filter over its cap (which
+        // can happen when the keep-tapped pool also holds optional MAY_NOT_UNTAP permanents outside
+        // the filter). The decision stays pending, so the rejection re-prompts; spell out the exact
+        // shortfall so the player can correct it rather than guess.
         for (limit in continuation.untapLimits) {
             val untappingMatching = limit.matchingPermanents.count { it in toUntap }
             if (untappingMatching > limit.max) {
+                val mustKeepMore = untappingMatching - limit.max
                 return ExecutionResult.error(
                     state,
-                    "Can't untap more than ${limit.max} of the restricted permanents"
+                    "At most ${limit.max} of the restricted permanents may untap; " +
+                        "keep $mustKeepMore more of them tapped"
                 )
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -781,6 +781,19 @@ class SacrificeAndPayContinuationResumer(
         val keepTapped = response.selectedCards.toSet()
         val toUntap = continuation.allPermanentsToUntap.filter { it !in keepTapped }
 
+        // Enforce any untap-count caps (Damping Field). The decision's minSelections already forces
+        // the player to keep enough tapped when the matching pool is homogeneous; this is defence in
+        // depth against a selection that satisfies the count but leaves a filter over its cap.
+        for (limit in continuation.untapLimits) {
+            val untappingMatching = limit.matchingPermanents.count { it in toUntap }
+            if (untappingMatching > limit.max) {
+                return ExecutionResult.error(
+                    state,
+                    "Can't untap more than ${limit.max} of the restricted permanents"
+                )
+            }
+        }
+
         var newState = state
         val events = mutableListOf<GameEvent>()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantKeywordExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantKeywordExecutor.kt
@@ -15,6 +15,13 @@ import kotlin.reflect.KClass
 /**
  * Executor for GrantKeywordEffect.
  * "Target creature gains [keyword] until end of turn"
+ *
+ * Works for any battlefield permanent, not just creatures: combat keywords (flying, trample,
+ * …) are no-ops on noncreatures, but ability flags such as `DOESNT_UNTAP` are meaningful on a
+ * noncreature artifact (Phyrexian Gremlins taps a target artifact and keeps it from untapping).
+ * The granted keyword lands in the projected keyword set either way; the layer that consumes it
+ * decides whether it does anything. So the executor only requires that the target be a permanent
+ * on the battlefield, not specifically a creature.
  */
 class GrantKeywordExecutor : EffectExecutor<GrantKeywordEffect> {
 
@@ -25,18 +32,17 @@ class GrantKeywordExecutor : EffectExecutor<GrantKeywordEffect> {
         effect: GrantKeywordEffect,
         context: EffectContext
     ): EffectResult {
-        // Resolve the target creature
+        // Resolve the target permanent
         val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid target for keyword grant")
 
-        // Verify target exists and is a creature (use projected types for animated lands etc.)
+        // Verify target still exists as a battlefield permanent
         val targetContainer = state.getEntity(targetId)
-            ?: return EffectResult.error(state, "Target creature no longer exists")
+            ?: return EffectResult.error(state, "Target permanent no longer exists")
         val cardComponent = targetContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Target is not a card")
-        val projected = state.projectedState
-        if (!projected.isCreature(targetId)) {
-            return EffectResult.error(state, "Target is not a creature")
+        if (targetId !in state.getBattlefield()) {
+            return EffectResult.error(state, "Target is no longer on the battlefield")
         }
 
         // Create a floating effect for the keyword grant

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -139,6 +139,7 @@ import com.wingedsheep.sdk.scripting.SuppressHexproofForGroup
 import com.wingedsheep.sdk.scripting.SuppressWardForGroup
 import com.wingedsheep.sdk.scripting.UntapDuringOtherUntapSteps
 import com.wingedsheep.sdk.scripting.UntapFilteredDuringOtherUntapSteps
+import com.wingedsheep.sdk.scripting.UntapLimitPerStep
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureIsLegendary
 import com.wingedsheep.sdk.scripting.conditions.Exists
@@ -778,6 +779,7 @@ class StaticAbilityHandler(
             is PreventManaPoolEmptying,
             is UntapDuringOtherUntapSteps,
             is UntapFilteredDuringOtherUntapSteps,
+            is UntapLimitPerStep,
 
             // Visibility / information (ClientStateTransformer / DrawCardPrimitive):
             is LookAtFaceDownCreatures,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -611,7 +611,8 @@ class StackResolver(
         ability: ActivatedAbilityOnStackComponent,
         targets: List<ChosenTarget> = emptyList(),
         targetRequirements: List<TargetRequirement> = emptyList(),
-        emitActivationEvent: Boolean = true
+        emitActivationEvent: Boolean = true,
+        costsTap: Boolean = false
     ): ExecutionResult {
         val (abilityId, stateWithId) = state.newEntity()
 
@@ -626,12 +627,17 @@ class StackResolver(
 
         val events = mutableListOf<GameEvent>()
         if (emitActivationEvent) {
+            // Abilities reaching the stack are never mana abilities (CR 605.3 — mana abilities
+            // resolve without the stack). costsTap lets the {T}-in-cost trigger family distinguish
+            // tap-cost abilities (which it must skip) from non-tap ones.
             events.add(
                 AbilityActivatedEvent(
                     ability.sourceId,
                     ability.sourceName,
                     ability.controllerId,
-                    abilityEntityId = abilityId
+                    abilityEntityId = abilityId,
+                    costsTap = costsTap,
+                    isManaAbility = false
                 )
             )
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArtifactPossessionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArtifactPossessionScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.ArtifactPossession
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Artifact Possession — {2}{B} Enchantment — Aura, "Enchant artifact".
+ *
+ * "Whenever enchanted artifact becomes tapped or a player activates an ability of enchanted
+ *  artifact without {T} in its activation cost, this Aura deals 2 damage to that artifact's
+ *  controller."
+ *
+ * Single-target ([TriggerBinding.ATTACHED]) member of the Antiquities tap/activate punisher family:
+ * only the enchanted artifact fires it (an un-enchanted artifact does nothing).
+ */
+class ArtifactPossessionScenarioTest : FunSpec({
+
+    val tapRock = card("Tap Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Add {C}."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = AddColorlessManaEffect(1)
+            manaAbility = true
+        }
+    }
+
+    val pingRock = card("Ping Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{1}: You gain 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{1}")
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(ArtifactPossession, tapRock, pingRock).forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 30) { bothPass(); guard++ }
+    }
+
+    // Put the artifact in play and cast Artifact Possession onto it (Aura attaches on resolution).
+    fun GameTestDriver.enchant(player: com.wingedsheep.sdk.model.EntityId, rockName: String): com.wingedsheep.sdk.model.EntityId {
+        val rock = putPermanentOnBattlefield(player, rockName)
+        val aura = putCardInHand(player, "Artifact Possession")
+        giveColorlessMana(player, 2)
+        giveMana(player, Color.BLACK, 1)
+        castSpell(player, aura, listOf(rock))
+        bothPass() // resolve the Aura
+        findPermanent(player, "Artifact Possession") shouldNotBe null
+        return rock
+    }
+
+    test("tapping the enchanted artifact deals 2 to that artifact's controller") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val rock = driver.enchant(me, "Tap Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Tap Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(me) shouldBe lifeBefore - 2
+    }
+
+    test("activating the enchanted artifact's non-{T} ability deals 2 to that artifact's controller") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val rock = driver.enchant(me, "Ping Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.giveColorlessMana(me, 1)
+        val abilityId = driver.cardRegistry.requireCard("Ping Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Ability half deals 2; the ability gains 1. Net -1.
+        driver.getLifeTotal(me) shouldBe lifeBefore - 1
+    }
+
+    test("an un-enchanted artifact does NOT fire Artifact Possession") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        // Enchant one rock, then tap a DIFFERENT, un-enchanted rock — no trigger.
+        driver.enchant(me, "Tap Rock")
+        val other = driver.putPermanentOnBattlefield(me, "Ping Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.giveColorlessMana(me, 1)
+        val abilityId = driver.cardRegistry.requireCard("Ping Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = other, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Only the un-enchanted rock's own +1 life; Artifact Possession (on the other rock) is silent.
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArtifactTapActivateTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArtifactTapActivateTriggerScenarioTest.kt
@@ -1,0 +1,238 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level coverage for the Antiquities "becomes tapped / activates an ability without {T} in
+ * its activation cost" trigger family (Haunting Wind, Powerleech, Artifact Possession).
+ *
+ * The feature is two composable halves:
+ *  - [Triggers.becomesTapped] with a [GameObjectFilter] (the tap half) — fires off [TappedEvent].
+ *  - [Triggers.activatesAbilityWithoutTap] (the ability half) — fires off the engine's
+ *    [com.wingedsheep.engine.core.AbilityActivatedEvent] when its `costsTap` flag is false,
+ *    regardless of whether the ability is a mana ability.
+ *
+ * These tests pin the *engine* rules (not a specific card): a {T}-cost ability fires only the tap
+ * half; a non-{T} non-mana ability fires only the ability half; a non-{T} *mana* ability fires the
+ * ability half (the case the default "isn't a mana ability" wording misses); a tapped-cost mana
+ * ability fires only the tap half; non-artifacts are filtered out; and "an opponent controls"
+ * scoping works.
+ */
+class ArtifactTapActivateTriggerScenarioTest : FunSpec({
+
+    // Watcher: counts +1 damage to itself each time an artifact's *non-{T}* ability is activated,
+    // globally (Haunting Wind shape, but routed at the controller for an easy assertion).
+    val nonTapWatcher = card("Non-Tap Watcher") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        oracleText = "Whenever a player activates an artifact's ability without {T} in its " +
+            "activation cost, this deals 1 damage to that artifact's controller."
+        triggeredAbility {
+            trigger = Triggers.activatesAbilityWithoutTap(
+                player = Player.Each,
+                sourceFilter = GameObjectFilter.Artifact
+            )
+            effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        }
+    }
+
+    // Watcher: counts +1 life each time an artifact becomes tapped, globally.
+    val tapWatcher = card("Tap Watcher") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        oracleText = "Whenever an artifact becomes tapped, you gain 1 life."
+        triggeredAbility {
+            trigger = Triggers.becomesTapped(
+                binding = TriggerBinding.ANY,
+                filter = GameObjectFilter.Artifact
+            )
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    // Artifact with a {T}: Add {C} mana ability (tap half should fire; ability half must NOT).
+    val tapManaRock = card("Tap Mana Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Add {C}."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = AddColorlessManaEffect(1)
+            manaAbility = true
+        }
+    }
+
+    // Artifact with a non-{T}, non-mana ability ("{1}: you gain 1 life"): ability half fires.
+    val nonTapNonManaArtifact = card("Spendthrift Engine") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{1}: You gain 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{1}")
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    // Artifact with a non-{T} MANA ability ("Sacrifice this artifact: Add {C}{C}"): ability half
+    // must fire even though it's a mana ability (the {T}-in-cost wording, not "isn't a mana ability").
+    val sacForManaArtifact = card("Sacrificial Battery") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "Sacrifice this artifact: Add {C}{C}."
+        activatedAbility {
+            cost = AbilityCost.SacrificeSelf
+            effect = AddColorlessManaEffect(2)
+            manaAbility = true
+        }
+    }
+
+    // A creature with a non-{T} non-mana ability — the artifact source filter must reject it.
+    val nonArtifactCreature = card("Chatty Bear") {
+        manaCost = "{1}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+        oracleText = "{1}: You gain 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{1}")
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(
+            nonTapWatcher, tapWatcher, tapManaRock, nonTapNonManaArtifact,
+            sacForManaArtifact, nonArtifactCreature
+        ).forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 30) {
+            bothPass(); guard++
+        }
+    }
+
+    test("a {T}-cost mana ability fires the tap half but NOT the non-{T} ability half") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Non-Tap Watcher")
+        driver.putPermanentOnBattlefield(me, "Tap Watcher")
+        val rock = driver.putPermanentOnBattlefield(me, "Tap Mana Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Tap Mana Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Tap half fired (gain 1 life); non-{T} ability half did NOT (no damage to me).
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+
+    test("a non-{T}, non-mana ability fires the ability half but NOT the tap half") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Non-Tap Watcher")
+        driver.putPermanentOnBattlefield(me, "Tap Watcher")
+        val engine = driver.putPermanentOnBattlefield(me, "Spendthrift Engine")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.giveColorlessMana(me, 1)
+        val abilityId = driver.cardRegistry.requireCard("Spendthrift Engine").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = engine, abilityId = abilityId))
+        driver.resolveStack()
+
+        // The ability resolved (+1 life from the artifact) and the ability half dealt 1 to me;
+        // the tap half did NOT fire (the artifact never tapped). Net: +1 (gain) - 1 (damage) = 0.
+        driver.getLifeTotal(me) shouldBe lifeBefore
+    }
+
+    test("a non-{T} MANA ability fires the ability half (the {T}-in-cost wording, not isn't-a-mana-ability)") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Non-Tap Watcher")
+        val battery = driver.putPermanentOnBattlefield(me, "Sacrificial Battery")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Sacrificial Battery").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = battery, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Sacrificing for mana is a non-{T} mana ability — the ability half fires and deals 1 to me.
+        driver.getLifeTotal(me) shouldBe lifeBefore - 1
+    }
+
+    test("the artifact source filter rejects a creature's non-{T} ability") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Non-Tap Watcher")
+        val bear = driver.putCreatureOnBattlefield(me, "Chatty Bear")
+        driver.removeSummoningSickness(bear)
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.giveColorlessMana(me, 1)
+        val abilityId = driver.cardRegistry.requireCard("Chatty Bear").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = bear, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Creature's ability is not an artifact's — only +1 from the gain, no damage.
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+
+    test("opponent-controls scoping: only an opponent's artifact ability fires the watcher") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Watcher keyed to "an opponent activates an artifact's ability without {T}".
+        val oppScopedWatcher = card("Opp Watcher") {
+            manaCost = "{2}"
+            typeLine = "Enchantment"
+            oracleText = "Whenever an opponent activates an artifact's ability without {T}, you gain 1 life."
+            triggeredAbility {
+                trigger = Triggers.activatesAbilityWithoutTap(
+                    player = Player.EachOpponent,
+                    sourceFilter = GameObjectFilter.Artifact.opponentControls()
+                )
+                effect = Effects.GainLife(1)
+            }
+        }
+        driver.registerCard(oppScopedWatcher)
+        driver.putPermanentOnBattlefield(me, "Opp Watcher")
+
+        // My own artifact ability does NOT fire the watcher.
+        val mine = driver.putPermanentOnBattlefield(me, "Spendthrift Engine")
+        driver.giveColorlessMana(me, 1)
+        val myAbilityId = driver.cardRegistry.requireCard("Spendthrift Engine").activatedAbilities[0].id
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = mine, abilityId = myAbilityId))
+        driver.resolveStack()
+        // +1 from my own artifact's gain effect, watcher did NOT fire.
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshnodsBattleGearScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshnodsBattleGearScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.AshnodsBattleGear
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ashnod's Battle Gear — tap-locked +2/-2 on a creature you control.
+ *
+ * {2}, {T}: Target creature you control gets +2/-2 for as long as this artifact remains tapped.
+ */
+class AshnodsBattleGearScenarioTest : FunSpec({
+
+    val abilityId = AshnodsBattleGear.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    test("+2/-2 applies while tapped and reverts when Battle Gear untaps") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gear = d.putPermanentOnBattlefield(p, "Ashnod's Battle Gear")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(gear)
+        d.removeSummoningSickness(bear)
+
+        d.giveMana(p, Color.WHITE, 2)
+        d.submit(
+            ActivateAbility(
+                playerId = p,
+                sourceId = gear,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        )
+        d.bothPass()
+
+        d.state.getEntity(gear)?.has<TappedComponent>() shouldBe true
+        // 3/3 -> 5/1
+        projector.getProjectedPower(d.state, bear) shouldBe 5
+        projector.getProjectedToughness(d.state, bear) shouldBe 1
+
+        // Untap Battle Gear on the next untap step -> buff ends, back to 3/3.
+        d.passPriorityUntil(Step.UNTAP)
+        d.submitCardSelection(p, emptyList())
+        d.state.getEntity(gear)?.has<TappedComponent>() shouldBe false
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+        projector.getProjectedToughness(d.state, bear) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ColossusOfSardiaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ColossusOfSardiaScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.ColossusOfSardia
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Colossus of Sardia — mandatory "doesn't untap" plus a pay-{9}-to-untap ability restricted to
+ * the controller's upkeep.
+ *
+ * Trample. This creature doesn't untap during your untap step.
+ * {9}: Untap this creature. Activate only during your upkeep.
+ */
+class ColossusOfSardiaScenarioTest : FunSpec({
+
+    val abilityId = ColossusOfSardia.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    test("9/9 trample; stays tapped through the untap step; {9} during upkeep untaps it") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colossus = d.putCreatureOnBattlefield(p, "Colossus of Sardia")
+        d.removeSummoningSickness(colossus)
+
+        projector.getProjectedPower(d.state, colossus) shouldBe 9
+        projector.getProjectedToughness(d.state, colossus) shouldBe 9
+        projector.project(d.state).hasKeyword(colossus, Keyword.TRAMPLE) shouldBe true
+
+        // Tap it (as if it attacked) and run to OUR next upkeep (turn 2). DOESNT_UNTAP filters it
+        // out of every untap step along the way, so it never gets the keep-tapped choice and
+        // remains tapped.
+        d.tapPermanent(colossus)
+        d.passPriorityUntil(Step.UPKEEP)        // opponent's upkeep
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN) // opponent's main
+        d.passPriorityUntil(Step.UPKEEP)        // our next upkeep
+        d.activePlayer shouldBe p
+        d.state.getEntity(colossus)?.has<TappedComponent>() shouldBe true
+
+        // Pay {9} during our upkeep to untap it.
+        d.giveColorlessMana(p, 9)
+        val result = d.submit(
+            ActivateAbility(playerId = p, sourceId = colossus, abilityId = abilityId)
+        )
+        result.isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(colossus)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("the {9} untap ability cannot be activated outside the controller's upkeep") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colossus = d.putCreatureOnBattlefield(p, "Colossus of Sardia")
+        d.removeSummoningSickness(colossus)
+        d.tapPermanent(colossus)
+
+        // In the main phase (not upkeep), the restriction must reject the activation.
+        d.giveColorlessMana(p, 9)
+        val result = d.submit(
+            ActivateAbility(playerId = p, sourceId = colossus, abilityId = abilityId)
+        )
+        result.isSuccess shouldBe false
+        d.state.getEntity(colossus)?.has<TappedComponent>() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DampingFieldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DampingFieldScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Damping Field — "Players can't untap more than one artifact during their untap steps."
+ *
+ * Models the global untap-count cap (UntapLimitPerStep). With more than one tapped artifact that
+ * would untap, the player must keep the excess tapped; exactly one untaps (their choice).
+ */
+class DampingFieldScenarioTest : FunSpec({
+
+    val Widget = CardDefinition.artifact(name = "Test Widget", manaCost = ManaCost.parse("{1}"))
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(Widget))
+        return d
+    }
+
+    test("with three tapped artifacts, only one untaps; the rest stay tapped") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val me = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(me, "Damping Field")
+        val a1 = d.putPermanentOnBattlefield(me, "Test Widget")
+        val a2 = d.putPermanentOnBattlefield(me, "Test Widget")
+        val a3 = d.putPermanentOnBattlefield(me, "Test Widget")
+        listOf(a1, a2, a3).forEach { d.tapPermanent(it) }
+
+        // Advance to our next untap step. The cap forces a keep-tapped decision.
+        d.passPriorityUntil(Step.UNTAP)
+        val decision = d.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        // Three artifacts would untap; at most one may — so at least two must be kept tapped.
+        decision.minSelections shouldBe 2
+
+        // Keep a1 and a2 tapped; a3 untaps.
+        d.submitCardSelection(me, listOf(a1, a2))
+        d.state.getEntity(a1)?.has<TappedComponent>() shouldBe true
+        d.state.getEntity(a2)?.has<TappedComponent>() shouldBe true
+        d.state.getEntity(a3)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("a single tapped artifact untaps freely — the cap is inert") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val me = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(me, "Damping Field")
+        val a1 = d.putPermanentOnBattlefield(me, "Test Widget")
+        d.tapPermanent(a1)
+
+        // Only one artifact — no decision; it untaps on our next untap step (turn 2).
+        d.passPriorityUntil(Step.UPKEEP)        // opponent's upkeep
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN) // opponent's main
+        d.passPriorityUntil(Step.UPKEEP)        // our next upkeep — untap already happened
+        d.activePlayer shouldBe me
+        d.state.getEntity(a1)?.has<TappedComponent>() shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HauntingWindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HauntingWindScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.HauntingWind
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Haunting Wind — {3}{B} Enchantment.
+ *
+ * "Whenever an artifact becomes tapped or a player activates an artifact's ability without {T} in
+ *  its activation cost, this enchantment deals 1 damage to that artifact's controller."
+ */
+class HauntingWindScenarioTest : FunSpec({
+
+    // Artifact with a {T}: Add {C} mana ability — activating it taps the artifact (tap half).
+    val tapRock = card("Tap Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Add {C}."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = AddColorlessManaEffect(1)
+            manaAbility = true
+        }
+    }
+
+    // Artifact with a non-{T} ability ("{1}: you gain 1 life") — activating it fires the ability half.
+    val pingRock = card("Ping Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{1}: You gain 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{1}")
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(HauntingWind, tapRock, pingRock).forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 30) { bothPass(); guard++ }
+    }
+
+    test("tapping an artifact deals 1 to that artifact's controller") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Haunting Wind")
+        val rock = driver.putPermanentOnBattlefield(me, "Tap Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Tap Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Tap half fired: 1 damage to the artifact's controller (me). The {T} ability half does NOT.
+        driver.getLifeTotal(me) shouldBe lifeBefore - 1
+    }
+
+    test("activating an artifact's non-{T} ability deals 1 to that artifact's controller") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Haunting Wind")
+        val rock = driver.putPermanentOnBattlefield(me, "Ping Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.giveColorlessMana(me, 1)
+        val abilityId = driver.cardRegistry.requireCard("Ping Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        // Ability half deals 1; the ability itself gains 1. Net 0; the artifact never tapped.
+        driver.getLifeTotal(me) shouldBe lifeBefore
+    }
+
+    test("global + 'that artifact's controller': Haunting Wind under the opponent still damages the artifact's controller") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Opponent controls Haunting Wind; I control (and tap) the artifact. The trigger is global
+        // ("an artifact becomes tapped"), and the damage goes to the artifact's controller — me —
+        // not to Haunting Wind's controller.
+        driver.putPermanentOnBattlefield(opp, "Haunting Wind")
+        val rock = driver.putPermanentOnBattlefield(me, "Tap Rock")
+
+        val myLifeBefore = driver.getLifeTotal(me)
+        val oppLifeBefore = driver.getLifeTotal(opp)
+        val abilityId = driver.cardRegistry.requireCard("Tap Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(me) shouldBe myLifeBefore - 1
+        driver.getLifeTotal(opp) shouldBe oppLifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhyrexianGremlinsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhyrexianGremlinsScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.PhyrexianGremlins
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.core.ManaCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Phyrexian Gremlins — imposed untap suppression. {T} taps a target artifact and grants it
+ * "doesn't untap during its controller's untap step for as long as Phyrexian Gremlins remains
+ * tapped." The grant rides the WhileSourceTapped one-way latch keyed to Gremlins.
+ */
+class PhyrexianGremlinsScenarioTest : FunSpec({
+
+    val abilityId = PhyrexianGremlins.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    // A vanilla artifact for the victim.
+    val Widget = CardDefinition.artifact(name = "Test Widget", manaCost = ManaCost.parse("{1}"))
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(Widget))
+        return d
+    }
+
+    test("taps target artifact and keeps it from untapping while Gremlins stays tapped") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val me = d.activePlayer!!
+        val opp = if (d.player1 == me) d.player2 else d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gremlins = d.putCreatureOnBattlefield(me, "Phyrexian Gremlins")
+        d.removeSummoningSickness(gremlins)
+        // The opponent controls an untapped artifact.
+        val widget = d.putPermanentOnBattlefield(opp, "Test Widget")
+
+        d.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = gremlins,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(widget))
+            )
+        )
+        d.bothPass()
+
+        // Gremlins tapped from the {T} cost; the widget is tapped and now "doesn't untap".
+        d.state.getEntity(gremlins)?.has<TappedComponent>() shouldBe true
+        d.state.getEntity(widget)?.has<TappedComponent>() shouldBe true
+        projector.project(d.state).hasKeyword(widget, AbilityFlag.DOESNT_UNTAP) shouldBe true
+
+        // Reach the opponent's untap step: the widget must stay tapped (Gremlins is still tapped).
+        d.passPriorityUntil(Step.UPKEEP) // opponent's beginning phase
+        d.activePlayer shouldBe opp
+        d.state.getEntity(widget)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("once Gremlins untaps, the lock releases and the artifact untaps") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val me = d.activePlayer!!
+        val opp = if (d.player1 == me) d.player2 else d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gremlins = d.putCreatureOnBattlefield(me, "Phyrexian Gremlins")
+        d.removeSummoningSickness(gremlins)
+        val widget = d.putPermanentOnBattlefield(opp, "Test Widget")
+
+        d.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = gremlins,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(widget))
+            )
+        )
+        d.bothPass()
+        d.state.getEntity(widget)?.has<TappedComponent>() shouldBe true
+
+        // The opponent's untap step (turn 1's other half) leaves the widget tapped — DOESNT_UNTAP —
+        // so it never pauses. The first untap step that pauses is OURS (Gremlins is MAY_NOT_UNTAP).
+        d.passPriorityUntil(Step.UNTAP)
+        d.activePlayer shouldBe me
+        // Still locked the whole time: the widget never untapped on the opponent's untap step.
+        d.state.getEntity(widget)?.has<TappedComponent>() shouldBe true
+
+        // Untap Gremlins: the WhileSourceTapped grant drops off the widget.
+        d.submitCardSelection(me, emptyList())
+        d.state.getEntity(gremlins)?.has<TappedComponent>() shouldBe false
+        projector.project(d.state).hasKeyword(widget, AbilityFlag.DOESNT_UNTAP) shouldBe false
+
+        // On the opponent's following untap step the widget untaps normally.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.activePlayer shouldBe opp
+        d.state.getEntity(widget)?.has<TappedComponent>() shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PowerleechScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PowerleechScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.Powerleech
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Powerleech — {G}{G} Enchantment.
+ *
+ * "Whenever an artifact an opponent controls becomes tapped or an opponent activates an artifact's
+ *  ability without {T} in its activation cost, you gain 1 life."
+ *
+ * The opponent-controlled filter is what distinguishes Powerleech from Haunting Wind. Here player2
+ * controls Powerleech and player1 (the active player, and player2's opponent) owns/taps the
+ * artifacts — so player1's artifact activity is exactly "an opponent's artifact" from player2's
+ * perspective, and the leech rewards player2.
+ */
+class PowerleechScenarioTest : FunSpec({
+
+    val tapRock = card("Tap Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Add {C}."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = AddColorlessManaEffect(1)
+            manaAbility = true
+        }
+    }
+
+    val pingRock = card("Ping Rock") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{1}: You gain 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{1}")
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(Powerleech, tapRock, pingRock).forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 30) { bothPass(); guard++ }
+    }
+
+    test("an opponent tapping an artifact gains the leech's controller 1 life") {
+        val driver = createDriver()
+        val active = driver.player1   // opponent (relative to Powerleech's controller)
+        val leecher = driver.player2  // controls Powerleech
+
+        driver.putPermanentOnBattlefield(leecher, "Powerleech")
+        val rock = driver.putPermanentOnBattlefield(active, "Tap Rock")
+
+        val leecherLifeBefore = driver.getLifeTotal(leecher)
+        val abilityId = driver.cardRegistry.requireCard("Tap Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = active, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(leecher) shouldBe leecherLifeBefore + 1
+    }
+
+    test("an opponent activating an artifact's non-{T} ability gains the leech's controller 1 life") {
+        val driver = createDriver()
+        val active = driver.player1
+        val leecher = driver.player2
+
+        driver.putPermanentOnBattlefield(leecher, "Powerleech")
+        val rock = driver.putPermanentOnBattlefield(active, "Ping Rock")
+
+        val leecherLifeBefore = driver.getLifeTotal(leecher)
+        driver.giveColorlessMana(active, 1)
+        val abilityId = driver.cardRegistry.requireCard("Ping Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = active, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(leecher) shouldBe leecherLifeBefore + 1
+    }
+
+    test("the controller's OWN artifact activity does NOT trigger Powerleech") {
+        val driver = createDriver()
+        val me = driver.player1 // controls both Powerleech and the rock
+
+        driver.putPermanentOnBattlefield(me, "Powerleech")
+        val rock = driver.putPermanentOnBattlefield(me, "Tap Rock")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Tap Rock").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = rock, abilityId = abilityId))
+        driver.resolveStack()
+
+        // My own artifact isn't "an artifact an opponent controls" — no life gained.
+        driver.getLifeTotal(me) shouldBe lifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TawnossWeaponryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TawnossWeaponryScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.TawnossWeaponry
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tawnos's Weaponry — the "tap-locked" +1/+1 buff plus optional self untap-skip.
+ *
+ * {2}, {T}: Target creature gets +1/+1 for as long as this artifact remains tapped.
+ * You may choose not to untap this artifact during your untap step.
+ */
+class TawnossWeaponryScenarioTest : FunSpec({
+
+    val abilityId = TawnossWeaponry.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        return d
+    }
+
+    fun GameTestDriver.activate(player: com.wingedsheep.sdk.model.EntityId, weaponry: com.wingedsheep.sdk.model.EntityId, target: com.wingedsheep.sdk.model.EntityId) {
+        giveMana(player, Color.WHITE, 2)
+        submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = weaponry,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        bothPass()
+    }
+
+    test("buff applies and persists while Weaponry stays tapped, drops when it untaps") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val weaponry = d.putPermanentOnBattlefield(p, "Tawnos's Weaponry")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser")
+        d.removeSummoningSickness(weaponry)
+        d.removeSummoningSickness(bear)
+
+        d.activate(p, weaponry, bear)
+
+        // Tapped from the {T} cost; the bear is 3/3 -> 4/4.
+        d.state.getEntity(weaponry)?.has<TappedComponent>() shouldBe true
+        projector.getProjectedPower(d.state, bear) shouldBe 4
+        projector.getProjectedToughness(d.state, bear) shouldBe 4
+
+        // Keep Weaponry tapped through the next untap step — buff survives.
+        d.passPriorityUntil(Step.UNTAP)
+        (d.pendingDecision is SelectCardsDecision) shouldBe true
+        d.submitCardSelection(p, listOf(weaponry))
+        d.state.getEntity(weaponry)?.has<TappedComponent>() shouldBe true
+        projector.getProjectedPower(d.state, bear) shouldBe 4
+
+        // Next untap step: untap Weaponry — buff ends immediately and does not return.
+        d.passPriorityUntil(Step.UNTAP)
+        d.submitCardSelection(p, emptyList())
+        d.state.getEntity(weaponry)?.has<TappedComponent>() shouldBe false
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+        projector.getProjectedToughness(d.state, bear) shouldBe 3
+    }
+
+    test("buff does not stack across turns while Weaponry stays tapped") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val weaponry = d.putPermanentOnBattlefield(p, "Tawnos's Weaponry")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser")
+        d.removeSummoningSickness(weaponry)
+        d.removeSummoningSickness(bear)
+        d.activate(p, weaponry, bear)
+
+        val effectCount = d.state.floatingEffects.size
+        d.passPriorityUntil(Step.UNTAP)
+        d.submitCardSelection(p, listOf(weaponry))
+        // Still +1/+1, not +2/+2, and no extra floating effect accrued.
+        projector.getProjectedPower(d.state, bear) shouldBe 4
+        d.state.floatingEffects.size shouldBe effectCount
+    }
+})


### PR DESCRIPTION
Implements 8 Antiquities cards (+ a 10E reprint row) across two related mechanics,
built by composing/extending existing SDK primitives rather than adding card-specific types.

### Cards
- **Haunting Wind, Powerleech, Artifact Possession** — "whenever an artifact becomes
  tapped or its ability is activated without {T} in its cost" punisher template.
- **Damping Field** — "players can't untap more than one artifact during their untap steps."
- **Phyrexian Gremlins** — taps a target artifact and locks it while Gremlins stays tapped.
- **Ashnod's Battle Gear (+2/-2), Tawnos's Weaponry (+1/+1)** — tap-locked stat buffs.
- **Colossus of Sardia** — mandatory "doesn't untap" + pay-{9}-during-upkeep to untap;
  canonical lives here (earliest printing), with a 10E `Printing` row.

### SDK / engine
- `ModifyStats` gains a `duration` param threading into the existing `ModifyStatsEffect`
  (reuses the `WhileSourceTapped` one-way latch).
- `Triggers.activatesAbilityWithoutTap` + `requireNoTapInCost`/`sourceFilter` flags on
  `AbilityActivatedEvent`, distinguishing "without {T} in cost" from "isn't a mana ability".
- New `UntapLimitPerStep(filter, max)` static ability (global untap-count cap).
- `GrantKeywordExecutor` generalized from creature-only to any battlefield permanent.
- The {T} TappedEvent of a mana ability now runs trigger detection (fixes "becomes tapped"
  triggers not firing when tapping for mana).

### Tests
Engine-level `ArtifactTapActivateTriggerScenarioTest` pins every axis (tap vs ability half,
mana vs non-mana, {T} vs non-{T}, source filter, opponent scoping) plus per-card scenario
tests. SDK reference doc, snapshot golden, and backlog updated. All cited CR numbers
(502.3, 605.1, 605.3) verified.