### PR TITLE
Gitignore Claude Code local-only files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ gradle-app.setting
 
 # Claude Code per-agent git worktrees (transient — never commit)
 .claude/worktrees/
+
+# Claude Code local-only files (auto-loaded, machine/contributor-specific — never commit)
+CLAUDE.local.md
+.claude/settings.local.json


### PR DESCRIPTION
Ignore CLAUDE.local.md and .claude/settings.local.json — both are auto-loaded by Claude Code but are machine/contributor-specific and should never be committed.