### PR TITLE
Handle NotSubtype card predicate in trigger detection

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -888,6 +888,8 @@ class TriggerMatcher(
                 cardComponent.typeLine.hasSubtype(predicate.subtype)
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes ->
                 predicate.subtypes.any { cardComponent.typeLine.hasSubtype(it) }
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.NotSubtype ->
+                !cardComponent.typeLine.hasSubtype(predicate.subtype)
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtLeast -> {
                 val cmc = if (isFaceDown) 0 else cardComponent.manaValue
                 cmc >= predicate.min

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherNotSubtypeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherNotSubtypeTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+
+/**
+ * Regression for the gap where [TriggerMatcher.matchesCardPredicate] had no branch for
+ * [CardPredicate.NotSubtype] and fell into the `error(...)` guard. Any death/leave trigger
+ * gated on a "non-<subtype>" event filter would crash trigger detection rather than match.
+ * No registered card hits this path yet — every current `NotSubtype` user puts it in a spell
+ * target or effect filter (evaluated elsewhere), not a trigger's event filter — so the guard
+ * turns the missing branch into a hard failure instead of a silent miss. The branch is needed
+ * to support future "whenever a non-<subtype> creature dies/leaves" triggers. The guard exists
+ * precisely because a silent `else -> true` pass-through once hid the IsNontoken bug for months.
+ *
+ * The trigger shape here is a death trigger filtered on `IsCreature + NotSubtype(Zombie)`:
+ * a non-Zombie creature dying must fire it; a Zombie dying must not.
+ */
+class TriggerMatcherNotSubtypeTest : FunSpec({
+
+    val nonZombieDeathWatcher = card("Non-Zombie Death Watcher") {
+        manaCost = "{2}"
+        colorIdentity = ""
+        typeLine = "Enchantment"
+        oracleText = "Whenever a non-Zombie creature dies, draw a card."
+
+        spell {}
+
+        triggeredAbility {
+            trigger = TriggerSpec(
+                event = EventPattern.ZoneChangeEvent(
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsCreature,
+                            CardPredicate.NotSubtype(Subtype("Zombie")),
+                        ),
+                    ),
+                    from = Zone.BATTLEFIELD,
+                    to = Zone.GRAVEYARD,
+                ),
+                binding = TriggerBinding.OTHER,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + nonZombieDeathWatcher)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.putPermanentOnBattlefield(driver.player1, "Non-Zombie Death Watcher")
+        return driver
+    }
+
+    fun detectorFor(driver: GameTestDriver): TriggerDetector =
+        TriggerDetector(driver.cardRegistry)
+
+    test("non-Zombie creature dying fires the non-Zombie death trigger") {
+        val driver = createDriver()
+        // Goblin Guide is a Goblin/Scout — a non-Zombie creature.
+        val dead = driver.putCardInGraveyard(driver.player1, "Goblin Guide")
+        val event = ZoneChangeEvent(
+            entityId = dead,
+            entityName = "Goblin Guide",
+            fromZone = Zone.BATTLEFIELD,
+            toZone = Zone.GRAVEYARD,
+            ownerId = driver.player1,
+        )
+
+        val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(event))
+
+        triggers.filter {
+            it.ability.trigger is EventPattern.ZoneChangeEvent
+        } shouldHaveSize 1
+    }
+
+    test("Zombie creature dying does NOT fire the non-Zombie death trigger") {
+        val driver = createDriver()
+        // Fear Creature is a Zombie — the NotSubtype(Zombie) predicate must reject it.
+        val dead = driver.putCardInGraveyard(driver.player1, "Fear Creature")
+        val event = ZoneChangeEvent(
+            entityId = dead,
+            entityName = "Fear Creature",
+            fromZone = Zone.BATTLEFIELD,
+            toZone = Zone.GRAVEYARD,
+            ownerId = driver.player1,
+        )
+
+        val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(event))
+
+        triggers.filter {
+            it.ability.trigger is EventPattern.ZoneChangeEvent
+        }.shouldBeEmpty()
+    }
+})


### PR DESCRIPTION
TriggerMatcher.matchesCardPredicate had no branch for CardPredicate.NotSubtype and fell into the error(...) guard, crashing trigger detection whenever a death/leave trigger was gated on a "non-<subtype>" filter (e.g. Noxious Ghoul's "whenever another non-Zombie creature dies"). NotSubtype is already handled in PredicateEvaluator, AffectsFilterResolver, and CostCalculator — this aligns the trigger matcher with them.

Adds a regression test mirroring Noxious Ghoul: a non-Zombie creature dying fires the trigger; a Zombie dying does not.