### PR TITLE
Add MTG Arena deck-list export to the sealed deckbuilder

### DIFF
--- a/web-client/src/components/sealed/DeckBuilderOverlay.tsx
+++ b/web-client/src/components/sealed/DeckBuilderOverlay.tsx
@@ -10,6 +10,7 @@ import { useDfcHoverFlip } from '../ui/useDfcHoverFlip'
 import { SetSynergiesButton, type Archetype } from '../draft/SetSynergiesOverlay'
 import { DeckbuilderChatPanel } from './DeckbuilderChatPanel'
 import { fetchAdvisors, type AdvisorInfo } from '@/api/aiAssist'
+import { buildArenaDeckList } from './arenaExport'
 import type { AutoBuildResult } from '@/store/slices/types'
 import {
   detectProducedColors,
@@ -148,6 +149,8 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
 
   const [hoveredCard, setHoveredCard] = useState<SealedCardInfo | null>(null)
   const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(null)
+  // Arena export modal: holds the rendered deck list while open, null when closed.
+  const [arenaExport, setArenaExport] = useState<string | null>(null)
   const [sortBy, setSortBy] = useState<'color' | 'cmc' | 'rarity'>('rarity')
   const [colorFilter, setColorFilter] = useState<Set<string>>(new Set())
   const [colorMode, setColorMode] = useState<ColorOp>('<=')
@@ -643,6 +646,35 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
               }}
             >
               Submit Deck
+            </button>
+          )}
+
+          {totalCount > 0 && (
+            <button
+              onClick={() =>
+                setArenaExport(
+                  buildArenaDeckList({
+                    deck: state.deck,
+                    cardPool: state.cardPool,
+                    basicLands: state.basicLands,
+                    landCounts: state.landCounts,
+                    commander: state.commander,
+                  })
+                )
+              }
+              title="Copy this deck in MTG Arena format"
+              style={{
+                padding: responsive.isMobile ? '6px 14px' : '8px 20px',
+                fontSize: responsive.fontSize.normal,
+                backgroundColor: '#2c5aa0',
+                color: 'white',
+                border: 'none',
+                borderRadius: 6,
+                cursor: 'pointer',
+                fontWeight: 600,
+              }}
+            >
+              Export
             </button>
           )}
 
@@ -1378,7 +1410,165 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
         </div>
       )}
 
+      {arenaExport !== null && (
+        <ArenaExportModal
+          text={arenaExport}
+          filename={`${state.setCodes.join('-') || 'sealed'}-deck.txt`}
+          responsive={responsive}
+          onClose={() => setArenaExport(null)}
+        />
+      )}
+
       <DeckbuilderChatPanel state={state} />
+    </div>
+  )
+}
+
+/**
+ * Modal showing the deck rendered as an MTG Arena deck list. The text sits in a
+ * read-only textarea so the user can hand-select it even where the Clipboard API is
+ * unavailable; "Copy" tries `navigator.clipboard` and flashes "Copied!" on success.
+ */
+function ArenaExportModal({
+  text,
+  filename,
+  responsive,
+  onClose,
+}: {
+  text: string
+  filename: string
+  responsive: ReturnType<typeof useResponsive>
+  onClose: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = useCallback(() => {
+    void navigator.clipboard?.writeText(text).then(
+      () => setCopied(true),
+      () => setCopied(false)
+    )
+  }, [text])
+
+  // Download the list as a .txt via a transient object URL — no server round-trip.
+  const download = useCallback(() => {
+    const url = URL.createObjectURL(new Blob([text], { type: 'text/plain' }))
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    // Revoke after the click has been dispatched — revoking synchronously can cancel
+    // the download in some browsers.
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+  }, [text, filename])
+
+  // Close on Escape, matching the backdrop/× affordances.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          backgroundColor: '#1e1e1e',
+          border: '1px solid #444',
+          borderRadius: 10,
+          padding: 20,
+          width: 'min(560px, 90vw)',
+          maxHeight: '80vh',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ color: 'white', fontWeight: 600, fontSize: responsive.fontSize.large }}>
+            Export — MTG Arena format
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#aaa',
+              fontSize: 22,
+              lineHeight: 1,
+              cursor: 'pointer',
+            }}
+          >
+            ×
+          </button>
+        </div>
+        <textarea
+          readOnly
+          value={text}
+          onFocus={(e) => e.currentTarget.select()}
+          style={{
+            width: '100%',
+            minHeight: 240,
+            resize: 'vertical',
+            backgroundColor: '#0f0f0f',
+            color: '#ddd',
+            border: '1px solid #333',
+            borderRadius: 6,
+            padding: 10,
+            fontFamily: 'monospace',
+            fontSize: responsive.fontSize.small,
+            whiteSpace: 'pre',
+            overflow: 'auto',
+          }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+          <button
+            onClick={download}
+            style={{
+              padding: '8px 20px',
+              fontSize: responsive.fontSize.normal,
+              backgroundColor: '#3a3a3a',
+              color: 'white',
+              border: '1px solid #555',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            Download .txt
+          </button>
+          <button
+            onClick={copy}
+            style={{
+              padding: '8px 20px',
+              fontSize: responsive.fontSize.normal,
+              backgroundColor: copied ? '#4caf50' : '#2c5aa0',
+              color: 'white',
+              border: 'none',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            {copied ? 'Copied!' : 'Copy to clipboard'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web-client/src/components/sealed/arenaExport.test.ts
+++ b/web-client/src/components/sealed/arenaExport.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { buildArenaDeckList, type ArenaExportInput } from './arenaExport'
+import { parseArenaDeckList } from '../deckbuilder/parseArenaDeck'
+import type { SealedCardInfo } from '@/types'
+
+// Minimal pool card — only the fields the exporter reads matter here.
+const card = (
+  name: string,
+  setCode?: string,
+  collectorNumber?: string
+): SealedCardInfo => ({
+  name,
+  manaCost: null,
+  typeLine: '',
+  rarity: 'common',
+  imageUri: null,
+  ...(setCode !== undefined ? { setCode } : {}),
+  ...(collectorNumber !== undefined ? { collectorNumber } : {}),
+})
+
+const base: ArenaExportInput = {
+  deck: [],
+  cardPool: [],
+  basicLands: [],
+  landCounts: {},
+  commander: null,
+}
+
+describe('buildArenaDeckList', () => {
+  it('renders copies with set + collector number, aggregated and sorted', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Lightning Bolt', 'Lightning Bolt', 'Ancestral Recall'],
+      cardPool: [
+        card('Lightning Bolt', 'lea', '161'),
+        card('Lightning Bolt', 'lea', '161'),
+        card('Ancestral Recall', 'lea', '47'),
+      ],
+    }
+    expect(buildArenaDeckList(input)).toBe(
+      ['Deck', '1 Ancestral Recall (LEA) 47', '2 Lightning Bolt (LEA) 161'].join('\n')
+    )
+  })
+
+  it('falls back to bare name when a card lacks printing metadata', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Test Goblin'],
+      cardPool: [card('Test Goblin')],
+    }
+    expect(buildArenaDeckList(input)).toBe(['Deck', '1 Test Goblin'].join('\n'))
+  })
+
+  it('emits basic lands from landCounts inside the Deck section', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Lightning Bolt'],
+      cardPool: [card('Lightning Bolt', 'lea', '161')],
+      basicLands: [card('Mountain', 'lea', '292')],
+      landCounts: { Mountain: 17, Island: 0 },
+    }
+    expect(buildArenaDeckList(input)).toBe(
+      ['Deck', '1 Lightning Bolt (LEA) 161', '17 Mountain (LEA) 292'].join('\n')
+    )
+  })
+
+  it('lists unused pool copies as the Sideboard', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Lightning Bolt'],
+      cardPool: [
+        card('Lightning Bolt', 'lea', '161'),
+        card('Lightning Bolt', 'lea', '161'), // one copy left in the pool
+        card('Shivan Dragon', 'lea', '174'),
+      ],
+    }
+    expect(buildArenaDeckList(input)).toBe(
+      [
+        'Deck',
+        '1 Lightning Bolt (LEA) 161',
+        '',
+        'Sideboard',
+        '1 Lightning Bolt (LEA) 161',
+        '1 Shivan Dragon (LEA) 174',
+      ].join('\n')
+    )
+  })
+
+  it('puts the commander in its own section, out of the maindeck and sideboard', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Atraxa, Praetors’ Voice', 'Sol Ring'],
+      cardPool: [
+        card('Atraxa, Praetors’ Voice', 'cmr', '1'),
+        card('Sol Ring', 'cmr', '472'),
+      ],
+      commander: 'Atraxa, Praetors’ Voice',
+    }
+    expect(buildArenaDeckList(input)).toBe(
+      [
+        'Commander',
+        '1 Atraxa, Praetors’ Voice (CMR) 1',
+        '',
+        'Deck',
+        '1 Sol Ring (CMR) 472',
+      ].join('\n')
+    )
+  })
+
+  it('returns empty string when there is nothing to export', () => {
+    expect(buildArenaDeckList(base)).toBe('')
+  })
+
+  it('round-trips through the Arena deck-list parser', () => {
+    const input: ArenaExportInput = {
+      ...base,
+      deck: ['Lightning Bolt', 'Lightning Bolt', 'Serra Angel'],
+      cardPool: [
+        card('Lightning Bolt', 'lea', '161'),
+        card('Lightning Bolt', 'lea', '161'),
+        card('Lightning Bolt', 'lea', '161'), // a third copy stays in the pool
+        card('Serra Angel', 'lea', '46'),
+      ],
+      basicLands: [card('Plains', 'lea', '286')],
+      landCounts: { Plains: 16 },
+    }
+    const parsed = parseArenaDeckList(buildArenaDeckList(input))
+    expect(parsed.errors).toEqual([])
+    expect(parsed.entries).toEqual([
+      expect.objectContaining({ count: 2, name: 'Lightning Bolt', setCode: 'LEA', collectorNumber: '161' }),
+      expect.objectContaining({ count: 1, name: 'Serra Angel', setCode: 'LEA', collectorNumber: '46' }),
+      expect.objectContaining({ count: 16, name: 'Plains', setCode: 'LEA', collectorNumber: '286' }),
+    ])
+    expect(parsed.sideboard).toEqual([
+      expect.objectContaining({ count: 1, name: 'Lightning Bolt', setCode: 'LEA', collectorNumber: '161' }),
+    ])
+  })
+})

--- a/web-client/src/components/sealed/arenaExport.ts
+++ b/web-client/src/components/sealed/arenaExport.ts
@@ -1,0 +1,102 @@
+/**
+ * Render a sealed/draft deck-building state into an MTG Arena deck list — the same
+ * text shape `parseArenaDeck.ts` reads back, so an exported deck round-trips through
+ * the deckbuilder's import flow (and pastes straight into Arena / Moxfield).
+ *
+ * Line shape per card is `count Name (SET) Collector`, falling back to `count Name`
+ * when the pool card carries no printing metadata (test cards lack it). Sections use
+ * Arena's headers — `Commander`, `Deck`, `Sideboard` — recognised by the parser's
+ * `SECTION_HEADERS` table.
+ *
+ * The leftover pool (cards opened/drafted but not in the maindeck) is emitted as the
+ * `Sideboard`, mirroring how Arena exports a limited pool — the player keeps a record
+ * of their whole pool, not just the 40 they sleeved up.
+ */
+import type { SealedCardInfo } from '@/types'
+
+/** The slice of deck-building state needed to render an Arena list. */
+export interface ArenaExportInput {
+  /** Card names in the maindeck (one entry per copy). */
+  readonly deck: readonly string[]
+  /** The opened/drafted pool — source of printing metadata and the sideboard. */
+  readonly cardPool: readonly SealedCardInfo[]
+  /** Basic lands available to add, carrying their own printing metadata. */
+  readonly basicLands: readonly SealedCardInfo[]
+  /** Basic-land copies added to the deck, by land name. */
+  readonly landCounts: Readonly<Record<string, number>>
+  /** Designated commander name (commander formats only); it lives in [deck] too. */
+  readonly commander: string | null
+}
+
+/** Format one Arena line: `count Name (SET) Collector`, or `count Name` without a printing. */
+function formatLine(count: number, name: string, printing: SealedCardInfo | undefined): string {
+  if (printing?.setCode && printing.collectorNumber) {
+    return `${count} ${name} (${printing.setCode.toUpperCase()}) ${printing.collectorNumber}`
+  }
+  return `${count} ${name}`
+}
+
+/** Tally a list of names into a name → count map. */
+function tally(names: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const name of names) counts.set(name, (counts.get(name) ?? 0) + 1)
+  return counts
+}
+
+/**
+ * Build the MTG Arena deck-list text for the given deck-building state. Returns the
+ * empty string when there is nothing to export (no maindeck cards or basic lands).
+ */
+export function buildArenaDeckList(input: ArenaExportInput): string {
+  const { deck, cardPool, basicLands, landCounts, commander } = input
+
+  // First printing seen per name wins — pool cards of the same name share a printing.
+  const printingByName = new Map<string, SealedCardInfo>()
+  for (const card of [...cardPool, ...basicLands]) {
+    if (!printingByName.has(card.name)) printingByName.set(card.name, card)
+  }
+
+  // How many copies of each name the pool actually opened — bounds the sideboard.
+  const poolCounts = tally(cardPool.map((c) => c.name))
+
+  // Raw maindeck usage (commander copy included) — used to subtract from the pool
+  // when computing the sideboard.
+  const rawDeckCounts = tally(deck)
+
+  const deckCounts = tally(deck)
+  // The commander lives in the command zone, not the maindeck (CR 903.6) — pull one
+  // copy out of the maindeck tally so it isn't double-listed.
+  if (commander) {
+    const remaining = (deckCounts.get(commander) ?? 0) - 1
+    if (remaining > 0) deckCounts.set(commander, remaining)
+    else deckCounts.delete(commander)
+  }
+
+  const sections: string[] = []
+
+  if (commander) {
+    sections.push(['Commander', formatLine(1, commander, printingByName.get(commander))].join('\n'))
+  }
+
+  const mainLines: string[] = []
+  for (const name of [...deckCounts.keys()].sort((a, b) => a.localeCompare(b))) {
+    mainLines.push(formatLine(deckCounts.get(name)!, name, printingByName.get(name)))
+  }
+  for (const name of Object.keys(landCounts).sort((a, b) => a.localeCompare(b))) {
+    const count = landCounts[name] ?? 0
+    if (count > 0) mainLines.push(formatLine(count, name, printingByName.get(name)))
+  }
+  if (mainLines.length > 0) sections.push(['Deck', ...mainLines].join('\n'))
+
+  // Sideboard = pool copies not used in the maindeck (commander excluded — it's not
+  // a sideboard card). Names absent from the deck list keep their full pool count.
+  const sideLines: string[] = []
+  for (const name of [...poolCounts.keys()].sort((a, b) => a.localeCompare(b))) {
+    const used = name === commander ? poolCounts.get(name)! : rawDeckCounts.get(name) ?? 0
+    const leftover = poolCounts.get(name)! - used
+    if (leftover > 0) sideLines.push(formatLine(leftover, name, printingByName.get(name)))
+  }
+  if (sideLines.length > 0) sections.push(['Sideboard', ...sideLines].join('\n'))
+
+  return sections.join('\n\n')
+}


### PR DESCRIPTION
Adds an Export button to the deckbuilder that renders the current deck as an MTG Arena deck list (Commander / Deck / Sideboard sections), shown in a modal with copy-to-clipboard and download-as-.txt. The leftover opened/drafted pool is emitted as the Sideboard so the player keeps a record of their whole pool.

The rendered text is the same shape parseArenaDeck.ts reads back, so an exported deck round-trips through the deckbuilder's import flow and pastes straight into Arena / Moxfield. Covered by arenaExport.test.ts, including a round-trip-through-the-parser case.

<img width="923" height="59" alt="image" src="https://github.com/user-attachments/assets/8fc4a47d-9af6-4d96-a5d4-59d11f517ea2" />

<img width="569" height="374" alt="image" src="https://github.com/user-attachments/assets/50b62596-84e0-4454-a347-8fa9fcde2ee6" />
