### PR TITLE
Add 6 Sneak cards to Teenage Mutant Ninja Turtles (TMT)

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -57,10 +57,10 @@ Gaps **resolved across the runs so far**:
   plus wiring in `CastSpellHandler`, `StackResolver`, and `ConditionEvaluator`
   so a permanent cast for Sneak enters tapped and attacking and carries the
   "sneak cost was paid" fact durably. Proven by `SneakTest` and per-card
-  scenario tests. 17 of 26 Sneak cards have shipped (incl. all four
+  scenario tests. 23 of 26 Sneak cards have shipped (incl. all four
   sneak-was-paid riders: `Leonardo, Leader in Blue`, `Turncoat Kunoichi`,
-  `The Last Ronin's Technique`, and the Karai rider). The remaining 9 carry
-  no separate blocker and are pending implementation only.
+  `The Last Ronin's Technique`, and the Karai rider). The remaining 3 each
+  carry a second engine gap beyond Sneak (see the Status section above).
 - **Gap C — Alliance (partly cleared)**: 6 of the 10 Alliance cards (`East
   Wind Avatar`, `EPF Point Squad`, `Mighty Mutanimals`, `Mutant Town
   Musicians`, `Raphael, Tough Turtle`, `Slash, Reptile Rampager`) shipped by
@@ -199,10 +199,11 @@ Composable cards (no engine change needed) can land directly on `main`, one comm
 Each gap is its own PR. A card with more than one gap is listed under its dominant one
 with the secondary noted inline. Quotes are from the card's oracle text in `tmt_full.json`.
 
-### Gap A — Sneak (alternative cost) — RESOLVED — 17 of 26 cards shipped
+### Gap A — Sneak (alternative cost) — RESOLVED — 23 of 26 cards shipped
 **Status:** the keyword + alternative-cost pipeline is fully implemented and tested.
-All four required pieces below landed; what remains is purely per-card authoring for
-the 9 unimplemented Sneak cards (none of which carry a *separate* engine blocker).
+All four required pieces below landed; the 3 unimplemented Sneak cards each carry a
+*second* engine gap beyond Sneak itself (see the Status section: `Leonardo's Technique`,
+`Leonardo, Sewer Samurai`, `Michelangelo's Technique`).
 
 > Sneak {cost} (You may cast this spell for {cost} if you also return an unblocked
 > attacker you control to hand during the declare blockers step.

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,19 +10,25 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-113 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+119 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
 
-The remaining 77 cards mostly cluster on a handful of unresolved gaps:
+The remaining 71 cards mostly cluster on a handful of unresolved gaps:
 - **Sneak** — RESOLVED (Gap A). The keyword, alt-cost plumbing, and
-  "sneak cost was paid" flag are fully wired; 17 of 26 Sneak cards have
-  shipped. The 9 still-pending Sneak cards carry no *other* recorded blocker —
-  they are unblocked at the mechanic level and simply await implementation
-  (`Dark Leo & Shredder`, `Karai, Future of the Foot`, `Kitsune's Technique`,
-  `Leonardo's Technique`, `Leonardo, Sewer Samurai`, `Michelangelo's
-  Technique`, `Michelangelo, Improviser`, `Raphael's Technique`,
-  `Shark Shredder, Killer Clone`).
+  "sneak cost was paid" flag are fully wired; 23 of 26 Sneak cards have
+  shipped. Of the 9 that were previously called "pure authoring", **6 were
+  genuinely composable and shipped** (`Dark Leo & Shredder`,
+  `Karai, Future of the Foot`, `Kitsune's Technique`, `Michelangelo, Improviser`,
+  `Raphael's Technique`, `Shark Shredder, Killer Clone`). The remaining **3 carry
+  a SECOND engine gap beyond Sneak** — the earlier "no other blocker" note was
+  wrong for them: `Leonardo's Technique` (up-to-two *target* graveyard reanimate
+  with a per-target MV≤3 filter — no multi-target zone-card selector exists),
+  `Leonardo, Sewer Samurai` (cast-creatures-from-graveyard *static permission* —
+  missing), `Michelangelo's Technique` (look-at-8, put up to 2 with *total* MV≤6
+  — aggregate-MV-budget selection; note `SelectCardsDecision.maxTotalManaValue`
+  already exists at the decision layer, so this may be closer to composable than
+  first thought). Each is its own `add-feature` PR.
 - **Disappear** — 9 cards (Gap B — unresolved)
 - **Alliance** — 4 cards left (Gap C — partly cleared; 6 shipped composably,
   the remaining 4 each have an *additional* unresolved blocker beyond Alliance
@@ -224,17 +230,20 @@ Tests: `SneakTest` plus per-card scenario tests (`JennikasTechniqueTest`,
 `TurncoatKunoichiTest`, `LeonardoLeaderInBlueTest`, `TheLastRoninsTechniqueTest`,
 `KaraisTechniqueTest`, `NewGenerationsTechniqueTest`, `FootNinjasTest`).
 
-Shipped (17): `Donatello's Technique`, `Donatello, Gadget Master`, `Foot Ninjas`,
+Shipped (23): `Donatello's Technique`, `Donatello, Gadget Master`, `Foot Ninjas`,
 `Jennika's Technique`, `Karai's Technique`, `Leonardo, Big Brother`,
 `Leonardo, Cutting Edge`, `Leonardo, Leader in Blue`, `New Generation's Technique`,
 `Oroku Saki, Shredder Rising`, `Raphael, the Nightwatcher`, `Shredder's Technique`,
 `Shredder, Unrelenting`, `Splinter's Technique`, `Splinter, Hamato Yoshi`,
-`The Last Ronin's Technique`, `Turncoat Kunoichi`.
+`The Last Ronin's Technique`, `Turncoat Kunoichi`, plus the 6 most recent:
+`Dark Leo & Shredder`, `Karai, Future of the Foot`, `Kitsune's Technique`,
+`Michelangelo, Improviser`, `Raphael's Technique`, `Shark Shredder, Killer Clone`.
 
-Still to author (9, mechanic-unblocked): `Dark Leo & Shredder`,
-`Karai, Future of the Foot`, `Kitsune's Technique`, `Leonardo's Technique`,
-`Leonardo, Sewer Samurai`, `Michelangelo's Technique`, `Michelangelo, Improviser`,
-`Raphael's Technique`, `Shark Shredder, Killer Clone`.
+Still to author (3 — each blocked on a SECOND gap, NOT pure authoring):
+`Leonardo's Technique` (multi-target GY reanimate, per-target MV≤3),
+`Leonardo, Sewer Samurai` (cast-from-graveyard static permission),
+`Michelangelo's Technique` (aggregate total-MV-≤6 selection). See the corrected
+Sneak bullet in the Status section above; each needs its own `add-feature` PR.
 
 ### Gap B — Disappear (ability-word trigger with "a permanent left the battlefield under your control this turn" condition) — 9 cards
 **Engine change:** generalize the existing `nonlandPermanentLeftBattlefieldThisTurn`
@@ -653,7 +662,6 @@ for what closed those.
 | Cool but Rude                         | Gap U (Class)                               |
 | Courier of Comestibles                | Gap V (search-or-fail-then-token)           |
 | Crustacean Commando                   | Gap W (Mutagen token)                       |
-| Dark Leo & Shredder                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Does Machines                         | Gap U (Class)                               |
 | Don & Leo, Problem Solvers            | Gap X (paired flicker)                      |
 | Don & Raph, Hard Science              | Gap Y (grant Affinity to next spell)        |
@@ -667,21 +675,18 @@ for what closed those.
 | Groundchuck & Dirtbag                 | Gap CC (tap-land-for-mana trigger)          |
 | Grounded for Life                     | Gap DD (cost reduction if target tapped)    |
 | Insectoid Exterminator                | Gap B (Disappear)                           |
-| Karai, Future of the Foot             | Gap A RESOLVED — pending authoring (no other blocker) |
-| Kitsune's Technique                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Kitsune, Dragon's Daughter            | "Exchange control of two creatures controlled by different players" — bespoke |
 | Koya, Death from Above                | Delayed end-step "you may pay; if not, return that card" conditional — bespoke |
 | Krang & Shredder                      | Gap B (Disappear) + Gap M (cast-from-exile-without-paying chain) |
 | Leader's Talent                       | Gap U (Class)                               |
 | Leatherhead, Swamp Stalker            | Hexproof counter + "may remove a counter; when you do, …" (Gap AA shape) |
-| Leonardo's Technique                  | Gap A RESOLVED — pending authoring (no other blocker) |
-| Leonardo, Sewer Samurai               | Gap A RESOLVED — pending authoring (no other blocker) |
+| Leonardo's Technique                  | Sneak OK; needs up-to-2 *target* GY reanimate, per-target MV≤3 (new gap) |
+| Leonardo, Sewer Samurai               | Sneak OK; needs cast-creatures-from-graveyard static permission (new gap) |
 | Lita, Little Orphan Amphibian         | Gap C (Alliance) + Gap E (mode-not-yet-chosen) |
 | Lord Dregg, Insect Invader            | Gap B (Disappear) + Gap M (Sacrifice-a-token cost) |
 | Madame Null, Power Broker             | Gap GG (may-pay-dynamic-life)               |
-| Michelangelo's Technique              | Gap A RESOLVED — pending authoring (no other blocker) |
+| Michelangelo's Technique              | Sneak OK; needs aggregate total-MV-≤6 selection over looked-at cards (new gap; `SelectCardsDecision.maxTotalManaValue` may already cover it) |
 | Michelangelo, Game Master             | Gap B (Disappear)                           |
-| Michelangelo, Improviser              | Gap A RESOLVED — pending authoring (no other blocker) |
 | Michelangelo, Mutant BFF              | Gap W (Mutagen) + counter-doubling replacement |
 | Michelangelo, Weirdness to 11         | Gap W (Mutagen) + counter-doubling replacement |
 | Mikey & Don, Party Planners           | Play-from-top + cast-Mutant/Ninja/Turtle-from-top — bespoke |
@@ -700,7 +705,6 @@ for what closed those.
 | Prehistoric Pet                       | Gap HH (can't-be-blocked-by-greater-power)  |
 | Purple Dragon Punks                   | Gap KK (artifact-spell-or-any-ability mana restriction) |
 | Putrid Pals                           | Gap B (Disappear)                           |
-| Raphael's Technique                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Raphael, Most Attitude                | Gap C (Alliance)                            |
 | Raphael, Ninja Destroyer              | Gap F (Enrage) + Gap G (persistent mana)    |
 | Rat King, Verminister                 | Gap B (Disappear) + Gap M (same-name reanimate) |
@@ -708,7 +712,6 @@ for what closed those.
 | Retro-Mutation                        | Type-overriding Aura + "loses all abilities" UEOT |
 | Return to the Sewers                  | Owner-chooses-top-or-bottom + Gap W (Mutagen) |
 | Sewer-veillance Cam                   | Gap II (tap-or-untap controller-chooses)    |
-| Shark Shredder, Killer Clone          | Gap A RESOLVED — pending authoring (no other blocker) |
 | Slithering Cryptid                    | Gap W (Mutagen)                             |
 | Technodrome                           | "Can't attack or block unless its power is 6 or greater" — Gap O-shape on self |
 | The Cloning of Shredder               | Gap MM (addedSubtypes on CreateTokenCopy)   |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,12 +10,19 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-96 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
-`cards.md` for the full checklist; the per-card commits on `tmt-scaffolding`
-all carry `flavorText` in metadata.
+113 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+`cards.md` for the full checklist (the authoritative status); the per-card
+commits all carry `flavorText` in metadata.
 
-The remaining 94 cards mostly cluster on a handful of unresolved gaps:
-- **Sneak** — 26 cards (Gap A — unresolved)
+The remaining 77 cards mostly cluster on a handful of unresolved gaps:
+- **Sneak** — RESOLVED (Gap A). The keyword, alt-cost plumbing, and
+  "sneak cost was paid" flag are fully wired; 17 of 26 Sneak cards have
+  shipped. The 9 still-pending Sneak cards carry no *other* recorded blocker —
+  they are unblocked at the mechanic level and simply await implementation
+  (`Dark Leo & Shredder`, `Karai, Future of the Foot`, `Kitsune's Technique`,
+  `Leonardo's Technique`, `Leonardo, Sewer Samurai`, `Michelangelo's
+  Technique`, `Michelangelo, Improviser`, `Raphael's Technique`,
+  `Shark Shredder, Killer Clone`).
 - **Disappear** — 9 cards (Gap B — unresolved)
 - **Alliance** — 4 cards left (Gap C — partly cleared; 6 shipped composably,
   the remaining 4 each have an *additional* unresolved blocker beyond Alliance
@@ -35,6 +42,19 @@ The remaining 94 cards mostly cluster on a handful of unresolved gaps:
 - Plus various one-offs from Gaps M and N–NN
 
 Gaps **resolved across the runs so far**:
+- **Gap A — Sneak — RESOLVED**: the full alternative-cost pipeline shipped.
+  SDK: `Keyword.SNEAK`, `KeywordAbility.Sneak(cost)`, the `sneak("{cost}")`
+  DSL helper on `CardBuilder`, the `ChoiceSlot.SNEAK` flag, and the
+  `Conditions.SneakCostWasPaid` predicate. Engine: `SneakWindow` (the
+  declare-blockers payment window that bounces an unblocked attacker),
+  `SneakCastEnumerator` (surfaces "cast for Sneak" only at the right step),
+  plus wiring in `CastSpellHandler`, `StackResolver`, and `ConditionEvaluator`
+  so a permanent cast for Sneak enters tapped and attacking and carries the
+  "sneak cost was paid" fact durably. Proven by `SneakTest` and per-card
+  scenario tests. 17 of 26 Sneak cards have shipped (incl. all four
+  sneak-was-paid riders: `Leonardo, Leader in Blue`, `Turncoat Kunoichi`,
+  `The Last Ronin's Technique`, and the Karai rider). The remaining 9 carry
+  no separate blocker and are pending implementation only.
 - **Gap C — Alliance (partly cleared)**: 6 of the 10 Alliance cards (`East
   Wind Avatar`, `EPF Point Squad`, `Mighty Mutanimals`, `Mutant Town
   Musicians`, `Raphael, Tough Turtle`, `Slash, Reptile Rampager`) shipped by
@@ -173,40 +193,48 @@ Composable cards (no engine change needed) can land directly on `main`, one comm
 Each gap is its own PR. A card with more than one gap is listed under its dominant one
 with the secondary noted inline. Quotes are from the card's oracle text in `tmt_full.json`.
 
-### Gap A — Sneak (alternative cost) — 26 cards
-**Engine change:** new keyword `SNEAK` + `KeywordAbility.Sneak(cost)` + alternative-cost
-plumbing that branches on a non-mana, mid-combat condition.
+### Gap A — Sneak (alternative cost) — RESOLVED — 17 of 26 cards shipped
+**Status:** the keyword + alternative-cost pipeline is fully implemented and tested.
+All four required pieces below landed; what remains is purely per-card authoring for
+the 9 unimplemented Sneak cards (none of which carry a *separate* engine blocker).
 
 > Sneak {cost} (You may cast this spell for {cost} if you also return an unblocked
 > attacker you control to hand during the declare blockers step.
 > [He/She/It enters tapped and attacking.])
 
-Required pieces:
-1. **Alt-cost gate at declare-blockers.** Today's alt-cost pipeline (`Flashback`,
-   `Harmonize`, `Impending`) all resolve at cast time. Sneak's payment piece — returning
-   an unblocked attacker you control to hand — happens during the declare-blockers step
-   *of the same turn the spell is cast*. The action enumerator must surface "cast for
-   Sneak" only when (a) it's the declare-blockers step of your combat, (b) you control
-   an unblocked attacker, and (c) the spell is castable at the current speed. Casting
-   for Sneak also queues the bounce-an-unblocked-attacker as an additional payment.
-2. **Permanent spells enter tapped and attacking.** When a creature/artifact-creature
-   spell resolves having paid its sneak cost, the permanent enters tapped and joins the
-   attack. This already exists for cascade/mobilize tokens (CreateTokenEffect with
-   `tappedAndAttacking`) — reuse the same `attackingState` plumbing for cast permanents.
-3. **Per-spell "sneak-was-paid" flag.** 4 cards (`Leonardo, Leader in Blue`,
-   `Turncoat Kunoichi`, `Karai, Future of the Foot`, `The Last Ronin's Technique`) read
-   "if [its] sneak cost was paid" later — at resolution, at ETB, or as a turn-long
-   rider on a damage trigger. Stash the flag on the spell-cast event (cast-time) and
-   on the resulting permanent's component (post-resolution), and expose it as a
-   `Condition.SneakCostWasPaid(source)` predicate.
-4. **DSL helper.** `sneak("{1}{W}") { ... }` on `CardBuilder`, mirroring `harmonize`
-   and `impending`.
+Delivered pieces:
+1. **Alt-cost gate at declare-blockers — DONE.** `SneakCastEnumerator`
+   (`rules-engine/.../legalactions/enumerators/`) surfaces "cast for Sneak" only when
+   it's the declare-blockers step of your combat, you control an unblocked attacker, and
+   the spell is castable. `SneakWindow` (`rules-engine/.../mechanics/`) drives the
+   bounce-an-unblocked-attacker payment.
+2. **Permanent spells enter tapped and attacking — DONE.** Cast permanents that paid
+   their sneak cost reuse the `attackingState` plumbing (wired through `CastSpellHandler`
+   and `StackResolver`).
+3. **Per-spell "sneak-was-paid" flag — DONE.** The fact rides the spell-cast context and
+   the resulting permanent via `ChoiceSlot.SNEAK`, and is read back through
+   `Conditions.SneakCostWasPaid` (`SourceConditions.kt`). Exercised by the four rider
+   cards: `Leonardo, Leader in Blue`, `Turncoat Kunoichi`, `The Last Ronin's Technique`,
+   and the Karai rider.
+4. **DSL helper — DONE.** `sneak("{1}{W}")` on `CardBuilder`, mirroring `harmonize` /
+   `impending`.
 
-Cards: `Action News Crew`? — _no, Channel_. Sneak cards (26):
-`The Last Ronin's Technique`, `Leonardo, Leader in Blue`, `Leonardo, Big Brother`,
-`Leonardo, Cutting Edge`, `Leonardo, Sewer Samurai`, `Leonardo's Technique`,
-`Turncoat Kunoichi`, `Karai, Future of the Foot`, plus the remaining 18 — full list
-is the cards with `"Sneak"` in their `keywords` array in `tmt_full.json`.
+Tests: `SneakTest` plus per-card scenario tests (`JennikasTechniqueTest`,
+`DonatellosTechniqueTest`, `ShreddersTechniqueTest`, `SplintersTechniqueTest`,
+`TurncoatKunoichiTest`, `LeonardoLeaderInBlueTest`, `TheLastRoninsTechniqueTest`,
+`KaraisTechniqueTest`, `NewGenerationsTechniqueTest`, `FootNinjasTest`).
+
+Shipped (17): `Donatello's Technique`, `Donatello, Gadget Master`, `Foot Ninjas`,
+`Jennika's Technique`, `Karai's Technique`, `Leonardo, Big Brother`,
+`Leonardo, Cutting Edge`, `Leonardo, Leader in Blue`, `New Generation's Technique`,
+`Oroku Saki, Shredder Rising`, `Raphael, the Nightwatcher`, `Shredder's Technique`,
+`Shredder, Unrelenting`, `Splinter's Technique`, `Splinter, Hamato Yoshi`,
+`The Last Ronin's Technique`, `Turncoat Kunoichi`.
+
+Still to author (9, mechanic-unblocked): `Dark Leo & Shredder`,
+`Karai, Future of the Foot`, `Kitsune's Technique`, `Leonardo's Technique`,
+`Leonardo, Sewer Samurai`, `Michelangelo's Technique`, `Michelangelo, Improviser`,
+`Raphael's Technique`, `Shark Shredder, Killer Clone`.
 
 ### Gap B — Disappear (ability-word trigger with "a permanent left the battlefield under your control this turn" condition) — 9 cards
 **Engine change:** generalize the existing `nonlandPermanentLeftBattlefieldThisTurn`
@@ -612,8 +640,9 @@ implemented, with the underlying blocker. Gaps reference the sections above
 "Composable — deferred" have all landed and been removed. Likewise, cards
 that subsequently landed in later runs (the six Alliance composables,
 Action News Crew, Casey Jones Vigilante, Escape Tunnel, Manhole Missile,
-Wingnut) have been removed from the table — see the "Gaps resolved" list at
-the top of the Status section for what closed those.
+Wingnut, and the 17 shipped Sneak cards once Gap A resolved) have been removed
+from the table — see the "Gaps resolved" list at the top of the Status section
+for what closed those.
 
 | Card                                  | Blocker / Gap                               |
 |---------------------------------------|---------------------------------------------|
@@ -624,16 +653,13 @@ the top of the Status section for what closed those.
 | Cool but Rude                         | Gap U (Class)                               |
 | Courier of Comestibles                | Gap V (search-or-fail-then-token)           |
 | Crustacean Commando                   | Gap W (Mutagen token)                       |
-| Dark Leo & Shredder                   | Gap A (Sneak)                               |
+| Dark Leo & Shredder                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Does Machines                         | Gap U (Class)                               |
 | Don & Leo, Problem Solvers            | Gap X (paired flicker)                      |
 | Don & Raph, Hard Science              | Gap Y (grant Affinity to next spell)        |
-| Donatello's Technique                 | Gap A (Sneak)                               |
-| Donatello, Gadget Master              | Gap A (Sneak) + token-with-overrides        |
 | Donatello, Mutant Mechanic            | Gap M (Pizza-Face-style type-grant)         |
 | Everything Pizza                      | Pentacolored sac activation that also draws + makes each opponent discard — bespoke |
 | Foot Mystic                           | Gap B (Disappear)                           |
-| Foot Ninjas                           | Gap A (Sneak)                               |
 | Fugitive Droid                        | Gap Z (artifact-ETB-this-turn + sac-counter)|
 | General Traag, Heart of Stone         | Gap AA (when-you-do sub-trigger)            |
 | Genghis Frog                          | Gap W (Mutagen token)                       |
@@ -641,26 +667,21 @@ the top of the Status section for what closed those.
 | Groundchuck & Dirtbag                 | Gap CC (tap-land-for-mana trigger)          |
 | Grounded for Life                     | Gap DD (cost reduction if target tapped)    |
 | Insectoid Exterminator                | Gap B (Disappear)                           |
-| Jennika's Technique                   | Gap A (Sneak)                               |
-| Karai's Technique                     | Gap A (Sneak)                               |
-| Karai, Future of the Foot             | Gap A (Sneak)                               |
-| Kitsune's Technique                   | Gap A (Sneak)                               |
+| Karai, Future of the Foot             | Gap A RESOLVED — pending authoring (no other blocker) |
+| Kitsune's Technique                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Kitsune, Dragon's Daughter            | "Exchange control of two creatures controlled by different players" — bespoke |
 | Koya, Death from Above                | Delayed end-step "you may pay; if not, return that card" conditional — bespoke |
 | Krang & Shredder                      | Gap B (Disappear) + Gap M (cast-from-exile-without-paying chain) |
 | Leader's Talent                       | Gap U (Class)                               |
 | Leatherhead, Swamp Stalker            | Hexproof counter + "may remove a counter; when you do, …" (Gap AA shape) |
-| Leonardo's Technique                  | Gap A (Sneak)                               |
-| Leonardo, Big Brother                 | Gap A (Sneak)                               |
-| Leonardo, Cutting Edge                | Gap A (Sneak)                               |
-| Leonardo, Leader in Blue              | Gap A (Sneak) + sneak-was-paid rider        |
-| Leonardo, Sewer Samurai               | Gap A (Sneak)                               |
+| Leonardo's Technique                  | Gap A RESOLVED — pending authoring (no other blocker) |
+| Leonardo, Sewer Samurai               | Gap A RESOLVED — pending authoring (no other blocker) |
 | Lita, Little Orphan Amphibian         | Gap C (Alliance) + Gap E (mode-not-yet-chosen) |
 | Lord Dregg, Insect Invader            | Gap B (Disappear) + Gap M (Sacrifice-a-token cost) |
 | Madame Null, Power Broker             | Gap GG (may-pay-dynamic-life)               |
-| Michelangelo's Technique              | Gap A (Sneak)                               |
+| Michelangelo's Technique              | Gap A RESOLVED — pending authoring (no other blocker) |
 | Michelangelo, Game Master             | Gap B (Disappear)                           |
-| Michelangelo, Improviser              | Gap A (Sneak)                               |
+| Michelangelo, Improviser              | Gap A RESOLVED — pending authoring (no other blocker) |
 | Michelangelo, Mutant BFF              | Gap W (Mutagen) + counter-doubling replacement |
 | Michelangelo, Weirdness to 11         | Gap W (Mutagen) + counter-doubling replacement |
 | Mikey & Don, Party Planners           | Play-from-top + cast-Mutant/Ninja/Turtle-from-top — bespoke |
@@ -668,42 +689,33 @@ the top of the Status section for what closed those.
 | Mondo Gecko                           | Discard-to-grant-color + hexproof-from-color combat trigger — bespoke |
 | Mutagen Man, Living Ooze              | Gap W (Mutagen) + activated-ability-cost-reduction static |
 | Mutant Chain Reaction                 | Gap W (Mutagen)                             |
-| New Generation's Technique            | Gap A (Sneak)                               |
 | Ninja Teen                            | Gap U (Class)                               |
 | North Wind Avatar                     | "Put a card you own from outside the game into your hand" (wishboard) |
 | Northampton Farm                      | Custom land with linked-exile mechanic — bespoke |
 | Novel Nunchaku                        | "When you do, equipped creature fights" sub-trigger (Gap AA shape) |
 | Ooze Spill                            | Gap W (Mutagen)                             |
-| Oroku Saki, Shredder Rising           | Gap A (Sneak)                               |
 | Paramecia Coloniex                    | Dies → "may exile; when you do …" sub-trigger (Gap AA shape) |
 | Party Dude                            | Gap U (Class)                               |
 | Pizza Face, Gastromancer              | Gap B (Disappear) + Gap M (type-grant on non-creature) |
 | Prehistoric Pet                       | Gap HH (can't-be-blocked-by-greater-power)  |
 | Purple Dragon Punks                   | Gap KK (artifact-spell-or-any-ability mana restriction) |
 | Putrid Pals                           | Gap B (Disappear)                           |
-| Raphael's Technique                   | Gap A (Sneak)                               |
+| Raphael's Technique                   | Gap A RESOLVED — pending authoring (no other blocker) |
 | Raphael, Most Attitude                | Gap C (Alliance)                            |
 | Raphael, Ninja Destroyer              | Gap F (Enrage) + Gap G (persistent mana)    |
-| Raphael, the Nightwatcher             | Gap A (Sneak)                               |
 | Rat King, Verminister                 | Gap B (Disappear) + Gap M (same-name reanimate) |
 | Ray Fillet, Man Ray                   | Gap W (Mutagen)                             |
 | Retro-Mutation                        | Type-overriding Aura + "loses all abilities" UEOT |
 | Return to the Sewers                  | Owner-chooses-top-or-bottom + Gap W (Mutagen) |
 | Sewer-veillance Cam                   | Gap II (tap-or-untap controller-chooses)    |
-| Shark Shredder, Killer Clone          | Gap A (Sneak)                               |
-| Shredder's Technique                  | Gap A (Sneak)                               |
-| Shredder, Unrelenting                 | Gap A (Sneak)                               |
+| Shark Shredder, Killer Clone          | Gap A RESOLVED — pending authoring (no other blocker) |
 | Slithering Cryptid                    | Gap W (Mutagen)                             |
-| Splinter's Technique                  | Gap A (Sneak)                               |
-| Splinter, Hamato Yoshi                | Gap A (Sneak)                               |
 | Technodrome                           | "Can't attack or block unless its power is 6 or greater" — Gap O-shape on self |
 | The Cloning of Shredder               | Gap MM (addedSubtypes on CreateTokenCopy)   |
 | The Last Ronin                        | Gap AA (Mill-X-then-when-you-do) + Gap NN (attacks-alone trigger) |
-| The Last Ronin's Technique            | Gap A (Sneak) + sneak-was-paid token rider  |
 | The Neutrinos                         | Gap C (Alliance)                            |
 | The Ooze                              | Gap W (Mutagen) + dies-with-counter trigger |
 | Tokka & Rahzar, Terrible Twos         | "Can't be countered" + mana-spent-less-than-MV trigger — bespoke |
-| Turncoat Kunoichi                     | Gap A (Sneak) + sneak-was-paid ETB rider    |
 | Turtle Lair                           | Gap JJ (multi-subtype mana restriction)     |
 | Turtle Van                            | Gap LL (crewed-this-turn filter)            |
 | Turtles Forever                       | Wishboard tutor (outside-the-game search)   |

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 113 / 190
+**Implemented:** 119 / 190
 ---
 
 - [x] Action News Crew
@@ -27,7 +27,7 @@
 - [ ] Courier of Comestibles
 - [x] Cowabunga!
 - [ ] Crustacean Commando
-- [ ] Dark Leo & Shredder
+- [x] Dark Leo & Shredder
 - [x] Death in the Family
 - [x] Dimension X
 - [x] Dimensional Exile
@@ -68,8 +68,8 @@
 - [x] Jennika's Technique
 - [x] Jennika, Bad Apple Big Sister
 - [x] Karai's Technique
-- [ ] Karai, Future of the Foot
-- [ ] Kitsune's Technique
+- [x] Karai, Future of the Foot
+- [x] Kitsune's Technique
 - [ ] Kitsune, Dragon's Daughter
 - [ ] Koya, Death from Above
 - [ ] Krang & Shredder
@@ -92,7 +92,7 @@
 - [x] Metalhead
 - [ ] Michelangelo's Technique
 - [ ] Michelangelo, Game Master
-- [ ] Michelangelo, Improviser
+- [x] Michelangelo, Improviser
 - [ ] Michelangelo, Mutant BFF
 - [ ] Michelangelo, Weirdness to 11
 - [x] Mighty Mutanimals
@@ -133,7 +133,7 @@
 - [x] Ragamuffin Raptor
 - [x] Raph & Leo, Sibling Rivals
 - [x] Raph & Mikey, Troublemakers
-- [ ] Raphael's Technique
+- [x] Raphael's Technique
 - [ ] Raphael, Most Attitude
 - [ ] Raphael, Ninja Destroyer
 - [x] Raphael, the Nightwatcher
@@ -150,7 +150,7 @@
 - [x] Savanti Romero, Time's Exile
 - [x] Saved by the Shell
 - [ ] Sewer-veillance Cam
-- [ ] Shark Shredder, Killer Clone
+- [x] Shark Shredder, Killer Clone
 - [x] Shredder's Armor
 - [x] Shredder's Revenge
 - [x] Shredder's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,7 +6,7 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (113 / 190).** Mechanics now exercised end-to-end:
+**Implementation progress (119 / 190).** Mechanics now exercised end-to-end:
 
 Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
 Menace, Reach (granted and printed), Indestructible, Ward, Equip, Double strike,
@@ -150,9 +150,9 @@ Cross-card combinators landed since the previous progress note:
 (`SneakWindow` declare-blockers payment, `SneakCastEnumerator`, and wiring in
 `CastSpellHandler` / `StackResolver` / `ConditionEvaluator` so a permanent cast
 for Sneak enters tapped and attacking and carries the "sneak cost was paid"
-fact). Proven by `SneakTest` and per-card scenario tests. 17 of 26 Sneak cards
-shipped (incl. all four sneak-was-paid riders); the remaining 9 are pending
-authoring only, with no separate engine blocker.
+fact). Proven by `SneakTest` and per-card scenario tests. 23 of 26 Sneak cards
+shipped (incl. all four sneak-was-paid riders); the remaining 3 each carry a
+second engine gap beyond Sneak (see `TODO.md` Gap A).
 
 **Still not exercised** — Disappear's per-controller permanent-left tracking,
 the display markers for Alliance / Channel / Disappear, Class enchantments, the
@@ -164,11 +164,11 @@ gaps stop the specific TMT cards from shipping.)
 
 ## New mechanics in TMT
 
-### Sneak — 26 cards — IMPLEMENTED (17/26 cards shipped)
+### Sneak — 26 cards — IMPLEMENTED (23/26 cards shipped)
 Alternative cost keyword. Fully wired in the SDK and engine (`Keyword.SNEAK`,
 `KeywordAbility.Sneak`, the `sneak("{cost}")` DSL helper, `SneakWindow`,
-`SneakCastEnumerator`, and `Conditions.SneakCostWasPaid`); the 9 unimplemented
-Sneak cards are pending authoring only. Reminder text:
+`SneakCastEnumerator`, and `Conditions.SneakCostWasPaid`); the 3 unimplemented
+Sneak cards each carry a second engine gap beyond Sneak. Reminder text:
 
 > Sneak {cost} (You may cast this spell for {cost} if you also return an
 > unblocked attacker you control to hand during the declare blockers step.

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,8 +6,7 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (96 / 190).** Mechanics now exercised end-to-end on
-`tmt-scaffolding`:
+**Implementation progress (113 / 190).** Mechanics now exercised end-to-end:
 
 Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
 Menace, Reach (granted and printed), Indestructible, Ward, Equip, Double strike,
@@ -145,19 +144,31 @@ Cross-card combinators landed since the previous progress note:
   needs the "Mill X. When you do, …" sub-trigger (Gap AA) plus an
   "attacks alone this turn" trigger condition (Gap NN).
 
-**Still not exercised** — the three new TMT mechanics' canonical pieces still
-missing (Sneak alt-cost pipeline, Disappear's per-controller permanent-left
-tracking, the display markers for Alliance / Channel / Disappear), Class
-enchantments, the Mutagen token, and the remaining bespoke Gap M / N–NN
-shapes catalogued in `TODO.md`. (Sagas and Vehicles/Crew are wired at the
-SDK level; only adjacent gaps stop the specific TMT cards from shipping.)
+**Sneak — RESOLVED.** The full alternative-cost pipeline shipped: SDK
+`Keyword.SNEAK` / `KeywordAbility.Sneak(cost)` / `sneak("{cost}")` DSL helper /
+`ChoiceSlot.SNEAK` flag / `Conditions.SneakCostWasPaid`, plus the engine pieces
+(`SneakWindow` declare-blockers payment, `SneakCastEnumerator`, and wiring in
+`CastSpellHandler` / `StackResolver` / `ConditionEvaluator` so a permanent cast
+for Sneak enters tapped and attacking and carries the "sneak cost was paid"
+fact). Proven by `SneakTest` and per-card scenario tests. 17 of 26 Sneak cards
+shipped (incl. all four sneak-was-paid riders); the remaining 9 are pending
+authoring only, with no separate engine blocker.
+
+**Still not exercised** — Disappear's per-controller permanent-left tracking,
+the display markers for Alliance / Channel / Disappear, Class enchantments, the
+Mutagen token, and the remaining bespoke Gap M / N–NN shapes catalogued in
+`TODO.md`. (Sagas and Vehicles/Crew are wired at the SDK level; only adjacent
+gaps stop the specific TMT cards from shipping.)
 
 ---
 
 ## New mechanics in TMT
 
-### Sneak — 26 cards
-Alternative cost keyword. Reminder text:
+### Sneak — 26 cards — IMPLEMENTED (17/26 cards shipped)
+Alternative cost keyword. Fully wired in the SDK and engine (`Keyword.SNEAK`,
+`KeywordAbility.Sneak`, the `sneak("{cost}")` DSL helper, `SneakWindow`,
+`SneakCastEnumerator`, and `Conditions.SneakCostWasPaid`); the 9 unimplemented
+Sneak cards are pending authoring only. Reminder text:
 
 > Sneak {cost} (You may cast this spell for {cost} if you also return an
 > unblocked attacker you control to hand during the declare blockers step.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DarkLeoAndShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DarkLeoAndShredder.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dark Leo & Shredder
+ * {W}{B}
+ * Legendary Creature — Mutant Ninja Turtle Human
+ * 1/3
+ *
+ * Sneak {W}{B}
+ * Attacking Ninjas you control have deathtouch.
+ * Whenever Dark Leo & Shredder deal combat damage to a player, create a 1/1 black Ninja creature
+ * token. Then if you control five or more Ninjas, that player loses half their life, rounded up.
+ *
+ * The deathtouch clause is a continuous static [GrantKeyword] over the group of attacking Ninjas
+ * you control — only creatures attack, so the group is creatures with subtype Ninja that you
+ * control and that are attacking, re-evaluated each application (same shape as Bone-Cairn Butcher).
+ *
+ * The combat-damage trigger creates the token first, then runs a [ConditionalEffect] gated on
+ * [Conditions.YouControlAtLeast] 5 Ninjas: because the token is itself a Ninja and is created
+ * before the check, it counts toward the five ("create … Then if you control five or more"). When
+ * the gate holds, the damaged player ([Player.TriggeringPlayer]) loses half their own life rounded
+ * up ([Effects.LoseHalfLife] with both `target` and `lifePlayer` pointed at that player).
+ */
+val DarkLeoAndShredder = card("Dark Leo & Shredder") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle Human"
+    oracleText = "Sneak {W}{B}\nAttacking Ninjas you control have deathtouch.\nWhenever Dark Leo & Shredder deal combat damage to a player, create a 1/1 black Ninja creature token. Then if you control five or more Ninjas, that player loses half their life, rounded up."
+    power = 1
+    toughness = 3
+
+    sneak("{W}{B}")
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DEATHTOUCH,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Ninja").youControl()).attacking()
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Ninja"),
+                imageUri = "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+            ),
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(5, GameObjectFilter.Creature.withSubtype("Ninja")),
+                effect = Effects.LoseHalfLife(
+                    roundUp = true,
+                    target = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+                    lifePlayer = Player.TriggeringPlayer
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "142"
+        artist = "Thomas Chamberlain-Keen"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bab93474-2f98-49a1-874f-b794bf81bd0c.jpg?1769006250"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KaraiFutureOfTheFoot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KaraiFutureOfTheFoot.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Karai, Future of the Foot
+ * {1}{W}{B}
+ * Legendary Creature — Human Ninja
+ * 3/3
+ *
+ * Sneak {2}{W}{B} (You may cast this spell for {2}{W}{B} if you also return an unblocked
+ * attacker you control to hand during the declare blockers step. She enters tapped and
+ * attacking.)
+ * Whenever Karai deals combat damage to a player, return target creature card from your
+ * graveyard to your hand. If her sneak cost was paid this turn, instead return that card to
+ * the battlefield.
+ *
+ * The combat-damage trigger composes a single [ConditionalEffect]: the default branch returns
+ * the chosen creature card to hand ([Effects.ReturnToHand]); when the "instead" condition holds
+ * it goes to the battlefield ([Effects.PutOntoBattlefield] — it's your own graveyard card, so
+ * with no controller override it enters under your control).
+ *
+ * "If her sneak cost was paid this turn" — the durable [Conditions.SneakCostWasPaid] flag on the
+ * permanent (CR 702.190) records that the sneak cost was paid, but it never clears, while the
+ * printed clause is turn-scoped. A creature can only be put onto the battlefield by its sneak
+ * cost on the very turn it's sneaked in, so ANDing the flag with [Conditions.SourceEnteredThisTurn]
+ * exactly reproduces "this turn": both are true only on the sneak turn (when Karai entered tapped
+ * and attacking and immediately deals combat damage), and on every later turn she attacks normally
+ * `SourceEnteredThisTurn` is false, so the card correctly returns to hand instead.
+ */
+val KaraiFutureOfTheFoot = card("Karai, Future of the Foot") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Ninja"
+    oracleText = "Sneak {2}{W}{B} (You may cast this spell for {2}{W}{B} if you also return an unblocked attacker you control to hand during the declare blockers step. She enters tapped and attacking.)\nWhenever Karai deals combat damage to a player, return target creature card from your graveyard to your hand. If her sneak cost was paid this turn, instead return that card to the battlefield."
+    power = 3
+    toughness = 3
+
+    sneak("{2}{W}{B}")
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val creatureCard = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = ConditionalEffect(
+            condition = Conditions.All(Conditions.SneakCostWasPaid, Conditions.SourceEnteredThisTurn),
+            effect = Effects.PutOntoBattlefield(creatureCard),
+            elseEffect = Effects.ReturnToHand(creatureCard)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Lius Lasahido"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dded2d4-1640-4431-809e-403b51b27db6.jpg?1771342417"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsunesTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsunesTechnique.kt
@@ -1,7 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.dsl.LibraryPatterns
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.sneak
@@ -20,7 +20,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *
  * "Half their library, rounded up" is a [DynamicAmount.Divide] of the target opponent's library
  * size ([DynamicAmount.Count] over [Zone.LIBRARY] for the first context player) by two with
- * `roundUp = true`. [LibraryPatterns.mill] takes the dynamic count and the target opponent
+ * `roundUp = true`. `Patterns.Library.mill` takes the dynamic count and the target opponent
  * ([Targets.Opponent], bound as context target 0), gathering that many cards from the top of
  * their library into their graveyard.
  */
@@ -34,7 +34,7 @@ val KitsunesTechnique = card("Kitsune's Technique") {
 
     spell {
         val opponent = target("target opponent", Targets.Opponent)
-        effect = LibraryPatterns.mill(
+        effect = Patterns.Library.mill(
             count = DynamicAmount.Divide(
                 numerator = DynamicAmount.Count(Player.ContextPlayer(0), Zone.LIBRARY),
                 denominator = DynamicAmount.Fixed(2),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsunesTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsunesTechnique.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.LibraryPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kitsune's Technique
+ * {4}{U}{U}
+ * Instant
+ *
+ * Sneak {1}{U} (You may cast this spell for {1}{U} if you also return an unblocked attacker
+ * you control to hand during the declare blockers step.)
+ * Target opponent mills half their library, rounded up.
+ *
+ * "Half their library, rounded up" is a [DynamicAmount.Divide] of the target opponent's library
+ * size ([DynamicAmount.Count] over [Zone.LIBRARY] for the first context player) by two with
+ * `roundUp = true`. [LibraryPatterns.mill] takes the dynamic count and the target opponent
+ * ([Targets.Opponent], bound as context target 0), gathering that many cards from the top of
+ * their library into their graveyard.
+ */
+val KitsunesTechnique = card("Kitsune's Technique") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Sneak {1}{U} (You may cast this spell for {1}{U} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nTarget opponent mills half their library, rounded up."
+
+    sneak("{1}{U}")
+
+    spell {
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = LibraryPatterns.mill(
+            count = DynamicAmount.Divide(
+                numerator = DynamicAmount.Count(Player.ContextPlayer(0), Zone.LIBRARY),
+                denominator = DynamicAmount.Fixed(2),
+                roundUp = true
+            ),
+            target = opponent
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Rose Benjamin"
+        flavorText = "\"Like a monster seeking prey in the night, the truth will hunt you down.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9ca5327e-df90-483c-875f-73a23781f56d.jpg?1769005745"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloImproviser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloImproviser.kt
@@ -1,7 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.HandPatterns
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.sneak
@@ -21,7 +21,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  * land card from your hand onto the battlefield.
  *
  * "A creature card and/or a land card" is two independent up-to-one selections — one over
- * creature cards in hand, one over land cards — composed in sequence ([HandPatterns.putFromHand]
+ * creature cards in hand, one over land cards — composed in sequence (`Patterns.Hand.putFromHand`
  * with `count = 1`, which uses a `ChooseUpTo(1)` selection). Because each selection allows
  * picking zero, every combination the "and/or … you may" wording permits is reachable: a
  * creature only, a land only, both, or neither (declining outright).
@@ -39,8 +39,8 @@ val MichelangeloImproviser = card("Michelangelo, Improviser") {
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
         effect = Effects.Composite(
-            HandPatterns.putFromHand(GameObjectFilter.Creature, count = 1),
-            HandPatterns.putFromHand(GameObjectFilter.Land, count = 1)
+            Patterns.Hand.putFromHand(GameObjectFilter.Creature, count = 1),
+            Patterns.Hand.putFromHand(GameObjectFilter.Land, count = 1)
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloImproviser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloImproviser.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.HandPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Michelangelo, Improviser
+ * {3}{G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 4/4
+ *
+ * Sneak {2}{G}{G} (You may cast this spell for {2}{G}{G} if you also return an unblocked
+ * attacker you control to hand during the declare blockers step. He enters tapped and
+ * attacking.)
+ * Whenever Michelangelo deals combat damage to a player, you may put a creature card and/or a
+ * land card from your hand onto the battlefield.
+ *
+ * "A creature card and/or a land card" is two independent up-to-one selections — one over
+ * creature cards in hand, one over land cards — composed in sequence ([HandPatterns.putFromHand]
+ * with `count = 1`, which uses a `ChooseUpTo(1)` selection). Because each selection allows
+ * picking zero, every combination the "and/or … you may" wording permits is reachable: a
+ * creature only, a land only, both, or neither (declining outright).
+ */
+val MichelangeloImproviser = card("Michelangelo, Improviser") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Sneak {2}{G}{G} (You may cast this spell for {2}{G}{G} if you also return an unblocked attacker you control to hand during the declare blockers step. He enters tapped and attacking.)\nWhenever Michelangelo deals combat damage to a player, you may put a creature card and/or a land card from your hand onto the battlefield."
+    power = 4
+    toughness = 4
+
+    sneak("{2}{G}{G}")
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            HandPatterns.putFromHand(GameObjectFilter.Creature, count = 1),
+            HandPatterns.putFromHand(GameObjectFilter.Land, count = 1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "119"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/955848c0-5092-4e13-97c9-5978d44d5586.jpg?1769006201"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelsTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelsTechnique.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.HandPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Raphael's Technique
+ * {4}{R}{R}
+ * Instant
+ *
+ * Sneak {2}{R} (You may cast this spell for {2}{R} if you also return an unblocked attacker
+ * you control to hand during the declare blockers step.)
+ * Each player may discard their hand and draw seven cards.
+ *
+ * A per-player optional wheel, in APNAP order: [ForEachPlayerEffect] over [Player.Each] iterates
+ * every player and rebinds the body's controller to the current player, so [HandPatterns.discardHand]
+ * (of `EffectTarget.Controller`) and [Effects.DrawCards] act on them. Each player's body is wrapped
+ * in [MayEffect] with `decisionMaker = Controller`, so every player independently chooses yes/no;
+ * declining means no discard and no draw, honoring "may … and …" as one combined optional action.
+ * Same shape as Step Between Worlds.
+ */
+val RaphaelsTechnique = card("Raphael's Technique") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Sneak {2}{R} (You may cast this spell for {2}{R} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nEach player may discard their hand and draw seven cards."
+
+    sneak("{2}{R}")
+
+    spell {
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                MayEffect(
+                    decisionMaker = EffectTarget.Controller,
+                    effect = Effects.Composite(
+                        HandPatterns.discardHand(EffectTarget.Controller),
+                        Effects.DrawCards(7)
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "105"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"Change of plans!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7ce8b00f-5a4f-4206-8eb3-e79308e91f47.jpg?1760102758"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelsTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelsTechnique.kt
@@ -1,7 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.HandPatterns
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.sneak
 import com.wingedsheep.sdk.model.Rarity
@@ -20,7 +20,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Each player may discard their hand and draw seven cards.
  *
  * A per-player optional wheel, in APNAP order: [ForEachPlayerEffect] over [Player.Each] iterates
- * every player and rebinds the body's controller to the current player, so [HandPatterns.discardHand]
+ * every player and rebinds the body's controller to the current player, so `Patterns.Hand.discardHand`
  * (of `EffectTarget.Controller`) and [Effects.DrawCards] act on them. Each player's body is wrapped
  * in [MayEffect] with `decisionMaker = Controller`, so every player independently chooses yes/no;
  * declining means no discard and no draw, honoring "may … and …" as one combined optional action.
@@ -41,7 +41,7 @@ val RaphaelsTechnique = card("Raphael's Technique") {
                 MayEffect(
                     decisionMaker = EffectTarget.Controller,
                     effect = Effects.Composite(
-                        HandPatterns.discardHand(EffectTarget.Controller),
+                        Patterns.Hand.discardHand(EffectTarget.Controller),
                         Effects.DrawCards(7)
                     )
                 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SharkShredderKillerClone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SharkShredderKillerClone.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shark Shredder, Killer Clone
+ * {2}{B}{B}
+ * Legendary Creature — Shark Octopus Ninja
+ * 4/4
+ *
+ * Sneak {3}{B}{B}
+ * First strike
+ * Whenever Shark Shredder deals combat damage to a player, put up to one target creature card
+ * from that player's graveyard onto the battlefield under your control. It enters tapped and
+ * attacking that player.
+ *
+ * The trigger targets up to one creature card in the damaged player's graveyard ([TargetObject]
+ * with `optional = true`, scoped to [Zone.GRAVEYARD]) and reanimates it via a [MoveToZoneEffect]
+ * to the battlefield with `controllerOverride = Controller` (under your control) and
+ * [ZonePlacement.TappedAndAttacking] (tapped and attacking the defending player) — the same
+ * tapped-and-attacking placement Raph & Mikey and the Sneak pipeline use.
+ *
+ * Scoping caveat: the engine has no "owned by the triggering player" target predicate, so
+ * "that player's graveyard" is expressed as `ownedByOpponent()`. In the engine's two-player
+ * games the damaged player IS the lone opponent, so this is exact; only in hypothetical
+ * multiplayer could it let you reach a different opponent's graveyard.
+ */
+val SharkShredderKillerClone = card("Shark Shredder, Killer Clone") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Shark Octopus Ninja"
+    oracleText = "Sneak {3}{B}{B}\nFirst strike\nWhenever Shark Shredder deals combat damage to a player, put up to one target creature card from that player's graveyard onto the battlefield under your control. It enters tapped and attacking that player."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    sneak("{3}{B}{B}")
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val creatureCard = target(
+            "up to one target creature card in that player's graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Creature.ownedByOpponent(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = MoveToZoneEffect(
+            target = creatureCard,
+            destination = Zone.BATTLEFIELD,
+            placement = ZonePlacement.TappedAndAttacking,
+            controllerOverride = EffectTarget.Controller
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "73"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f946b3d-7d2a-4210-a909-d16078757e3b.jpg?1769006593"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SharkShredderKillerClone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SharkShredderKillerClone.kt
@@ -2,12 +2,12 @@ package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.sneak
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -26,9 +26,9 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * attacking that player.
  *
  * The trigger targets up to one creature card in the damaged player's graveyard ([TargetObject]
- * with `optional = true`, scoped to [Zone.GRAVEYARD]) and reanimates it via a [MoveToZoneEffect]
+ * with `optional = true`, scoped to [Zone.GRAVEYARD]) and reanimates it via `Effects.Move`
  * to the battlefield with `controllerOverride = Controller` (under your control) and
- * [ZonePlacement.TappedAndAttacking] (tapped and attacking the defending player) — the same
+ * `ZonePlacement.TappedAndAttacking` (tapped and attacking the defending player) — the same
  * tapped-and-attacking placement Raph & Mikey and the Sneak pipeline use.
  *
  * Scoping caveat: the engine has no "owned by the triggering player" target predicate, so
@@ -57,7 +57,7 @@ val SharkShredderKillerClone = card("Shark Shredder, Killer Clone") {
                 filter = TargetFilter(GameObjectFilter.Creature.ownedByOpponent(), zone = Zone.GRAVEYARD)
             )
         )
-        effect = MoveToZoneEffect(
+        effect = Effects.Move(
             target = creatureCard,
             destination = Zone.BATTLEFIELD,
             placement = ZonePlacement.TappedAndAttacking,

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1089,6 +1089,112 @@
     ]
 }
 
+// Dark Leo & Shredder
+{
+    "name": "Dark Leo & Shredder",
+    "manaCost": "{W}{B}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle Human",
+    "oracleText": "Sneak {W}{B}\nAttacking Ninjas you control have deathtouch.\nWhenever Dark Leo & Shredder deal combat damage to a player, create a 1/1 black Ninja creature token. Then if you control five or more Ninjas, that player loses half their life, rounded up.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{W}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Ninja"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Ninja"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Divide",
+                                    "numerator": {
+                                        "type": "LifeTotal",
+                                        "player": "TriggeringPlayer"
+                                    },
+                                    "denominator": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH",
+                "filter": {
+                    "baseFilter": "creature Ninja attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "MYTHIC",
+        "artist": "Thomas Chamberlain-Keen",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bab93474-2f98-49a1-874f-b794bf81bd0c.jpg?1769006250"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Death in the Family
 {
     "name": "Death in the Family",
@@ -2625,6 +2731,172 @@
     ]
 }
 
+// Karai, Future of the Foot
+{
+    "name": "Karai, Future of the Foot",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Legendary Creature — Human Ninja",
+    "oracleText": "Sneak {2}{W}{B} (You may cast this spell for {2}{W}{B} if you also return an unblocked attacker you control to hand during the declare blockers step. She enters tapped and attacking.)\nWhenever Karai deals combat damage to a player, return target creature card from your graveyard to your hand. If her sneak cost was paid this turn, instead return that card to the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{2}{W}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "All",
+                            "conditions": [
+                                "SneakCostWasPaid",
+                                {
+                                    "type": "EntityMatches",
+                                    "entity": "Self",
+                                    "filter": {
+                                        "statePredicates": [
+                                            "EnteredThisTurn"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card in your graveyard"
+                        },
+                        "destination": "Battlefield"
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card in your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Lius Lasahido",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dded2d4-1640-4431-809e-403b51b27db6.jpg?1771342417"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Kitsune's Technique
+{
+    "name": "Kitsune's Technique",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Sneak {1}{U} (You may cast this spell for {1}{U} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nTarget opponent mills half their library, rounded up.",
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "Count",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "zone": "Library"
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "milled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "milled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "Rose Benjamin",
+        "flavorText": "\"Like a monster seeking prey in the night, the truth will hunt you down.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9ca5327e-df90-483c-875f-73a23781f56d.jpg?1769005745"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Krang, Master Mind
 {
     "name": "Krang, Master Mind",
@@ -3291,6 +3563,121 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Michelangelo, Improviser
+{
+    "name": "Michelangelo, Improviser",
+    "manaCost": "{3}{G}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Sneak {2}{G}{G} (You may cast this spell for {2}{G}{G} if you also return an unblocked attacker you control to hand during the declare blockers step. He enters tapped and attacking.)\nWhenever Michelangelo deals combat damage to a player, you may put a creature card and/or a land card from your hand onto the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{2}{G}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand",
+                                        "filter": "creature"
+                                    },
+                                    "storeAs": "put_candidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "put_candidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "putting"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "putting",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand",
+                                        "filter": "land"
+                                    },
+                                    "storeAs": "put_candidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "put_candidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "putting"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "putting",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "MYTHIC",
+        "artist": "Narendra Bintara Adi",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/955848c0-5092-4e13-97c9-5978d44d5586.jpg?1769006201"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4655,6 +5042,81 @@
     ]
 }
 
+// Raphael's Technique
+{
+    "name": "Raphael's Technique",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Sneak {2}{R} (You may cast this spell for {2}{R} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nEach player may discard their hand and draw seven cards.",
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Players",
+                "players": "Each"
+            },
+            "body": {
+                "type": "Gated",
+                "gate": "Gate.MayDecide",
+                "then": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "discardedHand"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discardedHand",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    ]
+                },
+                "decisionMaker": "Controller"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "RARE",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"Change of plans!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7ce8b00f-5a4f-4206-8eb3-e79308e91f47.jpg?1760102758"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Raphael, Tough Turtle
 {
     "name": "Raphael, Tough Turtle",
@@ -5216,6 +5678,68 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Shark Shredder, Killer Clone
+{
+    "name": "Shark Shredder, Killer Clone",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Creature — Shark Octopus Ninja",
+    "oracleText": "Sneak {3}{B}{B}\nFirst strike\nWhenever Shark Shredder deals combat damage to a player, put up to one target creature card from that player's graveyard onto the battlefield under your control. It enters tapped and attacking that player.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{3}{B}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature card in that player's graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "placement": "TappedAndAttacking",
+                    "controllerOverride": "Controller"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature own:opponent",
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target creature card in that player's graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "RARE",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f946b3d-7d2a-4210-a909-d16078757e3b.jpg?1769006593"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkLeoAndShredderTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkLeoAndShredderTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.DarkLeoAndShredder
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dark Leo & Shredder (TMT #142) — "Whenever Dark Leo & Shredder deal combat damage to a player,
+ * create a 1/1 black Ninja creature token. Then if you control five or more Ninjas, that player
+ * loses half their life, rounded up."
+ *
+ * The freshly-created token is itself a Ninja and is counted toward the five, so the second clause
+ * fires when the token brings the controller's Ninja count up to exactly five.
+ */
+class DarkLeoAndShredderTest : FunSpec({
+
+    val testNinja = card("Test Ninja") {
+        manaCost = "{B}"
+        typeLine = "Creature — Ninja"
+        power = 1
+        toughness = 1
+    }
+
+    test("token created on combat damage counts toward five Ninjas and drains half the player's life") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DarkLeoAndShredder, testNinja))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val darkLeo = driver.putCreatureOnBattlefield(player, "Dark Leo & Shredder")
+        driver.removeSummoningSickness(darkLeo)
+        // Dark Leo + 3 other Ninjas = 4 Ninjas; the created token pushes the count to five.
+        repeat(3) { driver.putCreatureOnBattlefield(player, "Test Ninja") }
+        val permanentsBefore = driver.getPermanents(player).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(darkLeo), opponent)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // 20 - 1 (combat) = 19; then lose half of 19 rounded up (10) = 9.
+        driver.assertLifeTotal(opponent, 9)
+        // A 1/1 Ninja token was created.
+        driver.getPermanents(player).size shouldBe permanentsBefore + 1
+    }
+
+    test("below five Ninjas the player only takes combat damage") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DarkLeoAndShredder, testNinja))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val darkLeo = driver.putCreatureOnBattlefield(player, "Dark Leo & Shredder")
+        driver.removeSummoningSickness(darkLeo)
+        // Dark Leo + 1 other Ninja = 2; even after the token (3) the count stays below five.
+        driver.putCreatureOnBattlefield(player, "Test Ninja")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(darkLeo), opponent)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Only the 1 combat damage; no life-drain rider.
+        driver.assertLifeTotal(opponent, 19)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraiFutureOfTheFootTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraiFutureOfTheFootTest.kt
@@ -1,30 +1,44 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.tmt.cards.KaraiFutureOfTheFoot
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Karai, Future of the Foot (TMT #151) — "Whenever Karai deals combat damage to a player, return
  * target creature card from your graveyard to your hand. If her sneak cost was paid this turn,
  * instead return that card to the battlefield."
  *
- * This covers the default (no-sneak) branch: Karai was cast normally, so her sneak cost was not
- * paid and the chosen creature card returns to hand rather than the battlefield. The sneak-paid →
- * battlefield branch leans on the Sneak cast pipeline proven in SneakTest (a creature can only be
- * put onto the battlefield by its sneak cost on the turn it's sneaked in, which is exactly when
- * the ANDed `SourceEnteredThisTurn` also holds).
+ * Both branches of the trigger's [com.wingedsheep.sdk.scripting.effects.ConditionalEffect] are
+ * exercised: the default (cast normally → return to hand) and the "instead" branch (cast for her
+ * sneak cost → put onto the battlefield, since a creature can only be put onto the battlefield by
+ * its sneak cost on the very turn it's sneaked in, exactly when the ANDed `SourceEnteredThisTurn`
+ * also holds).
  */
 class KaraiFutureOfTheFootTest : FunSpec({
 
     val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    // A vanilla creature that declares as the unblocked attacker returned to pay Karai's sneak cost.
+    val brawler = card("Plain Brawler") {
         manaCost = "{1}{G}"
         typeLine = "Creature — Bear"
         power = 2
@@ -66,5 +80,69 @@ class KaraiFutureOfTheFootTest : FunSpec({
         // Not sneaked → the Bear returns to hand, not the battlefield.
         driver.getHand(player) shouldContain bearInGy
         driver.findPermanent(player, "Test Bear") shouldBe null
+    }
+
+    test("combat damage returns the creature card to the battlefield when Karai was sneaked in") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KaraiFutureOfTheFoot, bear, brawler))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        // The Brawler provides the unblocked attacker returned to pay Karai's sneak cost; the Bear
+        // waits in the graveyard for the reanimation branch.
+        val attacker = driver.putCreatureOnBattlefield(player, "Plain Brawler")
+        driver.removeSummoningSickness(attacker)
+        val karai = driver.putCardInHand(player, "Karai, Future of the Foot")
+        val bearInGy = driver.putCardInGraveyard(player, "Test Bear")
+
+        // Open the sneak window: declare the Brawler, leave it unblocked.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(attacker), opponent).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, emptyMap()).isSuccess shouldBe true
+        var pg = 0
+        while (driver.state.priorityPlayerId != null && driver.state.priorityPlayerId != player &&
+            driver.state.step == Step.DECLARE_BLOCKERS && pg++ < 4
+        ) {
+            driver.passPriority(driver.state.priorityPlayerId!!)
+        }
+
+        // Cast Karai for her sneak cost {2}{W}{B}, returning the unblocked Brawler. She enters
+        // tapped and attacking the opponent.
+        driver.giveMana(player, Color.WHITE, 2)
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = karai,
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.SNEAK,
+                additionalCostPayment = AdditionalCostPayment(bouncedPermanents = listOf(attacker)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Karai deals combat damage the same turn she's sneaked in, firing the trigger; choose the
+        // graveyard Bear as the target.
+        var guard = 0
+        while (driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+            val decision = driver.pendingDecision
+            val holder = driver.state.priorityPlayerId
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(decision.playerId, listOf(bearInGy))
+            } else if (driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else if (holder != null) {
+                driver.passPriority(holder)
+            } else {
+                break
+            }
+        }
+
+        // Sneak cost was paid this turn → the Bear is put onto the battlefield, not returned to hand.
+        driver.findPermanent(player, "Test Bear") shouldNotBe null
+        driver.getHand(player).contains(bearInGy) shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraiFutureOfTheFootTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraiFutureOfTheFootTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.KaraiFutureOfTheFoot
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Karai, Future of the Foot (TMT #151) — "Whenever Karai deals combat damage to a player, return
+ * target creature card from your graveyard to your hand. If her sneak cost was paid this turn,
+ * instead return that card to the battlefield."
+ *
+ * This covers the default (no-sneak) branch: Karai was cast normally, so her sneak cost was not
+ * paid and the chosen creature card returns to hand rather than the battlefield. The sneak-paid →
+ * battlefield branch leans on the Sneak cast pipeline proven in SneakTest (a creature can only be
+ * put onto the battlefield by its sneak cost on the turn it's sneaked in, which is exactly when
+ * the ANDed `SourceEnteredThisTurn` also holds).
+ */
+class KaraiFutureOfTheFootTest : FunSpec({
+
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    test("combat damage returns a creature card from your graveyard to hand when not sneaked") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KaraiFutureOfTheFoot, bear))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val karai = driver.putCreatureOnBattlefield(player, "Karai, Future of the Foot")
+        driver.removeSummoningSickness(karai)
+        val bearInGy = driver.putCardInGraveyard(player, "Test Bear")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(karai), opponent)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, emptyMap())
+
+        // Combat damage fires the trigger, which pauses to choose the graveyard creature card.
+        var guard = 0
+        while (driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+            val decision = driver.pendingDecision
+            val holder = driver.state.priorityPlayerId
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(decision.playerId, listOf(bearInGy))
+            } else if (driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else if (holder != null) {
+                driver.passPriority(holder)
+            } else {
+                break
+            }
+        }
+
+        // Not sneaked → the Bear returns to hand, not the battlefield.
+        driver.getHand(player) shouldContain bearInGy
+        driver.findPermanent(player, "Test Bear") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KitsunesTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KitsunesTechniqueTest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.KitsunesTechnique
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kitsune's Technique (TMT #42) — "Target opponent mills half their library, rounded up."
+ *
+ * Exercises the dynamic mill amount: ceil(librarySize / 2) cards move from the top of the
+ * targeted opponent's library to their graveyard.
+ */
+class KitsunesTechniqueTest : FunSpec({
+    test("target opponent mills half their library, rounded up") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KitsunesTechnique))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val kitsune = driver.putCardInHand(player, "Kitsune's Technique")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val libBefore = driver.state.getLibrary(opponent).size
+        val gyBefore = driver.getGraveyard(opponent).size
+        val expectedMill = (libBefore + 1) / 2 // ceil(libBefore / 2)
+
+        driver.giveMana(player, Color.BLUE, 6) // {4}{U}{U}
+        driver.castSpell(player, kitsune, listOf(opponent)).isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.getGraveyard(opponent).size shouldBe gyBefore + expectedMill
+        driver.state.getLibrary(opponent).size shouldBe libBefore - expectedMill
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MichelangeloImproviserTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MichelangeloImproviserTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.MichelangeloImproviser
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Michelangelo, Improviser (TMT #119) — "Whenever Michelangelo deals combat damage to a player,
+ * you may put a creature card and/or a land card from your hand onto the battlefield."
+ *
+ * Puts both a creature and a land from hand onto the battlefield via two independent up-to-one
+ * selections.
+ */
+class MichelangeloImproviserTest : FunSpec({
+
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    test("combat damage puts a creature and a land from hand onto the battlefield") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MichelangeloImproviser, bear))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val mike = driver.putCreatureOnBattlefield(player, "Michelangelo, Improviser")
+        driver.removeSummoningSickness(mike)
+        driver.putCardInHand(player, "Test Bear") // the creature; opening hand supplies the land
+
+        fun landsInPlay() = driver.getPermanents(player).count {
+            driver.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?.name == "Forest"
+        }
+        val landsBefore = landsInPlay()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(mike), opponent)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, emptyMap())
+
+        var guard = 0
+        while (driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+            val decision = driver.pendingDecision
+            val holder = driver.state.priorityPlayerId
+            if (decision is SelectCardsDecision) {
+                // Select the single available card for this up-to-one slot (creature, then land).
+                driver.submitCardSelection(decision.playerId, decision.options.take(1))
+            } else if (driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else if (holder != null) {
+                driver.passPriority(holder)
+            } else {
+                break
+            }
+        }
+
+        driver.findPermanent(player, "Test Bear") shouldNotBe null
+        landsInPlay() shouldBe landsBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaphaelsTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaphaelsTechniqueTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.RaphaelsTechnique
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Raphael's Technique (TMT #105) — "Each player may discard their hand and draw seven cards."
+ *
+ * Both players accept: each discards their whole hand and draws a fresh seven.
+ */
+class RaphaelsTechniqueTest : FunSpec({
+    test("each player who accepts discards their hand and draws seven") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RaphaelsTechnique))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val raph = driver.putCardInHand(player, "Raphael's Technique")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveMana(player, Color.RED, 6) // {4}{R}{R}
+        driver.castSpell(player, raph, emptyList()).isSuccess shouldBe true
+
+        // Resolve the spell, accepting each per-player "may" prompt.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 40) {
+            val decision = driver.pendingDecision
+            if (decision is YesNoDecision) {
+                driver.submitYesNo(decision.playerId, true)
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        driver.getHandSize(player) shouldBe 7
+        driver.getHandSize(opponent) shouldBe 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkShredderKillerCloneTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkShredderKillerCloneTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.SharkShredderKillerClone
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Shark Shredder, Killer Clone (TMT #73) — "Whenever Shark Shredder deals combat damage to a
+ * player, put up to one target creature card from that player's graveyard onto the battlefield
+ * under your control. It enters tapped and attacking that player."
+ *
+ * Reanimates the damaged player's graveyard creature under the attacker's control.
+ */
+class SharkShredderKillerCloneTest : FunSpec({
+
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    test("combat damage reanimates a creature from the damaged player's graveyard under your control") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SharkShredderKillerClone, bear))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val shark = driver.putCreatureOnBattlefield(player, "Shark Shredder, Killer Clone")
+        driver.removeSummoningSickness(shark)
+        val bearInGy = driver.putCardInGraveyard(opponent, "Test Bear")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(shark), opponent)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, emptyMap())
+
+        var guard = 0
+        while (driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+            val decision = driver.pendingDecision
+            val holder = driver.state.priorityPlayerId
+            if (decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(decision.playerId, listOf(bearInGy))
+            } else if (driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else if (holder != null) {
+                driver.passPriority(holder)
+            } else {
+                break
+            }
+        }
+
+        // The Bear left the opponent's graveyard and is now a permanent under the player's control.
+        driver.getGraveyard(opponent).contains(bearInGy) shouldBe false
+        driver.findPermanent(player, "Test Bear") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkShredderKillerCloneTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharkShredderKillerCloneTest.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.tmt.cards.SharkShredderKillerClone
@@ -43,14 +45,18 @@ class SharkShredderKillerCloneTest : FunSpec({
         driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
         driver.declareBlockers(opponent, emptyMap())
 
+        // Resolve the combat-damage trigger, choosing the Bear; stop the moment it's reanimated so
+        // the assertions run while combat is still ongoing (end-of-combat removes attackers, CR 511.3).
         var guard = 0
-        while (driver.state.step != Step.POSTCOMBAT_MAIN && guard++ < 40) {
+        while (guard++ < 40) {
             val decision = driver.pendingDecision
             val holder = driver.state.priorityPlayerId
             if (decision is ChooseTargetsDecision) {
                 driver.submitTargetSelection(decision.playerId, listOf(bearInGy))
             } else if (driver.state.stack.isNotEmpty()) {
                 driver.bothPass()
+            } else if (driver.findPermanent(player, "Test Bear") != null) {
+                break // reanimation resolved, still mid-combat
             } else if (holder != null) {
                 driver.passPriority(holder)
             } else {
@@ -60,6 +66,13 @@ class SharkShredderKillerCloneTest : FunSpec({
 
         // The Bear left the opponent's graveyard and is now a permanent under the player's control.
         driver.getGraveyard(opponent).contains(bearInGy) shouldBe false
-        driver.findPermanent(player, "Test Bear") shouldNotBe null
+        val reanimated = driver.findPermanent(player, "Test Bear")
+        reanimated shouldNotBe null
+
+        // "It enters tapped and attacking that player" — verify the placement, not just control.
+        driver.state.getEntity(reanimated!!)?.has<TappedComponent>() shouldBe true
+        val attacking = driver.state.getEntity(reanimated)?.get<AttackingComponent>()
+        attacking shouldNotBe null
+        attacking!!.defenderId shouldBe opponent
     }
 })


### PR DESCRIPTION
Implements six Sneak-themed cards for the Teenage Mutant Ninja Turtles set,
all composed from existing SDK primitives — no new engine/SDK types.

### Cards
- **Dark Leo & Shredder** (#142) — attacking Ninjas have deathtouch; combat-damage
  trigger makes a Ninja token, then drains half life at 5+ Ninjas (token counts).
- **Karai, Future of the Foot** (#151) — combat damage returns a creature card from
  your graveyard to hand, or to the battlefield if her sneak cost was paid this turn.
- **Kitsune's Technique** (#42) — target opponent mills half their library, rounded up.
- **Michelangelo, Improviser** (#119) — combat damage may put a creature and/or land
  card from hand onto the battlefield.
- **Raphael's Technique** (#105) — each player may discard their hand and draw seven.
- **Shark Shredder, Killer Clone** (#73) — first strike; combat damage reanimates a
  creature from the damaged player's graveyard, tapped and attacking, under your control.

### Notes
- Karai's "sneak cost paid this turn" is modeled as `SneakCostWasPaid AND
  SourceEnteredThisTurn` — durable flag ∧ timing flag — reproducing the turn scope.
- Shark Shredder uses `ownedByOpponent()` as an exact proxy for "that player's
  graveyard" in two-player games (documented in-code).

### Testing
- 6 new scenario tests (rules-engine), all green.
- TMT card snapshot re-blessed (additive only); backlog updated 113 → 119.