### PR TITLE
DSK: implement creature cards (Most Valuable Slayer, Shroudstomper, Hand That Feeds)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HandThatFeeds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HandThatFeeds.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hand That Feeds
+ * {1}{R}
+ * Creature — Mutant
+ * 2/2
+ *
+ * Delirium — Whenever this creature attacks while there are four or more card types among
+ * cards in your graveyard, it gets +2/+0 and gains menace until end of turn.
+ *
+ * Delirium is an ability word (no rules meaning of its own); the [Triggers.Attacks] trigger
+ * carries an intervening-"if" gate of [Conditions.Delirium] (four+ distinct card types in your
+ * graveyard), modeled like Wickerfolk Thresher. The payoff buffs the source itself
+ * ([EffectTarget.Self]): +2/+0 via [Effects.ModifyStats] plus a menace [Effects.GrantKeyword],
+ * both lasting until end of turn (the facade default duration).
+ */
+val HandThatFeeds = card("Hand That Feeds") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Mutant"
+    power = 2
+    toughness = 2
+    oracleText = "Delirium — Whenever this creature attacks while there are four or more card " +
+        "types among cards in your graveyard, it gets +2/+0 and gains menace until end of turn. " +
+        "(It can't be blocked except by two or more creatures.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.Delirium()
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+            .then(Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Loïc Canavaggia"
+        flavorText = "In the darkness, Lana reached for Shay's hand and squeezed it for comfort. " +
+            "Then she heard Shay call to her from the next room."
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg?1726286367"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MostValuableSlayer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MostValuableSlayer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Most Valuable Slayer
+ * {3}{R}
+ * Creature — Human Warrior
+ * 2/4
+ *
+ * Whenever you attack, target attacking creature gets +1/+0 and gains first strike
+ * until end of turn.
+ *
+ * Modeled on the standard "Whenever you attack, buff a target attacker" shape (Hunter's
+ * Talent level 2): the once-per-combat [Triggers.YouAttack] trigger targets an attacking
+ * creature ([Targets.AttackingCreature]) and composes a +1/+0 [Effects.ModifyStats] with a
+ * first-strike [Effects.GrantKeyword], both lasting until end of turn (the facade default
+ * duration for ModifyStats and the explicit duration for the keyword grant).
+ */
+val MostValuableSlayer = card("Most Valuable Slayer") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever you attack, target attacking creature gets +1/+0 and gains first " +
+        "strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val attacker = target("attacking creature", Targets.AttackingCreature)
+        effect = Effects.ModifyStats(1, 0, attacker)
+            .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, attacker))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Patrik Hell"
+        flavorText = "Torain had never lost a match in his life, and he didn't plan to start now."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg?1726286383"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Shroudstomper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Shroudstomper.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shroudstomper
+ * {3}{W}{W}{B}{B}
+ * Creature — Elemental
+ * 5/5
+ *
+ * Deathtouch
+ * Whenever this creature enters or attacks, each opponent loses 2 life. You gain 2 life
+ * and draw a card.
+ *
+ * "Enters or attacks" is two distinct triggered abilities sharing one payoff (CR has no "or"
+ * trigger combiner), modeled like Sentinel of the Nameless City: one fires on
+ * [Triggers.EntersBattlefield], the other on [Triggers.Attacks]. The shared payoff composes a
+ * 2-life [Effects.LoseLife] against [Player.EachOpponent], a 2-life [Effects.GainLife] for the
+ * controller, and a single [Effects.DrawCards].
+ */
+val Shroudstomper = card("Shroudstomper") {
+    manaCost = "{3}{W}{W}{B}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Elemental"
+    power = 5
+    toughness = 5
+    oracleText = "Deathtouch\nWhenever this creature enters or attacks, each opponent loses 2 " +
+        "life. You gain 2 life and draw a card."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    val payoff = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+        .then(Effects.GainLife(2))
+        .then(Effects.DrawCards(1))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = payoff
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = payoff
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Campbell White"
+        flavorText = "\"At least the razorkin are happy when they kill you. The walkers don't even " +
+            "notice.\"\n—Angus, survivor scout"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg?1726286739"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -5339,6 +5339,71 @@
     ]
 }
 
+// Hand That Feeds
+{
+    "name": "Hand That Feeds",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Mutant",
+    "oracleText": "Delirium — Whenever this creature attacks while there are four or more card types among cards in your graveyard, it gets +2/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "In the darkness, Lana reached for Shay's hand and squeezed it for comfort. Then she heard Shay call to her from the next room.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg?1726286367"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hardened Escort
 {
     "name": "Hardened Escort",
@@ -7011,6 +7076,71 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Most Valuable Slayer
+{
+    "name": "Most Valuable Slayer",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever you attack, target attacking creature gets +1/+0 and gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "attacking creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "attacking creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "attacking creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Patrik Hell",
+        "flavorText": "Torain had never lost a match in his life, and he didn't plan to start now.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg?1726286383"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -9920,6 +10050,107 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Shroudstomper
+{
+    "name": "Shroudstomper",
+    "manaCost": "{3}{W}{W}{B}{B}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Deathtouch\nWhenever this creature enters or attacks, each opponent loses 2 life. You gain 2 life and draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Campbell White",
+        "flavorText": "\"At least the razorkin are happy when they kill you. The walkers don't even notice.\"\n—Angus, survivor scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg?1726286739"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskCreaturesGroupScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskCreaturesGroupScenarioTest.kt
@@ -1,0 +1,185 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the DSK creatures batch implemented from existing SDK primitives:
+ *
+ *  - Most Valuable Slayer ({3}{R} 2/4) — "Whenever you attack, target attacking creature gets
+ *    +1/+0 and gains first strike until end of turn."
+ *  - Shroudstomper ({3}{W}{W}{B}{B} 5/5, deathtouch) — "Whenever this creature enters or attacks,
+ *    each opponent loses 2 life. You gain 2 life and draw a card."
+ *  - Hand That Feeds ({1}{R} 2/2) — "Delirium — Whenever this creature attacks while there are
+ *    four or more card types among cards in your graveyard, it gets +2/+0 and gains menace until
+ *    end of turn."
+ *
+ * All three reuse existing effects/triggers/conditions, so this Kotest scenario net proves the
+ * composed behaviour rather than any new engine mechanic.
+ */
+class DskCreaturesGroupScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Most Valuable Slayer — attack trigger buffs a target attacker") {
+
+            test("target attacking creature gets +1/+0 and first strike until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Most Valuable Slayer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Base 2/2 before the attack trigger") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Most Valuable Slayer" to 2, "Grizzly Bears" to 2)
+                ).error shouldBe null
+
+                withClue("YouAttack trigger should ask for its attacking-creature target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Targeted attacker got +1/+0 and first strike") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+        }
+
+        context("Shroudstomper — enters/attacks drain, gain, and draw") {
+
+            test("entering drains each opponent 2, gains 2, and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withCardInHand(1, "Shroudstomper")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // Cast Shroudstomper; its enters trigger fires after it resolves.
+                game.castSpell(1, "Shroudstomper").error shouldBe null
+                game.resolveStack()
+
+                withClue("Each opponent lost 2 life") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Controller gained 2 life") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("Controller drew a card (hand was the spell only, now +1 from draw)") {
+                    // Spell left hand (-1), enters trigger drew one card (+1) => net == handBefore.
+                    game.handSize(1) shouldBe handBefore
+                }
+
+                val stomper = game.findPermanent("Shroudstomper")!!
+                withClue("Has deathtouch") {
+                    game.state.projectedState.hasKeyword(stomper, Keyword.DEATHTOUCH) shouldBe true
+                }
+            }
+
+            test("attacking drains each opponent 2, gains 2, and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Shroudstomper", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Shroudstomper" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Attacks payoff: opponent -2, controller +2, draw 1") {
+                    game.getLifeTotal(2) shouldBe 18
+                    game.getLifeTotal(1) shouldBe 22
+                    game.handSize(1) shouldBe (handBefore + 1)
+                }
+            }
+        }
+
+        context("Hand That Feeds — Delirium attack buff") {
+
+            test("with fewer than four card types in graveyard, attacking does nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hand That Feeds", summoningSickness = false)
+                    // Only three card types: creature, instant, sorcery.
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInGraveyard(1, "Doom Blade")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val hand = game.findPermanent("Hand That Feeds")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hand That Feeds" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Delirium off — vanilla 2/2, no menace") {
+                    game.state.projectedState.getPower(hand) shouldBe 2
+                    game.state.projectedState.getToughness(hand) shouldBe 2
+                    game.state.projectedState.hasKeyword(hand, Keyword.MENACE) shouldBe false
+                }
+            }
+
+            test("with four or more card types in graveyard, attacking grants +2/+0 and menace") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hand That Feeds", summoningSickness = false)
+                    // Four card types: creature, instant, sorcery, enchantment.
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInGraveyard(1, "Doom Blade")
+                    .withCardInGraveyard(1, "Test Enchantment")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val hand = game.findPermanent("Hand That Feeds")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hand That Feeds" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Delirium on — 2/2 + 2/0 = 4/2 with menace") {
+                    game.state.projectedState.getPower(hand) shouldBe 4
+                    game.state.projectedState.getToughness(hand) shouldBe 2
+                    game.state.projectedState.hasKeyword(hand, Keyword.MENACE) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Duskmourn: House of Horror creatures, each composed entirely from existing SDK primitives.

## Cards
- **Most Valuable Slayer** ({3}{R}, 2/4 Human Warrior) — Whenever you attack, target attacking creature gets +1/+0 and gains first strike until end of turn.
- **Shroudstomper** ({3}{W}{W}{B}{B}, 5/5 Elemental, deathtouch) — Whenever this enters or attacks, each opponent loses 2 life; you gain 2 life and draw a card.
- **Hand That Feeds** ({1}{R}, 2/2 Mutant) — Delirium: whenever it attacks with four or more card types in your graveyard, it gets +2/+0 and gains menace until end of turn.

## Substitutions
All three originally-assigned cards were swapped because they require new engine features rather than card authoring:
- **Norin, Swift Survivalist** — needs a this-turn-only play-permission exile primitive (existing one grants permanently).
- **Enduring Courage** — needs the unimplemented "Enduring" mechanic (dies → returns as non-creature enchantment).
- **Ghostly Keybearer** — needs a free targeted Room-door unlock effect.

## Tests
- New `DskCreaturesGroupScenarioTest` (5 tests) — pass.
- Card snapshot re-blessed; `DSK.json` diff is purely additive (only these 3 cards). `:mtg-sets` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)