### PR TITLE
DSK: implement spell cards (Break Down the Door, Under the Skin, Come Back Wrong)

### DIFF
--- a/backlog/dsk-engine-gaps.md
+++ b/backlog/dsk-engine-gaps.md
@@ -153,6 +153,19 @@ to a **player** that have no home yet.
     one of these N targeted objects; route effect A to it, effect B to the rest" decision.
     → **Trial of Agony**.
 
+14. **Repeat-an-effect-N-times (dynamic count) with cross-iteration entity accumulation.** No
+    iteration space repeats a body a *counted* number of times: `IterationSpace` covers
+    targets/players/collection/group/colors, and `RepeatWhileEffect` is a do-while gated by a
+    player choice or a `Condition` — neither runs a body exactly *X* times where X is a chosen
+    cast-time value. The card also needs each iteration's manifested creature accumulated into one
+    collection so the follow-up "put X +1/+1 counters on **each of those creatures**" can target
+    exactly the set just created (`AddCountersToCollection` with `DynamicAmount.XValue`). Needs an
+    `IterationSpace.Count(DynamicAmount)` (or a `RepeatNTimes`) plus an accumulating
+    `storeMovedAs`-style sink that survives across iterations.
+    → **Valgavoth's Onslaught** ("Manifest dread X times, then put X +1/+1 counters on each of
+      those creatures"). Skipped during the DSK spells batch (substituted **Come Back Wrong**)
+      rather than approximated — `add-feature` territory.
+
 ---
 
 ## Small / content-tier items (not subsystem gaps)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BreakDownTheDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BreakDownTheDoor.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Break Down the Door
+ * {2}{G}
+ * Instant
+ * Choose one —
+ * • Exile target artifact.
+ * • Exile target enchantment.
+ * • Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield
+ *   face down as a 2/2 creature and the other into your graveyard. Turn it face up any time
+ *   for its mana cost if it's a creature card.)
+ *
+ * "Choose one" modal spell, same shape as [TwistReality]. The two exile modes target an artifact
+ * or enchantment respectively (each a `target` slot resolved with [EffectTarget.ContextTarget]),
+ * and the third mode reuses the shared [Patterns.Library.manifestDread] recipe (CR 701.62).
+ */
+val BreakDownTheDoor = card("Break Down the Door") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Exile target artifact.\n" +
+        "• Exile target enchantment.\n" +
+        "• Manifest dread. (Look at the top two cards of your library. Put one onto the " +
+        "battlefield face down as a 2/2 creature and the other into your graveyard. Turn it " +
+        "face up any time for its mana cost if it's a creature card.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Exile target artifact") {
+                target("target", Targets.Artifact)
+                effect = Effects.Exile(EffectTarget.ContextTarget(0))
+            }
+            mode("Exile target enchantment") {
+                target("target", Targets.Enchantment)
+                effect = Effects.Exile(EffectTarget.ContextTarget(0))
+            }
+            mode(
+                "Manifest dread. (Look at the top two cards of your library. Put one onto the " +
+                    "battlefield face down as a 2/2 creature and the other into your graveyard. Turn " +
+                    "it face up any time for its mana cost if it's a creature card.)"
+            ) {
+                effect = Patterns.Library.manifestDread()
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Ralph Horsley"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg?1726286491"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ComeBackWrong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ComeBackWrong.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Come Back Wrong
+ * {2}{B}
+ * Sorcery
+ * Destroy target creature. If a creature card is put into a graveyard this way, return it to the
+ * battlefield under your control. Sacrifice it at the beginning of your next end step.
+ *
+ * Substituted into this group in place of Valgavoth's Onslaught, whose "manifest dread X times,
+ * then put X +1/+1 counters on each of those creatures" needs a count-driven (dynamic-X) repeat
+ * loop with cross-iteration accumulation of the manifested creatures — an engine feature that does
+ * not yet exist (`add-feature` territory), so it was skipped rather than approximated.
+ *
+ * Pipeline (the Zero Point Ballad / Kheru Lich Lord shape):
+ *   1. `GatherCards(ChosenTargets)` references the targeted creature.
+ *   2. `MoveCollection(..., MoveType.Destroy, storeMovedAs = "died")` destroys it via the standard
+ *      path; an indestructible target, or a token (which ceases to exist), drops out of `"died"` —
+ *      that's the "if a creature card is put into a graveyard this way" gate.
+ *   3. Select the nontoken creature card from `"died"` (SelectAll — no choice) and
+ *      `MoveCollection` it to the battlefield under your control, recapturing it as
+ *      `"comeBackWrong"`. With nothing in `"died"`, the select/move are no-ops.
+ *   4. `CreateDelayedTrigger` at the next end step sacrifices the reanimated permanent
+ *      ([EffectTarget.PipelineTarget]).
+ */
+val ComeBackWrong = card("Come Back Wrong") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. If a creature card is put into a graveyard this way, " +
+        "return it to the battlefield under your control. Sacrifice it at the beginning of your " +
+        "next end step."
+
+    val reanimated = EffectTarget.PipelineTarget("comeBackWrong")
+
+    spell {
+        target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "comeBackTargets"),
+                MoveCollectionEffect(
+                    from = "comeBackTargets",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Destroy,
+                    storeMovedAs = "died"
+                ),
+                // "If a creature card is put into a graveyard this way" — tokens cease to exist, so
+                // only a nontoken creature card remains to be reanimated.
+                SelectFromCollectionEffect(
+                    from = "died",
+                    selection = SelectionMode.All,
+                    filter = GameObjectFilter.Creature.nontoken(),
+                    storeSelected = "toReanimate"
+                ),
+                MoveCollectionEffect(
+                    from = "toReanimate",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    storeMovedAs = "comeBackWrong"
+                ),
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = Effects.SacrificeTarget(reanimated)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "86"
+        artist = "David Auden Nash"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg?1726286171"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnderTheSkin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnderTheSkin.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Under the Skin
+ * {2}{G}
+ * Sorcery
+ * Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face
+ * down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana
+ * cost if it's a creature card.)
+ * You may return a permanent card from your graveyard to your hand.
+ *
+ * Resolves in order: first the shared [Patterns.Library.manifestDread] recipe (CR 701.62 — note the
+ * card milled by manifest dread is itself an eligible return target if it's a permanent card), then
+ * an optional return of a permanent card from your graveyard to your hand. The "you may return" is a
+ * resolution-time selection (not a target): Gather every permanent card in your graveyard →
+ * [SelectionMode.ChooseUpTo] 1 (optional) → move it to hand. Same Gather/Select/Move shape as
+ * Overlord of the Balemurk's optional graveyard return.
+ */
+val UnderTheSkin = card("Under the Skin") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Manifest dread. (Look at the top two cards of your library. Put one onto the " +
+        "battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face " +
+        "up any time for its mana cost if it's a creature card.)\n" +
+        "You may return a permanent card from your graveyard to your hand."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                Patterns.Library.manifestDread(),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Permanent),
+                    storeAs = "underTheSkinReturnable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "underTheSkinReturnable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "underTheSkinToReturn",
+                    showAllCards = true,
+                    prompt = "You may return a permanent card from your graveyard to your hand",
+                    selectedLabel = "Return to hand",
+                    remainderLabel = "Leave in graveyard"
+                ),
+                MoveCollectionEffect(
+                    from = "underTheSkinToReturn",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Fernando Falcone"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg?1726286622"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1003,6 +1003,121 @@
     ]
 }
 
+// Break Down the Door
+{
+    "name": "Break Down the Door",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Exile target artifact.\n• Exile target enchantment.\n• Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "manifestDreadLooked"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "manifestDreadLooked",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "manifestDreadManifested",
+                                "storeRemainder": "manifestDreadGraveyard",
+                                "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                "remainderLabel": "Put into your graveyard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadManifested",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "faceDown": "MANIFEST"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "UNCOMMON",
+        "artist": "Ralph Horsley",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg?1726286491"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Broodspinner
 {
     "name": "Broodspinner",
@@ -1480,6 +1595,81 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Come Back Wrong
+{
+    "name": "Come Back Wrong",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "comeBackTargets"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "comeBackTargets",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy",
+                    "storeMovedAs": "died"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "died",
+                    "selection": "SelectAll",
+                    "filter": "creature nontoken",
+                    "storeSelected": "toReanimate"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toReanimate",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "storeMovedAs": "comeBackWrong"
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END",
+                    "effect": {
+                        "type": "SacrificeTarget",
+                        "target": {
+                            "type": "PipelineTarget",
+                            "collectionName": "comeBackWrong"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "RARE",
+        "artist": "David Auden Nash",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg?1726286171"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -11155,6 +11345,111 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Under the Skin
+{
+    "name": "Under the Skin",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nYou may return a permanent card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "storeAs": "underTheSkinReturnable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "underTheSkinReturnable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "underTheSkinToReturn",
+                    "prompt": "You may return a permanent card from your graveyard to your hand",
+                    "selectedLabel": "Return to hand",
+                    "remainderLabel": "Leave in graveyard",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "underTheSkinToReturn",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Fernando Falcone",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg?1726286622"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakDownTheDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakDownTheDoorScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Break Down the Door (DSK #170) — {2}{G} Instant.
+ *
+ * "Choose one —
+ *  • Exile target artifact.
+ *  • Exile target enchantment.
+ *  • Manifest dread."
+ *
+ * Pure composition: a "choose one" modal spell. Modes 0/1 are [com.wingedsheep.sdk.dsl.Effects.Exile]
+ * on an artifact / enchantment target; mode 2 reuses the shared manifest-dread recipe (the same
+ * shape as Twist Reality). No new SDK surface.
+ */
+class BreakDownTheDoorScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("mode 0 (exile artifact): exiles target artifact") {
+        val driver = newDriver()
+        val me = driver.player1
+        val artifact = driver.putPermanentOnBattlefield(driver.player2, "Artifact Creature")
+
+        val spell = driver.putCardInHand(me, "Break Down the Door")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(artifact)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(artifact))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(driver.player2, "Artifact Creature") shouldBe null
+        driver.state.getZone(driver.player2, Zone.EXILE).any { driver.getCardName(it) == "Artifact Creature" } shouldBe true
+    }
+
+    test("mode 1 (exile enchantment): exiles target enchantment") {
+        val driver = newDriver()
+        val me = driver.player1
+        // Growing Dread is a {G}{U} Enchantment — a legal target for "exile target enchantment".
+        val enchantment = driver.putPermanentOnBattlefield(driver.player2, "Growing Dread")
+
+        val spell = driver.putCardInHand(me, "Break Down the Door")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(enchantment)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(enchantment))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(driver.player2, "Growing Dread") shouldBe null
+    }
+
+    test("mode 2 (manifest dread): manifests one of the top two and bins the other") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val land = driver.putCardOnTopOfLibrary(me, "Forest")
+        val creature = driver.putCardOnTopOfLibrary(me, "Centaur Courser") // now top card
+
+        val spell = driver.putCardInHand(me, "Break Down the Door")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = emptyList(),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(emptyList()),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+
+        val entity = driver.state.getEntity(creature)
+        entity?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        entity?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        driver.state.projectedState.getPower(creature) shouldBe 2
+        driver.getGraveyard(me) shouldContain land
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ComeBackWrongScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ComeBackWrongScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Come Back Wrong (DSK #86) — {2}{B} Sorcery.
+ *
+ * "Destroy target creature. If a creature card is put into a graveyard this way, return it to the
+ *  battlefield under your control. Sacrifice it at the beginning of your next end step."
+ *
+ * Substituted into this batch in place of Valgavoth's Onslaught (which needs an as-yet-unbuilt
+ * dynamic-X repeat-N-times loop with cross-iteration entity accumulation — `add-feature` territory).
+ *
+ * Pure composition (Zero Point Ballad / Kheru Lich Lord shape): destroy the target via a
+ * MoveType.Destroy pipeline capturing what actually hit the graveyard, reanimate the nontoken
+ * creature card under your control, and arm a delayed end-step sacrifice on the reanimated permanent.
+ */
+class ComeBackWrongScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Come Back Wrong — destroy, reanimate under your control, delayed sacrifice") {
+
+            test("reanimates the destroyed creature under your control, then sacrifices it at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Come Back Wrong")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // opponent's 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Bears start under player 2's control") {
+                    game.state.getEntity(bears)?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                        ?.playerId shouldBe game.player2Id
+                }
+
+                game.castSpell(1, "Come Back Wrong", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("It's now on the battlefield under player 1's control (the same card entity)") {
+                    game.state.getEntity(bears)
+                        ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                        ?.playerId shouldBe game.player1Id
+                }
+
+                // Advance to this turn's end step — the delayed sacrifice fires.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Sacrificed at the beginning of the controller's next end step") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true // owner's graveyard
+                }
+            }
+
+            test("a destroyed token is not reanimated (it ceases to exist, not a creature card in a graveyard)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Come Back Wrong")
+                    // A creature token: when destroyed it goes to the graveyard then ceases to exist,
+                    // so there is no creature *card* to return.
+                    .withCardOnBattlefield(2, "Grizzly Bears", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val token = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Come Back Wrong", token).error shouldBe null
+                game.resolveStack()
+
+                withClue("The token is destroyed and not returned to anyone's battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnderTheSkinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnderTheSkinScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Under the Skin (DSK #203) — {2}{G} Sorcery.
+ *
+ * "Manifest dread. You may return a permanent card from your graveyard to your hand."
+ *
+ * Pure composition: the shared manifest-dread recipe, then an optional Gather → SelectUpTo(1) →
+ * Move-to-hand of a permanent card from your graveyard (the Overlord of the Balemurk shape). The
+ * manifest-dread pick comes first, then the optional return.
+ */
+class UnderTheSkinScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castUnderTheSkin(me: com.wingedsheep.sdk.model.EntityId) {
+        val spell = putCardInHand(me, "Under the Skin")
+        giveMana(me, Color.GREEN, 1)
+        giveColorlessMana(me, 2)
+        castSpell(me, spell)
+        while (!isPaused && state.stack.isNotEmpty()) bothPass()
+    }
+
+    test("manifests dread then returns a permanent card from the graveyard to hand") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        // A permanent card (creature) already in the graveyard to return.
+        val grizzly = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        // Top two of library for manifest dread: creature on top, land beneath.
+        val land = driver.putCardOnTopOfLibrary(me, "Forest")
+        val creature = driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+
+        driver.castUnderTheSkin(me)
+
+        // First pause: choose which of the looked-at two to manifest.
+        val manifestPick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = manifestPick.id, selectedCards = listOf(creature)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Second pause: optional return of a permanent card from the graveyard.
+        val returnPick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        returnPick.options shouldContain grizzly
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = returnPick.id, selectedCards = listOf(grizzly)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Manifested creature is a face-down 2/2; the land was binned.
+        driver.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        driver.state.getEntity(creature)?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        driver.getGraveyard(me) shouldContain land
+        // The permanent card was returned to hand.
+        driver.getHand(me) shouldContain grizzly
+        driver.getGraveyard(me) shouldNotContain grizzly
+    }
+
+    test("the optional return may be declined") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val grizzly = driver.putCardInGraveyard(me, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        val creature = driver.putCardOnTopOfLibrary(me, "Centaur Courser")
+
+        driver.castUnderTheSkin(me)
+        val manifestPick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = manifestPick.id, selectedCards = listOf(creature)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Decline the return (choose nothing — it's "up to one").
+        val returnPick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = returnPick.id, selectedCards = emptyList()))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The card stays in the graveyard; manifest still happened.
+        driver.getGraveyard(me) shouldContain grizzly
+        driver.getHand(me) shouldNotContain grizzly
+        driver.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+})


### PR DESCRIPTION
Implements three Duskmourn: House of Horror instants/sorceries, all composed from existing SDK primitives.

## Cards
- **Break Down the Door** ({2}{G} Instant) — Choose one: exile target artifact / exile target enchantment / manifest dread.
- **Under the Skin** ({2}{G} Sorcery) — Manifest dread, then optionally return a permanent card from your graveyard to hand.
- **Come Back Wrong** ({2}{B} Sorcery) — Destroy target creature, reanimate it under your control, sacrifice it at the next end step.

## Substitution
- **Valgavoth's Onslaught** was skipped (not approximated): "manifest dread X times, then put X +1/+1 counters on each of those creatures" needs a count-driven dynamic-X repeat loop with cross-iteration accumulation — genuine `add-feature` territory. Documented as gap #14 in `backlog/dsk-engine-gaps.md`. **Come Back Wrong** (also a missing DSK Draft spell) was implemented in its place.

## Tests
- 7 new scenario tests (rules-engine) — 0 failures.
- `CardDefinitionSnapshotTest` re-blessed; `DSK.json` diff purely additive. `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)