### PR TITLE
DSK: implement enchantment/misc cards (Sporogenic Infection, Trapped in the Screen, Threats Around Every Corner)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1682,6 +1682,13 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `Noncreature` / `Nonenchantment` / `Nonartifact` wrap each. `IsNonartifact` is the "nonartifact
   creature" leg of the Terror template ("destroy target nonartifact, nonblack creature") — pair with
   `IsCreature` + `.notColor(...)`. FQL keys: `nonland` / `noncreature` / `nonartifact`.
+- **Combined-type filters** — `GameObjectFilter.InstantOrSorcery` / `CreatureOrPlaneswalker` /
+  `CreatureOrEnchantment` / `ArtifactOrEnchantment` / `CreatureOrArtifact` / `ArtifactOrLand` /
+  `ArtifactCreatureOrEnchantment` each wrap a `CardPredicate.Or` of the named top-level types.
+  `ArtifactCreatureOrEnchantment` (the three-type O-Ring restriction) has matching target constants
+  `TargetFilter.ArtifactCreatureOrEnchantment` and
+  `TargetFilter.ArtifactCreatureOrEnchantmentOpponentControls` — the latter for "exile target
+  artifact, creature, or enchantment an opponent controls" (Trapped in the Screen).
 
 **Chained predicates**
 
@@ -1938,6 +1945,14 @@ work for abilities-on-stack (which carry no `CardComponent`).
   payoffs that target/choose/sacrifice/return "a creature that crewed/saddled it this turn" (Giant
   Beaver, Rambling Possum, The Gitrog, Calamity). For the *count* of those creatures use
   `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` instead.
+- `IsAttachedToBySource` (filter builder `notAttachedToBySource()`, which wraps it in a negation) —
+  source-relative: matches the permanent the effect's source is attached to, read from the source's
+  `AttachedToComponent.targetId`. Used negated for "other than enchanted/equipped creature"
+  exclusions on Aura/Equipment edicts — Sporogenic Infection: "target player sacrifices a creature of
+  their choice other than enchanted creature" via
+  `Effects.Sacrifice(GameObjectFilter.Creature.notAttachedToBySource(), 1, targetPlayer)`. Resolves
+  against `PredicateContext.sourceId`; inert with no source / unattached source, and never matches in
+  group-static projection or trigger-gating contexts (no source there).
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -154,6 +154,17 @@ data class GameObjectFilter(
         val ArtifactCreature = GameObjectFilter(
             cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsCreature)
         )
+        val ArtifactCreatureOrEnchantment = GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.Or(
+                    listOf(
+                        CardPredicate.IsArtifact,
+                        CardPredicate.IsCreature,
+                        CardPredicate.IsEnchantment
+                    )
+                )
+            )
+        )
         val NoncreaturePermanent = GameObjectFilter(
             cardPredicates = listOf(CardPredicate.IsNoncreature, CardPredicate.IsPermanent)
         )
@@ -614,6 +625,15 @@ data class GameObjectFilter(
      */
     fun notTargetedByAbilityFromSameNamedSource() = copy(
         statePredicates = statePredicates + StatePredicate.NotTargetedByAbilityFromSameNamedSource
+    )
+
+    /**
+     * Must NOT be the permanent the effect's source is attached to (its enchanted/equipped
+     * creature). "Other than enchanted creature" exclusions on Aura/Equipment edicts — e.g.
+     * Sporogenic Infection's "sacrifices a creature of their choice other than enchanted creature".
+     */
+    fun notAttachedToBySource() = copy(
+        statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsAttachedToBySource)
     )
 
     /** Must be attacking or blocking */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -126,6 +126,14 @@ data class TargetFilter(
         /** Target artifact or enchantment */
         val ArtifactOrEnchantment = TargetFilter(GameObjectFilter.Companion.ArtifactOrEnchantment)
 
+        /** Target artifact, creature, or enchantment */
+        val ArtifactCreatureOrEnchantment =
+            TargetFilter(GameObjectFilter.Companion.ArtifactCreatureOrEnchantment)
+
+        /** Target artifact, creature, or enchantment an opponent controls */
+        val ArtifactCreatureOrEnchantmentOpponentControls =
+            TargetFilter(GameObjectFilter.Companion.ArtifactCreatureOrEnchantment.opponentControls())
+
         /** Target creature or artifact */
         val CreatureOrArtifact = TargetFilter(GameObjectFilter.Companion.CreatureOrArtifact)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -453,6 +453,23 @@ sealed interface StatePredicate {
         override val description: String = "cast for its warp cost"
     }
 
+    /**
+     * The candidate permanent is the permanent the effect's source is attached to — i.e. the
+     * creature/permanent enchanted or equipped by the source (read from the source's
+     * `AttachedToComponent`). Source-relative: resolves against the source supplied in the
+     * evaluation context, and is false if the source isn't attached to anything or there is no
+     * source context.
+     *
+     * Negate with [Not] for "other than enchanted/equipped creature" exclusions in edict-style
+     * filters (Sporogenic Infection: "target player sacrifices a creature of their choice other
+     * than enchanted creature").
+     */
+    @SerialName("IsAttachedToBySource")
+    @Serializable
+    data object IsAttachedToBySource : Entity {
+        override val description: String = "that the source is attached to"
+    }
+
     // =============================================================================
     // Composite / Logical Combinators
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SporogenicInfection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SporogenicInfection.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sporogenic Infection
+ * {1}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, target player sacrifices a creature of their choice other than enchanted
+ * creature.
+ * When enchanted creature is dealt damage, destroy it.
+ *
+ * Standard Aura wiring: [auraTarget] enchants a creature (Targets.Creature), then two triggered
+ * abilities. The enters trigger is an edict — it names its own "target player" and forces that
+ * player to sacrifice a creature *of their choice* (the default [Effects.Sacrifice] / ForceSacrifice
+ * behaviour) restricted to a creature other than the one this Aura is attached to via the
+ * source-relative [GameObjectFilter.notAttachedToBySource] exclusion. The damage trigger uses the
+ * shared [Triggers.takesDamage] factory with [TriggerBinding.ATTACHED] ("enchanted creature is dealt
+ * damage") and destroys it via [EffectTarget.EnchantedCreature].
+ */
+val SporogenicInfection = card("Sporogenic Infection") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, target player sacrifices a creature of their choice other than " +
+        "enchanted creature.\n" +
+        "When enchanted creature is dealt damage, destroy it."
+
+    auraTarget = Targets.Creature
+
+    // When this Aura enters, target player sacrifices a creature of their choice other than
+    // enchanted creature.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Effects.Sacrifice(
+            filter = GameObjectFilter.Creature.notAttachedToBySource(),
+            count = 1,
+            target = player
+        )
+        description = "Target player sacrifices a creature of their choice other than enchanted creature."
+    }
+
+    // When enchanted creature is dealt damage, destroy it.
+    triggeredAbility {
+        trigger = Triggers.takesDamage(binding = TriggerBinding.ATTACHED)
+        effect = Effects.Destroy(EffectTarget.EnchantedCreature)
+        description = "Destroy enchanted creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg?1726286285"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ThreatsAroundEveryCorner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ThreatsAroundEveryCorner.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Threats Around Every Corner
+ * {3}{G}
+ * Enchantment
+ * When this enchantment enters, manifest dread.
+ * Whenever a face-down permanent you control enters, search your library for a basic land card,
+ * put it onto the battlefield tapped, then shuffle.
+ *
+ * The enters trigger reuses the shared [Patterns.Library.manifestDread] recipe. The payoff is a
+ * standard ANY-binding enters trigger filtered to face-down permanents you control
+ * ([GameObjectFilter.Any] + `faceDown().youControl()`) — note the manifest-dread permanent from the
+ * first trigger itself counts, so it fetches a land too. The fetch is the shared
+ * [Patterns.Library.searchLibrary] pipeline restricted to basic lands, entering the battlefield
+ * tapped, shuffling afterward.
+ */
+val ThreatsAroundEveryCorner = card("Threats Around Every Corner") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, manifest dread. (Look at the top two cards of your " +
+        "library. Put one onto the battlefield face down as a 2/2 creature and the other into your " +
+        "graveyard.)\n" +
+        "Whenever a face-down permanent you control enters, search your library for a basic land " +
+        "card, put it onto the battlefield tapped, then shuffle."
+
+    // When this enchantment enters, manifest dread.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.manifestDread()
+    }
+
+    // Whenever a face-down permanent you control enters, search your library for a basic land
+    // card, put it onto the battlefield tapped, then shuffle.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any.faceDown().youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            shuffleAfter = true
+        )
+        description = "Search your library for a basic land card, put it onto the battlefield " +
+            "tapped, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "200"
+        artist = "Andrea Piparo"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg?1726286614"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TrappedInTheScreen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TrappedInTheScreen.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Trapped in the Screen
+ * {2}{W}
+ * Enchantment
+ * Ward {2}
+ * When this enchantment enters, exile target artifact, creature, or enchantment an opponent
+ * controls until this enchantment leaves the battlefield.
+ *
+ * An Oblivion Ring variant restricted to "artifact, creature, or enchantment an opponent
+ * controls". Reuses the standard linked-exile pattern: [Effects.ExileUntilLeaves] on the enters
+ * trigger links the exiled card to this permanent, and [Effects.ReturnLinkedExileUnderOwnersControl]
+ * on the leaves trigger returns it (same wiring as Banishing Light). The new target filter
+ * [TargetFilter.ArtifactCreatureOrEnchantmentOpponentControls] is the reusable three-type
+ * opponent-controlled permanent restriction. Ward {2} is the standard [KeywordAbility.Ward].
+ */
+val TrappedInTheScreen = card("Trapped in the Screen") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Ward {2} (Whenever this enchantment becomes the target of a spell or ability an " +
+        "opponent controls, counter it unless that player pays {2}.)\n" +
+        "When this enchantment enters, exile target artifact, creature, or enchantment an opponent " +
+        "controls until this enchantment leaves the battlefield."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "artifact, creature, or enchantment an opponent controls",
+            TargetPermanent(filter = TargetFilter.ArtifactCreatureOrEnchantmentOpponentControls)
+        )
+        effect = Effects.ExileUntilLeaves(permanent)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Michael Phillippi"
+        flavorText = "Maggie had always wanted to be on television."
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg?1726285993"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10413,6 +10413,75 @@
     ]
 }
 
+// Sporogenic Infection
+{
+    "name": "Sporogenic Infection",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, target player sacrifices a creature of their choice other than enchanted creature.\nWhen enchanted creature is dealt damage, destroy it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateNot",
+                                "predicate": "IsAttachedToBySource"
+                            }
+                        ]
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "Target player sacrifices a creature of their choice other than enchanted creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "DamageReceivedEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "EnchantedCreature",
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "descriptionOverride": "Destroy enchanted creature."
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg?1726286285"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Stalked Researcher
 {
     "name": "Stalked Researcher",
@@ -10638,6 +10707,208 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Threats Around Every Corner
+{
+    "name": "Threats Around Every Corner",
+    "manaCost": "{3}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard.)\nWhenever a face-down permanent you control enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "facedown ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                "descriptionOverride": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "UNCOMMON",
+        "artist": "Andrea Piparo",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg?1726286614"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Trapped in the Screen
+{
+    "name": "Trapped in the Screen",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Ward {2} (Whenever this enchantment becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen this enchantment enters, exile target artifact, creature, or enchantment an opponent controls until this enchantment leaves the battlefield.",
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "artifact, creature, or enchantment an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|creature|enchantment ctrl:opponent"
+                    },
+                    "id": "artifact, creature, or enchantment an opponent controls"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Michael Phillippi",
+        "flavorText": "Maggie had always wanted to be on television.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg?1726285993"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -463,6 +463,7 @@ class BeginningPhaseManager(
         StatePredicate.CrewedOrSaddledSourceThisTurn,
         StatePredicate.IsWarpExiled,
         StatePredicate.NotTargetedByAbilityFromSameNamedSource,
+        StatePredicate.IsAttachedToBySource,
         StatePredicate.WasCastForWarp -> true
         is StatePredicate.AttachedToCardType -> true
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1624,6 +1624,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.CrewedOrSaddledSourceThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.NotTargetedByAbilityFromSameNamedSource,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttachedToBySource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true
         // Counter predicates require last-known-info to evaluate a creature that has already left

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1015,6 +1015,17 @@ class PredicateEvaluator {
                 state.projectedState.hasType(attached.targetId, predicate.cardType.name)
             }
 
+            // Source-relative — the candidate is the permanent the effect's source is attached
+            // to (its enchanted/equipped creature). Read the source's AttachedToComponent and
+            // compare its targetId to the candidate. False with no source or an unattached source.
+            // Negated via StatePredicate.Not for "other than enchanted creature" edicts
+            // (Sporogenic Infection).
+            StatePredicate.IsAttachedToBySource -> {
+                val sourceId = context?.sourceId ?: return false
+                val attachedTo = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
+                attachedTo == entityId
+            }
+
             // Saddled marker — set by BecomeSaddledExecutor when a Saddle ability resolves
             // (CR 702.171b). Cleared at end-of-turn cleanup or when the permanent leaves play.
             StatePredicate.IsSaddled -> container.has<SaddledComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -394,6 +394,10 @@ internal class AffectsFilterResolver {
         // source permanent, absent in group-static projection. Only meaningful in target/count
         // contexts via PredicateEvaluator / DynamicAmountEvaluator. Never match here.
         StatePredicate.CrewedOrSaddledSourceThisTurn -> false
+        // Source-relative: "the permanent the source is attached to" needs the ability's source
+        // permanent, absent in group-static projection. Only meaningful in target/gather-filter
+        // contexts via PredicateEvaluator. Never match here.
+        StatePredicate.IsAttachedToBySource -> false
         StatePredicate.EnteredThisTurn -> container.has<EnteredThisTurnComponent>()
         StatePredicate.WasDealtDamageThisTurn -> container.has<WasDealtDamageThisTurnComponent>()
         StatePredicate.HasDealtDamage -> container.has<HasDealtDamageComponent>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporogenicInfectionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporogenicInfectionScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.SporogenicInfection
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sporogenic Infection (DSK #117) — {1}{B} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  When this Aura enters, target player sacrifices a creature of their choice other than enchanted
+ *  creature.
+ *  When enchanted creature is dealt damage, destroy it."
+ *
+ * Exercises: an Aura attaching to a creature; an ETB edict that names its own target player and
+ * forces a sacrifice restricted to a creature *other than* the enchanted one (the new
+ * `notAttachedToBySource` source-relative filter); and a `takesDamage(binding = ATTACHED)` trigger
+ * that destroys the enchanted creature on any damage.
+ */
+class SporogenicInfectionScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + SporogenicInfection)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castSporogenicOn(caster: EntityId, victim: EntityId) {
+        giveMana(caster, Color.BLACK, 2)
+        val aura = putCardInHand(caster, "Sporogenic Infection")
+        castSpellWithTargets(caster, aura, listOf(ChosenTarget.Permanent(victim))).error shouldBe null
+        bothPass() // resolve the Aura spell → it enters attached → ETB edict trigger goes on stack
+    }
+
+    test("the Aura attaches to the enchanted creature and the ETB edict makes the target player sacrifice") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        // p2 has the to-be-enchanted creature plus a second creature it can sacrifice.
+        val enchanted = d.putCreatureOnBattlefield(p2, "Glory Seeker")
+        val other = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+
+        d.castSporogenicOn(caster = p1, victim = enchanted)
+
+        // The Aura is attached to the enchanted creature.
+        val aura = d.findPermanent(p1, "Sporogenic Infection")
+        aura.shouldNotBeNull()
+        d.state.getEntity(aura)?.get<AttachedToComponent>()?.targetId shouldBe enchanted
+
+        // ETB edict: choose p2 as the target player; p2 must sacrifice a creature OTHER than the
+        // enchanted one — so the only valid choice is the other creature (auto-sacrificed).
+        d.submitTargetSelection(p1, listOf(p2))
+        var guard = 0
+        while (guard++ < 10 && !(d.state.stack.isEmpty() && d.state.pendingDecision == null)) {
+            d.bothPass()
+        }
+
+        // The enchanted creature survives the edict; the other creature is sacrificed.
+        d.findPermanent(p2, "Glory Seeker").shouldNotBeNull()
+        d.findPermanent(p2, "Centaur Courser") shouldBe null
+    }
+
+    test("enchanted creature is destroyed when dealt any damage") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        val enchanted = d.putCreatureOnBattlefield(p2, "Glory Seeker")
+
+        d.castSporogenicOn(caster = p1, victim = enchanted)
+        // Resolve the ETB edict targeting p1 (who has no other creature → no sacrifice).
+        d.submitTargetSelection(p1, listOf(p1))
+        var guard = 0
+        while (guard++ < 10 && !(d.state.stack.isEmpty() && d.state.pendingDecision == null)) {
+            d.bothPass()
+        }
+        d.findPermanent(p2, "Glory Seeker").shouldNotBeNull()
+
+        // Lightning Bolt deals 3 damage to the enchanted 2/2 — the "dealt damage, destroy it"
+        // trigger fires and destroys it (independently of lethal damage).
+        val bolt = d.putCardInHand(p1, "Lightning Bolt")
+        d.giveMana(p1, Color.RED, 1)
+        d.castSpellWithTargets(p1, bolt, listOf(ChosenTarget.Permanent(enchanted))).error shouldBe null
+        guard = 0
+        while (guard++ < 10 && !(d.state.stack.isEmpty() && d.state.pendingDecision == null)) {
+            d.bothPass()
+        }
+
+        d.findPermanent(p2, "Glory Seeker") shouldBe null
+    }
+
+    test("edict cannot force the targeted player to sacrifice the enchanted creature when it is their only creature") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        // p2's ONLY creature is the one being enchanted — "other than enchanted creature" leaves
+        // p2 with no valid creature to sacrifice, so nothing is sacrificed.
+        val enchanted = d.putCreatureOnBattlefield(p2, "Glory Seeker")
+
+        d.castSporogenicOn(caster = p1, victim = enchanted)
+        d.submitTargetSelection(p1, listOf(p2))
+        var guard = 0
+        while (guard++ < 10 && !(d.state.stack.isEmpty() && d.state.pendingDecision == null)) {
+            d.bothPass()
+        }
+
+        // The enchanted creature is untouched — the edict found no other creature to take.
+        d.findPermanent(p2, "Glory Seeker").shouldNotBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreatsAroundEveryCornerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreatsAroundEveryCornerScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.ThreatsAroundEveryCorner
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Threats Around Every Corner (DSK #200) — {3}{G} Enchantment.
+ *
+ * "When this enchantment enters, manifest dread.
+ *  Whenever a face-down permanent you control enters, search your library for a basic land card,
+ *  put it onto the battlefield tapped, then shuffle."
+ *
+ * Exercises: the manifest-dread ETB recipe, and an ANY-binding "a face-down permanent you control
+ * enters" trigger that fires off the manifest-dread permanent itself and fetches a basic land
+ * entering tapped.
+ */
+class ThreatsAroundEveryCornerScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + ThreatsAroundEveryCorner)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.countTappedBasicLands(playerId: EntityId): Int =
+        getPermanents(playerId).count { id ->
+            val e = state.getEntity(id)
+            e?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Forest" &&
+                e.get<TappedComponent>() != null
+        }
+
+    test("ETB manifest dread makes a face-down permanent, which fetches a tapped basic land") {
+        val d = newDriver()
+        val you = d.player1
+
+        // Top two cards for manifest dread: a creature on top (to manifest), a Forest beneath.
+        d.putCardOnTopOfLibrary(you, "Forest")
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val before = d.countTappedBasicLands(you)
+
+        // Cast Threats Around Every Corner.
+        val enchant = d.putCardInHand(you, "Threats Around Every Corner")
+        d.giveMana(you, Color.GREEN, 4)
+        d.castSpell(you, enchant)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // First decision: manifest-dread pick — manifest the creature.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+
+        // Resolve everything: the face-down permanent entering fires the second ability, which
+        // searches for a basic land. With only basic Forests available the search auto-finds one;
+        // satisfy any library-search prompt that appears.
+        var guard = 0
+        while (guard++ < 20 && !(d.state.stack.isEmpty() && d.state.pendingDecision == null)) {
+            val pending = d.pendingDecision
+            if (pending is SelectCardsDecision && pending.options.isNotEmpty()) {
+                d.submitDecision(you, CardsSelectedResponse(decisionId = pending.id, selectedCards = listOf(pending.options.first())))
+            } else {
+                d.bothPass()
+            }
+        }
+
+        // The manifested card is a face-down permanent.
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+
+        // A basic land was fetched onto the battlefield tapped (net +1 over the starting count).
+        d.countTappedBasicLands(you) shouldBe before + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrappedInTheScreenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrappedInTheScreenScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.TrappedInTheScreen
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Trapped in the Screen (DSK #36) — {2}{W} Enchantment.
+ *
+ * "Ward {2}
+ *  When this enchantment enters, exile target artifact, creature, or enchantment an opponent
+ *  controls until this enchantment leaves the battlefield."
+ *
+ * An Oblivion Ring variant restricted to "artifact, creature, or enchantment an opponent controls".
+ * Exercises the linked-exile pattern (exile on ETB, return on leaves) and the new three-type
+ * opponent-controlled target filter.
+ */
+class TrappedInTheScreenScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + TrappedInTheScreen)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.isInExile(playerId: EntityId, cardName: String): Boolean =
+        state.getExile(playerId).any { state.getEntity(it)?.get<CardComponent>()?.name == cardName }
+
+    fun GameTestDriver.castTrappedTargeting(caster: EntityId, target: EntityId) {
+        giveMana(caster, Color.WHITE, 3)
+        val card = putCardInHand(caster, "Trapped in the Screen")
+        castSpell(caster, card)
+        bothPass() // resolve spell → enters → ETB trigger goes on stack
+        pendingDecision shouldNotBe null
+        submitTargetSelection(caster, listOf(target))
+        bothPass() // resolve ETB exile
+    }
+
+    test("exiles an opponent's creature on ETB and returns it when it leaves the battlefield") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        val creature = d.putCreatureOnBattlefield(p2, "Glory Seeker")
+        d.castTrappedTargeting(caster = p1, target = creature)
+
+        // The creature is exiled and linked to Trapped in the Screen.
+        d.findPermanent(p2, "Glory Seeker") shouldBe null
+        d.isInExile(p2, "Glory Seeker") shouldBe true
+        val trapped = d.findPermanent(p1, "Trapped in the Screen")
+        trapped.shouldNotBeNull()
+        d.state.getEntity(trapped)?.get<LinkedExileComponent>()?.exiledIds?.shouldContain(creature)
+
+        // Destroy Trapped in the Screen — the exiled creature returns.
+        val wipe = d.putCardInHand(p1, "Wipe Clean")
+        d.giveMana(p1, Color.WHITE, 2)
+        d.castSpellWithTargets(p1, wipe, listOf(ChosenTarget.Permanent(trapped)))
+        d.bothPass() // resolve Wipe Clean
+        d.bothPass() // resolve LTB return trigger
+
+        d.findPermanent(p2, "Glory Seeker").shouldNotBeNull()
+        d.findPermanent(p1, "Trapped in the Screen") shouldBe null
+    }
+
+    test("can exile an opponent's noncreature enchantment") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        // A plain enchantment (not a creature) is still a valid target — "artifact, creature, or
+        // enchantment", so the enchantment branch of the new filter resolves.
+        val enchantment = d.putPermanentOnBattlefield(p2, "Test Enchantment")
+        d.castTrappedTargeting(caster = p1, target = enchantment)
+
+        d.isInExile(p2, "Test Enchantment") shouldBe true
+        d.findPermanent(p2, "Test Enchantment") shouldBe null
+    }
+})


### PR DESCRIPTION
Implements all three assigned Duskmourn: House of Horror enchantment/misc cards — no substitutions. Composed from existing primitives plus two small, reusable SDK additions.

## Cards
- **Sporogenic Infection** ({1}{B} Aura — Enchant creature) — ETB edict (sacrifice a creature other than enchanted creature); destroys the enchanted creature whenever it's dealt damage.
- **Trapped in the Screen** ({2}{W} Enchantment, Ward {2}) — ETB exiles target artifact, creature, or enchantment an opponent controls until it leaves (O-Ring linked-exile).
- **Threats Around Every Corner** ({3}{G} Enchantment) — ETB manifest dread; whenever a face-down permanent you control enters, fetch a basic land tapped.

## Reusable SDK additions
- `StatePredicate.IsAttachedToBySource` + `notAttachedToBySource()` filter — source-relative "other than enchanted/equipped creature" exclusions for any Aura/Equipment edict. Wired through `PredicateEvaluator` and the other exhaustive `when` blocks.
- `GameObjectFilter.ArtifactCreatureOrEnchantment` + matching `TargetFilter` variants.
- `docs/card-sdk-language-reference.md` updated for both.

## Tests
- 6 new scenario tests (attachment, edict + "other than" exclusion + no-valid-sacrifice edge, damage-destroys, exile/return on leave, manifest-dread→tapped-land fetch) — BUILD SUCCESSFUL.
- `CardDefinitionSnapshotTest` re-blessed; only `DSK.json` changed. `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)