### PR TITLE
Add FIN creature cards: Cactuar, Coeurl, Gaelicat, Gigantoad, Hill Gigas

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Cactuar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Cactuar.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cactuar
+ * {G}
+ * Creature — Plant
+ * 3/3
+ *
+ * Trample
+ * At the beginning of your end step, if this creature didn't enter the battlefield this turn,
+ * return it to its owner's hand.
+ *
+ * Intervening-if (CR 603.4): the bounce trigger only fires if Cactuar didn't enter this turn —
+ * modeled as the negation of [Conditions.SourceEnteredThisTurn]. The condition is re-checked at
+ * resolution, so a Cactuar that entered this turn is left alone (it can attack and stay for the
+ * turn it arrives, then bounces on a later end step).
+ */
+val Cactuar = card("Cactuar") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\nAt the beginning of your end step, if this creature didn't enter the " +
+        "battlefield this turn, return it to its owner's hand."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.Not(Conditions.SourceEnteredThisTurn)
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+        description = "At the beginning of your end step, if this creature didn't enter the " +
+            "battlefield this turn, return it to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "177"
+        artist = "Kevin Sidharta"
+        flavorText = "A cactus with legs that loves to run hither and thither. Watch out for its thorns!"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5273db4-6214-41e4-825a-612fca8bbe03.jpg?1748706421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Coeurl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Coeurl.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Coeurl
+ * {1}{W}
+ * Creature — Cat Beast
+ * 2/2
+ *
+ * {1}{W}, {T}: Tap target nonenchantment creature.
+ *
+ * The "nonenchantment creature" filter composes the existing creature filter with the
+ * [GameObjectFilter.Nonenchantment] predicate via the public `and` combiner — no new SDK type.
+ */
+val Coeurl = card("Coeurl") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Beast"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{W}, {T}: Tap target nonenchantment creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Creature and GameObjectFilter.Nonenchantment)),
+        )
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Miho Midorikawa"
+        flavorText = "A lean and limber predator whose whiskers acquire charge from naturally-occurring " +
+            "electric particles in the atmosphere."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7604b534-5480-42fa-bc36-bbae730f8582.jpg?1748705798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Gaelicat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Gaelicat.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gaelicat
+ * {2}{W}
+ * Creature — Cat
+ * 1/3
+ *
+ * Flying, vigilance
+ * As long as you control two or more artifacts, this creature gets +2/+0.
+ *
+ * The conditional buff is a continuous static modification gated by
+ * [Conditions.YouControlAtLeast] over the artifact filter, recomputed at projection.
+ */
+val Gaelicat = card("Gaelicat") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 3
+    oracleText = "Flying, vigilance\nAs long as you control two or more artifacts, this creature gets +2/+0."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(2, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Narendra Bintara Adi"
+        flavorText = "\"That's the ticket! Now, let's get moving to North Mountain!\"\n—Galuf Baldesion"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29606c49-e1a4-49c3-883b-9122c08bbbc7.jpg?1748705839"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Gigantoad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Gigantoad.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gigantoad
+ * {3}{G}
+ * Creature — Frog
+ * 4/4
+ *
+ * As long as you control seven or more lands, this creature gets +2/+2.
+ *
+ * Continuous static modification gated by [Conditions.YouControlAtLeast] over the land filter,
+ * recomputed at projection.
+ */
+val Gigantoad = card("Gigantoad") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Frog"
+    power = 4
+    toughness = 4
+    oracleText = "As long as you control seven or more lands, this creature gets +2/+2."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(7, GameObjectFilter.Land),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Hristo D. Chukov"
+        flavorText = "The gigantoad is known to venture outside of its comfort zone during downpours" +
+            "—much to the surprise of unsuspecting hikers."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc10d648-4053-460f-bc52-9c20477bf6de.jpg?1748706462"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HillGigas.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HillGigas.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Hill Gigas
+ * {4}{R}{R}
+ * Creature — Giant
+ * 5/4
+ *
+ * Trample, haste
+ * Mountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it,
+ * put it into your hand, then shuffle.)
+ */
+val HillGigas = card("Hill Gigas") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 5
+    toughness = 4
+    oracleText = "Trample, haste\nMountaincycling {2} ({2}, Discard this card: Search your library " +
+        "for a Mountain card, reveal it, put it into your hand, then shuffle.)"
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    keywordAbility(KeywordAbility.typecycling("Mountain", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Heonhwa"
+        flavorText = "\"This place is dangerous! Be careful!\"\n—Zozo resident"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a8b3e1e-5c10-4360-ac1c-83b2e026278c.jpg?1748706292"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -718,6 +718,61 @@
     ]
 }
 
+// Cactuar
+{
+    "name": "Cactuar",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "Trample\nAt the beginning of your end step, if this creature didn't enter the battlefield this turn, return it to its owner's hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "EntityMatches",
+                        "entity": "Self",
+                        "filter": {
+                            "statePredicates": [
+                                "EnteredThisTurn"
+                            ]
+                        }
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if this creature didn't enter the battlefield this turn, return it to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Sidharta",
+        "flavorText": "A cactus with legs that loves to run hither and thither. Watch out for its thorns!",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5273db4-6214-41e4-825a-612fca8bbe03.jpg?1748706421"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Call the Mountain Chocobo
 {
     "name": "Call the Mountain Chocobo",
@@ -1547,6 +1602,68 @@
     ]
 }
 
+// Coeurl
+{
+    "name": "Coeurl",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Beast",
+    "oracleText": "{1}{W}, {T}: Tap target nonenchantment creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    "IsNonenchantment"
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Miho Midorikawa",
+        "flavorText": "A lean and limber predator whose whiskers acquire charge from naturally-occurring electric particles in the atmosphere.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7604b534-5480-42fa-bc36-bbae730f8582.jpg?1748705798"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Coliseum Behemoth
 {
     "name": "Coliseum Behemoth",
@@ -2312,6 +2429,110 @@
     ]
 }
 
+// Gaelicat
+{
+    "name": "Gaelicat",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Flying, vigilance\nAs long as you control two or more artifacts, this creature gets +2/+0.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Narendra Bintara Adi",
+        "flavorText": "\"That's the ticket! Now, let's get moving to North Mountain!\"\n—Galuf Baldesion",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/29606c49-e1a4-49c3-883b-9122c08bbbc7.jpg?1748705839"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Gigantoad
+{
+    "name": "Gigantoad",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Frog",
+    "oracleText": "As long as you control seven or more lands, this creature gets +2/+2.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Hristo D. Chukov",
+        "flavorText": "The gigantoad is known to venture outside of its comfort zone during downpours—much to the surprise of unsuspecting hikers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc10d648-4053-460f-bc52-9c20477bf6de.jpg?1748706462"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gladiolus Amicitia
 {
     "name": "Gladiolus Amicitia",
@@ -2728,6 +2949,46 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Hill Gigas
+{
+    "name": "Hill Gigas",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Trample, haste\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Mountain"
+                    }
+                ]
+            },
+            "displayPrefix": "Mountaincycling"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Heonhwa",
+        "flavorText": "\"This place is dangerous! Be careful!\"\n—Zozo resident",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a8b3e1e-5c10-4360-ac1c-83b2e026278c.jpg?1748706292"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinCreatureCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinCreatureCardsScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Cactuar
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Coeurl
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Gaelicat
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Gigantoad
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the FIN "creatures" batch. Cactuar (intervening-if end-step self-bounce),
+ * Coeurl (tap target nonenchantment creature via a composed filter), Gaelicat / Gigantoad
+ * (conditional static P/T buffs). Hill Gigas reuses stock Trample/Haste/Mountaincycling and is
+ * left to the snapshot net.
+ */
+class FinCreatureCardsScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(vararg cards: com.wingedsheep.sdk.model.CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        cards.forEach { driver.registerCard(it) }
+        return driver
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Cactuar
+    // ---------------------------------------------------------------------------------------------
+
+    test("Cactuar stays at end step the turn it entered (intervening-if fails)") {
+        val driver = createDriver(Cactuar)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val cactuar = driver.putCreatureOnBattlefield(active, "Cactuar")
+        // Mark it as having entered this turn — the intervening-if must then NOT fire.
+        driver.replaceState(
+            driver.state.updateEntity(cactuar) {
+                it.with(com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent)
+            }
+        )
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.state.getBattlefield().contains(cactuar) shouldBe true
+    }
+
+    test("Cactuar returns to hand at end step when it didn't enter this turn") {
+        val driver = createDriver(Cactuar)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        // putCreatureOnBattlefield does not stamp EnteredThisTurnComponent, so Cactuar reads as
+        // "didn't enter this turn" — the bounce trigger fires at the controller's end step.
+        val cactuar = driver.putCreatureOnBattlefield(active, "Cactuar")
+        val handBefore = driver.getHandSize(active)
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.state.getBattlefield().contains(cactuar) shouldBe false
+        driver.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Coeurl
+    // ---------------------------------------------------------------------------------------------
+
+    test("Coeurl taps target nonenchantment creature") {
+        val driver = createDriver(Coeurl)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val coeurl = driver.putCreatureOnBattlefield(active, "Coeurl")
+        driver.removeSummoningSickness(coeurl)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.giveMana(active, Color.WHITE, 2)
+
+        driver.isTapped(victim) shouldBe false
+
+        val abilityId = Coeurl.activatedAbilities.first().id
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = active,
+                sourceId = coeurl,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, victim)),
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.isTapped(victim) shouldBe true
+        // Coeurl itself is tapped as part of the {T} cost.
+        driver.isTapped(coeurl) shouldBe true
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Gaelicat
+    // ---------------------------------------------------------------------------------------------
+
+    test("Gaelicat gets +2/+0 only while you control two or more artifacts") {
+        val driver = createDriver(Gaelicat)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val cat = driver.putCreatureOnBattlefield(active, "Gaelicat")
+
+        // No artifacts: base 1/3.
+        projector.getProjectedPower(driver.state, cat) shouldBe 1
+        projector.getProjectedToughness(driver.state, cat) shouldBe 3
+
+        // One artifact: still base (need two or more).
+        driver.putPermanentOnBattlefield(active, "Ornithopter")
+        projector.getProjectedPower(driver.state, cat) shouldBe 1
+
+        // Two artifacts: +2/+0 → 3/3.
+        driver.putPermanentOnBattlefield(active, "Ornithopter")
+        projector.getProjectedPower(driver.state, cat) shouldBe 3
+        projector.getProjectedToughness(driver.state, cat) shouldBe 3
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Gigantoad
+    // ---------------------------------------------------------------------------------------------
+
+    test("Gigantoad gets +2/+2 only while you control seven or more lands") {
+        val driver = createDriver(Gigantoad)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val toad = driver.putCreatureOnBattlefield(active, "Gigantoad")
+
+        // Six lands: base 4/4.
+        repeat(6) { driver.putLandOnBattlefield(active, "Forest") }
+        projector.getProjectedPower(driver.state, toad) shouldBe 4
+        projector.getProjectedToughness(driver.state, toad) shouldBe 4
+
+        // Seventh land: +2/+2 → 6/6.
+        driver.putLandOnBattlefield(active, "Forest")
+        projector.getProjectedPower(driver.state, toad) shouldBe 6
+        projector.getProjectedToughness(driver.state, toad) shouldBe 6
+    }
+})


### PR DESCRIPTION
Implements five Final Fantasy (FIN) creatures from the Creatures-theme batch. All five compose existing SDK primitives — no engine/SDK/feature work was needed, so none were skipped for capability reasons.

## Implemented
- **Cactuar** `{G}` 3/3 Plant — Trample; at the beginning of your end step, if it didn't enter this turn, return it to its owner's hand. Modeled as an intervening-if (`triggerCondition = Conditions.Not(Conditions.SourceEnteredThisTurn)`) + `Effects.ReturnToHand(EffectTarget.Self)`.
- **Coeurl** `{1}{W}` 2/2 Cat Beast — `{1}{W}, {T}: Tap target nonenchantment creature.` The "nonenchantment creature" filter composes the existing creature filter with `GameObjectFilter.Nonenchantment` via the public `and` combiner (no new SDK type).
- **Gaelicat** `{2}{W}` 1/3 Cat — Flying, vigilance; `ConditionalStaticAbility(ModifyStats(+2/+0), YouControlAtLeast(2, Artifact))`.
- **Gigantoad** `{3}{G}` 4/4 Frog — `ConditionalStaticAbility(ModifyStats(+2/+2), YouControlAtLeast(7, Land))`.
- **Hill Gigas** `{4}{R}{R}` 5/4 Giant — Trample, haste, Mountaincycling {2} (`KeywordAbility.typecycling("Mountain", {2})`).

## Skipped
None. All five were implementable with existing primitives.

## Tests run
- `FinCreatureCardsScenarioTest` (new, rules-engine) — 5 tests, all pass: Cactuar stays the turn it entered / bounces otherwise, Coeurl taps a target creature (and taps itself for `{T}`), Gaelicat gains +2/+0 only at 2+ artifacts, Gigantoad gains +2/+2 only at 7+ lands.
- `CardDefinitionSnapshotTest` (re-blessed; diff is purely the five new card trees) and `CardLintTest` — both pass.
- `mtg-sets` compiles cleanly; `just check-card-printing "Cactuar"` confirms FIN is the sole/earliest printing and the canonical placement is correct (all five are FIN-original cards, so no reprint rows needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)