### PR TITLE
Add FIN spell cards: Chocobo Kick, Elixir, Ether, Self-Destruct, Sleep Magic

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ChocoboKick.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ChocoboKick.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Chocobo Kick
+ * {1}{G}
+ * Sorcery
+ *
+ * Kicker—Return a land you control to its owner's hand. (You may return a land you control to its
+ * owner's hand in addition to any other costs as you cast this spell.)
+ * Target creature you control deals damage equal to its power to target creature an opponent
+ * controls. If this spell was kicked, the creature you control deals twice that much damage instead.
+ *
+ * The kicker is a non-mana additional cost (returning a land). When it's paid, the damage dealt by
+ * the controlled creature is doubled — modeled by branching the damage amount on [WasKicked].
+ */
+val ChocoboKick = card("Chocobo Kick") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Kicker—Return a land you control to its owner's hand. (You may return a land you control to its owner's hand in addition to any other costs as you cast this spell.)\n" +
+        "Target creature you control deals damage equal to its power to target creature an opponent controls. If this spell was kicked, the creature you control deals twice that much damage instead."
+
+    keywordAbility(KeywordAbility.kicker(Costs.additional.ReturnToHand(GameObjectFilter.Land)))
+
+    spell {
+        val yourCreature = target("creature you control", Targets.CreatureYouControl)
+        val theirCreature = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.DealDamage(
+                DynamicAmount.Multiply(DynamicAmounts.targetPower(0), 2),
+                theirCreature,
+                damageSource = yourCreature
+            ),
+            elseEffect = Effects.DealDamage(
+                DynamicAmounts.targetPower(0),
+                theirCreature,
+                damageSource = yourCreature
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Ben Wootten"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff8c8be0-8223-499c-8704-cb68e0a42ce2.jpg?1748706427"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Elixir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Elixir.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Elixir
+ * {1}
+ * Artifact
+ *
+ * This artifact enters tapped.
+ * {5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library.
+ * You gain life equal to the number of cards shuffled into your library this way.
+ *
+ * Gathers only the nonland cards from the controller's graveyard, shuffles them into the library,
+ * then gains life equal to the count actually moved (`shuffled_count`). Lands stay in the graveyard.
+ */
+val Elixir = card("Elixir") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "This artifact enters tapped.\n" +
+        "{5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library. You gain life equal to the number of cards shuffled into your library this way."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.ExileSelf)
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Nonland),
+                    storeAs = "shuffled"
+                ),
+                MoveCollectionEffect(
+                    from = "shuffled",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Shuffled)
+                ),
+                Effects.GainLife(DynamicAmount.VariableReference("shuffled_count"), EffectTarget.Controller)
+            )
+        )
+        description = "{5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library. You gain life equal to the number of cards shuffled into your library this way."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Takeuchi Moto"
+        flavorText = "Fully recovers HP and MP."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4b05d37-df62-475c-8371-735ed2fa1b05.jpg?1748706750"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Elixir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Elixir.kt
@@ -40,7 +40,7 @@ val Elixir = card("Elixir") {
 
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.ExileSelf)
-        effect = CompositeEffect(
+        effect = Effects.Composite(
             listOf(
                 GatherCardsEffect(
                     source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Nonland),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ether.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ether.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ether
+ * {3}{U}
+ * Artifact
+ *
+ * {T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn,
+ * copy that spell. You may choose new targets for the copy.
+ *
+ * This is a mana ability (per the official rulings) — it adds mana, has no target, and doesn't use
+ * the stack. It also sets up a one-shot "copy your next instant/sorcery this turn" delayed trigger
+ * via [Effects.CopyNextSpellCast].
+ */
+val Ether = card("Ether") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.ExileSelf)
+        manaAbility = true
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLUE),
+            Effects.CopyNextSpellCast()
+        )
+        description = "{T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "53"
+        artist = "Ben Wootten"
+        flavorText = "Restores 20 MP."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/896ee6e9-15a9-4974-b576-50f4759fac38.jpg?1748705952"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SelfDestruct.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SelfDestruct.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Self-Destruct
+ * {1}{R}
+ * Instant
+ *
+ * Target creature you control deals X damage to any other target and X damage to itself, where X
+ * is its power.
+ *
+ * The controlled creature (target index 0) is the damage source for both prongs, so X is read off
+ * its power as last-known information while the damage is dealt. The "any other target" is target
+ * index 1 (any target — creature, player, planeswalker, or battle).
+ */
+val SelfDestruct = card("Self-Destruct") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature you control deals X damage to any other target and X damage to itself, where X is its power."
+
+    spell {
+        val yourCreature = target("creature you control", Targets.CreatureYouControl)
+        val other = target("any other target", TargetOther(baseRequirement = AnyTarget()))
+        effect = Effects.DealDamage(
+            DynamicAmounts.targetPower(0),
+            other,
+            damageSource = yourCreature
+        ) then Effects.DealDamage(
+            DynamicAmounts.targetPower(0),
+            yourCreature,
+            damageSource = yourCreature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Liiga Smilshkalne"
+        flavorText = "\"Hah! If I'd just left you in the lurch, I'd look like a jerk for all of history!\"\n—Gilgamesh"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7661003c-bf83-46bb-bcc0-8fbf5819ffa8.jpg?1748706346"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SleepMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SleepMagic.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sleep Magic
+ * {U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * When enchanted creature is dealt damage, sacrifice this Aura.
+ *
+ * Same lock as Charmed Sleep, plus a "released on damage" trigger: the ATTACHED-bound
+ * `takesDamage` trigger fires when the enchanted creature is dealt damage and sacrifices the Aura,
+ * freeing the creature to untap again.
+ */
+val SleepMagic = card("Sleep Magic") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap enchanted creature.\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "When enchanted creature is dealt damage, sacrifice this Aura."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.takesDamage(binding = TriggerBinding.ATTACHED)
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Le Vuong"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c96cae63-7625-48e3-aaba-5b1632a8642d.jpg?1748706038"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1080,6 +1080,95 @@
     ]
 }
 
+// Chocobo Kick
+{
+    "name": "Chocobo Kick",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Kicker—Return a land you control to its owner's hand. (You may return a land you control to its owner's hand in addition to any other costs as you cast this spell.)\nTarget creature you control deals damage equal to its power to target creature an opponent controls. If this spell was kicked, the creature you control deals twice that much damage instead.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomReturnToHand",
+                    "filter": "land"
+                }
+            }
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": "WasKicked"
+            },
+            "then": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "multiplier": 2
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "creature an opponent controls"
+                },
+                "damageSource": {
+                    "type": "BoundVariable",
+                    "name": "creature you control"
+                }
+            },
+            "otherwise": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "EntityProperty",
+                    "entity": "Target",
+                    "numericProperty": "Power"
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "creature an opponent controls"
+                },
+                "damageSource": {
+                    "type": "BoundVariable",
+                    "name": "creature you control"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Ben Wootten",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff8c8be0-8223-499c-8704-cb68e0a42ce2.jpg?1748706427"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Chocobo Racetrack
 {
     "name": "Chocobo Racetrack",
@@ -2066,6 +2155,121 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Elixir
+{
+    "name": "Elixir",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters tapped.\n{5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library. You gain life equal to the number of cards shuffled into your library this way.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "nonland"
+                            },
+                            "storeAs": "shuffled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "shuffled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Shuffled"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "VariableReference",
+                                "variableName": "shuffled_count"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library. You gain life equal to the number of cards shuffled into your library this way."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "UNCOMMON",
+        "artist": "Takeuchi Moto",
+        "flavorText": "Fully recovers HP and MP.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4b05d37-df62-475c-8371-735ed2fa1b05.jpg?1748706750"
+    },
+    "colorIdentityOverride": []
+}
+
+// Ether
+{
+    "name": "Ether",
+    "manaCost": "{3}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLUE"
+                        },
+                        "CopyNextSpellCast"
+                    ]
+                },
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Wootten",
+        "flavorText": "Restores 20 MP.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/896ee6e9-15a9-4974-b576-50f4759fac38.jpg?1748705952"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4957,6 +5161,77 @@
     ]
 }
 
+// Self-Destruct
+{
+    "name": "Self-Destruct",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control deals X damage to any other target and X damage to itself, where X is its power.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any other target"
+                    },
+                    "damageSource": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    },
+                    "damageSource": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": "AnyTarget",
+                "id": "any other target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Liiga Smilshkalne",
+        "flavorText": "\"Hah! If I'd just left you in the lurch, I'd look like a jerk for all of history!\"\n—Gilgamesh",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7661003c-bf83-46bb-bcc0-8fbf5819ffa8.jpg?1748706346"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Sephiroth's Intervention
 {
     "name": "Sephiroth's Intervention",
@@ -5116,6 +5391,59 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Sleep Magic
+{
+    "name": "Sleep Magic",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen enchanted creature is dealt damage, sacrifice this Aura.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "DamageReceivedEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "SacrificeTarget",
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Le Vuong",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c96cae63-7625-48e3-aaba-5b1632a8642d.jpg?1748706038"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChocoboKickScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChocoboKickScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chocobo Kick (FIN #178) — {1}{G} Sorcery.
+ *
+ * "Kicker—Return a land you control to its owner's hand.
+ *  Target creature you control deals damage equal to its power to target creature an opponent
+ *  controls. If this spell was kicked, the creature you control deals twice that much damage
+ *  instead."
+ *
+ * Tests the unkicked one-sided "fight": the controlled creature deals damage equal to its power to
+ * the opposing creature, and the dealer takes none back. Composes ConditionalEffect(WasKicked, …)
+ * + DealDamage(targetPower(0), source = controlled creature); no new SDK.
+ */
+class ChocoboKickScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("unkicked: 3-power creature deals 3 damage to the opposing 2/2, killing it; dealer survives") {
+        val driver = newDriver()
+        val yours = driver.putCreatureOnBattlefield(driver.player1, "Hill Giant") // 3/3
+        val theirs = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears") // 2/2
+
+        val kick = driver.putCardInHand(driver.player1, "Chocobo Kick")
+        driver.giveMana(driver.player1, Color.GREEN, 1)
+        driver.giveColorlessMana(driver.player1, 1)
+        driver.castSpell(driver.player1, kick, listOf(yours, theirs)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 3 damage to a 2/2 is lethal; the 3/3 dealer takes nothing back and survives.
+        driver.findPermanent(driver.player2, "Grizzly Bears") shouldBe null
+        driver.findPermanent(driver.player1, "Hill Giant") shouldBe yours
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElixirScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElixirScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Elixir (FIN #256) — {1} Artifact.
+ *
+ * "This artifact enters tapped.
+ *  {5}, {T}, Exile this artifact: Shuffle all nonland cards from your graveyard into your library.
+ *  You gain life equal to the number of cards shuffled into your library this way."
+ *
+ * Verifies the filtered shuffle (lands stay in the graveyard) and that the life gained equals the
+ * number of nonland cards moved.
+ */
+class ElixirScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("shuffles only nonland cards into library and gains life equal to the count") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        // Three nonland cards + two lands in the graveyard.
+        driver.putCardInGraveyard(me, "Grizzly Bears")
+        driver.putCardInGraveyard(me, "Hill Giant")
+        driver.putCardInGraveyard(me, "Shock")
+        driver.putCardInGraveyard(me, "Forest")
+        driver.putCardInGraveyard(me, "Forest")
+
+        val elixir = driver.putPermanentOnBattlefield(me, "Elixir")
+        driver.untapPermanent(elixir)
+
+        val startingLife = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Elixir").activatedAbilities[0].id
+
+        driver.giveColorlessMana(me, 5)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = elixir,
+                abilityId = abilityId
+            )
+        )
+        driver.bothPass()
+
+        // Gained life equal to the three nonland cards shuffled in.
+        driver.getLifeTotal(me) shouldBe startingLife + 3
+
+        // The two lands remain in the graveyard.
+        val graveyard = driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD))
+            .mapNotNull { driver.state.getEntity(it)?.get<CardComponent>()?.name }
+        graveyard.count { it == "Forest" } shouldBe 2
+        graveyard.contains("Grizzly Bears") shouldBe false
+        graveyard.contains("Hill Giant") shouldBe false
+        graveyard.contains("Shock") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EtherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EtherScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ether (FIN #53) — {3}{U} Artifact.
+ *
+ * "{T}, Exile this artifact: Add {U}. When you next cast an instant or sorcery spell this turn,
+ *  copy that spell. You may choose new targets for the copy."
+ *
+ * The ability is a mana ability (it adds {U}, has no target, doesn't use the stack) that also sets
+ * up a one-shot "copy your next instant/sorcery this turn" rider. Here, after activating it, casting
+ * Shock (2 damage) at the opponent copies the spell, so the opponent takes 4 total.
+ */
+class EtherScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("activating Ether copies the next instant cast, doubling Shock's damage") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val ether = driver.putPermanentOnBattlefield(me, "Ether")
+        driver.untapPermanent(ether)
+
+        val abilityId = driver.cardRegistry.requireCard("Ether").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(playerId = me, sourceId = ether, abilityId = abilityId)
+        )
+
+        val startingLife = driver.getLifeTotal(opp)
+
+        // Cast Shock at the opponent (its {R} cost is paid from the {R} we give here).
+        val shock = driver.putCardInHand(me, "Shock")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, shock, listOf(opp)).isSuccess shouldBe true
+
+        // Resolve the copy (keeping the opponent as its target) and the original Shock.
+        var guard = 0
+        while (driver.stackSize > 0 && guard < 20) {
+            if (driver.state.pendingDecision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(me, listOf(opp))
+            } else {
+                driver.bothPass()
+            }
+            guard++
+        }
+
+        // 2 (original Shock) + 2 (copy) = 4 damage to the opponent.
+        driver.getLifeTotal(opp) shouldBe startingLife - 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfDestructScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfDestructScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Self-Destruct (FIN #157) — {1}{R} Instant.
+ *
+ * "Target creature you control deals X damage to any other target and X damage to itself, where X
+ *  is its power."
+ *
+ * The controlled creature is the damage source for both prongs and X is read off its power. Here a
+ * 3/3 deals 3 to a 2/2 (killing it) and 3 to itself (killing itself).
+ */
+class SelfDestructScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("3/3 deals 3 to the opposing 2/2 and 3 to itself — both die") {
+        val driver = newDriver()
+        val yours = driver.putCreatureOnBattlefield(driver.player1, "Hill Giant") // 3/3
+        val theirs = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears") // 2/2
+
+        val boom = driver.putCardInHand(driver.player1, "Self-Destruct")
+        driver.giveMana(driver.player1, Color.RED, 1)
+        driver.giveColorlessMana(driver.player1, 1)
+        driver.castSpell(driver.player1, boom, listOf(yours, theirs)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(driver.player2, "Grizzly Bears") shouldBe null
+        driver.findPermanent(driver.player1, "Hill Giant") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SleepMagicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SleepMagicScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sleep Magic (FIN #74) — {U} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  When this Aura enters, tap enchanted creature.
+ *  Enchanted creature doesn't untap during its controller's untap step.
+ *  When enchanted creature is dealt damage, sacrifice this Aura."
+ *
+ * Verifies the ETB tap and the "released on damage" trigger: when the enchanted creature is dealt
+ * damage (here by a Shock), the Aura is sacrificed.
+ */
+class SleepMagicScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Resolve everything on the stack (the spell, then any triggered abilities it produced).
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (stackSize > 0 && guard < 20) {
+            bothPass()
+            guard++
+        }
+    }
+
+    test("ETB taps the enchanted creature, and damaging it sacrifices the Aura") {
+        val driver = newDriver()
+        val creature = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        val aura = driver.putCardInHand(driver.player1, "Sleep Magic")
+        driver.giveMana(driver.player1, Color.BLUE, 1)
+        driver.castSpell(driver.player1, aura, listOf(creature)).isSuccess shouldBe true
+        driver.resolveStack()
+
+        // ETB trigger taps the enchanted creature, and the Aura is attached.
+        driver.isTapped(creature) shouldBe true
+        driver.findPermanent(driver.player1, "Sleep Magic") shouldBe aura
+
+        // Deal damage to the enchanted creature: Shock it.
+        val shock = driver.putCardInHand(driver.player1, "Shock")
+        driver.giveMana(driver.player1, Color.RED, 1)
+        driver.castSpell(driver.player1, shock, listOf(creature)).isSuccess shouldBe true
+        driver.resolveStack()
+
+        // The "when enchanted creature is dealt damage" trigger sacrifices the Aura.
+        driver.findPermanent(driver.player1, "Sleep Magic") shouldBe null
+    }
+})


### PR DESCRIPTION
Implements five Final Fantasy (FIN) cards from the instants/sorceries batch, all using existing SDK primitives — no new engine/SDK features were required.

## Cards implemented
- **Chocobo Kick** ({1}{G} Sorcery) — Kicker (return a land you control to its owner's hand). Target creature you control deals damage equal to its power to a target opponent creature; doubled if kicked. Modeled with `KeywordAbility.kicker(Costs.additional.ReturnToHand(Land))` + `ConditionalEffect(WasKicked, …)` branching the `DealDamage` amount between `targetPower(0)` and `Multiply(targetPower(0), 2)`.
- **Self-Destruct** ({1}{R} Instant) — Target creature you control deals X damage to any other target and X to itself, X = its power. Uses `TargetOther(AnyTarget())` so the second target must differ from the controlled creature; the creature is the `damageSource` for both prongs.
- **Sleep Magic** ({U} Aura) — Enchant creature; ETB tap; doesn't untap (`GrantKeyword(DOESNT_UNTAP)`); and a `takesDamage(binding = ATTACHED)` trigger that sacrifices the Aura when the enchanted creature is dealt damage. Same shape as Charmed Sleep plus the damage-release trigger.
- **Elixir** ({1} Artifact) — Enters tapped (`EntersTapped`). `{5}, {T}, Exile`: a filtered Gather→Move pipeline shuffles only **nonland** graveyard cards into the library, then gains life equal to the count moved (`VariableReference("shuffled_count")`). Lands stay in the graveyard.
- **Ether** ({3}{U} Artifact) — `{T}, Exile`: add {U} and set up `CopyNextSpellCast()` for the next instant/sorcery this turn. Authored as a mana ability (`manaAbility = true`) per the official ruling that "Ether's ability is a mana ability."

## Cards skipped
None — all five were implementable with existing primitives.

## Tests run
- Added scenario tests for all five cards in `rules-engine` (`ChocoboKickScenarioTest`, `SelfDestructScenarioTest`, `SleepMagicScenarioTest`, `ElixirScenarioTest`, `EtherScenarioTest`) — all pass.
- Re-blessed the FIN card snapshot (`CardDefinitionSnapshotTest`); diff shows only the five new card trees added, nothing else moved.
- `CardLintTest` passes.
- `just check-card-printing` confirms FIN is the canonical (earliest real) printing for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)