### PR TITLE
DSK: spells & removal batch

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -922,7 +922,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   in `from` matching it (the rest stay), letting one revealed pile be split by type in successive
   steps — e.g. revealed lands → battlefield tapped, the rest → graveyard/library (Sméagol, Galadriel
   of Lothlórien, The Ring Goes South). (Equivalent to a `FilterCollection` partition; the inline
-  filter just avoids naming an intermediate collection.)
+  filter just avoids naming an intermediate collection.) `storeMovedAs = "<key>"` captures the
+  resulting entity ids under a pipeline collection; `markEnteredViaSourceAbility = true` stamps each
+  card that lands on the battlefield with `EnteredViaAbilityComponent(this source)` so a later
+  `GatherCards(CardSource.EnteredViaThisResolution)` can re-collect them from live battlefield state.
 - `ChangeTargetEffect(spell, newTarget)` — change a spell's target.
 - `ChangeSpellTargetEffect(spell, filter)` — same, filtered.
 - `ReselectTargetRandomlyEffect(spell)` — re-choose targets at random.
@@ -1244,9 +1247,16 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `manifest(count = 1)` — manifest the top N cards (CR 701.40): each is put onto the battlefield
   face down as a 2/2 creature (one at a time). A manifested creature card can be turned face up for
   its mana cost; a manifested non-creature can't.
-- `manifestDread()` — "Manifest dread" (CR 701.62, Duskmourn): look at the top two cards of your
-  library, manifest one of them (your choice), and put the other into your graveyard. Composes
-  gather → select → move-face-down(MANIFEST) → move-to-graveyard.
+- `manifestDread(markEntered = false)` — "Manifest dread" (CR 701.62, Duskmourn): look at the top
+  two cards of your library, manifest one of them (your choice), and put the other into your
+  graveyard. Composes gather → select → move-face-down(MANIFEST) → move-to-graveyard. Pass
+  `markEntered = true` to stamp each manifested permanent with `EnteredViaAbilityComponent(this
+  source)`, so wrapping it in `RepeatDynamicTimes(X, manifestDread(markEntered = true))` lets a later
+  `GatherCards(CardSource.EnteredViaThisResolution)` re-collect every creature this spell manifested
+  (across all X iterations and the per-iteration manifest-dread pick pauses) and reference "each of
+  those creatures" — e.g. **Valgavoth's Onslaught**: `RepeatDynamicTimes(XValue, manifestDread(true))`
+  → `GatherCards(EnteredViaThisResolution, "manifested")` → `AddCountersToCollection("manifested",
+  +1/+1, XValue)`.
 
 **Reveal patterns**
 
@@ -1436,6 +1446,14 @@ effect = Effects.Pipeline {
   those cards" (Fortune, Loyal Steed): `gather(CreaturesThatSaddledSource)` → `chooseUpTo(1)` →
   exile linked to the Mount alongside `CardSource.Self` → `gather(FromLinkedExile())` → return
   under owners' control.
+- `CardSource.EnteredViaThisResolution` — every permanent this resolving spell/ability put onto the
+  battlefield, found by the `EnteredViaAbilityComponent(this source)` stamp that a
+  `MoveCollection(markEnteredViaSourceAbility = true)` leaves (restricted to permanents still on the
+  battlefield). Reads live battlefield state rather than a pipeline collection, so it survives the
+  pauses of a multi-step resolution and the per-iteration contexts of a `RepeatDynamicTimes` body.
+  Backs "manifest dread X times, then put X +1/+1 counters on each of those creatures" (Valgavoth's
+  Onslaught): `RepeatDynamicTimes(XValue, manifestDread(markEntered = true))` →
+  `gather(EnteredViaThisResolution)` → `AddCountersToCollection(+1/+1, XValue)`.
 
 A card needing a genuinely **new step semantic** (a new capture kind, a new decision shape) still
 adds the `Effect` + executor first (`add-feature`); the builder only composes the existing

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -126,7 +126,7 @@ object LibraryPatterns {
      * the library the gather simply yields what's there (one card → manifest it, nothing to the
      * graveyard; empty library → nothing happens).
      */
-    fun manifestDread(): CompositeEffect = CompositeEffect(
+    fun manifestDread(markEntered: Boolean = false): CompositeEffect = CompositeEffect(
         listOf(
             GatherCardsEffect(
                 source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2)),
@@ -144,7 +144,13 @@ object LibraryPatterns {
             MoveCollectionEffect(
                 from = "manifestDreadManifested",
                 destination = CardDestination.ToZone(Zone.BATTLEFIELD),
-                faceDown = FaceDownMode.MANIFEST
+                faceDown = FaceDownMode.MANIFEST,
+                // Stamp the manifested permanent with EnteredViaAbilityComponent(this source) so a
+                // later CardSource.EnteredViaThisResolution gather can collect every creature this
+                // spell manifested — even across the manifest-dread pick pauses and a
+                // RepeatDynamicTimes body — backing "manifest dread X times, then put X +1/+1
+                // counters on each of those creatures" (Valgavoth's Onslaught).
+                markEnteredViaSourceAbility = markEntered
             ),
             MoveCollectionEffect(
                 from = "manifestDreadGraveyard",

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -231,6 +231,25 @@ sealed interface CardSource {
     data object CreaturesThatSaddledSource : CardSource {
         override val description: String = "creatures that saddled it this turn"
     }
+
+    /**
+     * Every permanent that was put onto the battlefield by *this* resolving spell or ability, read
+     * off the `EnteredViaAbilityComponent(sourceId == context.sourceId)` stamp left by a
+     * [MoveCollectionEffect] with `markEnteredViaSourceAbility = true`. Restricted to permanents
+     * still on the battlefield.
+     *
+     * Unlike accumulating into a pipeline collection, this reads *live battlefield state*, so it
+     * survives the pauses a multi-step resolution makes (e.g. a manifest-dread pick) and a
+     * `RepeatDynamicTimes` body — every iteration's permanent carries the same stamp. Backs
+     * "manifest dread X times, then put X +1/+1 counters on each of *those* creatures"
+     * (Valgavoth's Onslaught): `RepeatDynamicTimes(X, manifestDread(markEntered = true))` →
+     * `GatherCards(EnteredViaThisResolution)` → `AddCountersToCollection(...)`.
+     */
+    @SerialName("EnteredViaThisResolution")
+    @Serializable
+    data object EnteredViaThisResolution : CardSource {
+        override val description: String = "permanents put onto the battlefield this way"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/JumpScare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/JumpScare.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jump Scare
+ * {W}
+ * Instant
+ * Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror
+ * enchantment creature in addition to its other types.
+ *
+ * A single until-end-of-turn buff on one target creature, composed from atomic effects:
+ *   +2/+2 (ModifyStats, EndOfTurn) + grant flying (GrantKeyword) + add the "Horror" creature
+ *   subtype + add the "enchantment" card type. The creature already has the creature type, so
+ *   the type changes ("becomes a Horror enchantment creature in addition to its other types")
+ *   reduce to adding the Horror subtype and the enchantment card type for the turn. All four
+ *   pieces use [Duration.EndOfTurn] so they expire together in the cleanup step.
+ */
+val JumpScare = card("Jump Scare") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature gets +2/+2, gains flying, and becomes a " +
+        "Horror enchantment creature in addition to its other types."
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.Composite(
+            listOf(
+                Effects.ModifyStats(2, 2, target = EffectTarget.ContextTarget(0), duration = Duration.EndOfTurn),
+                Effects.GrantKeyword(Keyword.FLYING, target = EffectTarget.ContextTarget(0), duration = Duration.EndOfTurn),
+                Effects.AddCreatureType("Horror", target = EffectTarget.ContextTarget(0), duration = Duration.EndOfTurn),
+                Effects.AddCardType("ENCHANTMENT", target = EffectTarget.ContextTarget(0), duration = Duration.EndOfTurn)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "John Tedrick"
+        flavorText = "\"Boo!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg?1726285919"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TrialOfAgony.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TrialOfAgony.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trial of Agony
+ * {R}
+ * Sorcery
+ * Choose two target creatures controlled by the same opponent. That player chooses one of
+ * those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block
+ * this turn.
+ *
+ * Same Gather/Select/split shape as Barrin's Spite, with two differences: the two targets must
+ * be controlled by the *same opponent* (TargetCreature with `sameController` + the
+ * opponent-controls filter), and the split effects are "deal 5 damage to the chosen one" plus
+ * "the other can't block this turn" instead of sacrifice/bounce.
+ *
+ *   Gather(ChosenTargets) → SelectFromCollection (the targets' controller — the opponent — picks
+ *   one, the remainder is "the other") → DealDamage 5 to the chosen → CantBlock the other.
+ *
+ * Fizzle handling falls out of the pipeline for free, as in Barrin's Spite: the stack resolver
+ * strips illegal targets before the effect runs, so if only one of the two targets survives,
+ * the gathered collection holds just that creature. ChooseExactly(1) auto-picks it for the 5
+ * damage and the (empty) remainder applies can't-block to nothing.
+ */
+val TrialOfAgony = card("Trial of Agony") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose two target creatures controlled by the same opponent. That player " +
+        "chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and " +
+        "the other can't block this turn."
+
+    spell {
+        target = TargetCreature(
+            count = 2,
+            sameController = true,
+            filter = TargetFilter.CreatureOpponentControls
+        )
+        effect = Effects.Composite(
+            listOf(
+                // 1. Reference the two targeted creatures.
+                GatherCardsEffect(
+                    source = CardSource.ChosenTargets,
+                    storeAs = "trialCreatures"
+                ),
+                // 2. Their controller (the opponent) chooses one; the other is the remainder.
+                SelectFromCollectionEffect(
+                    from = "trialCreatures",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.ControllerOfSelection,
+                    storeSelected = "trialChosen",
+                    storeRemainder = "trialOther",
+                    useTargetingUI = true,
+                    prompt = "Choose one of the two creatures to take 5 damage"
+                ),
+                // 3. Trial of Agony deals 5 damage to the chosen creature.
+                Effects.DealDamage(5, EffectTarget.PipelineTarget("trialChosen", 0)),
+                // 4. The other can't block this turn.
+                ForEachInCollectionEffect(
+                    collection = "trialOther",
+                    effect = Effects.CantBlock(EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Mike Sass"
+        flavorText = "All it took to shatter their lifelong bond was a scrap of hope."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg?1726286448"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothsOnslaught.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothsOnslaught.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Valgavoth's Onslaught
+ * {X}{X}{G}
+ * Sorcery
+ * Manifest dread X times, then put X +1/+1 counters on each of those creatures.
+ *
+ * The `{X}{X}` cost means the player pays 2X generic mana, but the *chosen value* of X (read via
+ * [DynamicAmount.XValue]) is what drives the effect — same convention as Devastating Onslaught /
+ * Another Round. So with X=3 the spell costs {6}{G}, manifests dread 3 times, then puts 3 +1/+1
+ * counters on each of the 3 manifested creatures.
+ *
+ * Resolution:
+ *   - [RepeatDynamicTimesEffect] runs [Patterns.Library.manifestDread] X times with
+ *     `markEntered = true`, so each manifested permanent is stamped as "entered via this spell".
+ *   - [GatherCardsEffect] from [CardSource.EnteredViaThisResolution] then collects *all* of those
+ *     manifested creatures — it reads live battlefield state, so it survives the manifest-dread
+ *     pick pauses and the per-iteration contexts of RepeatDynamicTimes (where a pipeline-collection
+ *     accumulator would be overwritten each iteration).
+ *   - [Effects.AddCountersToCollection] puts X +1/+1 counters on each gathered creature —
+ *     "each of those creatures".
+ *
+ * Edge cases: with X=0 nothing happens (RepeatDynamicTimes no-ops, the gather is empty, no
+ * counters); a manifest dread with fewer than two cards in the library manifests what's there
+ * (CR 701.62); a manifested creature that has left the battlefield before counters are placed is
+ * not gathered (the source restricts to permanents still on the battlefield).
+ */
+val ValgavothsOnslaught = card("Valgavoth's Onslaught") {
+    manaCost = "{X}{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Manifest dread X times, then put X +1/+1 counters on each of those creatures. " +
+        "(To manifest dread, look at the top two cards of your library, then put one onto the " +
+        "battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face " +
+        "up any time for its mana cost if it's a creature card.)"
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                RepeatDynamicTimesEffect(
+                    amount = DynamicAmount.XValue,
+                    body = Patterns.Library.manifestDread(markEntered = true)
+                ),
+                GatherCardsEffect(
+                    source = CardSource.EnteredViaThisResolution,
+                    storeAs = "valgavothManifested"
+                ),
+                Effects.AddCountersToCollection(
+                    collectionName = "valgavothManifested",
+                    counterType = Counters.PLUS_ONE_PLUS_ONE,
+                    amount = DynamicAmount.XValue
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "Lie Setiawan"
+        flavorText = "Tyvar and the Wanderer were done running."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg?1726286630"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -6596,6 +6596,75 @@
     ]
 }
 
+// Jump Scare
+{
+    "name": "Jump Scare",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror enchantment creature in addition to its other types.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "AddCreatureType",
+                    "subtype": "Horror",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "AddCardType",
+                    "cardType": "ENCHANTMENT",
+                    "duration": "EndOfTurn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "John Tedrick",
+        "flavorText": "\"Boo!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg?1726285919"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Killer's Mask
 {
     "name": "Killer's Mask",
@@ -11333,6 +11402,84 @@
     ]
 }
 
+// Trial of Agony
+{
+    "name": "Trial of Agony",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "trialCreatures"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "trialCreatures",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "chooser": "ControllerOfSelection",
+                    "storeSelected": "trialChosen",
+                    "storeRemainder": "trialOther",
+                    "prompt": "Choose one of the two creatures to take 5 damage",
+                    "useTargetingUI": true
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "PipelineTarget",
+                        "collectionName": "trialChosen"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "trialOther"
+                    },
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "sameController": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Sass",
+        "flavorText": "All it took to shatter their lifelong bond was a scrap of hope.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg?1726286448"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tunnel Surveyor
 {
     "name": "Tunnel Surveyor",
@@ -12528,6 +12675,95 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Valgavoth's Onslaught
+{
+    "name": "Valgavoth's Onslaught",
+    "manaCost": "{X}{X}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Manifest dread X times, then put X +1/+1 counters on each of those creatures. (To manifest dread, look at the top two cards of your library, then put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RepeatDynamicTimes",
+                    "amount": "XValue",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "manifestDreadLooked"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "manifestDreadLooked",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "manifestDreadManifested",
+                                "storeRemainder": "manifestDreadGraveyard",
+                                "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                "remainderLabel": "Put into your graveyard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadManifested",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "faceDown": "MANIFEST",
+                                "markEnteredViaSourceAbility": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": "EnteredViaThisResolution",
+                    "storeAs": "valgavothManifested"
+                },
+                {
+                    "type": "AddCountersToCollection",
+                    "collectionName": "valgavothManifested",
+                    "counterType": "+1/+1",
+                    "amount": "XValue"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "flavorText": "Tyvar and the Wanderer were done running.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg?1726286630"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Vanish from Sight

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -217,6 +217,20 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                     ?.filter { it in battlefield }
                     ?: emptyList()
             }
+
+            is CardSource.EnteredViaThisResolution -> {
+                // Permanents this resolving spell/ability put onto the battlefield, identified by the
+                // EnteredViaAbilityComponent stamp (markEnteredViaSourceAbility) referencing this
+                // source. Reads live battlefield state, so it survives the pauses of a multi-step
+                // resolution and a RepeatDynamicTimes body (Valgavoth's Onslaught).
+                val sourceId = context.sourceId
+                    ?: return EffectResult.error(state, "No source entity for EnteredViaThisResolution")
+                state.getBattlefield().filter { entityId ->
+                    state.getEntity(entityId)
+                        ?.get<com.wingedsheep.engine.state.components.battlefield.EnteredViaAbilityComponent>()
+                        ?.sourceId == sourceId
+                }
+            }
         }
 
         if (cards.isEmpty()) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JumpScareScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JumpScareScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Jump Scare ({W} instant) — Duskmourn: House of Horror.
+ *
+ * "Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror enchantment
+ * creature in addition to its other types."
+ *
+ * Composed from atomic until-end-of-turn effects (ModifyStats + GrantKeyword + AddCreatureType +
+ * AddCardType). Verifies all four pieces apply together and that they expire at end of turn.
+ */
+class JumpScareScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+    }
+
+    test("grants +2/+2, flying, Horror subtype, and enchantment type until end of turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A vanilla 3/3 with no evasion to start.
+        val courser = d.putCreatureOnBattlefield(you, "Centaur Courser")
+        d.state.projectedState.getPower(courser) shouldBe 3
+        d.state.projectedState.getToughness(courser) shouldBe 3
+        d.state.projectedState.hasKeyword(courser, Keyword.FLYING) shouldBe false
+        d.state.projectedState.hasType(courser, "ENCHANTMENT") shouldBe false
+
+        val spell = d.putCardInHand(you, "Jump Scare")
+        d.giveMana(you, Color.WHITE, 1)
+        d.castSpell(you, spell, targets = listOf(courser))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // +2/+2 → 5/5, flying, Horror creature subtype, and enchantment card type, still a creature.
+        d.state.projectedState.getPower(courser) shouldBe 5
+        d.state.projectedState.getToughness(courser) shouldBe 5
+        d.state.projectedState.hasKeyword(courser, Keyword.FLYING) shouldBe true
+        d.state.projectedState.hasSubtype(courser, "Horror") shouldBe true
+        d.state.projectedState.hasType(courser, "ENCHANTMENT") shouldBe true
+        d.state.projectedState.isCreature(courser) shouldBe true
+
+        // Everything is "until end of turn" — pass into the next turn and the buffs are gone.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.state.projectedState.getPower(courser) shouldBe 3
+        d.state.projectedState.getToughness(courser) shouldBe 3
+        d.state.projectedState.hasKeyword(courser, Keyword.FLYING) shouldBe false
+        d.state.projectedState.hasSubtype(courser, "Horror") shouldBe false
+        d.state.projectedState.hasType(courser, "ENCHANTMENT") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrialOfAgonyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrialOfAgonyScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Trial of Agony ({R} sorcery) — Duskmourn: House of Horror.
+ *
+ * "Choose two target creatures controlled by the same opponent. That player chooses one of those
+ * creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn."
+ *
+ * Same Gather → Select(opponent chooses) → split shape as Barrin's Spite, with damage + can't-block
+ * as the split effects. Verifies the opponent makes the choice, the chosen creature takes 5 damage
+ * (dies if its toughness ≤ 5), and the other creature is barred from blocking that turn.
+ */
+class TrialOfAgonyScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+    }
+
+    test("opponent chooses one of two targets to take 5 damage; the other can't block") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two creatures controlled by the same opponent.
+        val a = d.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3
+        val b = d.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3
+
+        val spell = d.putCardInHand(you, "Trial of Agony")
+        d.giveMana(you, Color.RED, 1)
+        d.castSpell(you, spell, targets = listOf(a, b))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The targets' controller (the opponent) chooses which one takes the damage.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.playerId shouldBe opponent
+        pick.options.toSet() shouldBe setOf(a, b)
+
+        // Opponent sacrifices nothing here — they pick `a` to take the 5 damage.
+        d.submitDecision(opponent, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(a)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // `a` took 5 damage — a 3/3 dies as a state-based action and is in the graveyard.
+        d.getPermanents(opponent) shouldContainExactlyInAnyOrder listOf(b)
+
+        // `b` (the other, undamaged) carries the can't-block-this-turn restriction.
+        d.state.projectedState.cantBlock(b) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothsOnslaughtScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothsOnslaughtScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Valgavoth's Onslaught ({X}{X}{G}) — Duskmourn: House of Horror.
+ *
+ * "Manifest dread X times, then put X +1/+1 counters on each of those creatures."
+ *
+ * Exercises the manifest-dread accumulation capability: `RepeatDynamicTimes(XValue,
+ * manifestDread(accumulateInto = "valgavothManifested"))` grows one collection of every manifested
+ * permanent across all X iterations (via MoveCollection's `accumulateMoved` flag), and
+ * `AddCountersToCollection` then puts X +1/+1 counters on each of them. The chosen value of X (not
+ * the doubled {X}{X} mana) drives both the repeat count and the counter count.
+ */
+class ValgavothsOnslaughtScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    /** Resolve one manifest-dread pick (manifest the named card; bin the other). */
+    fun GameTestDriver.resolveManifestPick(you: EntityId, manifest: EntityId) {
+        val pick = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(manifest)))
+        while (!isPaused && state.stack.isNotEmpty()) bothPass()
+    }
+
+    test("X=2 manifests dread twice and puts 2 +1/+1 counters on each manifested creature") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top of library (top-most last): for the first manifest dread, look at [c1, land1];
+        // for the second, look at [c2, land2]. We manifest the creatures both times.
+        val land2 = d.putCardOnTopOfLibrary(you, "Forest")
+        val c2 = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+        val land1 = d.putCardOnTopOfLibrary(you, "Forest")
+        val c1 = d.putCardOnTopOfLibrary(you, "Centaur Courser") // current top card
+
+        // Cast with X=2 → {X}{X}{G} = {4}{G} = 5 mana (4 generic + 1 green).
+        val spell = d.putCardInHand(you, "Valgavoth's Onslaught")
+        d.giveMana(you, Color.GREEN, 5)
+        d.castXSpell(you, spell, xValue = 2)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // First manifest dread looks at the top two (c1 on top, land1 beneath); manifest c1.
+        d.resolveManifestPick(you, c1)
+        // Second manifest dread looks at the next two (c2, land2); manifest c2.
+        d.resolveManifestPick(you, c2)
+
+        // Both creatures manifested as face-down 2/2s, each then gets 2 +1/+1 counters → 4/4.
+        d.getPermanents(you).shouldContainAll(listOf(c1, c2))
+        for (creature in listOf(c1, c2)) {
+            val entity = d.state.getEntity(creature)
+            entity?.get<FaceDownComponent>() shouldBe FaceDownComponent
+            entity?.get<ManifestedComponent>() shouldBe ManifestedComponent
+            // base 2/2 + two +1/+1 counters = 4/4 (the counters landed on *each* manifested creature).
+            d.state.projectedState.getPower(creature) shouldBe 4
+            d.state.projectedState.getToughness(creature) shouldBe 4
+        }
+    }
+
+    test("X=0 manifests nothing and places no counters") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val permanentsBefore = d.getPermanents(you).toSet()
+
+        // X=0 → {G} = 1 green mana; RepeatDynamicTimes no-ops and the accumulator is empty.
+        val spell = d.putCardInHand(you, "Valgavoth's Onslaught")
+        d.giveMana(you, Color.GREEN, 1)
+        d.castXSpell(you, spell, xValue = 0)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isPaused shouldBe false
+        // No new manifested permanents entered the battlefield.
+        d.getPermanents(you).toSet() shouldBe permanentsBefore
+    }
+})


### PR DESCRIPTION
Implements a batch of Duskmourn: House of Horror spells.

## Cards

- **Jump Scare** ({W} instant) — implemented. Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror enchantment creature in addition to its other types. Composed from atomic until-end-of-turn effects (ModifyStats + GrantKeyword + AddCreatureType + AddCardType).
- **Trial of Agony** ({R} sorcery) — implemented. Choose two target creatures controlled by the same opponent; that opponent chooses one to take 5 damage, and the other can't block this turn. Same Gather → Select(opponent chooses) → split shape as Barrin's Spite, with damage + can't-block as the split effects.
- **Valgavoth's Onslaught** ({X}{X}{G} sorcery) — implemented. Manifest dread X times, then put X +1/+1 counters on each of those creatures (X is the chosen value, not the doubled mana).
- **Break Down the Door** — already implemented on main (assigned but pre-existing); not touched.
- **Sporogenic Infection** — already implemented on main (assigned but pre-existing); not touched.
- **Under the Skin** — already implemented on main (assigned but pre-existing); not touched.

All six assigned cards are now present in the set; this PR adds the three that were missing.

## SDK / engine additions

For Valgavoth's Onslaught's "X times, then each of those creatures":

- **New `CardSource.EnteredViaThisResolution`** — gathers every permanent this resolving spell/ability put onto the battlefield, via the existing `EnteredViaAbilityComponent` stamp that `MoveCollection(markEnteredViaSourceAbility = true)` leaves. It reads *live battlefield state*, so it survives the manifest-dread pick pauses and the per-iteration contexts of `RepeatDynamicTimes` — where a pipeline-collection accumulator would be overwritten each iteration. (An earlier `accumulateMoved`-flag approach was prototyped and discarded for exactly this fragility.)
- **`Patterns.Library.manifestDread(markEntered = false)`** gains an opt-in flag to apply that stamp. Default `false` leaves every existing caller unchanged (ManifestDread regression suite stays green).
- `docs/card-sdk-language-reference.md` updated for both the new source and the `manifestDread` parameter.

mtgish generator (Step 8b): no bridge/emitter change — the base `ManifestDread` IR tag already has a handler, and the "manifest dread N times + counters" shape is an X-carrying composition the emitter declines to render whole. The new `CardSource` is internal plumbing with no standalone IR tag.

## Tests

rules-engine scenario tests (all green):
- `JumpScareScenarioTest` — all four pieces apply together; everything expires at end of turn.
- `TrialOfAgonyScenarioTest` — the opponent makes the choice, the chosen 3/3 takes 5 (dies as an SBA), the other carries can't-block-this-turn.
- `ValgavothsOnslaughtScenarioTest` — X=2 manifests dread twice and each manifested creature becomes a 4/4; X=0 is a no-op.
- `ManifestDreadScenarioTest` regression suite unchanged and passing.

DSK card snapshot re-blessed (diff is exactly the three new cards). `just check-card-printing` confirms DSK as the canonical earliest printing for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)