### PR TITLE
TMT: foundation commons + Mutagen token & Disappear (18 cards)

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -246,32 +246,30 @@ Still to author (3 — each blocked on a SECOND gap, NOT pure authoring):
 `Michelangelo's Technique` (aggregate total-MV-≤6 selection). See the corrected
 Sneak bullet in the Status section above; each needs its own `add-feature` PR.
 
-### Gap B — Disappear (ability-word trigger with "a permanent left the battlefield under your control this turn" condition) — 9 cards
-**Engine change:** generalize the existing `nonlandPermanentLeftBattlefieldThisTurn`
-flag and add a Condition usable inside any triggered ability.
+### Gap B — Disappear — RESOLVED (no engine change needed; the premise below was wrong)
+**Engine change: NONE.** The earlier premise — that only a *global, nonland-only*
+flag existed — was incorrect. A **per-controller, all-permanent** tracker already
+ships: `PermanentLeftBattlefieldThisTurnComponent(count)` on each player, set in
+`ZoneTransitionService` for every permanent (lands and tokens included) that leaves
+that player's battlefield, credited to the last-known controller, and cleared at
+cleanup. The matching Condition (`PermanentLeftBattlefieldThisTurn(Player.You)`,
+DSL `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`) already reads it for the
+ability's controller in both resolution and projection — it is exactly "if a
+permanent left the battlefield under your control this turn" and is what LTR
+Shortcut to Mushrooms uses. Wire it as `triggerCondition` (the intervening-if, CR
+603.4) on the existing `Triggers.EntersBattlefield` / `Triggers.YourEndStep`.
 
-Required pieces:
-1. **Per-player, all-permanent tracking.** The current flag in `GameState` is global and
-   nonland-only (used by EOE's Void / Spellwarp). Disappear needs **any** permanent
-   (lands included) that left the battlefield while under that **player's** control,
-   per-turn. Suggested rename / addition:
-   `permanentLeftBattlefieldThisTurnByController: Map<PlayerId, Boolean>` set in
-   `ZoneTransitionService` whenever a permanent moves out of the battlefield (destroy,
-   sacrifice, exile, bounce, phase-out). Existing Void uses can keep reading the
-   nonland-restricted flag or migrate; do not silently change Void's filter.
-2. **`Condition.PermanentLeftBattlefieldUnderYourControlThisTurn`** that reads the
-   per-controller map for the triggered ability's controller.
-3. The triggers themselves are existing primitives (`Triggers.EtbSelf`,
-   `Triggers.AtYourEndStep`, and an enters-with-counters static for `Putrid Pals`).
-   Wire them with the new condition and the existing effect library.
+Shipped composably (4 pure): `Foot Mystic` (ETB → 1/1 black Ninja token),
+`Insectoid Exterminator` (end step → scry 1), `Michelangelo, Game Master`
+(end step → +1/+1 counter on self), `Putrid Pals` (enters-with-two-counters via
+the Benalish Lancer conditional-ETB-counters idiom).
 
-Triggers used across the 9 cards:
-- End-step (7): `Insectoid Exterminator`, `Lord Dregg, Insect Invader`,
-  `Rat King, Verminister`, `Michelangelo, Game Master`, `West Wind Avatar`,
-  `Krang & Shredder`, `Pizza Face, Gastromancer`
-- ETB (1): `Foot Mystic`
-- "Enters with two +1/+1 counters if ..." (1): `Putrid Pals` — needs
-  `entersWith(counters, condition)` if not already supported.
+Still blocked, but on a *second* gap (Disappear itself is no longer the holdup):
+- End-step Disappear + secondary gap: `Lord Dregg, Insect Invader` (Sacrifice-a-
+  token cost — Gap M), `Rat King, Verminister` (same-name reanimate — Gap M),
+  `West Wind Avatar` (token-or-land sac filter — Gap M), `Krang & Shredder`
+  (reveal-until + cast-from-exile chain — Gap M), `Pizza Face, Gastromancer`
+  (type-grant on a non-creature — Gap M).
 
 ### Gap C — Alliance (ability-word trigger) — partly RESOLVED
 **Engine change:** still none required for behavior — `Triggers.OtherCreatureEnters`

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 125 / 190
+**Implemented:** 129 / 190
 ---
 
 - [x] Action News Crew
@@ -47,7 +47,7 @@
 - [x] Featherbrained Filcher
 - [x] Foot Elite
 - [x] Foot Headquarters
-- [ ] Foot Mystic
+- [x] Foot Mystic
 - [x] Foot Ninjas
 - [x] Frog Butler
 - [ ] Fugitive Droid
@@ -64,7 +64,7 @@
 - [x] Ice Cream Kitty
 - [x] Illegitimate Business
 - [x] Improvised Arsenal
-- [ ] Insectoid Exterminator
+- [x] Insectoid Exterminator
 - [x] Jennika's Technique
 - [x] Jennika, Bad Apple Big Sister
 - [x] Karai's Technique
@@ -91,7 +91,7 @@
 - [x] Mechanized Ninja Cavalry
 - [x] Metalhead
 - [ ] Michelangelo's Technique
-- [ ] Michelangelo, Game Master
+- [x] Michelangelo, Game Master
 - [x] Michelangelo, Improviser
 - [ ] Michelangelo, Mutant BFF
 - [ ] Michelangelo, Weirdness to 11
@@ -128,7 +128,7 @@
 - [x] Primordial Pachyderm
 - [x] Punk Frogs
 - [ ] Purple Dragon Punks
-- [ ] Putrid Pals
+- [x] Putrid Pals
 - [x] Quintessential Katana
 - [x] Ragamuffin Raptor
 - [x] Raph & Leo, Sibling Rivals

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 136 / 190
+**Implemented:** 137 / 190
 ---
 
 - [x] Action News Crew
@@ -53,7 +53,7 @@
 - [ ] Fugitive Droid
 - [x] General Traag, Heart of Stone
 - [x] Genghis Frog
-- [ ] Go Ninja Go
+- [x] Go Ninja Go
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
 - [x] Guac & Marshmallow Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 119 / 190
+**Implemented:** 120 / 190
 ---
 
 - [x] Action News Crew
@@ -26,7 +26,7 @@
 - [ ] Cool but Rude
 - [ ] Courier of Comestibles
 - [x] Cowabunga!
-- [ ] Crustacean Commando
+- [x] Crustacean Commando
 - [x] Dark Leo & Shredder
 - [x] Death in the Family
 - [x] Dimension X

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 129 / 190
+**Implemented:** 130 / 190
 ---
 
 - [x] Action News Crew
@@ -84,7 +84,7 @@
 - [ ] Leonardo, Sewer Samurai
 - [x] Lessons from Life
 - [ ] Lita, Little Orphan Amphibian
-- [ ] Lord Dregg, Insect Invader
+- [x] Lord Dregg, Insect Invader
 - [ ] Madame Null, Power Broker
 - [x] Make Your Move
 - [x] Manhole Missile

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 130 / 190
+**Implemented:** 131 / 190
 ---
 
 - [x] Action News Crew
@@ -123,7 +123,7 @@
 - [x] Pain 101
 - [ ] Paramecia Coloniex
 - [ ] Party Dude
-- [ ] Pizza Face, Gastromancer
+- [x] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet
 - [x] Primordial Pachyderm
 - [x] Punk Frogs

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 124 / 190
+**Implemented:** 125 / 190
 ---
 
 - [x] Action News Crew
@@ -105,7 +105,7 @@
 - [x] Mouser Foundry
 - [x] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze
-- [ ] Mutant Chain Reaction
+- [x] Mutant Chain Reaction
 - [x] Mutant Town
 - [x] Mutant Town Musicians
 - [x] Negate

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 135 / 190
+**Implemented:** 136 / 190
 ---
 
 - [x] Action News Crew
@@ -169,7 +169,7 @@
 - [x] Super Shredder
 - [x] Tainted Treats
 - [x] TCRI Building
-- [ ] Technodrome
+- [x] Technodrome
 - [x] Tenderize
 - [ ] The Cloning of Shredder
 - [ ] The Last Ronin

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 134 / 190
+**Implemented:** 135 / 190
 ---
 
 - [x] Action News Crew
@@ -114,7 +114,7 @@
 - [x] Nobody
 - [ ] North Wind Avatar
 - [ ] Northampton Farm
-- [ ] Novel Nunchaku
+- [x] Novel Nunchaku
 - [x] Null Group Biological Assets
 - [x] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 131 / 190
+**Implemented:** 132 / 190
 ---
 
 - [x] Action News Crew
@@ -191,7 +191,7 @@
 - [x] Utrom Scientists
 - [ ] Venus, Torn Between Worlds
 - [x] Weather Maker
-- [ ] West Wind Avatar
+- [x] West Wind Avatar
 - [x] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway
 - [x] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 120 / 190
+**Implemented:** 124 / 190
 ---
 
 - [x] Action News Crew
@@ -52,7 +52,7 @@
 - [x] Frog Butler
 - [ ] Fugitive Droid
 - [ ] General Traag, Heart of Stone
-- [ ] Genghis Frog
+- [x] Genghis Frog
 - [ ] Go Ninja Go
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
@@ -118,7 +118,7 @@
 - [x] Null Group Biological Assets
 - [x] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza
-- [ ] Ooze Spill
+- [x] Ooze Spill
 - [x] Oroku Saki, Shredder Rising
 - [x] Pain 101
 - [ ] Paramecia Coloniex
@@ -157,7 +157,7 @@
 - [x] Shredder, Unrelenting
 - [x] Skateboard
 - [x] Slash, Reptile Rampager
-- [ ] Slithering Cryptid
+- [x] Slithering Cryptid
 - [x] South Wind Avatar
 - [x] Spicy Oatmeal Pizza
 - [x] Splinter's Technique
@@ -194,4 +194,4 @@
 - [ ] West Wind Avatar
 - [x] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway
-- [ ] Zoo Escapees
+- [x] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 133 / 190
+**Implemented:** 134 / 190
 ---
 
 - [x] Action News Crew
@@ -121,7 +121,7 @@
 - [x] Ooze Spill
 - [x] Oroku Saki, Shredder Rising
 - [x] Pain 101
-- [ ] Paramecia Coloniex
+- [x] Paramecia Coloniex
 - [ ] Party Dude
 - [x] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 132 / 190
+**Implemented:** 133 / 190
 ---
 
 - [x] Action News Crew
@@ -51,7 +51,7 @@
 - [x] Foot Ninjas
 - [x] Frog Butler
 - [ ] Fugitive Droid
-- [ ] General Traag, Heart of Stone
+- [x] General Traag, Heart of Stone
 - [x] Genghis Frog
 - [ ] Go Ninja Go
 - [ ] Groundchuck & Dirtbag

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -773,6 +773,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateMunitionsToken(count?)` — Munitions noncreature artifact tokens (Weapons Manufacturing); the LTB damage
   trigger lives on the predefined `Munitions` `CardDefinition` and is picked up automatically by the engine's
   `TriggerAbilityResolver`.
+- `CreateMutagenToken(count?)` / `CreateMutagenToken(amount: DynamicAmount)` — Mutagen noncreature artifact tokens
+  (Teenage Mutant Ninja Turtles). The token is `"Artifact — Mutagen"` with the sorcery-speed activated ability
+  `"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature."`, defined on the predefined `Mutagen`
+  `CardDefinition` (so the ability is resolved automatically). The `DynamicAmount` overload serves X-count makers
+  (Mutagen Man, Living Ooze — "create X Mutagen tokens").
 - `CreatePermanentEmblem(name, abilities)` — planeswalker emblem with static abilities.
 
 ### Ability granting

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1946,6 +1946,24 @@ object Effects {
         CreatePredefinedTokenEffect("Munitions", count)
 
     /**
+     * Create Mutagen artifact tokens (Teenage Mutant Ninja Turtles).
+     * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+     *  Activate only as a sorcery."
+     *
+     * @param count Number of tokens to create
+     */
+    fun CreateMutagenToken(count: Int = 1): Effect =
+        CreatePredefinedTokenEffect("Mutagen", count)
+
+    /**
+     * Create a dynamic number of Mutagen artifact tokens — the count is evaluated at
+     * resolution time. Used for X-cost makers like Mutagen Man, Living Ooze
+     * ("create X Mutagen tokens").
+     */
+    fun CreateMutagenToken(count: DynamicAmount): Effect =
+        CreatePredefinedTokenEffect("Mutagen", dynamicCount = count)
+
+    /**
      * Create Everywhere land tokens (Overlord of the Hauntwoods).
      * "A colorless land token named Everywhere that is every basic land type."
      * The token has all five basic land subtypes and taps for any color (the mana

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CrustaceanCommando.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CrustaceanCommando.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crustacean Commando
+ * {1}{U}
+ * Creature — Crab Mutant Soldier
+ * 0/3
+ *
+ * When this creature enters, create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val CrustaceanCommando = card("Crustacean Commando") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab Mutant Soldier"
+    oracleText = "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 0
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Narendra Bintara Adi"
+        flavorText = "\"Wondering what I've got in the box? Pain, soldier! And lots of it!\"\n—Herman"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9528cc07-df4b-417f-ad65-c2fae6fc2d49.jpg?1771502563"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootMystic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootMystic.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Foot Mystic
+ * {3}{B}
+ * Creature — Human Ninja Warlock
+ * 2/4
+ *
+ * Lifelink
+ * Disappear — When this creature enters, if a permanent left the battlefield
+ * under your control this turn, create a 1/1 black Ninja creature token.
+ */
+val FootMystic = card("Foot Mystic") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Ninja Warlock"
+    oracleText = "Lifelink\nDisappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Ninja"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+        )
+        description = "Disappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Irina Nordsol"
+        flavorText = "Mashima would protect the soul of Oroku Saki at any cost."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61e40a18-6cc8-436d-826b-1cf8cd037df3.jpg?1771586860"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GeneralTraagHeartOfStone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GeneralTraagHeartOfStone.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * General Traag, Heart of Stone
+ * {3}{R}{R}
+ * Legendary Artifact Creature — Elemental Soldier
+ * 4/3
+ *
+ * Trample
+ * When General Traag enters, you may sacrifice another artifact. When you do,
+ * General Traag deals 4 damage to target creature.
+ */
+val GeneralTraagHeartOfStone = card("General Traag, Heart of Stone") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact Creature — Elemental Soldier"
+    oracleText = "Trample\nWhen General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    // "you may sacrifice another artifact. When you do, [deal 4 to target creature]" —
+    // the reflexive trigger picks its target only after the optional sacrifice is paid.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = SacrificeEffect(GameObjectFilter.Artifact, excludeSource = true),
+            optional = true,
+            reflexiveEffect = Effects.DealDamage(4, EffectTarget.ContextTarget(0), damageSource = EffectTarget.Self),
+            reflexiveTargetRequirements = listOf(Targets.Creature)
+        )
+        description = "When General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Kevin Sidharta"
+        flavorText = "\"Lord Krang, we arrive. We obey. We conquer.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e02e971f-6008-4c82-acd2-2aed13009ccb.jpg?1771502622"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GenghisFrog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GenghisFrog.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Genghis Frog
+ * {G}{U}
+ * Legendary Creature — Frog Mutant Rogue
+ * 1/3
+ *
+ * Trample
+ * Whenever Genghis Frog or another Mutant you control enters, create a Mutagen
+ * token. (It's an artifact with "{1}, {T}, Sacrifice this token: Put a +1/+1
+ * counter on target creature. Activate only as a sorcery.")
+ */
+val GenghisFrog = card("Genghis Frog") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Frog Mutant Rogue"
+    oracleText = "Trample\nWhenever Genghis Frog or another Mutant you control enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    // "Genghis Frog or another Mutant you control" — ANY binding so Genghis's own
+    // ETB counts too, filtered to Mutants you control.
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype("Mutant")),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateMutagenToken()
+        description = "Whenever Genghis Frog or another Mutant you control enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Zoltan Boros"
+        flavorText = "\"Free our brothers! The human reign of terror around here ends tonight!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7df26085-eedb-4bdd-a60a-aabfbe9c3157.jpg?1771342425"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GoNinjaGo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GoNinjaGo.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Go Ninja Go
+ * {R}{W}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Exile target creature you control, then return it to the battlefield under
+ *   its owner's control.
+ * • Go Ninja Go deals damage equal to the greatest power among creatures you
+ *   control to target creature an opponent controls.
+ */
+val GoNinjaGo = card("Go Ninja Go") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n• Exile target creature you control, then return it to the battlefield under its owner's control.\n• Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Exile target creature you control, then return it to the battlefield under its owner's control") {
+                val creature = target("target creature you control", Targets.CreatureYouControl)
+                effect = Effects.Move(creature, Zone.EXILE)
+                    .then(Effects.Move(creature, Zone.BATTLEFIELD))
+            }
+            mode("Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls") {
+                val opponentCreature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+                effect = Effects.DealDamage(
+                    DynamicAmount.AggregateBattlefield(
+                        Player.You,
+                        GameObjectFilter.Creature,
+                        Aggregation.MAX,
+                        CardNumericProperty.POWER
+                    ),
+                    opponentCreature
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "149"
+        artist = "Patrick Gañas"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90e68cd8-ea76-4bd1-9199-474da9c3e8bf.jpg?1771587007"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/InsectoidExterminator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/InsectoidExterminator.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Insectoid Exterminator
+ * {2}{B}
+ * Creature — Insect Mutant
+ * 2/2
+ *
+ * Flying
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, scry 1.
+ */
+val InsectoidExterminator = card("Insectoid Exterminator") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Mutant"
+    oracleText = "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Patterns.Library.scry(1)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff26f7ff-7f70-4204-9b48-de9e21dc89ec.jpg?1771586866"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LordDreggInsectInvader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LordDreggInsectInvader.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Lord Dregg, Insect Invader
+ * {3}{B}
+ * Legendary Creature — Insect Warrior
+ * 3/2
+ *
+ * Flying
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, create a 1/1 black Insect Warrior
+ * creature token with flying.
+ * {3}{G}, Sacrifice a token: Draw a card.
+ */
+val LordDreggInsectInvader = card("Lord Dregg, Insect Invader") {
+    manaCost = "{3}{B}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Insect Warrior"
+    oracleText = "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying.\n{3}{G}, Sacrifice a token: Draw a card."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Insect", "Warrior"),
+            keywords = setOf(Keyword.FLYING)
+        )
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{G}"),
+            Costs.Sacrifice(GameObjectFilter.Token)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d1a9c8a-d0b6-4d83-a168-8078de4b14c7.jpg?1771586872"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloGameMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloGameMaster.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Michelangelo, Game Master
+ * {2}{G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 3/3
+ *
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, put a +1/+1 counter on Michelangelo.
+ */
+val MichelangeloGameMaster = card("Michelangelo, Game Master") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Eilene Cherie"
+        flavorText = "\"A teacher must be ready to accept responsibility for the student, especially when the student is a weirdo.\"\n—Splinter"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e914c3d-2eed-48bf-af9a-a8998fd5111d.jpg?1771502708"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantChainReaction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantChainReaction.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Mutant Chain Reaction
+ * {2}{G}
+ * Sorcery
+ *
+ * Destroy up to one target artifact, enchantment, or creature with flying.
+ * Create a Mutagen token. (It's an artifact with "{1}, {T}, Sacrifice this
+ * token: Put a +1/+1 counter on target creature. Activate only as a sorcery.")
+ */
+val MutantChainReaction = card("Mutant Chain Reaction") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy up to one target artifact, enchantment, or creature with flying. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+
+    spell {
+        // "up to one target artifact, enchantment, or creature with flying"
+        val permanent = target(
+            "up to one target artifact, enchantment, or creature with flying",
+            TargetPermanent(
+                count = 1,
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.IsArtifact,
+                                    CardPredicate.IsEnchantment,
+                                    CardPredicate.And(
+                                        listOf(
+                                            CardPredicate.IsCreature,
+                                            CardPredicate.HasKeyword(Keyword.FLYING)
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        // The destroy no-ops if no target was chosen; the token is always created.
+        effect = Effects.Composite(
+            Effects.Destroy(permanent),
+            Effects.CreateMutagenToken()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Dominik Mayer"
+        flavorText = "\"We live together, we train together, we fight together, we stand together . . . We are ninjas.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8763e0ee-a48e-424f-8bce-132582d5944b.jpg?1771342410"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NovelNunchaku.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NovelNunchaku.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Novel Nunchaku
+ * {2}{G}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, attach it to target creature you control. When you
+ * do, equipped creature fights up to one target creature an opponent controls.
+ * Equipped creature gets +1/+1 and has trample.
+ * Equip {3}
+ */
+val NovelNunchaku = card("Novel Nunchaku") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEquipped creature gets +1/+1 and has trample.\nEquip {3}"
+
+    // ETB: attach to a creature you control, then that (now equipped) creature fights
+    // up to one opponent creature — the Chelonian Tackle "X then fights up to one" shape.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val yourCreature = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        val opponentCreature = target(
+            "up to one target creature an opponent controls",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = Effects.AttachEquipment(yourCreature)
+            .then(Effects.Fight(yourCreature, opponentCreature))
+        description = "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Marina Ortega Lorente"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f37ef012-c566-4d16-acf8-6079244907be.jpg?1771502723"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OozeSpill.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OozeSpill.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ooze Spill
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell. Create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val OozeSpill = card("Ooze Spill") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+
+    spell {
+        target = Targets.Spell
+        // Counter the spell, then create the Mutagen token. The spell is the only
+        // target, so if it is an illegal target on resolution (CR 608.2b) Ooze Spill
+        // is removed and neither effect happens.
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.CreateMutagenToken()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "Svetlin Velinov"
+        flavorText = "Lab safety is everyone's business."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/beef76b7-856e-48ab-bc73-e4f456c3a100.jpg?1771586813"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ParameciaColoniex.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ParameciaColoniex.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Paramecia Coloniex
+ * {1}{B}
+ * Creature — Zombie Worm
+ * 2/2
+ *
+ * When this creature enters, mill three cards.
+ * When this creature dies, you may exile it. When you do, put target creature
+ * card from your graveyard on top of your library.
+ */
+val ParameciaColoniex = card("Paramecia Coloniex") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Worm"
+    oracleText = "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(3)
+        description = "When this creature enters, mill three cards."
+    }
+
+    // "you may exile it. When you do, put target creature card from your graveyard on
+    // top of your library." triggerZone = GRAVEYARD lets "it" reference Self; the
+    // reflexive trigger picks its graveyard target only after the optional exile.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Exile(EffectTarget.Self),
+            optional = true,
+            reflexiveEffect = Effects.PutOnTopOfLibrary(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.CreatureCardInYourGraveyard)
+        )
+        description = "When this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "70"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/654e2646-78ac-4b08-bed1-3c71355d55fc.jpg?1771586897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PizzaFaceGastromancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PizzaFaceGastromancer.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pizza Face, Gastromancer
+ * {3}{B}{G}
+ * Legendary Artifact Creature — Food Mutant
+ * 2/4
+ *
+ * When Pizza Face enters, create a Food token.
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, put three +1/+1 counters on up to
+ * one other target artifact or creature. If it isn't a creature, it becomes a
+ * 0/0 Mutant creature in addition to its other types.
+ * {10}, {T}, Sacrifice Pizza Face: You gain 15 life.
+ */
+val PizzaFaceGastromancer = card("Pizza Face, Gastromancer") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Artifact Creature — Food Mutant"
+    oracleText = "When Pizza Face enters, create a Food token.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types.\n{10}, {T}, Sacrifice Pizza Face: You gain 15 life."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+        description = "When Pizza Face enters, create a Food token."
+    }
+
+    // Disappear — three +1/+1 counters on up to one other target artifact or creature;
+    // a noncreature target also becomes a 0/0 Mutant creature in addition to its other
+    // types (same conditional-BecomeCreature idiom as Brilliance Unleashed).
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        target = TargetObject(
+            count = 1,
+            optional = true,
+            filter = TargetFilter.CreatureOrArtifact.copy(excludeSelf = true)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.ContextTarget(0))
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.Not(
+                        Conditions.TargetMatchesFilter(GameObjectFilter.Creature)
+                    ),
+                    effect = Effects.BecomeCreature(
+                        target = EffectTarget.ContextTarget(0),
+                        power = 0,
+                        toughness = 0,
+                        creatureTypes = setOf("Mutant"),
+                        duration = Duration.Permanent
+                    )
+                )
+            )
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{10}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(15)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Villarrte"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b03cf0bb-3207-4e8e-bb3f-e3e4367aa86e.jpg?1771599896"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PutridPals.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PutridPals.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Putrid Pals
+ * {2}{B/G}{B/G}
+ * Creature — Human Ooze Mutant
+ * 3/3
+ *
+ * Deathtouch
+ * Disappear — This creature enters with two +1/+1 counters on it if a permanent
+ * left the battlefield under your control this turn.
+ *
+ * Modeled with the engine's standard conditional "enters with counters" idiom
+ * (Benalish Lancer): an EntersBattlefield trigger gated by the Disappear
+ * intervening-if that places the two counters.
+ */
+val PutridPals = card("Putrid Pals") {
+    manaCost = "{2}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Human Ooze Mutant"
+    oracleText = "Deathtouch\nDisappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        description = "Disappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Kevin Sidharta"
+        flavorText = "\"Beats working in the sewers. Too many freaky mutants down there.\"\n—Muckman"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42cdb88d-675a-43bb-b85c-51c4cc526315.jpg?1771587057"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlitheringCryptid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlitheringCryptid.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slithering Cryptid
+ * {2}{G/U}
+ * Creature — Fish Mutant
+ * 2/3
+ *
+ * When this creature enters, create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val SlitheringCryptid = card("Slithering Cryptid") {
+    manaCost = "{2}{G/U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Fish Mutant"
+    oracleText = "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Nicholas Gregory"
+        flavorText = "\"The Slithery! He's snatches little kids an' keeps 'em in cages! He don't got no legs and just slithers.\"\n—Lita"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d35cb39-8832-4cf1-be73-8de49fbea529.jpg?1771502794"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Technodrome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Technodrome.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Technodrome
+ * {2}
+ * Artifact Creature — Construct
+ * 3/3
+ *
+ * Reach, trample
+ * This creature can't attack or block unless its power is 6 or greater.
+ * {T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature.
+ */
+val Technodrome = card("Technodrome") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "Reach, trample\nThis creature can't attack or block unless its power is 6 or greater.\n{T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    // "can't attack or block unless its power is 6 or greater" — compares the source's
+    // own (projected) power to 6.
+    val powerAtLeastSix = Compare(
+        DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power),
+        ComparisonOperator.GTE,
+        DynamicAmount.Fixed(6)
+    )
+    staticAbility {
+        ability = CantAttackUnless(condition = powerAtLeastSix)
+    }
+    staticAbility {
+        ability = CantBlockUnless(condition = powerAtLeastSix)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        effect = Effects.DrawCards(1)
+            .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Greg Staples"
+        flavorText = "Even unfinished, the Technodrome was magnificent, a wonder of alien technology."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/287f5ab0-b15b-4507-8a24-585f9a9841ad.jpg?1769006421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WestWindAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WestWindAvatar.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * West Wind Avatar
+ * {5}{G}{G}
+ * Creature — Cat Spirit Avatar
+ * 7/7
+ *
+ * Trample
+ * Whenever this creature enters or attacks, you may sacrifice a token or a land.
+ * If you do, you gain 3 life.
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, draw a card.
+ */
+val WestWindAvatar = card("West Wind Avatar") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Spirit Avatar"
+    oracleText = "Trample\nWhenever this creature enters or attacks, you may sacrifice a token or a land. If you do, you gain 3 life.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.TRAMPLE)
+
+    // "you may sacrifice a token or a land. If you do, you gain 3 life."
+    val tokenOrLand = GameObjectFilter(
+        cardPredicates = listOf(
+            CardPredicate.Or(listOf(CardPredicate.IsToken, CardPredicate.IsLand))
+        )
+    )
+    val sacrificeForLife = MayEffect(
+        Effects.Sacrifice(tokenOrLand, count = 1, target = EffectTarget.Controller)
+            .then(Effects.GainLife(3))
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = sacrificeForLife
+        description = "Whenever this creature enters, you may sacrifice a token or a land. If you do, you gain 3 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = sacrificeForLife
+        description = "Whenever this creature attacks, you may sacrifice a token or a land. If you do, you gain 3 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.DrawCards(1)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Oriana Menendez"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4b8f7e6-9bff-430b-b2f5-4308d57d1194.jpg?1771586987"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZooEscapees.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZooEscapees.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zoo Escapees
+ * {1}{G}
+ * Creature — Boar Rhino
+ * 2/2
+ *
+ * When this creature leaves the battlefield, create a Mutagen token. (It's an
+ * artifact with "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target
+ * creature. Activate only as a sorcery.")
+ */
+val ZooEscapees = card("Zoo Escapees") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar Rhino"
+    oracleText = "When this creature leaves the battlefield, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature leaves the battlefield, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Mirko Failoni"
+        flavorText = "They imagine that out beyond the zoo, beyond the pen, there exists another world, and it encroaches with rapid certainty upon their own . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f57ba8ff-2f8c-4ca1-9b13-42a7cc213e99.jpg?1771502750"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.tokens
 
+import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
@@ -439,6 +440,29 @@ object PredefinedTokens {
     }
 
     /**
+     * Mutagen token — a colorless artifact (Teenage Mutant Ninja Turtles) with:
+     * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+     *  Activate only as a sorcery."
+     *
+     * Same shape as the [Map] token (mana + tap + sacrifice-self, sorcery-speed,
+     * single creature target), but places a +1/+1 counter instead of an explore.
+     */
+    val Mutagen = card("Mutagen") {
+        typeLine = "Artifact — Mutagen"
+
+        activatedAbility {
+            val creature = target("target creature", Targets.Creature)
+            cost = Costs.Composite(
+                Costs.Mana("{1}"),
+                Costs.Tap,
+                Costs.SacrificeSelf
+            )
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            timing = TimingRule.SorcerySpeed
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -458,6 +482,7 @@ object PredefinedTokens {
         Incubator,
         Drone,
         Everywhere,
-        Munitions
+        Munitions,
+        Mutagen
     )
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3468,6 +3468,91 @@
     ]
 }
 
+// Lord Dregg, Insect Invader
+{
+    "name": "Lord Dregg, Insect Invader",
+    "manaCost": "{3}{B}",
+    "typeLine": "Legendary Creature — Insect Warrior",
+    "oracleText": "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying.\n{3}{G}, Sacrifice a token: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Insect",
+                        "Warrior"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "token"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d1a9c8a-d0b6-4d83-a168-8078de4b14c7.jpg?1771586872"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Make Your Move
 {
     "name": "Make Your Move",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1910,6 +1910,55 @@
     ]
 }
 
+// Foot Mystic
+{
+    "name": "Foot Mystic",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Ninja Warlock",
+    "oracleText": "Lifelink\nDisappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Ninja"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Irina Nordsol",
+        "flavorText": "Mashima would protect the soul of Oroku Saki at any cost.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61e40a18-6cc8-436d-826b-1cf8cd037df3.jpg?1771586860"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Foot Ninjas
 {
     "name": "Foot Ninjas",
@@ -2614,6 +2663,47 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Insectoid Exterminator
+{
+    "name": "Insectoid Exterminator",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect Mutant",
+    "oracleText": "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff26f7ff-7f70-4204-9b48-de9e21dc89ec.jpg?1771586866"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3644,6 +3734,47 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Michelangelo, Game Master
+{
+    "name": "Michelangelo, Game Master",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Eilene Cherie",
+        "flavorText": "\"A teacher must be ready to accept responsibility for the student, especially when the student is a weirdo.\"\n—Splinter",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e914c3d-2eed-48bf-af9a-a8998fd5111d.jpg?1771502708"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4938,6 +5069,50 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Putrid Pals
+{
+    "name": "Putrid Pals",
+    "manaCost": "{2}{B/G}{B/G}",
+    "typeLine": "Creature — Human Ooze Mutant",
+    "oracleText": "Deathtouch\nDisappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"Beats working in the sewers. Too many freaky mutants down there.\"\n—Muckman",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42cdb88d-675a-43bb-b85c-51c4cc526315.jpg?1771587057"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1089,6 +1089,43 @@
     ]
 }
 
+// Crustacean Commando
+{
+    "name": "Crustacean Commando",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Crab Mutant Soldier",
+    "oracleText": "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Narendra Bintara Adi",
+        "flavorText": "\"Wondering what I've got in the box? Pain, soldier! And lots of it!\"\n—Herman",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9528cc07-df4b-417f-ad65-c2fae6fc2d49.jpg?1771502563"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dark Leo & Shredder
 {
     "name": "Dark Leo & Shredder",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5080,6 +5080,138 @@
     ]
 }
 
+// Pizza Face, Gastromancer
+{
+    "name": "Pizza Face, Gastromancer",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Legendary Artifact Creature — Food Mutant",
+    "oracleText": "When Pizza Face enters, create a Food token.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types.\n{10}, {T}, Sacrifice Pizza Face: You gain 15 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "descriptionOverride": "When Pizza Face enters, create a Food token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Not",
+                                    "condition": {
+                                        "type": "EntityMatches",
+                                        "entity": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "filter": "creature"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "BecomeCreature",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "creatureTypes": [
+                                    "Mutant"
+                                ],
+                                "duration": "Permanent"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|artifact",
+                        "excludeSelf": true
+                    }
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{10}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 15
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Villarrte",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b03cf0bb-3207-4e8e-bb3f-e3e4367aa86e.jpg?1771599896"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Primordial Pachyderm
 {
     "name": "Primordial Pachyderm",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2166,6 +2166,92 @@
     ]
 }
 
+// Go Ninja Go
+{
+    "name": "Go Ninja Go",
+    "manaCost": "{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Exile target creature you control, then return it to the battlefield under its owner's control.\n• Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                },
+                                "destination": "Exile"
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    ],
+                    "description": "Exile target creature you control, then return it to the battlefield under its owner's control"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature",
+                            "aggregation": "MAX",
+                            "property": "POWER"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "target creature an opponent controls"
+                        }
+                    ],
+                    "description": "Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "UNCOMMON",
+        "artist": "Patrick Gañas",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90e68cd8-ea76-4bd1-9199-474da9c3e8bf.jpg?1771587007"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7824,6 +7824,102 @@
     ]
 }
 
+// Technodrome
+{
+    "name": "Technodrome",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Reach, trample\nThis creature can't attack or block unless its power is 6 or greater.\n{T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "MYTHIC",
+        "artist": "Greg Staples",
+        "flavorText": "Even unfinished, the Technodrome was magnificent, a wonder of alien technology.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/287f5ab0-b15b-4507-8a24-585f9a9841ad.jpg?1769006421"
+    }
+}
+
 // Tenderize
 {
     "name": "Tenderize",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4135,6 +4135,73 @@
     ]
 }
 
+// Mutant Chain Reaction
+{
+    "name": "Mutant Chain Reaction",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy up to one target artifact, enchantment, or creature with flying. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target artifact, enchantment, or creature with flying"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsArtifact",
+                                    "IsEnchantment",
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasKeyword",
+                                                "keyword": "FLYING"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "up to one target artifact, enchantment, or creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Dominik Mayer",
+        "flavorText": "\"We live together, we train together, we fight together, we stand together . . . We are ninjas.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8763e0ee-a48e-424f-8bce-132582d5944b.jpg?1771342410"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mutant Town
 {
     "name": "Mutant Town",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8271,6 +8271,106 @@
     }
 }
 
+// West Wind Avatar
+{
+    "name": "West Wind Avatar",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Cat Spirit Avatar",
+    "oracleText": "Trample\nWhenever this creature enters or attacks, you may sacrifice a token or a land. If you do, you gain 3 life.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForceSacrifice",
+                                "filter": "token|land",
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature enters, you may sacrifice a token or a land. If you do, you gain 3 life."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForceSacrifice",
+                                "filter": "token|land",
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may sacrifice a token or a land. If you do, you gain 3 life."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Oriana Menendez",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4b8f7e6-9bff-430b-b2f5-4308d57d1194.jpg?1771586987"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Wingnut, Bat on the Belfry
 {
     "name": "Wingnut, Bat on the Belfry",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4719,6 +4719,117 @@
     ]
 }
 
+// Novel Nunchaku
+{
+    "name": "Novel Nunchaku",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEquipped creature gets +1/+1 and has trample.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "Fight",
+                            "target1": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            },
+                            "target2": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "up to one target creature an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Marina Ortega Lorente",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f37ef012-c566-4d16-acf8-6079244907be.jpg?1771502723"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Null Group Biological Assets
 {
     "name": "Null Group Biological Assets",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2008,6 +2008,50 @@
     ]
 }
 
+// Genghis Frog
+{
+    "name": "Genghis Frog",
+    "manaCost": "{G}{U}",
+    "typeLine": "Legendary Creature — Frog Mutant Rogue",
+    "oracleText": "Trample\nWhenever Genghis Frog or another Mutant you control enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Mutant ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "Whenever Genghis Frog or another Mutant you control enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Free our brothers! The human reign of terror around here ends tonight!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7df26085-eedb-4bdd-a60a-aabfbe9c3157.jpg?1771342425"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",
@@ -4589,6 +4633,45 @@
     }
 }
 
+// Ooze Spill
+{
+    "name": "Ooze Spill",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Lab safety is everyone's business.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/beef76b7-856e-48ab-bc73-e4f456c3a100.jpg?1771586813"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Oroku Saki, Shredder Rising
 {
     "name": "Oroku Saki, Shredder Rising",
@@ -6288,6 +6371,44 @@
     ]
 }
 
+// Slithering Cryptid
+{
+    "name": "Slithering Cryptid",
+    "manaCost": "{2}{G/U}",
+    "typeLine": "Creature — Fish Mutant",
+    "oracleText": "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"The Slithery! He's snatches little kids an' keeps 'em in cages! He don't got no legs and just slithers.\"\n—Lita",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d35cb39-8832-4cf1-be73-8de49fbea529.jpg?1771502794"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // South Wind Avatar
 {
     "name": "South Wind Avatar",
@@ -7844,5 +7965,42 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Zoo Escapees
+{
+    "name": "Zoo Escapees",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Boar Rhino",
+    "oracleText": "When this creature leaves the battlefield, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Mirko Failoni",
+        "flavorText": "They imagine that out beyond the zoo, beyond the pen, there exists another world, and it encroaches with rapid certainty upon their own . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f57ba8ff-2f8c-4ca1-9b13-42a7cc213e99.jpg?1771502750"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2057,6 +2057,71 @@
     ]
 }
 
+// General Traag, Heart of Stone
+{
+    "name": "General Traag, Heart of Stone",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Artifact Creature — Elemental Soldier",
+    "oracleText": "Trample\nWhen General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Sacrifice",
+                        "filter": "artifact",
+                        "excludeSource": true
+                    },
+                    "reflexiveEffect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"Lord Krang, we arrive. We obey. We conquer.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e02e971f-6008-4c82-acd2-2aed13009ccb.jpg?1771502622"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Genghis Frog
 {
     "name": "Genghis Frog",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5145,6 +5145,99 @@
     ]
 }
 
+// Paramecia Coloniex
+{
+    "name": "Paramecia Coloniex",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Worm",
+    "oracleText": "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, mill three cards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Exile"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "When this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/654e2646-78ac-4b08-bed1-3c71355d55fc.jpg?1771586897"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pizza Face, Gastromancer
 {
     "name": "Pizza Face, Gastromancer",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisappearMichelangeloScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisappearMichelangeloScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Disappear intervening-if test, exercised through Michelangelo, Game Master (TMT):
+ * "Disappear — At the beginning of your end step, if a permanent left the battlefield
+ *  under your control this turn, put a +1/+1 counter on Michelangelo."
+ *
+ * Disappear reuses the existing per-controller `PermanentLeftBattlefieldThisTurnComponent`
+ * tracker (set in ZoneTransitionService for any permanent — lands included — leaving that
+ * player's battlefield) via the `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`
+ * intervening-if (CR 603.4). These tests prove the condition gates the end-step trigger:
+ * the counter lands only when a permanent actually left this turn.
+ */
+class DisappearMichelangeloScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCards(PredefinedTokens.allTokens) // GameTestDriver doesn't auto-register tokens
+        return d
+    }
+
+    test("a permanent leaving this turn satisfies Disappear — counter is placed") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mike = d.putCreatureOnBattlefield(p, "Michelangelo, Game Master") // 3/3
+        // Sacrifice a Food via its own ability so a permanent genuinely leaves the
+        // battlefield through ZoneTransitionService (which credits the controller).
+        val food = d.putPermanentOnBattlefield(p, "Food")
+        d.giveMana(p, Color.GREEN, 2)
+        d.submit(
+            ActivateAbility(
+                playerId = p,
+                sourceId = food,
+                abilityId = PredefinedTokens.Food.activatedAbilities.first().id
+            )
+        ).isSuccess shouldBe true
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        // Advance to the end step; the Disappear trigger fires (intervening-if true) and resolves.
+        d.passPriorityUntil(Step.END)
+        guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        projector.getProjectedPower(d.state, mike) shouldBe 4
+        projector.getProjectedToughness(d.state, mike) shouldBe 4
+    }
+
+    test("no permanent left this turn — Disappear does not trigger, no counter") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mike = d.putCreatureOnBattlefield(p, "Michelangelo, Game Master")
+
+        d.passPriorityUntil(Step.END)
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        // Intervening-if is false (nothing left the battlefield), so the trigger never resolves.
+        projector.getProjectedPower(d.state, mike) shouldBe 3
+        projector.getProjectedToughness(d.state, mike) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
@@ -30,7 +30,7 @@ import io.kotest.matchers.shouldBe
  *  1. Activating the ability puts a +1/+1 counter on the target creature and the cost
  *     sacrifices the token (it leaves the battlefield) and pays {1} + {T}.
  *  2. "Activate only as a sorcery" — the ability is illegal outside the controller's main
- *     phase with an empty stack (here: during upkeep), per CR 302.6.
+ *     phase with an empty stack (here: during upkeep), per CR 307.5.
  *  3. The [Effects.CreateMutagenToken] facade actually produces a registered "Mutagen"
  *     artifact token (noncreature) end to end.
  */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Feature test for the predefined **Mutagen** token (Teenage Mutant Ninja Turtles).
+ *
+ * "It's an artifact with '{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target
+ *  creature. Activate only as a sorcery.'"
+ *
+ * Proves the three load-bearing clauses of the token:
+ *  1. Activating the ability puts a +1/+1 counter on the target creature and the cost
+ *     sacrifices the token (it leaves the battlefield) and pays {1} + {T}.
+ *  2. "Activate only as a sorcery" — the ability is illegal outside the controller's main
+ *     phase with an empty stack (here: during upkeep), per CR 302.6.
+ *  3. The [Effects.CreateMutagenToken] facade actually produces a registered "Mutagen"
+ *     artifact token (noncreature) end to end.
+ */
+class MutagenTokenScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+    val mutagenAbilityId = PredefinedTokens.Mutagen.activatedAbilities.first().id
+
+    // Inline maker that exercises the Effects.CreateMutagenToken() facade on ETB.
+    val mutagenMaker = card("Mutagen Maker") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateMutagenToken()
+            description = "When this creature enters, create a Mutagen token."
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCards(PredefinedTokens.allTokens) // GameTestDriver doesn't auto-register tokens
+        d.registerCards(listOf(mutagenMaker))
+        return d
+    }
+
+    test("{1}, {T}, Sacrifice this token: put a +1/+1 counter on target creature") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mutagen = d.putPermanentOnBattlefield(p, "Mutagen")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(bear)
+        d.giveMana(p, Color.BLUE, 1)
+
+        d.submit(
+            ActivateAbility(
+                playerId = p,
+                sourceId = mutagen,
+                abilityId = mutagenAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        // +1/+1 counter applied: 3/3 -> 4/4.
+        projector.getProjectedPower(d.state, bear) shouldBe 4
+        projector.getProjectedToughness(d.state, bear) shouldBe 4
+
+        // The token paid its own sacrifice and is gone.
+        d.state.getBattlefield().contains(mutagen) shouldBe false
+    }
+
+    test("activate only as a sorcery — illegal during the controller's upkeep") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.UPKEEP)
+
+        val mutagen = d.putPermanentOnBattlefield(p, "Mutagen")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser")
+        d.removeSummoningSickness(bear)
+        d.giveMana(p, Color.BLUE, 1)
+
+        // Upkeep is not a main phase, so the sorcery-speed ability must be rejected.
+        d.submitExpectFailure(
+            ActivateAbility(
+                playerId = p,
+                sourceId = mutagen,
+                abilityId = mutagenAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        )
+
+        // Untouched: token still present, creature still 3/3.
+        d.state.getBattlefield().contains(mutagen) shouldBe true
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+    }
+
+    test("Effects.CreateMutagenToken() creates a registered Mutagen artifact token") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val before = mutagenTokens(d.state, p).toSet()
+        val maker = d.putCardInHand(p, "Mutagen Maker")
+        d.giveMana(p, Color.BLUE, 2)
+        d.castSpell(p, maker)
+        // Resolve the spell, then its ETB trigger (each is a separate stack object).
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        val created = mutagenTokens(d.state, p) - before
+        created.size shouldBe 1
+        val card = d.state.getEntity(created.first())!!.get<CardComponent>()!!
+        card.name shouldBe "Mutagen"
+        card.typeLine.isArtifact shouldBe true
+        card.typeLine.isCreature shouldBe false
+    }
+})
+
+private fun mutagenTokens(state: GameState, player: EntityId): List<EntityId> =
+    state.getBattlefield().filter {
+        val e = state.getEntity(it) ?: return@filter false
+        e.has<TokenComponent>() &&
+            e.get<ControllerComponent>()?.playerId == player &&
+            e.get<CardComponent>()?.name == "Mutagen"
+    }


### PR DESCRIPTION
Implements the foundation/commons batch for Teenage Mutant Ninja Turtles
(TMT), 119 → 137 cards. Adds no new SDK types — every card composes
existing primitives.

## What's new
- **Mutagen token** — predefined `CardDefinition` ("{1}, {T}, Sacrifice:
  +1/+1 counter on target creature. Sorcery speed.") + `Effects.CreateMutagenToken()`
  facade (with a `DynamicAmount` overload for future X-makers), mirroring
  the existing Munitions token. Reference doc updated.
- **18 cards** — Crustacean Commando, Foot Mystic, General Traag, Genghis
  Frog, Go Ninja Go, Insectoid Exterminator, Lord Dregg, Michelangelo,
  Mutant Chain Reaction, Novel Nunchaku, Ooze Spill, Paramecia Coloniex,
  Pizza Face, Putrid Pals, Slithering Cryptid, Technodrome, West Wind
  Avatar, Zoo Escapees.
- **Disappear** cards reuse the existing
  `Conditions.YouHadPermanentLeaveBattlefieldThisTurn` intervening-if.

## Notable reuse
- Go Ninja Go's blink is the same `Move(EXILE).then(Move(BATTLEFIELD))`
  idiom as BLB SplashPortal; modal burn uses `DynamicAmount.AggregateBattlefield(MAX power)`.

## Tests
- `MutagenTokenScenarioTest` — counter + self-sacrifice, sorcery-speed
  rejection (CR 307.5), facade produces a registered noncreature artifact.
- `DisappearMichelangeloScenarioTest` — both branches of the intervening-if.
- TMT snapshot re-blessed (additive). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)